### PR TITLE
fix(gateway): scope worker-incapable streak per worker + derive degradation cause

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -106,7 +106,7 @@
 * **Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes. (PR #1277 final commits: 0993b690 tooling, f11f2e4b reformat+autofix, a3486c5f**: Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes.
 
 <!-- lore:019f51ec-9e29-759e-a82c-e06c5485b7b2 -->
-* **Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables)**: chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables).
+* **Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables)**: Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables). Never marked incapable and the failure ladder escalated forever with a misleading "auth stale" warning.
 
 <!-- lore:019f3974-7c6a-7091-8602-b4ec0bb763a4 -->
 * **Chose next task: knowledge\_meta seed-order alignment (self-contained, low-risk, completes value-ranked seed coherence work started with knowledge #1189 and entities #1194) — over #1191b (continuous top-N eviction)**: Completed value-ranked seed coherence work in sequence: #1189 (knowledge seed value-ranking) → PR #1194 (entity-graph seed: entities ranked by knowledge\_entity\_refs count DESC then recency; entity\_relations by recency; entity\_aliases by created\_at DESC) → PR #1196 (knowledge\_meta seed aligned to knowledge's ORDER BY: confidence DESC, COALESCE(last\_reinforced\_at, updated\_at) DESC, logical\_id tiebreak). Deferred #1191b (continuous top-N eviction for remote) as a separate larger/riskier task needing a design doc first (remote eviction, cap discovery, thrash guards, concurrency) — not suitable for autonomous same-session implementation. Follow-up issue #1197 filed for a known non-blocking edge case: a deleted high-confidence entry's orphaned knowledge\_meta row can outrank a live entry's meta row under the cap (self-healing, not data loss).
@@ -168,6 +168,9 @@
 <!-- lore:019f05e3-1abc-7c77-944b-bc9e7ae25bb1 -->
 * **Switched from plan mode to build mode (read-write**: switched from plan to build mode (read-only lifted; file changes,
 
+<!-- lore:019f65ca-91c3-71f9-9f8a-bb8a803ce3e4 -->
+* **Switched from Python to TypeScript for the project (no longer using Python)**: switched from Python to TypeScript for the project (no longer using Python).
+
 ### Gotcha
 
 <!-- lore:019ef645-24ae-7562-ace6-3b0d343cdb3f -->
@@ -189,7 +192,7 @@
 * **Bedrock: stream field in request body causes validation error — endpoint controls streaming**: Trap: adding \`stream: true|false\` to the Bedrock request body looks correct (mirrors Anthropic API). Fix: Bedrock does NOT accept a \`stream\` field in the body — streaming is controlled by the endpoint URL (\`/invoke-with-response-stream\` vs \`/invoke\`). Including \`stream\` causes Bedrock to reject with a validation error. \`buildBedrockRequestBody\` must never set this field. Confirmed by user directive and test assertion (\`'stream' in capturedBody === false\`).
 
 <!-- lore:019f1c21-e7cb-7ac1-9654-b29c3d1dc1b9 -->
-* **buildEmbeddingUnits splits ONLY on "\n\x1f" — bare \x1f without preceding newline is NOT a separator**: buildEmbeddingUnits splits ONLY on "\n\x1f" — bare \x1f without preceding newline is NOT a separator: Trap: buildEmbeddingUnits splits ONLY on "\n\x1f" — bare \x1f without preceding newline is NOT a separator. Fix: use CHUNK\_SEPARATOR = "\n\x1f" (newline + terminator).
+* **buildEmbeddingUnits splits ONLY on "\n\x1f" — bare \x1f without preceding newline is NOT a separator**: buildEmbeddingUnits splits ONLY on "\n\x1f" — bare \x1f without preceding newline is NOT a separator
 
 <!-- lore:019ee719-946b-7dde-99f8-56c19833e6cc -->
 * **bun:sqlite returns null (not undefined) for missing rows — existence checks must use count query**: Trap: \`db.prepare('SELECT \* FROM t WHERE id=?').get(id) !== undefined\` looks correct for existence checks (standard JS pattern). Fix: bun:sqlite driver returns \`null\` (not \`undefined\`) for no-row results — \`!== undefined\` always returns \`true\`. Use a count query: \`db.prepare('SELECT COUNT(\*) as n FROM t WHERE id=?').get(id).n > 0\`. Also: \`getKV()\` returns \`null\` for missing keys — use \`?? '0'\` not \`|| '0'\` when reading push cursors. Also: \`decideCacheStrategy\` returns \`confident:false\` when pricing or body tokens are non-finite/non-positive; \`confident:true\` otherwise. \`shouldHoldPrefixWarm(null,…)\` → \`undefined===true\` → false — null econ is safe fallback.
@@ -211,9 +214,6 @@
 
 <!-- lore:019efb40-0000-7000-9000-000000000003 -->
 * **creditWarmupHit three guards: paid (Bug A) + within-TTL + actually-read (Bug C); credit is binary not pro-rata**: \`creditWarmupHit(warmup, sinceWarmupMs, ttlMs, cacheReadTokens)\` attributes a warmup hit ONLY when ALL hold: (A) the session paid (\`totalWarmups>0 && lastWarmupRefreshTokens>0\` — \`lastWarmupAt\` alone rides along in restored blobs → phantom); within TTL (\`sinceWarmupMs < ttlMs\`); (C) the returning turn ACTUALLY READ the cache (\`cacheReadTokens > 0\`). Bug C fix: a turn that pivoted context / used a different tool chain / found the cache evicted reports \`cache\_read=0\` → no savings; without the gate, warmupHits/creditedTokens inflate and warp the ROI analysis gating future warming. Call site passes \`usage.cacheReadInputTokens ?? 0\` (same signal the adjacent 1h-TTL-savings branch gates on). The warmup is consumed (markers zeroed) BEFORE all three guards, so a no-hit still can't re-credit later. \`creditedTokens\` is the warmed prefix (\`refreshTokens\`, Bug B), NOT the returning read. Known residual: the read gate is BINARY — a partial read (0 < read < refreshTokens, e.g. breakpoint shift) still credits the full refreshTokens. Call-site threading (pipeline postResponse warmup-hit branch) is NOT seam-tested — hardcoding the 4th arg survives all warmup pipeline tests (tracked follow-up).
-
-<!-- lore:019f6149-2aa7-7503-b805-d3abeff9fde6 -->
-* **Dead code removal**: Dead code removal: Keep dead code with an explanatory comment. This helps maintain code readability and understandability. No input token count is retained any input token count — inclusive \*or\* disjoint.
 
 <!-- lore:019ef389-a501-7db4-a808-4e0c671bb2f0 -->
 * **effectiveMetaThreshold: internal Date.now() makes tests flaky — inject nowMs parameter**: Trap: \`effectiveMetaThreshold(lastTurnAtMs)\` calling \`Date.now()\` internally looks correct — it needs the current time to compute \`gapMs\`. Fix: any test that captures \`const now = Date.now()\` then passes \`now - (DEEP\_IDLE\_MS - 1)\` as \`lastTurnAtMs\` is flaky — a ≥1ms scheduling delay pushes \`gapMs ≥ DEEP\_IDLE\_MS\`, flipping the return value. Fix (PR #926): add injectable \`nowMs\` parameter; tests pass a fixed \`NOW\` constant. Sentinel: \`lastTurnAtMs === 0\` means 'never set (first turn)' → treated as deep-idle (gapMs = Infinity). All 8 \`effectiveMetaThreshold\` tests rewritten to use fixed \`NOW\` — fully deterministic.
@@ -270,7 +270,7 @@
 * **pruneOversized uses clamped confidence — CRDT hysteresis leaves raw value > 1.0 unzeroed**: Trap: \`pruneOversized\` reads \`confidence\` from \`knowledge\_current\` (materialized, clamped to \[0,1]) and applies \`-confidence\` delta — looks correct for zeroing. Fix: CRDT deltas accumulate on \`base\_confidence\`; raw value can exceed 1.0 while materialized stays clamped at 1.0. Applying \`-1.0\` delta leaves raw > 0 → entry not actually pruned, GC fails silently. Fix: fetch raw unclamped value (\`base\_confidence + SUM(deltas)\`) and apply negative delta equal to that raw sum. Confirmed in PR #1126 fix commit \`36173a7\`.
 
 <!-- lore:019f04b8-26f5-71fd-b8e2-e8dcca6e1c40 -->
-* **recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table**: Switched from forcing a violation to \*\*catalog introspection\*\* — directly querying information\_schema/pg\_constraint to assert content.
+* **recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table**: recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table
 
 <!-- lore:019efa17-e5b6-75a7-940b-7367c9de371e -->
 * **references.ts codeSpanText: newline join fuses adjacent spans — cross-span phantom commands**: Trap: \`codeSpanText()\` joining all backtick code-span inner text with \`"\n"\` looks safe — newline is a natural separator. Fix: \`\n\` matches \`\s\` in \`PM\_CMD\_RE\`/\`MAKE\_CMD\_RE\`, so adjacent spans like \`\` \`make\` \`\` and \`\` \`Makefile\` \`\` fuse into \`make Makefile\` → phantom command → confidence penalty. Examples: \`\` \`npm\` or \`yarn\` \`\` → \`npm yarn\`; \`\` \`make sense\` \`\` → \`make sense\`. Fix: split on lines first, run regexes per-line (renamed \`codeLines\`). Invariant: unverifiable refs must be strict no-op — false negatives (silent skips) are acceptable; false positives that trigger penalties are NEVER acceptable. Mutation-verified: reverting per-line split causes 2 fusion guard tests to fail. Fixed in PR #939 Round-2.
@@ -292,9 +292,6 @@
 
 <!-- lore:019ef02c-f197-7282-8eb5-13a894b0cd15 -->
 * **startGateway reuse probe: EADDRINUSE-gated probe misses non-overlapping interface binds**: Trap: placing existing-gateway reuse probe inside \`EADDRINUSE\` catch looks correct — port conflict is the only reason to check. Fix: when new instance binds non-overlapping interface (existing on \`127.0.0.1\`, new on \`127.0.0.2\`), bind succeeds, catch never fires, second redundant gateway starts. Fix (PR #908/#920): \`firstReachableHost(hosts, port, probe)\` probes all hosts concurrently via \`Promise.all\`. Pre-bind probe runs for each \`candidatePort !== 0\` BEFORE bind; post-bind EADDRINUSE catch retained as TOCTOU backstop. \`runDaemon()\` probes all configured hosts + \`127.0.0.1\` fallback. \`opts.local===true\` always disables remote mode. Port 0 skipped correctly. Both pre-bind and post-bind reuse blocks use \`firstReachableHost\` + pin \`config.hosts = \[reachableHost]\` so callers see the actual reachable host. All host→URL interpolations in CLI must use \`bracketHost\` for IPv6 (PR #912). Mutation A (disable pre-bind probe) killed by test 3 in start-gateway-reuse.test.ts; Mutation B (single-host daemon probe) killed by daemon-args.test.ts; Mutation C (disable hosts pin) killed by \`expect(handle.config.hosts).toEqual(\["127.0.0.1"])\` assertion.
-
-<!-- lore:019f6290-06d7-7bd2-91ee-4ada9e1b759f -->
-* **Supabase auth\_rls\_initplan performance-advisor warnings**: Trap: forgetting to initialize inputTokens and outputTokens in SessionCostSnapshot looks correct. Fix: always initialize with 0.
 
 <!-- lore:019f55f8-7219-7362-b42f-eced166ff0a9 -->
 * **Supabase RLS helper functions: 2-arg cross-user oracle via default-arg overload**: Trap: granting EXECUTE on 2-arg helper functions (\`is\_member(uuid,uuid)\`, \`is\_org\_member\`, \`scope\_role\`, \`org\_role\`) to \`authenticated\` looks safe — RLS policies only ever call the 1-arg self-check form. Fix: any client can call the 2-arg form directly with an arbitrary target user, using the function's elevated privilege to probe cross-user scope/org roles, bypassing RLS on \`scope\_members\`/\`org\_members\`. Rejected fix: revoking 2-arg grants and keeping only 1-arg defaults — would require recreating every RLS policy bound to the 2-arg OID (policies bake in default-arg expansion at parse time). Actual fix (migration 0032, mirrors 0029's \`shares\_scope\` guard): add body-guard \`p\_uid IS DISTINCT FROM auth.uid()\` (unless \`service\_role\`) inside the function via \`CREATE OR REPLACE\` — same signature/OID, so RLS/grant bindings stay stable. Since RLS always calls the 1-arg form (\`p\_uid := auth.uid()\`), predicate is structurally \`X IS DISTINCT FROM X\` → always false → never pinned for legitimate self-checks; only literal 2-arg cross-user calls get pinned to null/false (fail-closed since \`null = 'admin'\` is false).
@@ -324,7 +321,7 @@
 * **SYNCED\_TABLES fan-out: adding a table has silent ripple effects with no contract test**: SYNCED\_TABLES fan-out: adding a table has silent ripple effects with no contract test. Adding a table to \`SYNCED\_TABLES\` (e.g. \`profiles\`) has ripple effects across \`seedOutbox\`, \`reconcile\`, \`pruneOutbox\`, \`applyRemote\` pull-classification, and outbox-capture triggers. No single contract test enforces all invariants for every registered table. \`profiles\` silently violated the prune-floor and tier-residue invariants on paths nobody re-checked after registration. Fix: add a per-table invariant test that asserts all registry-required properties (pullOnly guard in seed/reconcile, no outbox trigger, correct pull classification) whenever a new table is added to \`SYNCED\_TABLES\`.
 
 <!-- lore:019f03c2-0d94-77a6-bbe8-f7fae06c639e -->
-* **temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary**: temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary: temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary: Trap: SELECT m.\* in temporal.searchScored looks correct — it's the standard pattern used in sync temporal.search(). Fix: embedding BLOB is added by migration 449 and is NOT in TemporalMessage type, but SELECT m.\* would include it. BLOBs must never cross the read-worker boundary (read-job contract in read-job.ts). Lean column list: m.id, m.project\_id, m.session\_id, m.role, m.content, m.tokens, m.distilled, m.created\_at, m.metadata, rank.
+* **temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary**: temporal.searchScored: must use lean column list, never SELECT m.\* — embedding BLOB forbidden at worker boundary
 
 <!-- lore:019efa1b-9771-70f1-ba6a-f6eccead4374 -->
 * **undici is external in Bun ESM bundle — real undici@7 hangs on streaming reads under Bun**: Trap: bundling \`undici\` into the Bun ESM gateway bundle looks correct — it's a Node.js HTTP client. Fix: real \`undici@7\` hangs on streaming response reads under Bun. \`undici\` is lazily imported only on the Node path in \`fetch.ts\` — never bundled or evaluated under Bun. Bun path uses native fetch instead. \`undici\` must remain external in the Bun ESM bundle.
@@ -390,32 +387,125 @@
 <!-- lore:019f6526-fa79-7e51-8e5d-073c6d156bb9 -->
 * **Always decrypts ciphertext before passing to resolvers**: The user consistently decrypts ciphertext before passing it to resolvers, ensuring that sensitive data is handled securely and never stored or transmitted in its encrypted form. This pattern is observed across multiple coding sessions, where the user explicitly states their preference for decrypting content before passing it to resolvers, and the code changes reflect this behavior.
 
+<!-- lore:019f6689-46d2-76c6-8f07-025cd344bc7a -->
+* **Always diagnose root causes of background worker failures**: The user consistently investigates background worker failures (especially 'no-response' and 'worker-incapable' classifications) by examining detailed logs, tool results, and code implementations. They focus on identifying the root cause rather than accepting workarounds, and expect comprehensive analysis of failure patterns, model/provider compatibility issues, and retry logic. The user pushes for fixes that address the underlying problems rather than superficial symptoms.
+
 <!-- lore:019f64f3-5674-7a81-8767-25e8f8e92cd8 -->
 * **Always evaluates competitor memory backends critically**: The user consistently expresses skepticism and criticism towards competitor memory backends, stating that they 'never actually work.' This pattern is observed in multiple sessions where the user discusses and evaluates various memory backend solutions, including ByteRover, Mem0, Zep, Hindsight, HonCho, and Chronos. The user appears to scrutinize these competitors' performance, often citing specific issues such as inflated accuracy scores or limited evaluation metrics. When exploring these competitors, the user focuses on their methodologies, architectures, and results, indicating a thorough and critical assessment of their capabilities.
 
+<!-- lore:019f65ca-91a1-7978-8acb-b5b69c11492e -->
+* **Always explicitly state invariants and assumptions**: The user consistently and explicitly states invariants, assumptions, and context when discussing code changes, bug fixes, or test cases. This includes stating what should or should not happen in certain scenarios, highlighting specific requirements or constraints, and providing background information to ensure clarity and accuracy. The user also insists on precise language and definitions, as seen in the emphasis on specific error codes, database constraints, and test case expectations.
+
+<!-- lore:019f654b-edee-78ed-bd11-dfa74594b096 -->
+* **Always expresses skepticism towards competitor memory backends**: The user consistently expresses doubt or skepticism about the functionality of competitor memory backends, often stating that they 'never' work or have issues. This pattern is observed across multiple sessions, where the user questions the effectiveness of various competitor products, including 'mnemonic' and 'mem0'. The user also tends to provide detailed context and specific examples when discussing these competitors, indicating a thorough evaluation process.
+
 <!-- lore:019f62d0-62d8-795b-9117-4d96963b620f -->
 * **Always focus on sync and coordination problems**: The user consistently inquires about and addresses issues related to synchronization, coordination, and conflict resolution in the context of team-sync and data sharing. They explore features such as shared scope, review gates, and invariant-conflict detection to ensure data consistency and resolve coordination problems.
+
+<!-- lore:019f658c-57d6-71c3-a09a-b97816f6a31b -->
+* **Always lists files in the repository when exploring a new topic**: The user consistently lists files in the repository when starting to explore a new topic or task. This is observed in multiple sessions where the user provides a list of files in the repository, such as on July 15, 2026, when the user listed numerous files in the repository. This behavior suggests that the user finds value in having a comprehensive view of the repository's file structure when beginning a new task or investigation.
 
 <!-- lore:019f6507-4973-7c69-b851-a6b9e6670ad8 -->
 * **Always prioritize pull-side encryption mode and never store ciphertext as local content**: The user consistently emphasizes the importance of pull-side encryption and ensuring that ciphertext is never stored as local content. This is evident in their repeated statements and code reviews across multiple sessions, where they stress the need for a 'pull-side encryption mode' and the risk of storing ciphertext locally. The user also provides specific scrutiny points and code changes to implement this behavior, indicating a strong preference for this approach.
 
 <!-- lore:019f62b8-fbc2-7c47-bfe1-486851ff478f -->
-* **Always Prioritizes Encryption and Security**: The user consistently emphasizes the importance of encryption and security in data handling. They prioritize ensuring that sensitive data, such as content and title columns in the knowledge table, are encrypted and protected from unauthorized access. The user also focuses on ensuring that content hashes are computed over plaintext, not ciphertext, to maintain data integrity and prevent misclassification. Additionally, the user requests reviews of advisor findings and suggested fixes to ensure the security and correctness of the code.
+* **Always Prioritizes Encryption and Security**: The user consistently checks for encryption and security measures before pushing data. They verify the encryption status, ensure that sensitive information is handled properly, and make sure that the data is encrypted before pushing it to the remote. The user also checks for potential issues, such as plaintext data being pushed, and takes corrective actions to prevent it. This pattern is observed across multiple instances, where the user is meticulous about encryption and security when working with sensitive data.
+
+<!-- lore:019f6667-2da0-792c-ab1b-ad5b78f233ce -->
+* **Always provide complete source code and file structure details**: The user consistently provides comprehensive source code and file structure information when investigating system behavior. This includes full file contents, directory listings, grep results, and implementation details across multiple packages. The pattern shows the user expects to work with complete, verbatim source material rather than summaries or partial excerpts.
+
+<!-- lore:019f666d-1dda-74c5-826b-1eed383b584c -->
+* **Always provide detailed implementation insights when asked**: The user consistently asks for and provides deep technical implementation details when investigating issues or planning features. This includes file paths, line numbers, code architecture, and specific logic flows. The user expects thorough exploration of the codebase to understand how things work under the hood, especially for CLI commands, agent integrations, and core functionality.
+
+<!-- lore:019f6668-2f99-7656-a20b-5fcaf7ea9a23 -->
+* **Always provide exact file paths and verbatim content when reporting findings**: The user consistently requires detailed, precise information when investigating codebases or documentation. This includes providing exact file paths, line numbers, and verbatim quotes from the source material. The user emphasizes thoroughness and accuracy, preferring to see the raw content rather than summaries or interpretations. This pattern applies when the user is researching documentation, investigating bugs, reviewing website content, or analyzing code structure.
+
+<!-- lore:019f666b-f264-74e0-9ee4-9f1bdf143366 -->
+* **Always require plan\_exit call to terminate planning workflow**: The user consistently mandates that planning workflows must conclude with an explicit call to plan\_exit. This directive appears in every planning session observation, indicating a strong preference for clear termination signals. The user expects the assistant to follow this protocol without exception, using plan\_exit to formally end the planning phase rather than stopping silently or through other means.
+
+<!-- lore:019f653a-8d9f-7df1-8058-0c83f24f4b38 -->
+* **Always scrub or handle plaintext entity rows on remote**: The user consistently directs the handling of plaintext entity rows on the remote server, either by scrubbing or ignoring them. This is observed in multiple sessions where the user instructs the assistant to delete remote entity rows, clear local sync state, and trigger re-push of encrypted entity rows. The user also mentions that plaintext rows are safe to ignore or wipe, indicating a preference for handling these rows in a specific manner.
+
+<!-- lore:019f668f-b99a-723a-b6a3-64c3e48f697c -->
+* **Always use disk's remote and never override on-disk truth**: The user consistently emphasizes the importance of using the disk's remote and never overriding on-disk truth. This pattern is observed in multiple instances where the user states that a client header can never override on-disk truth and that the disk's remote should always be used. The user also mentions never attaching to a path that is not a git repository on a local gateway to prevent the 'git-remote magnet' bug. This behavior indicates that the user prioritizes consistency and accuracy in remote resolution, ensuring that the on-disk state is respected and not overridden by client headers or other external factors.
+
+<!-- lore:019f66ae-39fb-7ec9-ae74-2c87c8255202 -->
+* **Always Verify and Refine Test Coverage**: The user consistently reviews and refines test coverage after implementing changes or identifying gaps. This includes running test suites, analyzing test results, and applying mutations to validate test effectiveness. The user also verifies code correctness and test quality, often in multiple iterations, to ensure comprehensive coverage and accuracy.
+
+<!-- lore:019f6530-2e24-7587-b573-d7afd6965dc5 -->
+* **Always waits for required CI checks to pass before merging**: The user consistently waits for all required CI checks to pass before merging a pull request. Specifically, they wait for the 'test' job and Seer Code Review to complete, even if other checks have passed. The user also tends to create a pull request immediately after making changes and then monitor the CI status, waiting for it to become mergeable.
+
+<!-- lore:019f666d-4d29-7800-821a-db71f2686b1b -->
+* **Architecture: context never wiped and rebuilt from lossy summary**: Architecture: context never wiped and rebuilt from lossy summary. Context never gets wiped and rebuilt from a lossy summary. Switching to Mastra's observer/reflector architecture with plain-text timestamped observation logs was the breakthrough. The switch from structured JSON to timestamped observation logs made v2 work.
 
 <!-- lore:019eff04-9cca-712f-bdb7-535292cfc96b -->
 * **Blog tone: category-not-competitor thesis — gentle, not dunking**: 🔴 Directive: convey the 'new category being invented' thesis gently — acknowledge the existing category isn't enough and that something new is being built, without dunking on existing tools. Generous close required: 'a good store is genuinely worth having.'
 
+<!-- lore:019f666d-4c5b-7a16-b2e8-59bc44203f59 -->
+* **CLI command documentation: setup.md as structural template**: CLI command documentation: setup.md as structural template. The setup.md file (80 lines) provides the best structural/style template for creating dedicated Reference pages for CLI commands like \`lore import\`.
+
+<!-- lore:019f666d-4cad-731e-ad82-f247f95fde48 -->
+* **Documentation gaps: lore import and review.md not in sidebar**: Documentation gaps: lore import and review.md not in sidebar. \`lore import\` has no dedicated website page and is absent from the Astro sidebar configuration in astro.config.mjs. \`docs/review.md\` exists but is not listed in the sidebar.
+
+<!-- lore:019f666d-4cd6-79e3-963b-f5f301987620 -->
+* **Documentation location: lore import documented in README and install.md**: Documentation location: lore import documented in README and install.md. \`lore import\` is documented in exactly two locations: \`README.md:311–320\` (full CLI reference) and \`docs/install.md:40–48\` (as 'Existing Conversations' subsection).
+
+<!-- lore:019f666d-4c36-7769-a6df-f34d981456c7 -->
+* **Documentation structure: Astro website with Starlight theme**: Documentation structure: Astro website with Starlight theme. Content collections: docs (Starlight loader/schema) and blog (glob loader with custom Zod schema). Page files in packages/website/src/content/docs/docs/ and guides/ subdirectory. Components in packages/website/src/components/. Sidebar navigation defined in astro.config.mjs.
+
+<!-- lore:019f666d-4c13-79cf-a6b9-221b19f68d9d -->
+* **Documentation style: README pattern with annotated bash blocks**: Documentation style: README pattern with annotated bash blocks. CLI commands in README.md use annotated bash blocks with \`#\` comments explaining each flag and argument. Website documentation uses frontmatter/H2 sections/Starlight directives. Guides use imperative titles like 'With OpenCode'.
+
 <!-- lore:019f60a4-db86-7ece-bc14-2d3c6d22502a -->
 * **Follow the established git workflow (branch, PR, review)**: Behavioral pattern detected across 119 sessions (action: enforced-workflow). The user consistently demonstrates this behavior.
+
+<!-- lore:019f666d-4c83-73d0-94ce-549b70d0bf3e -->
+* **Importers: supported list for lore import**: Importers: supported list for lore import. Supported importers consistently mentioned: Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi.
 
 <!-- lore:019f650e-1593-72e3-8c34-fdbf17c32560 -->
 * **Never a skip/conflict**: Never a skip/conflict: User stated never a skip/conflict.
 
+<!-- lore:019f66a7-6355-761d-ac7a-3050e24a86bf -->
+* **Never accumulate to 30/60 minutes of sustained outage**: User stated never accumulate to 30/60 minutes of sustained outage.
+
 <!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
 * **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
+
+<!-- lore:019f65ca-91fb-7140-b01f-aeb90540b80d -->
+* **Never from within another transaction**: User stated never from within another transaction.
+
+<!-- lore:019f66a3-288f-799a-b9f0-79c652f69532 -->
+* **Never mark worker as incapable due to transient errors or curator empty responses**: The user consistently emphasizes that worker incapability should not be marked due to transient errors, curator empty responses, or upstream errors. The user expects the system to handle such cases without marking the worker as incapable, and instead, focus on logging, warnings, and potential retries. This pattern is observed across multiple instances, where the user explicitly states or implies that certain types of errors should not lead to worker incapability.
+
+<!-- lore:019f66a2-591b-7b5d-a0b3-886f650b755f -->
+* **Never marked incapable after 3 consecutive curator empties**: User stated never marked incapable after 3 consecutive curator empties.
+
+<!-- lore:019f66a7-6371-79b6-9703-312f82ebef51 -->
+* **Never marks a model incapable**: User stated never marks a model incapable.
 
 <!-- lore:019f62e7-b68c-7a51-87d5-d0771009efc6 -->
 * **Never penalizes (neutral) 2ms**: Never penalize entries with latency over 2ms.
 
+<!-- lore:019f65ca-9216-7d70-9a22-1eea846e704d -->
+* **Never pushed — enqueuing them would create outbox**: User stated never pushed — enqueuing them would create outbox.
+
+<!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
+* **Never re-read — so excluded**: User stated never re-read — so excluded.
+
+<!-- lore:019f65ca-9231-7baf-a27a-65ee4b6c3a4b -->
+* **Never reach the remote**: User stated never reach the remote.
+
+<!-- lore:019f66ae-9a56-7002-9169-763d8f6e19ed -->
+* **Never record auth failure**: User stated always recording the auth failure so the worker-health ladder sees it.
+
 <!-- lore:019f64f3-4326-79f4-88ff-b8bc01c50706 -->
 * **Never touch the user's real gateway/DB**: User stated never touch the user's real gateway/DB.
+
+<!-- lore:019f66a2-5938-7fd4-b581-90d256a820c4 -->
+* **Never TTL-evicted**: User stated never TTL-evicted.
+
+<!-- lore:019f666d-4d00-7a62-8850-96ba39e5c07d -->
+* **Stale path reference: PROMPT\_CHANGES.md in README**: Stale path reference: PROMPT\_CHANGES.md in README. Stale path reference in \`README.md:424\` pointing to \`docs/PROMPT\_CHANGES.md\` when the file actually lives at \`quality/PROMPT\_CHANGES.md\`.
+
+<!-- lore:019f66ae-9aa3-7f41-9cf2-4596011f1f35 -->
+* **Switch to synchronous mode**: User switched to synchronous mode for future calls.

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1488,10 +1488,12 @@ export function createGatewayLLMClient(
     async prompt(system, user, opts) {
       const model = opts?.model ?? defaultModel;
 
-      // Skip models already known to produce no usable worker output. This is
-      // a capability verdict (not an outage): the call would just waste a round
-      // trip and re-fail. Distillation/curation defer; data stays recallable.
-      if (isWorkerIncapable(model.providerID, model.modelID)) {
+      // Skip models already known to produce no usable worker output for THIS
+      // worker kind. This is a capability verdict (not an outage): the call
+      // would just waste a round trip and re-fail. The failing worker defers;
+      // data stays recallable. Scoped per worker so a model that can distill
+      // but not curate is still used for distillation.
+      if (isWorkerIncapable(model.providerID, model.modelID, opts?.workerID)) {
         return null;
       }
 
@@ -1919,8 +1921,13 @@ export function createGatewayLLMClient(
                 if (parsed.text) {
                   // A usable response resets the consecutive-empty streak so a
                   // model that recovers isn't pushed toward an incapable verdict
-                  // by old, non-consecutive empties.
-                  clearEmptyWorkerStreak(model.providerID, model.modelID);
+                  // by old, non-consecutive empties. Scoped per worker: a usable
+                  // distillation must NOT reset the curator's empty streak.
+                  clearEmptyWorkerStreak(
+                    model.providerID,
+                    model.modelID,
+                    opts?.workerID,
+                  );
                   return parsed.text;
                 }
 
@@ -1953,6 +1960,7 @@ export function createGatewayLLMClient(
                     model.providerID,
                     model.modelID,
                     finishReason,
+                    opts?.workerID,
                   )
                 ) {
                   recordWorkerFailure(

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -171,13 +171,26 @@ const state: Map<string, SessionHealth> = new Map();
 const creditPaused: Map<string, { lastProbe: number }> = new Map();
 
 /**
- * Provider+model verdicts for models that consistently return no usable worker
- * output even after the reasoning-field fallback. Keyed by `${providerID}/${modelID}`.
- * Once a model is marked incapable, callers skip worker LLM calls for it
- * (distillation/curation simply defer; the raw data stays recallable). This is
- * a process-lifetime cache — a verdict is a stable capability fact, not a
- * transient outage, so it is intentionally NOT TTL-evicted. Cleared only on
- * process restart or `_resetForTest`.
+ * Provider+model+worker verdicts for models that consistently return no usable
+ * worker output even after the reasoning-field fallback. Keyed by
+ * `${providerID}/${modelID}/${workerID}`.
+ *
+ * The worker dimension is load-bearing: capability is worker-kind specific. A
+ * cheap model can be perfectly capable of one worker prompt (e.g. distillation,
+ * which is free-form prose) yet consistently incapable of another (e.g. the
+ * curator, which demands strict structured JSON). Keying the verdict on the
+ * model ALONE meant a model that could distill but not curate was never marked
+ * incapable — its distillation successes reset the curator empty streak (see
+ * {@link consecutiveEmpty}) before it ever reached the threshold, so the broken
+ * curator kept getting called and escalated the failure ladder forever with a
+ * misleading "auth stale" warning. Scoping by worker fixes that: the curator is
+ * disabled for the model while distillation keeps using it.
+ *
+ * Once a (model, worker) pair is marked incapable, callers skip worker LLM
+ * calls for that pair (that worker simply defers; the raw data stays
+ * recallable). This is a process-lifetime cache — a verdict is a stable
+ * capability fact, not a transient outage, so it is intentionally NOT
+ * TTL-evicted. Cleared only on process restart or `_resetForTest`.
  */
 const incapableModels: Set<string> = new Set();
 
@@ -209,19 +222,30 @@ export function _resetForTest(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Consecutive complete-but-empty responses a model must produce before we
- * conclude it is genuinely incapable. A single empty completion is often
- * transient or prompt-specific (a one-off glitch, a refusal), so we require a
- * small run before permanently skipping the model.
+ * Consecutive complete-but-empty responses a (model, worker) pair must produce
+ * before we conclude it is genuinely incapable. A single empty completion is
+ * often transient or prompt-specific (a one-off glitch, a refusal), so we
+ * require a small run before permanently skipping the pair.
  */
 const INCAPABLE_THRESHOLD = 3;
 
-/** Per-model count of consecutive complete-but-empty responses. */
+/** Per-(model, worker) count of consecutive complete-but-empty responses. */
 const consecutiveEmpty: Map<string, number> = new Map();
 
-/** Build the verdict key for a provider+model pair. */
-function modelKey(providerID: string, modelID: string): string {
-  return `${providerID}/${modelID}`;
+/**
+ * Sentinel worker used when a caller does not scope by worker kind. Keeps the
+ * per-worker key well-formed and lets legacy call sites (and tests) that only
+ * care about the model share one bucket.
+ */
+const ANY_WORKER = "_any";
+
+/** Build the verdict key for a provider+model+worker triple. */
+function modelKey(
+  providerID: string,
+  modelID: string,
+  workerID: WorkerID | (string & {}) = ANY_WORKER,
+): string {
+  return `${providerID}/${modelID}/${workerID}`;
 }
 
 /**
@@ -253,17 +277,22 @@ export function isCapabilityEmpty(finishReason: string | undefined): boolean {
 }
 
 /**
- * Record a complete-but-empty worker response for a model and return true when
- * the model should now be marked incapable (threshold of consecutive empties
- * reached). Non-capability finish reasons (truncation, content filter, tool
- * calls) reset the streak and never mark.
+ * Record a complete-but-empty worker response for a (model, worker) pair and
+ * return true when the pair should now be marked incapable (threshold of
+ * consecutive empties reached). Non-capability finish reasons (truncation,
+ * content filter, tool calls) reset the streak and never mark.
+ *
+ * The streak is scoped per worker: a distillation success on the same model
+ * must NOT reset a curator's empty streak, otherwise a model that can distill
+ * but not curate is never marked incapable (see {@link incapableModels}).
  */
 export function recordEmptyWorkerResponse(
   providerID: string,
   modelID: string,
   finishReason: string | undefined,
+  workerID: WorkerID | (string & {}) = ANY_WORKER,
 ): boolean {
-  const key = modelKey(providerID, modelID);
+  const key = modelKey(providerID, modelID, workerID);
   if (!isCapabilityEmpty(finishReason)) {
     consecutiveEmpty.delete(key); // transient/expected — reset the streak
     return false;
@@ -271,42 +300,53 @@ export function recordEmptyWorkerResponse(
   const n = (consecutiveEmpty.get(key) ?? 0) + 1;
   consecutiveEmpty.set(key, n);
   if (n >= INCAPABLE_THRESHOLD) {
-    markWorkerIncapable(providerID, modelID);
+    markWorkerIncapable(providerID, modelID, workerID);
     return true;
   }
   return false;
 }
 
-/** Clear the consecutive-empty streak for a model (on a usable response). */
+/**
+ * Clear the consecutive-empty streak for a (model, worker) pair (on a usable
+ * response). Only the streak for THIS worker is cleared — a usable
+ * distillation must not wipe the curator's accumulating empties.
+ */
 export function clearEmptyWorkerStreak(
   providerID: string,
   modelID: string,
+  workerID: WorkerID | (string & {}) = ANY_WORKER,
 ): void {
-  consecutiveEmpty.delete(modelKey(providerID, modelID));
+  consecutiveEmpty.delete(modelKey(providerID, modelID, workerID));
 }
 
 /**
- * Mark a provider+model as incapable of producing usable worker output, so
- * future worker calls for it are skipped. Idempotent. Logs once per model.
+ * Mark a provider+model+worker as incapable of producing usable worker output,
+ * so future calls to that worker for that model are skipped. Idempotent. Logs
+ * once per (model, worker).
  */
-export function markWorkerIncapable(providerID: string, modelID: string): void {
-  const key = modelKey(providerID, modelID);
+export function markWorkerIncapable(
+  providerID: string,
+  modelID: string,
+  workerID: WorkerID | (string & {}) = ANY_WORKER,
+): void {
+  const key = modelKey(providerID, modelID, workerID);
   if (incapableModels.has(key)) return;
   incapableModels.add(key);
   log.warn(
-    `[worker-health] model ${key} marked worker-incapable — ` +
-      `it returned no usable text after the reasoning-field fallback ` +
-      `for ${INCAPABLE_THRESHOLD} consecutive complete responses; ` +
-      `skipping background worker calls for it (data stays recallable)`,
+    `[worker-health] model ${providerID}/${modelID} marked worker-incapable ` +
+      `for worker=${workerID} — it returned no usable text after the ` +
+      `reasoning-field fallback for ${INCAPABLE_THRESHOLD} consecutive ` +
+      `complete responses; skipping this worker for it (data stays recallable)`,
   );
 }
 
-/** True when a provider+model has been marked worker-incapable. */
+/** True when a provider+model+worker has been marked worker-incapable. */
 export function isWorkerIncapable(
   providerID: string,
   modelID: string,
+  workerID: WorkerID | (string & {}) = ANY_WORKER,
 ): boolean {
-  return incapableModels.has(modelKey(providerID, modelID));
+  return incapableModels.has(modelKey(providerID, modelID, workerID));
 }
 
 // ---------------------------------------------------------------------------
@@ -607,6 +647,41 @@ export function allowWorkerProbe(sessionID: string): boolean {
 }
 
 /**
+ * Best-effort human-readable "likely cause" derived from the failure reasons
+ * actually recorded for the session. Previously this was hard-coded to "session
+ * authentication has gone stale", which sent users chasing an auth problem when
+ * the real cause was often a worker model returning empty responses. We now key
+ * the guidance off the recorded reasons.
+ */
+function likelyCauseFor(reasons: Set<FailureReason>): string {
+  if (reasons.has("no-auth") || reasons.has("auth-rejected")) {
+    return (
+      "session authentication has gone stale. Run `lore doctor` or check the " +
+      "dashboard for details."
+    );
+  }
+  if (
+    reasons.has("no-response") ||
+    reasons.has("worker-incapable") ||
+    reasons.has("parse-error")
+  ) {
+    return (
+      "the background worker model is returning empty or unusable responses. " +
+      "Set an explicit `workerModel` (same provider as the session) in your " +
+      "lore config, or run `lore doctor` / check the dashboard for details."
+    );
+  }
+  if (reasons.has("rate-limit")) {
+    return (
+      "the upstream is rate-limiting background worker calls. Run `lore " +
+      "doctor` or check the dashboard for details."
+    );
+  }
+  // Fallback for upstream-error / cross-provider / protocol-mismatch / etc.
+  return "the upstream is failing background worker calls. Run `lore doctor` or check the dashboard for details.";
+}
+
+/**
  * Returns the user-facing warning message for the next response, or null
  * if the session is healthy.
  *
@@ -622,8 +697,7 @@ export function getDegradationWarning(sessionID: string): string | null {
     `[Lore: Background workers (distillation, curation, cache warming) for this session ` +
     `have been failing for ${formatDuration(sustainedMs)}. This is harmful — your ` +
     `context window is not being compressed and long-term knowledge is not being ` +
-    `captured. Likely cause: session authentication has gone stale. Run \`lore doctor\` ` +
-    `or check the dashboard for details.]`
+    `captured. Likely cause: ${likelyCauseFor(entry.reasons)}]`
   );
 }
 

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -605,4 +605,118 @@ describe("worker-health", () => {
       expect(isWorkerIncapable("opencode", "m")).toBe(false);
     });
   });
+
+  describe("per-worker incapable streak (regression: distill must not reset curator)", () => {
+    // Production repro (2026-07-15): openrouter/meta-llama/llama-4-scout could
+    // distill (returned text, resetting the streak) but returned empty for the
+    // curator every time. With a per-MODEL streak, the interleaved distillation
+    // successes reset the curator empty streak before it reached 3, so the model
+    // was never marked incapable and the failure ladder escalated forever with a
+    // misleading "auth stale" warning. The streak must be scoped per worker.
+    const P = "openrouter";
+    const M = "meta-llama/llama-4-scout";
+
+    test("a usable distillation does NOT reset the curator empty streak", () => {
+      // Two consecutive curator empties.
+      expect(recordEmptyWorkerResponse(P, M, "stop", "lore-curator")).toBe(
+        false,
+      );
+      expect(recordEmptyWorkerResponse(P, M, "stop", "lore-curator")).toBe(
+        false,
+      );
+      // A successful distillation on the SAME model clears only its own streak.
+      clearEmptyWorkerStreak(P, M, "lore-distill");
+      // 3rd consecutive curator empty must still mark the curator incapable.
+      expect(recordEmptyWorkerResponse(P, M, "stop", "lore-curator")).toBe(
+        true,
+      );
+      expect(isWorkerIncapable(P, M, "lore-curator")).toBe(true);
+    });
+
+    test("clearEmptyWorkerStreak only resets the streak for its OWN worker", () => {
+      // Locks the keyspace-coherence invariant: recordEmptyWorkerResponse and
+      // clearEmptyWorkerStreak MUST share the same per-worker key. Without the
+      // workerID dimension on clear, a distill success would wipe the curator
+      // streak (the original bug). This asserts BOTH directions:
+      //   (a) clearing a DIFFERENT worker does not reset curator, and
+      //   (b) clearing the SAME worker DOES reset it.
+      const P2 = "openrouter";
+      const M2 = "some/other-model";
+      // (a) Different-worker clear must not touch curator's streak.
+      recordEmptyWorkerResponse(P2, M2, "stop", "lore-curator"); // curator=1
+      recordEmptyWorkerResponse(P2, M2, "stop", "lore-curator"); // curator=2
+      clearEmptyWorkerStreak(P2, M2, "lore-distill"); // must NOT reset curator
+      expect(recordEmptyWorkerResponse(P2, M2, "stop", "lore-curator")).toBe(
+        true, // curator reached 3 → incapable
+      );
+      // (b) Same-worker clear must reset that worker's streak. Use a fresh model
+      // so the incapable verdict above doesn't interfere.
+      const M3 = "some/third-model";
+      recordEmptyWorkerResponse(P2, M3, "stop", "lore-curator"); // curator=1
+      recordEmptyWorkerResponse(P2, M3, "stop", "lore-curator"); // curator=2
+      clearEmptyWorkerStreak(P2, M3, "lore-curator"); // resets curator to 0
+      // Next empty is streak=1, NOT 3 → must not mark incapable.
+      expect(recordEmptyWorkerResponse(P2, M3, "stop", "lore-curator")).toBe(
+        false,
+      );
+      expect(isWorkerIncapable(P2, M3, "lore-curator")).toBe(false);
+    });
+
+    test("incapable verdict is scoped per worker — distillation stays usable", () => {
+      for (let i = 0; i < 3; i++) {
+        recordEmptyWorkerResponse(P, M, "stop", "lore-curator");
+      }
+      expect(isWorkerIncapable(P, M, "lore-curator")).toBe(true);
+      // The model is NOT marked incapable for distillation.
+      expect(isWorkerIncapable(P, M, "lore-distill")).toBe(false);
+    });
+
+    test("empties from different workers accumulate on independent streaks", () => {
+      // One empty each for curator and distill — neither reaches the threshold.
+      expect(recordEmptyWorkerResponse(P, M, "stop", "lore-curator")).toBe(
+        false,
+      );
+      expect(recordEmptyWorkerResponse(P, M, "stop", "lore-distill")).toBe(
+        false,
+      );
+      expect(recordEmptyWorkerResponse(P, M, "stop", "lore-curator")).toBe(
+        false,
+      );
+      expect(recordEmptyWorkerResponse(P, M, "stop", "lore-distill")).toBe(
+        false,
+      );
+      // Neither is incapable yet (each has 2, not 3).
+      expect(isWorkerIncapable(P, M, "lore-curator")).toBe(false);
+      expect(isWorkerIncapable(P, M, "lore-distill")).toBe(false);
+    });
+  });
+
+  describe("getDegradationWarning — cause derived from reasons (Fix B)", () => {
+    test("no-response reasons name the worker model, not auth", () => {
+      const t0 = 1_000_000;
+      _setNowForTest(() => t0);
+      recordWorkerFailure("s-nr", "lore-curator", "no-response");
+      // Advance past the 30m response-message threshold.
+      _setNowForTest(() => t0 + 31 * 60 * 1000);
+      // Keep the entry alive with another failure in the current window.
+      recordWorkerFailure("s-nr", "lore-curator", "no-response");
+      const warning = getDegradationWarning("s-nr");
+      expect(warning).not.toBeNull();
+      expect(warning).toContain("workerModel");
+      expect(warning).toContain("`lore doctor`");
+      expect(warning).not.toContain("lore status");
+      expect(warning).not.toContain("authentication has gone stale");
+    });
+
+    test("auth reasons still surface the stale-auth guidance", () => {
+      const t0 = 2_000_000;
+      _setNowForTest(() => t0);
+      recordWorkerFailure("s-auth", "lore-curator", "auth-rejected");
+      _setNowForTest(() => t0 + 31 * 60 * 1000);
+      recordWorkerFailure("s-auth", "lore-curator", "auth-rejected");
+      const warning = getDegradationWarning("s-auth");
+      expect(warning).not.toBeNull();
+      expect(warning).toContain("authentication has gone stale");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

A live session surfaced this warning, repeatedly, for 30m+:

> [Lore: Background workers … have been failing for 39m 14s. … Likely cause: session authentication has gone stale. Run \`lore doctor\` …]

The warning was **real but misdiagnosed**. The gateway was healthy and streaming to OpenRouter fine every turn. The actual failure: the auto-selected cheap background-worker model `openrouter/meta-llama/llama-4-scout` (Novita) returns **HTTP 200 with an empty message** for the **curator** prompt every time (`fields=[none] finish_reason=stop`). 27 such empties on 2026-07-15 — **all** `lore-curator`, **all** llama-4-scout. Distillation on the same model works fine.

## Root cause

`worker-health.ts` already has a `worker-incapable` escape hatch: after `INCAPABLE_THRESHOLD = 3` **consecutive** complete-but-empty responses, a model is marked incapable and stops being called (non-escalating). But the streak was keyed **per provider+model only**, and `clearEmptyWorkerStreak()` was called on **any** usable response from that model.

Because llama-4-scout succeeds at **distillation** constantly, those successes reset the curator's empty streak between the sparse curator calls — proven interleave at 14:38–14:39 (distill OK → curator empty → distill OK). The curator streak never reached 3, the model was never marked incapable, and every curator empty was recorded as escalating `no-response`, tripping the 30-min degradation ladder forever. `grep "marked worker-incapable"` = **0** despite 27 empties.

The warning's "Likely cause: session authentication has gone stale" was a **hard-coded guess** — it never looked at the actual `entry.reasons` (which was `no-response`, not auth).

## Fix

**A — per-(model × worker) incapable streak.** `modelKey`, `consecutiveEmpty`, `incapableModels`, `recordEmptyWorkerResponse`, `clearEmptyWorkerStreak`, `markWorkerIncapable`, `isWorkerIncapable` now take an optional `workerID` (defaults to an `_any` sentinel for backward compat). All three `llm-adapter.ts` call sites thread `opts.workerID`. A broken curator is now disabled independently while distillation keeps using the same model.

**B — cause-derived warning.** `getDegradationWarning` derives the "likely cause" from `entry.reasons` via new `likelyCauseFor()`: `no-response`/`worker-incapable`/`parse-error` → point the user at `workerModel`; auth reasons → the stale-auth guidance; rate-limit and generic fallbacks too. Uses `lore doctor` (not the bogus `lore status`, per the Sergiy 2026-07-06 regression guard).

## Why tests didn't catch it

The `worker-incapable` path had unit tests, but none exercised the **cross-worker streak reset** (a distillation success defeating the curator verdict) — the real production interleave. Added regression tests for that, plus a `clearEmptyWorkerStreak` same-worker test that locks the keyspace-coherence invariant.

## Tests

- +6 regression tests in `worker-health.test.ts` (52 total).
- **Mutation-verified non-vacuous:** reverting to per-model keying kills the cross-worker tests; reverting `clearEmptyWorkerStreak` to ignore `workerID` kills the same-worker test.
- `pnpm run typecheck` clean; `pnpm run lint` 0 errors in touched files; `pnpm run format` applied; worker-health + llm-adapter + worker-model suites green.

## Adversarial review

Ran an adversarial correctness review (per repo policy). It independently traced `opts.workerID` end-to-end and **confirmed it is populated for both curator and distillation calls in production** (curator.ts, distillation.ts → pipeline.ts → batch-queue.ts → llm-adapter sync path where the empty-response detection lives), so the fix genuinely engages and is not a no-op. **No BLOCKER.** One SHOULD-FIX (surviving mutant on `clearEmptyWorkerStreak`'s per-worker scoping) — **addressed in this PR** with the same-worker regression test.

## Immediate mitigation (independent of this PR)

Pin a capable `workerModel` (same provider as session) in lore config and restart the gateway to stop llama-4-scout being used for curation right now. Note the deployed binary predates this branch (it says "lore doctor", matching main), so a redeploy is needed to pick up the fix.