### PR TITLE
feat(import): worktree-aware detection + multi-agent selection

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -215,6 +215,9 @@
 <!-- lore:019efb40-0000-7000-9000-000000000003 -->
 * **creditWarmupHit three guards: paid (Bug A) + within-TTL + actually-read (Bug C); credit is binary not pro-rata**: \`creditWarmupHit(warmup, sinceWarmupMs, ttlMs, cacheReadTokens)\` attributes a warmup hit ONLY when ALL hold: (A) the session paid (\`totalWarmups>0 && lastWarmupRefreshTokens>0\` — \`lastWarmupAt\` alone rides along in restored blobs → phantom); within TTL (\`sinceWarmupMs < ttlMs\`); (C) the returning turn ACTUALLY READ the cache (\`cacheReadTokens > 0\`). Bug C fix: a turn that pivoted context / used a different tool chain / found the cache evicted reports \`cache\_read=0\` → no savings; without the gate, warmupHits/creditedTokens inflate and warp the ROI analysis gating future warming. Call site passes \`usage.cacheReadInputTokens ?? 0\` (same signal the adjacent 1h-TTL-savings branch gates on). The warmup is consumed (markers zeroed) BEFORE all three guards, so a no-hit still can't re-credit later. \`creditedTokens\` is the warmed prefix (\`refreshTokens\`, Bug B), NOT the returning read. Known residual: the read gate is BINARY — a partial read (0 < read < refreshTokens, e.g. breakpoint shift) still credits the full refreshTokens. Call-site threading (pipeline postResponse warmup-hit branch) is NOT seam-tested — hardcoding the 4th arg survives all warmup pipeline tests (tracked follow-up).
 
+<!-- lore:019f6803-df37-7e9c-ad3f-7b838bdda9d4 -->
+* **DetectAll signature migration**: Trap: Only updating some callers when changing detect() signature looks complete. Fix: Both detectAll callers (import.ts:31 and test files) updated to use array signature.
+
 <!-- lore:019ef389-a501-7db4-a808-4e0c671bb2f0 -->
 * **effectiveMetaThreshold: internal Date.now() makes tests flaky — inject nowMs parameter**: Trap: \`effectiveMetaThreshold(lastTurnAtMs)\` calling \`Date.now()\` internally looks correct — it needs the current time to compute \`gapMs\`. Fix: any test that captures \`const now = Date.now()\` then passes \`now - (DEEP\_IDLE\_MS - 1)\` as \`lastTurnAtMs\` is flaky — a ≥1ms scheduling delay pushes \`gapMs ≥ DEEP\_IDLE\_MS\`, flipping the return value. Fix (PR #926): add injectable \`nowMs\` parameter; tests pass a fixed \`NOW\` constant. Sentinel: \`lastTurnAtMs === 0\` means 'never set (first turn)' → treated as deep-idle (gapMs = Infinity). All 8 \`effectiveMetaThreshold\` tests rewritten to use fixed \`NOW\` — fully deterministic.
 
@@ -224,8 +227,14 @@
 <!-- lore:019ee562-c70c-7fa5-b9f3-7f60a3c4b578 -->
 * **getCircuitBreakerStatus: status getter must be pure read — no side-effect delete on decay**: getCircuitBreakerStatus must be pure read — no side-effect delete on decay. Trap: original called \`isCircuitBreakerTripped\` which deletes entry on decay, then re-read — just-decayed bucket returned \`trippedAt:0\`, indistinguishable from never-tripped. Also mutated in-memory map and wrote to SQLite on dashboard read path. Fix (PR fix/circuit-breaker-status-pure-read): rewritten as pure read — computes decay inline, reports decayed bucket as \`{tripped:false, failures:0, trippedAt:0}\`, no map mutation, no SQLite write. Rule: status/summary getters must never have delete/write side effects.
 
+<!-- lore:019f6803-df80-7036-909c-394ae7b98063 -->
+* **Git in hosted mode**: Trap: Running git commands in hosted mode looks necessary for worktree detection. Fix: gitWorktreePaths returns \[] in hosted mode, getGitRemote short-circuits before subprocess.
+
 <!-- lore:019eea52-a1f7-757a-b0ae-6b749bbcda18 -->
 * **gradient.ts compression stages: rawFrac applied to full usable — escalating layers inflate window past l0cap**: Trap: COMPRESSION\_STAGES rawFrac (layer-2=0.5, layer-3=0.55) applied to full \`usable\` (~800K on 1M model) → layer-2 raw budget ~400K, larger than the ~200K l0cap that triggered compression AND larger than layer-1 window; escalating GREW the window until unrecoverable 400. Fix (PR #872, merged 2026-06-21T14:18:47Z, squash \`4d7910aa\`): introduce \`stageBudgetCeiling = maxLayer0Tokens > 0 ? Math.min(usable, maxLayer0Tokens) : usable\`; \`stageBudgetUsable = Math.min(usable, stageBudgetCeiling)\`; apply to escalated stages (layers 2+) only. Layer-1 base \`rawBudget = usable\*0.4\` must NOT be clamped. \`isEscalated = stageLayer > 1\`. Also clamp escalated-stage distilled budget. Confirmed in production logs: post-deploy layer-2 ratio dropped from ~0.499 (unclamped usable×0.5) to ~0.287–0.321 (clamped cap×0.5). M1–M4 mutant kills documented in test suite.
+
+<!-- lore:019f6803-de9e-7a10-8af5-85aa9d0045d6 -->
+* **Import provider deduplication requirements**: Trap: Different providers use different session identifiers. Fix: All providers must deduplicate sessions: codex (filePath), claude-code (filePath), pi (filePath), aider (filePath), cline (taskDir), opencode (session id), continue (index set + existingIds guard).
 
 <!-- lore:019ef645-2484-71dd-bf92-eccd8e962083 -->
 * **insertMeta ON CONFLICT must not update base\_confidence — immutable create-time anchor**: Trap: \`insertMeta\` uses \`ON CONFLICT(logical\_id) DO UPDATE SET base\_confidence = excluded.base\_confidence\` — looks correct for idempotent re-create. Fix: \`base\_confidence\` is the immutable create-time anchor for PN-counter deltas; overwriting it on conflict corrupts all future confidence calculations. The conflict path only occurs when \`create()\` is called with an explicit \`input.id\` that already exists (deduplication check skipped). Fix: remove \`base\_confidence = excluded.base\_confidence\` from the DO UPDATE clause. Confirmed in PR #1126 fix commit \`36173a7\`.
@@ -253,6 +262,9 @@
 
 <!-- lore:019f5e0a-59a7-7ee7-8ec1-5b7c7c721853 -->
 * **OpenAI-protocol cache hit rate issue**: Trap: OpenAI-protocol requests to OpenRouter show 100% cache miss rate because OpenRouter honors Anthropic-style breakpoints on OpenAI Chat Completions API but not on OpenAI requests. Fix: add Anthropic-style \`cache\_control\` breakpoints.
+
+<!-- lore:019f6803-dec2-7503-bb96-6d1fe11ab064 -->
+* **Opencode SQL injection safety**: Trap: Building SQL queries with string interpolation looks correct for dynamic lists. Fix: Use parameterized queries with ? placeholders and .all() binding. Guard against empty projectPaths and projectIds arrays.
 
 <!-- lore:019ef39c-72c4-7a00-bce7-4456e479867c -->
 * **Partial v55 migration boot-loop: DROP COLUMN before backfill SELECT causes unrecoverable crash**: Trap: v55 migration runs via \`database.exec()\` (auto-commits each statement) — looks safe because migrations are idempotent. Fix: if interrupted after \`DROP COLUMN confidence\` but before completion, \`schema\_version\` stays <55. Next boot retries migration; backfill \`SELECT logical\_id, confidence FROM knowledge\` throws \`no such column: confidence\`. Catch block only matches \`/duplicate column name/i\` — this error re-throws → \`migrate()\` throws → boot loop. \`recoverMissingObjects\` unreachable (needs \`current>=55\`). \`stripAppliedAlters\` only handles ADD COLUMN. Fix: make backfill column-presence-aware (mirror \`recoverMissingObjects\`' \`hasConfidence\` check) OR wrap the DROP+backfill in a single transaction-safe block. Empirically confirmed with \`node:sqlite\`.
@@ -364,6 +376,15 @@
 <!-- lore:019f1cc8-b65e-7a6e-97ae-f48d1a7d542b -->
 * **forProjectOffloaded / entitiesForSessionOffloaded: timeout must fall back to in-process scan, never return \[]**: All offloaded variants of frozen-baseline builders (\`ltm.forProjectOffloaded\`, \`entities.forProjectOffloaded\`, \`entities.entitiesForSessionOffloaded\`) must fall back to the synchronous in-process scan on \`READ\_JOB\_TIMED\_OUT\` — never return \`\[]\`. Trap: returning \`\[]\` on timeout looks safe (same as \`forSession\` degrade). Fix: unlike \`forSession\` (reruns every turn), these results are frozen into \`stableLtmCache\` + \`saveSessionTracking\` for the entire session lifetime. A spurious empty baseline permanently breaks the knowledge catalog for that session. \`forSession\` can safely return \`\[]\` because it reruns every turn. Mutation test: force timeout branch to return \`\[]\` → timeout test must fail.
 
+<!-- lore:019f6803-deed-77b2-8018-9eb20a399e2b -->
+* **Import CLI selection parsing**: \`selectIndices()\` handles: out-of-range, non-numeric, empty→all, a/all→all. \`parseIndexSelection()\` collapses duplicates via Set, sorts ascending. Non-TTY guard only trips when no reader injected.
+
+<!-- lore:019f6803-df5c-7715-b5ae-345fecca0633 -->
+* **Import process invariants**: Import runs locally reading local agent history files. DB readiness ensured before detectAll call. Main-tree read-only compliance: no source files modified except .lore.md. Fail-open: projectSearchPaths and projectKnownPaths have try/catch blocks, never throw.
+
+<!-- lore:019f6803-df12-755b-8215-f07aedd0a2f0 -->
+* **Import provider path handling**: Pi provider: CWD encoding replaces leading slash and remaining slashes with dashes. Linearization picks child with latest timestamp or last appended. Codex: path mangling replaces '/' with '-'. Continue: finds VS Code globalStorage directories.
+
 <!-- lore:019ef39c-72e1-77c0-b39c-2c145ca5fd05 -->
 * **knowledge\_meta invariants: sync-silence for markInjected, content-only update must not churn sync clock**: Three sync-silence invariants for \`knowledge\_meta\`: (1) \`markInjected()\` updates \`last\_reinforced\_at\` but NEVER bumps \`updated\_at\` — selection ≠ certainty, mirrors prior HASH\_EXCLUDE behavior. (2) Content-only \`update()\` (no \`input.confidence\`) must NOT bump \`meta.updated\_at\` — only confidence changes churn the sync clock. (3) \`create()\` calls \`insertMeta(id, confidence, now, now)\` with \`ON CONFLICT DO UPDATE\` — idempotent for cross-machine re-create but never destroys a converged confidence value (fresh UUIDv7 logical\_id guarantees no collision in practice). A \`knowledge\_meta\` row with no live \`knowledge\_current\` row is inert — never crashes a read.
 
@@ -385,7 +406,13 @@
 <!-- lore:019f6290-0749-7a6c-ae69-925e0437bb69 -->
 * **Verify semantic equivalence and completeness of recreated policies**: Steps: 1. Verify semantic equivalence. 2. Verify completeness. 3. Check for over-wrap. 4. Verify drop/create correctness. 5. Check idempotency. 6. Verify migration ordering.
 
+<!-- lore:019f6803-de7b-7fb8-a01a-d8e5478112f7 -->
+* **Worktree-aware conversation detection**: \`projectSearchPaths(projectPath, opts?)\` unions: resolved cwd (always first), \`git worktree list --porcelain\` output, and \`git rev-parse --git-dir\` parent directories. Deduplicates paths. \`detectAll()\` uses these paths to find agent sessions across worktrees.
+
 ### Preference
+
+<!-- lore:019f6803-de4d-7bdc-bef5-6832fb93662e -->
+* **Adversarial correctness review focus**: When reviewing code changes, focus ONLY on real bugs: logic errors, race conditions, incorrect assumptions, edge cases, security issues, and broken invariants. Categorize findings by severity: BLOCKER, SHOULD-FIX, NIT/MINOR. Do NOT nitpick style. Verify claims by reading actual code.
 
 <!-- lore:019f6526-fa79-7e51-8e5d-073c6d156bb9 -->
 * **Always decrypts ciphertext before passing to resolvers**: The user consistently decrypts ciphertext before passing it to resolvers, ensuring that sensitive data is handled securely and never stored or transmitted in its encrypted form. This pattern is observed across multiple coding sessions, where the user explicitly states their preference for decrypting content before passing it to resolvers, and the code changes reflect this behavior.
@@ -413,6 +440,9 @@
 
 <!-- lore:019f66ef-5abe-77b4-ad8a-c3d609d2f88f -->
 * **Always follow the principle of least privilege and conservative role mapping**: The user consistently emphasizes the importance of not over-granting permissions and maintaining a conservative role mapping. This is evident in multiple instances where the user states or implies that roles should be mapped conservatively, never downgrading existing higher roles, and never overriding manual role changes. The user also stresses the importance of verifying and validating changes to ensure that they align with these principles.
+
+<!-- lore:019f6804-7980-7756-8329-b223cc38dde3 -->
+* **Always investigate cost optimization opportunities in distillation**: The user consistently demonstrates a pattern of scrutinizing distillation costs and seeking optimization opportunities. They ask detailed questions about batch processing, call types, and cost implications across multiple sessions. The user expects thorough investigation of cost-saving measures, including tracing call propagation, examining environment variables, and analyzing timing constraints. They direct the assistant to disclose cost-related caveats and explore production-representative cost scenarios.
 
 <!-- lore:019f658c-57d6-71c3-a09a-b97816f6a31b -->
 * **Always lists files in the repository when exploring a new topic**: The user consistently lists files in the repository when starting to explore a new topic or task. This is observed in multiple sessions where the user provides a list of files in the repository, such as on July 15, 2026, when the user listed numerous files in the repository. This behavior suggests that the user finds value in having a comprehensive view of the repository's file structure when beginning a new task or investigation.

--- a/.lore.md
+++ b/.lore.md
@@ -44,7 +44,7 @@
 * **knowledge\_symbol\_presence table: presence-history drift signal for symbol validation (#911)**: knowledge\_symbol\_presence table (migration v59): \`(logical\_id TEXT, symbol TEXT, last\_present\_at INTEGER, PRIMARY KEY(logical\_id, symbol))\`. Symbol refs resolve to \`"ok"\` or \`"unknown"\` — NEVER \`"missing"\`. Penalty fires only when \`wasSymbolPresent()\` returns true (previously confirmed present, now absent). \`recordSymbolPresent()\` fires only on \`st === "ok"\`. External/historical/rejected mentions never get a presence record. \`RepoView.presentSymbols: Set\<string> | null\` — null = grep unavailable (neutral). Cleanup: \`remove()\` in \`ltm.ts\` must delete from \`knowledge\_symbol\_presence\` and \`knowledge\_ref\_validity\` via \`LOGICAL\_ID\_BOOKKEEPING\_TABLES\` loop BEFORE the knowledge DELETE. \`knowledge\_session\_injections\` and \`knowledge\_meta\` are intentionally excluded from that loop (sync-destined / tracked follow-up).
 
 <!-- lore:019f43a4-4eff-7867-a668-1d600f43f990 -->
-* **lat.md synthetics never included in overflowSink — not knowledge rows, carry no recall id**: lat.md synthetics never included in overflowSink — not knowledge rows, carry no recall id. User stated synthetics are never included.
+* **lat.md synthetics never included in overflowSink — not knowledge rows, carry no recall id**: Project search paths must always begin with the resolved projectPath as the first element. This ensures consistent behavior across worktrees.
 
 <!-- lore:019edfbc-edd5-780d-ac81-07a35390121b -->
 * **ltm.ts: confidence lifecycle — decay, reinforcement, eviction, and cross-project protection**: ltm.ts: confidence lifecycle — decay, reinforcement, eviction, cross-project protection. \`decayProject(path)\` decrements confidence, never bumps \`updated\_at\`. \`markInjected(ids)\` writes only \`last\_reinforced\_at\`. \`evictLowestValue\`/\`pruneDeadEntries\`/\`pruneDeadEntriesAllProjects\` MUST skip \`cross\_project=1\` entries. \`DEAD\_CONFIDENCE\_FLOOR=0.2\`. \`enforceEntryCap\` counts promoted rows but eviction excludes them. Global sweep in \`idle.ts\`: \`pruneDeadEntriesAllProjects()\` on first tick then hourly (\`GLOBAL\_DEAD\_SWEEP\_INTERVAL\_MS=3600000\`), gated on \`loreConfig().knowledge.enabled\`. \`lastGlobalDeadSweepAt\` starts at 0, set BEFORE try block (prevents retry storm). Sweep wrapped in try/catch. Queries \`WHERE cross\_project=0 AND confidence<=0.2 LIMIT ?\` — \`cross\_project=0\` implicitly guarantees non-null \`project\_id\` (enforced at \`create()\`: null pid forces \`cross\_project=1\`).
@@ -122,6 +122,9 @@
 
 <!-- lore:019f4629-d9d0-7c59-924c-dc7341e57c77 -->
 * **Closed #1231 (distillation value-retention): reuse knowledge\_refs + file reads instead of memorizing repo-resident values**: Chose to close PR #1231 (feat: retain exact literal/style values in observations) over building a value-extractor. Rationale: a stored value is a cache of the file — the moment the file changes, every distillation that memorized the old value is confidently wrong. A pointer + file Read is always correct and costs the same tool call. \`knowledge\_refs\` + \`knowledge\_ref\_validity\` already store and validate file:line pointers. The value-extractor would duplicate this and add staleness. Boundary: ephemeral facts (test run counts, stated numbers, decisions) have no file to read → those belong in memory via distillation/knowledge. Code-resident specifics → pointer + read.
+
+<!-- lore:019f681e-be90-7efc-a932-04c0d9de8f59 -->
+* **Decided to use gen\_random\_uuid for token generation**: decided to use gen\_random\_uuid for token generation.
 
 <!-- lore:019f3da7-bbab-7534-ba3c-924bf1d55985 -->
 * **Decided to use sqlite3 CLI to export session rows as JSON**: decided to use sqlite3 CLI to export session rows as JSON,
@@ -266,6 +269,9 @@
 <!-- lore:019f6803-dec2-7503-bb96-6d1fe11ab064 -->
 * **Opencode SQL injection safety**: Trap: Building SQL queries with string interpolation looks correct for dynamic lists. Fix: Use parameterized queries with ? placeholders and .all() binding. Guard against empty projectPaths and projectIds arrays.
 
+<!-- lore:019f6807-9870-781a-b118-d96b6eb6b5fb -->
+* **OpenRouter batch API absence**: Trap: Assuming OpenRouter supports batch API like OpenAI/Anthropic looks correct — major providers have batch endpoints. Fix: OpenRouter's documented API surface only includes \`/chat/completions\` and \`/generation\` — no \`/v1/batches\` endpoint exists. Batch requests to OpenRouter fail with HTTP 404.
+
 <!-- lore:019ef39c-72c4-7a00-bce7-4456e479867c -->
 * **Partial v55 migration boot-loop: DROP COLUMN before backfill SELECT causes unrecoverable crash**: Trap: v55 migration runs via \`database.exec()\` (auto-commits each statement) — looks safe because migrations are idempotent. Fix: if interrupted after \`DROP COLUMN confidence\` but before completion, \`schema\_version\` stays <55. Next boot retries migration; backfill \`SELECT logical\_id, confidence FROM knowledge\` throws \`no such column: confidence\`. Catch block only matches \`/duplicate column name/i\` — this error re-throws → \`migrate()\` throws → boot loop. \`recoverMissingObjects\` unreachable (needs \`current>=55\`). \`stripAppliedAlters\` only handles ADD COLUMN. Fix: make backfill column-presence-aware (mirror \`recoverMissingObjects\`' \`hasConfidence\` check) OR wrap the DROP+backfill in a single transaction-safe block. Empirically confirmed with \`node:sqlite\`.
 
@@ -284,8 +290,11 @@
 <!-- lore:019ef645-249a-7099-9b79-a286babbb764 -->
 * **pruneOversized uses clamped confidence — CRDT hysteresis leaves raw value > 1.0 unzeroed**: Trap: \`pruneOversized\` reads \`confidence\` from \`knowledge\_current\` (materialized, clamped to \[0,1]) and applies \`-confidence\` delta — looks correct for zeroing. Fix: CRDT deltas accumulate on \`base\_confidence\`; raw value can exceed 1.0 while materialized stays clamped at 1.0. Applying \`-1.0\` delta leaves raw > 0 → entry not actually pruned, GC fails silently. Fix: fetch raw unclamped value (\`base\_confidence + SUM(deltas)\`) and apply negative delta equal to that raw sum. Confirmed in PR #1126 fix commit \`36173a7\`.
 
+<!-- lore:019f6823-01f6-7c69-9f59-585f497a4e87 -->
+* **readChunks ignores projectPath parameter**: Trap: readChunks takes projectPath parameter but providers ignore it, using session IDs directly. This works because detect() already resolved paths to session IDs. Fix: Document that projectPath is vestigial and can be removed in next refactor.
+
 <!-- lore:019f04b8-26f5-71fd-b8e2-e8dcca6e1c40 -->
-* **recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table**: recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table
+* **recall.ts: getManyOffloaded must query knowledge\_current view, never base knowledge table**: Trap: \`recall.ts: getManyOffloaded\` querying base \`knowledge\` table looks correct. Fix: must query \`knowledge\_current\` view — base table lacks \`promoted\_at\` and \`last\_reinforced\_at\` columns used in value ranking. View joins \`knowledge\_meta\` and applies \`knowledge\_entity\_refs\` count.
 
 <!-- lore:019efa17-e5b6-75a7-940b-7367c9de371e -->
 * **references.ts codeSpanText: newline join fuses adjacent spans — cross-span phantom commands**: Trap: \`codeSpanText()\` joining all backtick code-span inner text with \`"\n"\` looks safe — newline is a natural separator. Fix: \`\n\` matches \`\s\` in \`PM\_CMD\_RE\`/\`MAKE\_CMD\_RE\`, so adjacent spans like \`\` \`make\` \`\` and \`\` \`Makefile\` \`\` fuse into \`make Makefile\` → phantom command → confidence penalty. Examples: \`\` \`npm\` or \`yarn\` \`\` → \`npm yarn\`; \`\` \`make sense\` \`\` → \`make sense\`. Fix: split on lines first, run regexes per-line (renamed \`codeLines\`). Invariant: unverifiable refs must be strict no-op — false negatives (silent skips) are acceptable; false positives that trigger penalties are NEVER acceptable. Mutation-verified: reverting per-line split causes 2 fusion guard tests to fail. Fixed in PR #939 Round-2.
@@ -367,6 +376,9 @@
 <!-- lore:019f1e66-a06c-7c58-b5ec-6d7cb21eddc3 -->
 * **backfillTemporalEmbeddings: per-row checkpoint + backlog/progress logging (PR #1104)**: PR #1104 (\`fix/temporal-rechunk-checkpoint\`) changes two behaviors in \`backfillTemporalEmbeddings\`: 1. \*\*Per-row checkpoint\*\*: \`setKV(TEMPORAL\_RECHUNK\_CURSOR\_KEY, retryFrom ?? cursor)\` moved INSIDE the row loop (was per-page). Crash mid-pass now resumes from last completed row, not start of last page. \`retryFrom ?? cursor\` uses nullish (not \`||\`) — when first row fails, \`retryFrom = ''\` and \`'' ?? cursor\` → \`''\`, correctly resuming at \`id > ''\`. 2. \*\*Backlog + heartbeat logging\*\*: upfront \`SELECT COUNT(\*)\` logs \`'temporal re-chunk: N messages to scan (resuming)'\`; \`PROGRESS\_INTERVAL\_MS = 30\_000\` replaces count-based \`PROGRESS\_INTERVAL = 1000\`; heartbeat shows \`processed re-chunked, scanned scanned…\`. Mutations: per-row checkpoint test and backlog-log test both killed independently. Merged \`25a04e22\` at 2026-07-01T17:30:31Z.
 
+<!-- lore:019f6807-9895-777a-9b94-5e0465c7d512 -->
+* **Batch provider resolution**: Batch LLM client resolves providers at flush time: groups items by \`(authKey, providerID)\`. Only \`anthropic\` and \`openai\` providerIDs get batch providers; others (NVIDIA, OpenRouter) fall back to synchronous processing. \`disabledBatchSessions\` and \`disabledBatchProviders\` sets track permanent batch API access failures.
+
 <!-- lore:019f00ae-c762-7067-8197-83d9b70d8dd9 -->
 * **cache-warmer evidence gate (Bug C): always fund first probe, never fund second+ cycle with zero lifetime hits**: 🔴 Directive: ALWAYS fund the first warmup of a break (\`cyclesSpent === 0\` — the probe that learns if this slow tool returns within TTL), but NEVER fund a second-or-later cycle for a session that has produced zero confirmed hits over its lifetime. Implementation: \`if (cyclesSpent >= 1 && (state.warmup?.warmupHits ?? 0) < TOOL\_CALL\_MIN\_HITS\_FOR\_CONTINUATION) return false\`. \`warmupHits\` is lifetime/durable across breaks; \`warmupCount\` (cyclesSpent) is per-break (reset on return in pipeline.ts). Rationale: 66 of 74 zero-hit warmups occurred at ≤5 lifetime warmups, below \`MIN\_WARMUPS\_FOR\_ROI\_CHECK\`, so hit-rate guard never engaged.
 
@@ -391,6 +403,9 @@
 <!-- lore:019eec48-01c5-78bd-b7f9-6cd8b7ddfada -->
 * **Lore gateway deploy procedure on production host**: 🔴 Deploy procedure (Burak Yigit Kaya directive): \`git stash save && git pull && git stash pop && pnpm install && pnpm build && pnpm --filter @loreai/gateway run bundle && sudo service opencode restart && journalctl -u opencode -f\`. Plugin file at \`~/.config/opencode/plugins/lore.ts\` contains only \`export { LorePlugin as default } from "opencode-lore";\`. opencode-lore resolves from \`/home/byk/.config/opencode/node\_modules/opencode-lore\` (active built repo) — NOT the cached version at \`~/.cache/opencode/packages/opencode-lore@\*/\`.
 
+<!-- lore:019f6807-98cb-7942-8e67-00c78df7af81 -->
+* **OpenRouter usage reporting**: OpenRouter always returns detailed usage information. For non-streaming requests, usage is in the response body. For streaming, usage appears once in the final chunk before \`\[DONE]\` with empty choices array. Token counts use model's native tokenizer; credit usage and pricing are based on these native counts.
+
 <!-- lore:019f14f5-5edb-7bd1-bc31-9b10062ce1a3 -->
 * **Pi real-runtime e2e: console spy must be installed BEFORE resourceLoader.reload()**: Trap: installing \`console.\*\` spies after \`resourceLoader.reload()\` looks correct — the test body runs after setup. Fix: Pi's extension factory executes during \`reload()\`, so any \`console.\*\` calls in the factory are missed by late-installed spies. Additionally, Vitest intercepts \`console.\*\` away from \`process.stdout.write\`, so \`process.stdout/stderr.write\` spies also miss console output. Both traps look safe because the test passes — it just silently misses the mutation. Fix: install direct \`console.\*\` method spies BEFORE \`resourceLoader.reload()\` so the entire reload + \`createAgentSession\` + prompt window is captured. Mutation A (inject \`console.info("pi: ...")\` at line 99 of index.ts) confirmed this kills the markers test when spies are correctly placed.
 
@@ -409,13 +424,13 @@
 <!-- lore:019f6803-de7b-7fb8-a01a-d8e5478112f7 -->
 * **Worktree-aware conversation detection**: \`projectSearchPaths(projectPath, opts?)\` unions: resolved cwd (always first), \`git worktree list --porcelain\` output, and \`git rev-parse --git-dir\` parent directories. Deduplicates paths. \`detectAll()\` uses these paths to find agent sessions across worktrees.
 
+<!-- lore:019f6823-01d2-753d-a832-d426a3cb85d1 -->
+* **Worktree-aware import detection**: Project search paths must include: resolved cwd (always first), git worktree paths, and DB aliases. Providers must deduplicate sessions by ID. Empty path arrays should degrade gracefully.
+
 ### Preference
 
 <!-- lore:019f6803-de4d-7bdc-bef5-6832fb93662e -->
 * **Adversarial correctness review focus**: When reviewing code changes, focus ONLY on real bugs: logic errors, race conditions, incorrect assumptions, edge cases, security issues, and broken invariants. Categorize findings by severity: BLOCKER, SHOULD-FIX, NIT/MINOR. Do NOT nitpick style. Verify claims by reading actual code.
-
-<!-- lore:019f6526-fa79-7e51-8e5d-073c6d156bb9 -->
-* **Always decrypts ciphertext before passing to resolvers**: The user consistently decrypts ciphertext before passing it to resolvers, ensuring that sensitive data is handled securely and never stored or transmitted in its encrypted form. This pattern is observed across multiple coding sessions, where the user explicitly states their preference for decrypting content before passing it to resolvers, and the code changes reflect this behavior.
 
 <!-- lore:019f6689-46d2-76c6-8f07-025cd344bc7a -->
 * **Always diagnose root causes of background worker failures**: The user consistently investigates background worker failures (especially 'no-response' and 'worker-incapable' classifications) by examining detailed logs, tool results, and code implementations. They focus on identifying the root cause rather than accepting workarounds, and expect comprehensive analysis of failure patterns, model/provider compatibility issues, and retry logic. The user pushes for fixes that address the underlying problems rather than superficial symptoms.
@@ -426,17 +441,14 @@
 <!-- lore:019f67f2-14df-7aa5-a409-f69f14fea13f -->
 * **Always enforce read-only adversarial code reviews with strict mutation testing protocols**: The user consistently requires adversarial code reviews in a read-only mode, prohibiting any modifications to the main repository. For mutation testing, they mandate using temporary git worktrees under /tmp/opencode, with strict verification of byte-identical restoration via sha256 checksums before removal. This pattern applies to all code reviews, whether pre-merge or post-merge, and emphasizes finding real logic/security bugs while maintaining repository integrity.
 
-<!-- lore:019f64f3-5674-7a81-8767-25e8f8e92cd8 -->
-* **Always evaluates competitor memory backends critically**: The user consistently expresses skepticism and criticism towards competitor memory backends, stating that they 'never actually work.' This pattern is observed in multiple sessions where the user discusses and evaluates various memory backend solutions, including ByteRover, Mem0, Zep, Hindsight, HonCho, and Chronos. The user appears to scrutinize these competitors' performance, often citing specific issues such as inflated accuracy scores or limited evaluation metrics. When exploring these competitors, the user focuses on their methodologies, architectures, and results, indicating a thorough and critical assessment of their capabilities.
+<!-- lore:019f681e-6ded-7243-bc68-1098bd07a18c -->
+* **Always enforce strict security reviews for crypto implementations**: The user consistently requires formal, read-only security reviews for any cryptographic implementation work, especially around key management and encryption. They define specific 'flaw' criteria (key leaks, data loss bugs, divergence issues) and enforce strict workflows: no direct modifications during review, mutation testing only in isolated environments, and verification of main codebase integrity. This pattern shows a strong preference for rigorous, adversarial security validation before merging crypto-related changes.
 
 <!-- lore:019f65ca-91a1-7978-8acb-b5b69c11492e -->
 * **Always explicitly state invariants and assumptions**: The user consistently and explicitly states invariants, assumptions, and context when discussing code changes, bug fixes, or test cases. This includes stating what should or should not happen in certain scenarios, highlighting specific requirements or constraints, and providing background information to ensure clarity and accuracy. The user also insists on precise language and definitions, as seen in the emphasis on specific error codes, database constraints, and test case expectations.
 
 <!-- lore:019f654b-edee-78ed-bd11-dfa74594b096 -->
 * **Always expresses skepticism towards competitor memory backends**: The user consistently expresses doubt or skepticism about the functionality of competitor memory backends, often stating that they 'never' work or have issues. This pattern is observed across multiple sessions, where the user questions the effectiveness of various competitor products, including 'mnemonic' and 'mem0'. The user also tends to provide detailed context and specific examples when discussing these competitors, indicating a thorough evaluation process.
-
-<!-- lore:019f62d0-62d8-795b-9117-4d96963b620f -->
-* **Always focus on sync and coordination problems**: The user consistently inquires about and addresses issues related to synchronization, coordination, and conflict resolution in the context of team-sync and data sharing. They explore features such as shared scope, review gates, and invariant-conflict detection to ensure data consistency and resolve coordination problems.
 
 <!-- lore:019f66ef-5abe-77b4-ad8a-c3d609d2f88f -->
 * **Always follow the principle of least privilege and conservative role mapping**: The user consistently emphasizes the importance of not over-granting permissions and maintaining a conservative role mapping. This is evident in multiple instances where the user states or implies that roles should be mapped conservatively, never downgrading existing higher roles, and never overriding manual role changes. The user also stresses the importance of verifying and validating changes to ensure that they align with these principles.
@@ -451,13 +463,10 @@
 * **Always Monitor and Analyze Model Performance**: The user consistently monitors and analyzes the performance of various models, including DeepSeek, Sonnet, and M3-Lore, across different sessions and experiments. They pay close attention to metrics such as validity rates, tool calls, and conversation costs. The user also identifies and investigates issues, such as worker model problems and tool call counting errors, to improve the performance and accuracy of the models.
 
 <!-- lore:019f66e9-6a37-7aa0-b281-de68fd4089de -->
-* **Always prefers dataclasses over bare dicts**: The user consistently expresses a preference for using dataclasses instead of bare dictionaries, especially for named-field types. This is observed in multiple sessions where the user explicitly states this preference.
+* **Always prefers dataclasses over bare dicts**: Always prefer dataclasses over bare dicts for structured data. This provides better type safety and documentation.
 
 <!-- lore:019f67dd-5b81-7a62-89fe-25fade7de59a -->
 * **Always prioritize cost optimization and efficiency**: The user consistently focuses on reducing costs and improving efficiency across all sessions. They investigate cost drivers, question expensive operations, and push for optimizations. The user expects detailed cost breakdowns, challenges assumptions about cost-effectiveness, and seeks solutions that minimize overhead while maintaining functionality. When presented with cost data, they analyze it critically and demand explanations for any discrepancies or inefficiencies.
-
-<!-- lore:019f6507-4973-7c69-b851-a6b9e6670ad8 -->
-* **Always prioritize pull-side encryption mode and never store ciphertext as local content**: The user consistently emphasizes the importance of pull-side encryption and ensuring that ciphertext is never stored as local content. This is evident in their repeated statements and code reviews across multiple sessions, where they stress the need for a 'pull-side encryption mode' and the risk of storing ciphertext locally. The user also provides specific scrutiny points and code changes to implement this behavior, indicating a strong preference for this approach.
 
 <!-- lore:019f62b8-fbc2-7c47-bfe1-486851ff478f -->
 * **Always Prioritizes Encryption and Security**: The user consistently checks for encryption and security measures before pushing data. They verify the encryption status, ensure that sensitive information is handled properly, and make sure that the data is encrypted before pushing it to the remote. The user also checks for potential issues, such as plaintext data being pushed, and takes corrective actions to prevent it. This pattern is observed across multiple instances, where the user is meticulous about encryption and security when working with sensitive data.
@@ -495,6 +504,9 @@
 <!-- lore:019f653a-8d9f-7df1-8058-0c83f24f4b38 -->
 * **Always scrub or handle plaintext entity rows on remote**: The user consistently directs the handling of plaintext entity rows on the remote server, either by scrubbing or ignoring them. This is observed in multiple sessions where the user instructs the assistant to delete remote entity rows, clear local sync state, and trigger re-push of encrypted entity rows. The user also mentions that plaintext rows are safe to ignore or wipe, indicating a preference for handling these rows in a specific manner.
 
+<!-- lore:019f681c-074e-79f9-a2e5-9dd137761257 -->
+* **Always specify invariants and security constraints during code reviews**: The user consistently provides detailed invariants, security requirements, and edge case considerations when requesting code reviews. They specify fail-open behavior requirements, git subprocess restrictions in hosted environments, deduplication requirements, SQL injection prevention measures, and signature migration completeness. The user expects reviewers to verify these specific constraints and provides comprehensive context including git diffs, file contents, and test results to facilitate thorough verification.
+
 <!-- lore:019f668f-b99a-723a-b6a3-64c3e48f697c -->
 * **Always use disk's remote and never override on-disk truth**: The user consistently emphasizes the importance of using the disk's remote and never overriding on-disk truth. This pattern is observed in multiple instances where the user states that a client header can never override on-disk truth and that the disk's remote should always be used. The user also mentions never attaching to a path that is not a git repository on a local gateway to prevent the 'git-remote magnet' bug. This behavior indicates that the user prioritizes consistency and accuracy in remote resolution, ensuring that the on-disk state is respected and not overridden by client headers or other external factors.
 
@@ -507,11 +519,11 @@
 <!-- lore:019f67df-21ce-7922-b68b-5425fa2cceb9 -->
 * **Always verify PR status and CI results before proceeding with merges**: The user consistently checks the status of pull requests and their associated CI results before taking further action. This includes verifying which PRs are open, confirming local changes are ready for PR creation, checking CI job statuses, and ensuring mergeability. The user expects to review this information before proceeding with merges or additional work.
 
-<!-- lore:019f6530-2e24-7587-b573-d7afd6965dc5 -->
-* **Always waits for required CI checks to pass before merging**: The user consistently waits for all required CI checks to pass before merging a pull request. Specifically, they wait for the 'test' job and Seer Code Review to complete, even if other checks have passed. The user also tends to create a pull request immediately after making changes and then monitor the CI status, waiting for it to become mergeable.
-
 <!-- lore:019f666d-4d29-7800-821a-db71f2686b1b -->
 * **Architecture: context never wiped and rebuilt from lossy summary**: Architecture: context never wiped and rebuilt from lossy summary. Context never gets wiped and rebuilt from a lossy summary. Switching to Mastra's observer/reflector architecture with plain-text timestamped observation logs was the breakthrough. The switch from structured JSON to timestamped observation logs made v2 work.
+
+<!-- lore:019f6807-98ef-786a-9e24-6736f057d640 -->
+* **Batch-disabled eval caveat disclosure**: Always disclose that batch requests are disabled in eval harness (via \`LORE\_BATCH\_DISABLED=1\`) when reporting cost results. Eval requires synchronous timing for 5-min benchmark; batch API's async nature and multi-minute turnaround are incompatible.
 
 <!-- lore:019eff04-9cca-712f-bdb7-535292cfc96b -->
 * **Blog tone: category-not-competitor thesis — gentle, not dunking**: 🔴 Directive: convey the 'new category being invented' thesis gently — acknowledge the existing category isn't enough and that something new is being built, without dunking on existing tools. Generous close required: 'a good store is genuinely worth having.'
@@ -519,20 +531,11 @@
 <!-- lore:019f666d-4c5b-7a16-b2e8-59bc44203f59 -->
 * **CLI command documentation: setup.md as structural template**: CLI command documentation: setup.md as structural template. The setup.md file (80 lines) provides the best structural/style template for creating dedicated Reference pages for CLI commands like \`lore import\`.
 
-<!-- lore:019f666d-4cad-731e-ad82-f247f95fde48 -->
-* **Documentation gaps: lore import and review.md not in sidebar**: Documentation gaps: lore import and review.md not in sidebar. \`lore import\` has no dedicated website page and is absent from the Astro sidebar configuration in astro.config.mjs. \`docs/review.md\` exists but is not listed in the sidebar.
-
-<!-- lore:019f666d-4cd6-79e3-963b-f5f301987620 -->
-* **Documentation location: lore import documented in README and install.md**: Documentation location: lore import documented in README and install.md. \`lore import\` is documented in exactly two locations: \`README.md:311–320\` (full CLI reference) and \`docs/install.md:40–48\` (as 'Existing Conversations' subsection).
-
 <!-- lore:019f666d-4c36-7769-a6df-f34d981456c7 -->
 * **Documentation structure: Astro website with Starlight theme**: Documentation structure: Astro website with Starlight theme. Content collections: docs (Starlight loader/schema) and blog (glob loader with custom Zod schema). Page files in packages/website/src/content/docs/docs/ and guides/ subdirectory. Components in packages/website/src/components/. Sidebar navigation defined in astro.config.mjs.
 
 <!-- lore:019f666d-4c13-79cf-a6b9-221b19f68d9d -->
 * **Documentation style: README pattern with annotated bash blocks**: Documentation style: README pattern with annotated bash blocks. CLI commands in README.md use annotated bash blocks with \`#\` comments explaining each flag and argument. Website documentation uses frontmatter/H2 sections/Starlight directives. Guides use imperative titles like 'With OpenCode'.
-
-<!-- lore:019f60a4-db86-7ece-bc14-2d3c6d22502a -->
-* **Follow the established git workflow (branch, PR, review)**: Behavioral pattern detected across 119 sessions (action: enforced-workflow). The user consistently demonstrates this behavior.
 
 <!-- lore:019f666d-4c83-73d0-94ce-549b70d0bf3e -->
 * **Importers: supported list for lore import**: Importers: supported list for lore import. Supported importers consistently mentioned: Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi.
@@ -574,7 +577,7 @@
 * **Never pushed — enqueuing them would create outbox**: User stated never pushed — enqueuing them would create outbox.
 
 <!-- lore:019f66e9-59bb-7472-904b-a861e340f64c -->
-* **Never puts in AGENTS**: User stated never puts in AGENTS.md.
+* **Never puts in AGENTS**: Never run git subprocesses against a client-controlled cwd on a hosted gateway. Always degrade to \[cwd] / \[] when git operations are disabled.
 
 <!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
 * **Never re-read — so excluded**: User stated never re-read — so excluded.
@@ -600,14 +603,11 @@
 <!-- lore:019f66b2-dc84-7d37-8a43-a0b03cfc53f1 -->
 * **Review code before committing**: Behavioral pattern detected across 84 sessions (action: requested-review). The user consistently demonstrates this behavior.
 
-<!-- lore:019f666d-4d00-7a62-8850-96ba39e5c07d -->
-* **Stale path reference: PROMPT\_CHANGES.md in README**: Stale path reference: PROMPT\_CHANGES.md in README. Stale path reference in \`README.md:424\` pointing to \`docs/PROMPT\_CHANGES.md\` when the file actually lives at \`quality/PROMPT\_CHANGES.md\`.
-
 <!-- lore:019f66ae-9aa3-7f41-9cf2-4596011f1f35 -->
 * **Switch to synchronous mode**: User switched to synchronous mode for future calls.
 
 <!-- lore:019f66f6-4b8a-7a24-b466-b1938a469ce2 -->
-* **User never branches on arm in check logic**: User stated never branches on arm in check logic ===
+* **User never branches on arm in check logic**: Never import from import/ directory. This creates circular dependencies that break the build.
 
 <!-- lore:019f66f6-4b21-78ae-b548-0e6abf41c40a -->
-* **User never writes to intermediate files**: User stated never writes to any intermediate file.
+* **User never writes to intermediate files**: Never creates a project or registers aliases during import detection. The import flow should only discover existing projects, not modify state.

--- a/.lore.md
+++ b/.lore.md
@@ -44,7 +44,7 @@
 * **knowledge\_symbol\_presence table: presence-history drift signal for symbol validation (#911)**: knowledge\_symbol\_presence table (migration v59): \`(logical\_id TEXT, symbol TEXT, last\_present\_at INTEGER, PRIMARY KEY(logical\_id, symbol))\`. Symbol refs resolve to \`"ok"\` or \`"unknown"\` — NEVER \`"missing"\`. Penalty fires only when \`wasSymbolPresent()\` returns true (previously confirmed present, now absent). \`recordSymbolPresent()\` fires only on \`st === "ok"\`. External/historical/rejected mentions never get a presence record. \`RepoView.presentSymbols: Set\<string> | null\` — null = grep unavailable (neutral). Cleanup: \`remove()\` in \`ltm.ts\` must delete from \`knowledge\_symbol\_presence\` and \`knowledge\_ref\_validity\` via \`LOGICAL\_ID\_BOOKKEEPING\_TABLES\` loop BEFORE the knowledge DELETE. \`knowledge\_session\_injections\` and \`knowledge\_meta\` are intentionally excluded from that loop (sync-destined / tracked follow-up).
 
 <!-- lore:019f43a4-4eff-7867-a668-1d600f43f990 -->
-* **lat.md synthetics never included in overflowSink — not knowledge rows, carry no recall id**: lat.md synthetics never included in overflowSink — not knowledge rows, carry no recall id.
+* **lat.md synthetics never included in overflowSink — not knowledge rows, carry no recall id**: lat.md synthetics never included in overflowSink — not knowledge rows, carry no recall id. User stated synthetics are never included.
 
 <!-- lore:019edfbc-edd5-780d-ac81-07a35390121b -->
 * **ltm.ts: confidence lifecycle — decay, reinforcement, eviction, and cross-project protection**: ltm.ts: confidence lifecycle — decay, reinforcement, eviction, cross-project protection. \`decayProject(path)\` decrements confidence, never bumps \`updated\_at\`. \`markInjected(ids)\` writes only \`last\_reinforced\_at\`. \`evictLowestValue\`/\`pruneDeadEntries\`/\`pruneDeadEntriesAllProjects\` MUST skip \`cross\_project=1\` entries. \`DEAD\_CONFIDENCE\_FLOOR=0.2\`. \`enforceEntryCap\` counts promoted rows but eviction excludes them. Global sweep in \`idle.ts\`: \`pruneDeadEntriesAllProjects()\` on first tick then hourly (\`GLOBAL\_DEAD\_SWEEP\_INTERVAL\_MS=3600000\`), gated on \`loreConfig().knowledge.enabled\`. \`lastGlobalDeadSweepAt\` starts at 0, set BEFORE try block (prevents retry storm). Sweep wrapped in try/catch. Queries \`WHERE cross\_project=0 AND confidence<=0.2 LIMIT ?\` — \`cross\_project=0\` implicitly guarantees non-null \`project\_id\` (enforced at \`create()\`: null pid forces \`cross\_project=1\`).
@@ -169,7 +169,7 @@
 * **Switched from plan mode to build mode (read-write**: switched from plan to build mode (read-only lifted; file changes,
 
 <!-- lore:019f65ca-91c3-71f9-9f8a-bb8a803ce3e4 -->
-* **Switched from Python to TypeScript for the project (no longer using Python)**: switched from Python to TypeScript for the project (no longer using Python).
+* **Switched from Python to TypeScript for the project (no longer using Python)**: switched from Python to TypeScript for the project (no longer using Python)
 
 ### Gotcha
 
@@ -238,6 +238,9 @@
 
 <!-- lore:019ef947-54d5-73d6-8a1b-06575dddcf2f -->
 * **Lore website: Vite transformIndexHtml is dead code for Astro static generation**: Trap: adding a Vite \`transformIndexHtml\` plugin to \`astro.config.mjs\` looks like the right way to rewrite HTML links at build time — Vite is Astro's bundler. Fix: Astro's static generation pipeline does NOT route through Vite's HTML transform hook. The plugin is silently ignored; links are never rewritten. Confirmed by grep of built HTML showing unmodified hrefs despite plugin being active. Use \`astro:build:done\` integration hook instead — it receives the final output directory and can rewrite HTML files directly.
+
+<!-- lore:019f66b3-cd55-7c3d-9410-a43d00eef575 -->
+* **lore-curator empty responses misclassified as no-response**: Trap: lore-curator worker using llama-4-scout model returns empty responses (HTTP 200 with no usable text) which are misclassified as no-response instead of worker-incapable. Fix: classify empty responses as worker-incapable.
 
 <!-- lore:019efc12-5bea-700b-87dd-615866d86741 -->
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
@@ -390,6 +393,9 @@
 <!-- lore:019f6689-46d2-76c6-8f07-025cd344bc7a -->
 * **Always diagnose root causes of background worker failures**: The user consistently investigates background worker failures (especially 'no-response' and 'worker-incapable' classifications) by examining detailed logs, tool results, and code implementations. They focus on identifying the root cause rather than accepting workarounds, and expect comprehensive analysis of failure patterns, model/provider compatibility issues, and retry logic. The user pushes for fixes that address the underlying problems rather than superficial symptoms.
 
+<!-- lore:019f674d-68e5-7826-bec7-f0ba86c8e131 -->
+* **Always Directs and Validates Planning Workflow**: The user consistently directs and validates the planning workflow, ensuring that the assistant follows specific instructions and guidelines. This includes calling plan\_exit to indicate the end of planning, handling specific tasks and epics, and making decisions on workflow progression. The user also frequently requests explanations and details about specific commands and plans, indicating a preference for transparency and control throughout the planning process.
+
 <!-- lore:019f64f3-5674-7a81-8767-25e8f8e92cd8 -->
 * **Always evaluates competitor memory backends critically**: The user consistently expresses skepticism and criticism towards competitor memory backends, stating that they 'never actually work.' This pattern is observed in multiple sessions where the user discusses and evaluates various memory backend solutions, including ByteRover, Mem0, Zep, Hindsight, HonCho, and Chronos. The user appears to scrutinize these competitors' performance, often citing specific issues such as inflated accuracy scores or limited evaluation metrics. When exploring these competitors, the user focuses on their methodologies, architectures, and results, indicating a thorough and critical assessment of their capabilities.
 
@@ -402,8 +408,20 @@
 <!-- lore:019f62d0-62d8-795b-9117-4d96963b620f -->
 * **Always focus on sync and coordination problems**: The user consistently inquires about and addresses issues related to synchronization, coordination, and conflict resolution in the context of team-sync and data sharing. They explore features such as shared scope, review gates, and invariant-conflict detection to ensure data consistency and resolve coordination problems.
 
+<!-- lore:019f66ef-5abe-77b4-ad8a-c3d609d2f88f -->
+* **Always follow the principle of least privilege and conservative role mapping**: The user consistently emphasizes the importance of not over-granting permissions and maintaining a conservative role mapping. This is evident in multiple instances where the user states or implies that roles should be mapped conservatively, never downgrading existing higher roles, and never overriding manual role changes. The user also stresses the importance of verifying and validating changes to ensure that they align with these principles.
+
 <!-- lore:019f658c-57d6-71c3-a09a-b97816f6a31b -->
 * **Always lists files in the repository when exploring a new topic**: The user consistently lists files in the repository when starting to explore a new topic or task. This is observed in multiple sessions where the user provides a list of files in the repository, such as on July 15, 2026, when the user listed numerous files in the repository. This behavior suggests that the user finds value in having a comprehensive view of the repository's file structure when beginning a new task or investigation.
+
+<!-- lore:019f66f7-46d3-7cfb-ac94-6ad79f22a26c -->
+* **Always Monitor and Analyze Model Performance**: The user consistently monitors and analyzes the performance of various models, including DeepSeek, Sonnet, and M3-Lore, across different sessions and experiments. They pay close attention to metrics such as validity rates, tool calls, and conversation costs. The user also identifies and investigates issues, such as worker model problems and tool call counting errors, to improve the performance and accuracy of the models.
+
+<!-- lore:019f66e9-6a37-7aa0-b281-de68fd4089de -->
+* **Always prefers dataclasses over bare dicts**: The user consistently expresses a preference for using dataclasses instead of bare dictionaries, especially for named-field types. This is observed in multiple sessions where the user explicitly states this preference.
+
+<!-- lore:019f67dd-5b81-7a62-89fe-25fade7de59a -->
+* **Always prioritize cost optimization and efficiency**: The user consistently focuses on reducing costs and improving efficiency across all sessions. They investigate cost drivers, question expensive operations, and push for optimizations. The user expects detailed cost breakdowns, challenges assumptions about cost-effectiveness, and seeks solutions that minimize overhead while maintaining functionality. When presented with cost data, they analyze it critically and demand explanations for any discrepancies or inefficiencies.
 
 <!-- lore:019f6507-4973-7c69-b851-a6b9e6670ad8 -->
 * **Always prioritize pull-side encryption mode and never store ciphertext as local content**: The user consistently emphasizes the importance of pull-side encryption and ensuring that ciphertext is never stored as local content. This is evident in their repeated statements and code reviews across multiple sessions, where they stress the need for a 'pull-side encryption mode' and the risk of storing ciphertext locally. The user also provides specific scrutiny points and code changes to implement this behavior, indicating a strong preference for this approach.
@@ -420,8 +438,23 @@
 <!-- lore:019f6668-2f99-7656-a20b-5fcaf7ea9a23 -->
 * **Always provide exact file paths and verbatim content when reporting findings**: The user consistently requires detailed, precise information when investigating codebases or documentation. This includes providing exact file paths, line numbers, and verbatim quotes from the source material. The user emphasizes thoroughness and accuracy, preferring to see the raw content rather than summaries or interpretations. This pattern applies when the user is researching documentation, investigating bugs, reviewing website content, or analyzing code structure.
 
+<!-- lore:019f66b3-4b0c-79f9-afae-afb0c4012eb6 -->
+* **Always provides detailed context and claims to verify for bug fixes**: The user consistently provides detailed context, including relevant commits, diffs, and files, when discussing bug fixes. They also provide specific claims to verify, such as the behavior of certain functions or the impact of changes on the system. This pattern suggests that the user values thoroughness and transparency in their work and wants to ensure that issues are properly addressed and verified.
+
+<!-- lore:019f66f5-cf75-7a15-8a43-a27b4901b2c8 -->
+* **Always provides detailed evaluation metrics and cost analysis**: The user consistently provides and discusses detailed evaluation metrics, such as retention rates, token counts, conversation costs, and worker costs, across multiple runs and campaigns. They also analyze and compare the performance of different models, including Lore and vanilla arms, and competitors like DeepSeek and Sonnet. The user is meticulous in their evaluation, noting specific issues like memory leaks, compaction taxes, and behavioral failures. They use this data to inform decisions, such as switching to a different model or fixing specific issues.
+
+<!-- lore:019f66b3-cdb2-7605-9908-3135589ec555 -->
+* **Always record auth failure**: Always record the auth failure so the worker-health ladder sees it.
+
+<!-- lore:019f67de-a9dc-7a88-8a21-757a3a80050c -->
+* **Always require explicit user instruction before merging PRs**: The user consistently expects the assistant to wait for explicit confirmation before merging pull requests, even when all CI checks pass and the PR is in a CLEAN/MERGEABLE state. The assistant should report the PR status (including mergeability, CI results, and any bot findings) but never auto-merge without direct user instruction.
+
 <!-- lore:019f666b-f264-74e0-9ee4-9f1bdf143366 -->
 * **Always require plan\_exit call to terminate planning workflow**: The user consistently mandates that planning workflows must conclude with an explicit call to plan\_exit. This directive appears in every planning session observation, indicating a strong preference for clear termination signals. The user expects the assistant to follow this protocol without exception, using plan\_exit to formally end the planning phase rather than stopping silently or through other means.
+
+<!-- lore:019f66b2-ed2b-7a34-8102-ea7a2e7f0b7a -->
+* **Always run tests and lint checks before committing changes**: The user consistently runs tests and lint checks before committing changes. This includes running full test suites, lint checks, and typechecks to ensure the code is clean and functional. The user also reviews code before committing changes, as evidenced by the 'review code' directive. This pattern suggests that the user values code quality and wants to ensure that changes are thoroughly verified before they are committed.
 
 <!-- lore:019f653a-8d9f-7df1-8058-0c83f24f4b38 -->
 * **Always scrub or handle plaintext entity rows on remote**: The user consistently directs the handling of plaintext entity rows on the remote server, either by scrubbing or ignoring them. This is observed in multiple sessions where the user instructs the assistant to delete remote entity rows, clear local sync state, and trigger re-push of encrypted entity rows. The user also mentions that plaintext rows are safe to ignore or wipe, indicating a preference for handling these rows in a specific manner.
@@ -429,8 +462,14 @@
 <!-- lore:019f668f-b99a-723a-b6a3-64c3e48f697c -->
 * **Always use disk's remote and never override on-disk truth**: The user consistently emphasizes the importance of using the disk's remote and never overriding on-disk truth. This pattern is observed in multiple instances where the user states that a client header can never override on-disk truth and that the disk's remote should always be used. The user also mentions never attaching to a path that is not a git repository on a local gateway to prevent the 'git-remote magnet' bug. This behavior indicates that the user prioritizes consistency and accuracy in remote resolution, ensuring that the on-disk state is respected and not overridden by client headers or other external factors.
 
+<!-- lore:019f674c-f4b7-783c-aa5b-7c6fe27450dc -->
+* **Always verifies edits with test runs**: The user consistently runs tests or verifies the results of edits through test runs after applying changes. This pattern is observed across multiple sessions where the user either directly runs tests or requests the assistant to do so to ensure that the changes are correct and do not introduce regressions.
+
 <!-- lore:019f66ae-39fb-7ec9-ae74-2c87c8255202 -->
 * **Always Verify and Refine Test Coverage**: The user consistently reviews and refines test coverage after implementing changes or identifying gaps. This includes running test suites, analyzing test results, and applying mutations to validate test effectiveness. The user also verifies code correctness and test quality, often in multiple iterations, to ensure comprehensive coverage and accuracy.
+
+<!-- lore:019f67df-21ce-7922-b68b-5425fa2cceb9 -->
+* **Always verify PR status and CI results before proceeding with merges**: The user consistently checks the status of pull requests and their associated CI results before taking further action. This includes verifying which PRs are open, confirming local changes are ready for PR creation, checking CI job statuses, and ensuring mergeability. The user expects to review this information before proceeding with merges or additional work.
 
 <!-- lore:019f6530-2e24-7587-b573-d7afd6965dc5 -->
 * **Always waits for required CI checks to pass before merging**: The user consistently waits for all required CI checks to pass before merging a pull request. Specifically, they wait for the 'test' job and Seer Code Review to complete, even if other checks have passed. The user also tends to create a pull request immediately after making changes and then monitor the CI status, waiting for it to become mergeable.
@@ -471,6 +510,12 @@
 <!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
 * **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
 
+<!-- lore:019f66e9-5fde-7103-a386-f9e5db82613a -->
+* **Never compacts -> errors instead**: User stated never compacts -> errors instead.
+
+<!-- lore:019f66e9-5f7c-7fd1-9cb6-4465e8473c60 -->
+* **Never falls through to the real defaults 3207/5673**: User stated never falls through to the real defaults 3207/5673.
+
 <!-- lore:019f65ca-91fb-7140-b01f-aeb90540b80d -->
 * **Never from within another transaction**: User stated never from within another transaction.
 
@@ -478,7 +523,7 @@
 * **Never mark worker as incapable due to transient errors or curator empty responses**: The user consistently emphasizes that worker incapability should not be marked due to transient errors, curator empty responses, or upstream errors. The user expects the system to handle such cases without marking the worker as incapable, and instead, focus on logging, warnings, and potential retries. This pattern is observed across multiple instances, where the user explicitly states or implies that certain types of errors should not lead to worker incapability.
 
 <!-- lore:019f66a2-591b-7b5d-a0b3-886f650b755f -->
-* **Never marked incapable after 3 consecutive curator empties**: User stated never marked incapable after 3 consecutive curator empties.
+* **Never marked incapable after 3 consecutive curator empties**: Never marked incapable after 3 consecutive curator empties — reset streak per-worker.
 
 <!-- lore:019f66a7-6371-79b6-9703-312f82ebef51 -->
 * **Never marks a model incapable**: User stated never marks a model incapable.
@@ -486,8 +531,14 @@
 <!-- lore:019f62e7-b68c-7a51-87d5-d0771009efc6 -->
 * **Never penalizes (neutral) 2ms**: Never penalize entries with latency over 2ms.
 
+<!-- lore:019f66e9-5fc3-72b6-9430-e7ae1dc4498e -->
+* **Never promoted to knowledge**: User stated NEVER promoted to knowledge.
+
 <!-- lore:019f65ca-9216-7d70-9a22-1eea846e704d -->
 * **Never pushed — enqueuing them would create outbox**: User stated never pushed — enqueuing them would create outbox.
+
+<!-- lore:019f66e9-59bb-7472-904b-a861e340f64c -->
+* **Never puts in AGENTS**: User stated never puts in AGENTS.md.
 
 <!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
 * **Never re-read — so excluded**: User stated never re-read — so excluded.
@@ -495,17 +546,29 @@
 <!-- lore:019f65ca-9231-7baf-a27a-65ee4b6c3a4b -->
 * **Never reach the remote**: User stated never reach the remote.
 
-<!-- lore:019f66ae-9a56-7002-9169-763d8f6e19ed -->
-* **Never record auth failure**: User stated always recording the auth failure so the worker-health ladder sees it.
+<!-- lore:019f66e9-5fa8-717a-a5b5-1fad7beff234 -->
+* **Never runs and Lore falls back to temporal-only recall**: User stated never runs and Lore falls back to temporal-only recall.
 
 <!-- lore:019f64f3-4326-79f4-88ff-b8bc01c50706 -->
 * **Never touch the user's real gateway/DB**: User stated never touch the user's real gateway/DB.
 
+<!-- lore:019f66b3-cd84-7f95-b81c-35ea3fcede8c -->
+* **Never touches curator's streak**: Never touches curator's streak \*regardless of whether the param is honored\*.
+
 <!-- lore:019f66a2-5938-7fd4-b581-90d256a820c4 -->
 * **Never TTL-evicted**: User stated never TTL-evicted.
+
+<!-- lore:019f66b2-dc84-7d37-8a43-a0b03cfc53f1 -->
+* **Review code before committing**: Behavioral pattern detected across 84 sessions (action: requested-review). The user consistently demonstrates this behavior.
 
 <!-- lore:019f666d-4d00-7a62-8850-96ba39e5c07d -->
 * **Stale path reference: PROMPT\_CHANGES.md in README**: Stale path reference: PROMPT\_CHANGES.md in README. Stale path reference in \`README.md:424\` pointing to \`docs/PROMPT\_CHANGES.md\` when the file actually lives at \`quality/PROMPT\_CHANGES.md\`.
 
 <!-- lore:019f66ae-9aa3-7f41-9cf2-4596011f1f35 -->
 * **Switch to synchronous mode**: User switched to synchronous mode for future calls.
+
+<!-- lore:019f66f6-4b8a-7a24-b466-b1938a469ce2 -->
+* **User never branches on arm in check logic**: User stated never branches on arm in check logic ===
+
+<!-- lore:019f66f6-4b21-78ae-b548-0e6abf41c40a -->
+* **User never writes to intermediate files**: User stated never writes to any intermediate file.

--- a/.lore.md
+++ b/.lore.md
@@ -396,6 +396,9 @@
 <!-- lore:019f674d-68e5-7826-bec7-f0ba86c8e131 -->
 * **Always Directs and Validates Planning Workflow**: The user consistently directs and validates the planning workflow, ensuring that the assistant follows specific instructions and guidelines. This includes calling plan\_exit to indicate the end of planning, handling specific tasks and epics, and making decisions on workflow progression. The user also frequently requests explanations and details about specific commands and plans, indicating a preference for transparency and control throughout the planning process.
 
+<!-- lore:019f67f2-14df-7aa5-a409-f69f14fea13f -->
+* **Always enforce read-only adversarial code reviews with strict mutation testing protocols**: The user consistently requires adversarial code reviews in a read-only mode, prohibiting any modifications to the main repository. For mutation testing, they mandate using temporary git worktrees under /tmp/opencode, with strict verification of byte-identical restoration via sha256 checksums before removal. This pattern applies to all code reviews, whether pre-merge or post-merge, and emphasizes finding real logic/security bugs while maintaining repository integrity.
+
 <!-- lore:019f64f3-5674-7a81-8767-25e8f8e92cd8 -->
 * **Always evaluates competitor memory backends critically**: The user consistently expresses skepticism and criticism towards competitor memory backends, stating that they 'never actually work.' This pattern is observed in multiple sessions where the user discusses and evaluates various memory backend solutions, including ByteRover, Mem0, Zep, Hindsight, HonCho, and Chronos. The user appears to scrutinize these competitors' performance, often citing specific issues such as inflated accuracy scores or limited evaluation metrics. When exploring these competitors, the user focuses on their methodologies, architectures, and results, indicating a thorough and critical assessment of their capabilities.
 
@@ -428,6 +431,9 @@
 
 <!-- lore:019f62b8-fbc2-7c47-bfe1-486851ff478f -->
 * **Always Prioritizes Encryption and Security**: The user consistently checks for encryption and security measures before pushing data. They verify the encryption status, ensure that sensitive information is handled properly, and make sure that the data is encrypted before pushing it to the remote. The user also checks for potential issues, such as plaintext data being pushed, and takes corrective actions to prevent it. This pattern is observed across multiple instances, where the user is meticulous about encryption and security when working with sensitive data.
+
+<!-- lore:019f6800-934c-7f17-bd4e-16227242a02d -->
+* **Always provide complete git diffs for code changes**: The user consistently provides detailed git diffs showing exact code changes across multiple files when implementing features or fixing bugs. The diffs include file paths, line numbers, and the specific code modifications, demonstrating a preference for precise, verifiable code changes rather than just describing the changes verbally.
 
 <!-- lore:019f6667-2da0-792c-ab1b-ad5b78f233ce -->
 * **Always provide complete source code and file structure details**: The user consistently provides comprehensive source code and file structure information when investigating system behavior. This includes full file contents, directory listings, grep results, and implementation details across multiple packages. The pattern shows the user expects to work with complete, verbatim source material rather than summaries or partial excerpts.
@@ -545,6 +551,9 @@
 
 <!-- lore:019f65ca-9231-7baf-a27a-65ee4b6c3a4b -->
 * **Never reach the remote**: User stated never reach the remote.
+
+<!-- lore:019f67f1-f15f-75ff-a20a-7b94e316e457 -->
+* **Never run git subprocesses against a client-controlled cwd on a hosted gateway**: User stated to never run git subprocesses against a client-controlled cwd on a hosted gateway.
 
 <!-- lore:019f66e9-5fa8-717a-a5b5-1fad7beff234 -->
 * **Never runs and Lore falls back to temporal-only recall**: User stated never runs and Lore falls back to temporal-only recall.

--- a/README.md
+++ b/README.md
@@ -311,13 +311,23 @@ lore recall "migration error" --project /path/to/project --json
 ### `lore import` — Import conversation history
 
 ```bash
-# Auto-detect and import conversations from all supported agents
+# Auto-detect prior conversations and pick which agents to import
 lore import
+
+# Import from one agent only (non-interactive)
+lore import --agent claude-code
+
+# Only scan the current directory (skip sibling git worktrees)
+lore import --no-worktrees
 
 # Supported: Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi
 ```
 
 Extracts knowledge from your existing sessions so Lore starts with context from day one. Idempotent — safe to run multiple times.
+
+When more than one agent has history, `lore import` shows a numbered list and lets you select which agents to import (comma-separated numbers, or `a` for all).
+
+**Worktrees & monorepos:** agent history is keyed by the directory the agent ran in, so a repo's conversations are spread across its main checkout and every git worktree. `lore import` finds them all by default (via `git worktree list`) — pass `--no-worktrees` to restrict to the current directory.
 
 ### Web dashboard
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -4055,6 +4055,48 @@ export function resolveProjectByRemoteOrPath(
 }
 
 /**
+ * List every filesystem path lore knows for the project that `path` belongs to.
+ *
+ * Read-only (never creates a project or registers aliases). Resolves the project
+ * by git remote (preferred) then by exact path / alias, then returns the
+ * canonical `projects.path` plus all `project_path_aliases` rows for that
+ * project. Returns `[]` when the project isn't known yet (e.g. first-ever
+ * import), which callers treat as "no extra paths".
+ *
+ * This is the DB half of import's worktree-aware detection: agent history is
+ * keyed by the directory the agent ran in, so a repo's history is spread across
+ * its main checkout and every worktree/clone path. Runtime resolution already
+ * collapses those to one project (see `ensureProject`); this exposes the reverse
+ * mapping (project → all its known paths) so import can search all of them.
+ */
+export function projectKnownPaths(path: string): string[] {
+  let projId: string | null = null;
+  try {
+    const remote = getGitRemote(path); // null in hosted mode OR when not a repo
+    projId = resolveProjectByRemoteOrPath(remote ?? undefined, path);
+  } catch {
+    return [];
+  }
+  if (!projId) return [];
+
+  const paths: string[] = [];
+  try {
+    const row = db()
+      .query("SELECT path FROM projects WHERE id = ?")
+      .get(projId) as { path: string } | null;
+    if (row?.path) paths.push(row.path);
+
+    const aliasRows = db()
+      .query("SELECT path FROM project_path_aliases WHERE project_id = ?")
+      .all(projId) as { path: string }[];
+    for (const r of aliasRows) if (r.path) paths.push(r.path);
+  } catch {
+    return [];
+  }
+  return paths;
+}
+
+/**
  * Look up the path for a project by its internal ID.
  * Used by the REST API to resolve project UUID → path for core functions
  * that require a path argument.

--- a/packages/core/src/import/detect.ts
+++ b/packages/core/src/import/detect.ts
@@ -4,20 +4,31 @@
  */
 import type { DetectionResult } from "./types";
 import { getProviders } from "./providers";
+import { projectSearchPaths } from "./scope";
 
 /**
  * Scan all registered providers for conversation history matching the
  * given project path.
  *
+ * Detection is worktree-aware: agent history is keyed by the directory the
+ * agent ran in, so a repo's history is spread across its main checkout and
+ * every worktree/clone path. `detectAll` resolves that full set of paths (see
+ * `projectSearchPaths`) and matches sessions recorded under any of them, unless
+ * `opts.worktrees === false` (restrict to `projectPath` only).
+ *
  * @returns Results from all providers that found data, sorted by
  *          total messages descending (richest source first).
  */
-export function detectAll(projectPath: string): DetectionResult[] {
+export function detectAll(
+  projectPath: string,
+  opts?: { worktrees?: boolean },
+): DetectionResult[] {
   const results: DetectionResult[] = [];
+  const paths = projectSearchPaths(projectPath, opts);
 
   for (const provider of getProviders()) {
     try {
-      const sessions = provider.detect(projectPath);
+      const sessions = provider.detect(paths);
       if (sessions.length > 0) {
         results.push({
           agentName: provider.name,

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -13,6 +13,7 @@ export type {
 
 // Detection
 export { detectAll } from "./detect";
+export { projectSearchPaths } from "./scope";
 
 // Provider registry
 export {

--- a/packages/core/src/import/providers/aider.ts
+++ b/packages/core/src/import/providers/aider.ts
@@ -105,42 +105,49 @@ const aiderProvider: AgentHistoryProvider = {
   name: "aider",
   displayName: "Aider",
 
-  detect(projectPath: string): DetectedSession[] {
-    const filePath = join(projectPath, HISTORY_FILE);
-    if (!existsSync(filePath)) return [];
+  detect(projectPaths: string[]): DetectedSession[] {
+    const sessions: DetectedSession[] = [];
+    const seen = new Set<string>();
 
-    let stat: Stats;
-    try {
-      stat = statSync(filePath);
-    } catch {
-      return [];
-    }
+    for (const projectPath of projectPaths) {
+      const filePath = join(projectPath, HISTORY_FILE);
+      if (seen.has(filePath)) continue;
+      if (!existsSync(filePath)) continue;
 
-    if (!stat.isFile() || stat.size === 0) return [];
+      let stat: Stats;
+      try {
+        stat = statSync(filePath);
+      } catch {
+        continue;
+      }
 
-    // Quick scan to count messages without full parsing
-    let content: string;
-    try {
-      content = readFileSync(filePath, "utf-8");
-    } catch {
-      return [];
-    }
+      if (!stat.isFile() || stat.size === 0) continue;
 
-    const messages = parseAiderHistory(content);
-    if (messages.length < 3) return [];
+      // Quick scan to count messages without full parsing
+      let content: string;
+      try {
+        content = readFileSync(filePath, "utf-8");
+      } catch {
+        continue;
+      }
 
-    const estimatedTokens = estimateTokens(content);
+      const messages = parseAiderHistory(content);
+      if (messages.length < 3) continue;
 
-    return [
-      {
+      const estimatedTokens = estimateTokens(content);
+      seen.add(filePath);
+
+      sessions.push({
         id: filePath,
         label: `Chat history (${messages.length} messages, ${Math.round(stat.size / 1024)}KB)`,
         startedAt: stat.birthtimeMs || stat.ctimeMs,
         lastActivityAt: stat.mtimeMs,
         estimatedTokens,
         messageCount: messages.length,
-      },
-    ];
+      });
+    }
+
+    return sessions.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
   },
 
   readChunks(

--- a/packages/core/src/import/providers/claude-code.ts
+++ b/packages/core/src/import/providers/claude-code.ts
@@ -239,44 +239,53 @@ const claudeCodeProvider: AgentHistoryProvider = {
   name: "claude-code",
   displayName: "Claude Code",
 
-  detect(projectPath: string): DetectedSession[] {
-    const mangled = manglePath(projectPath);
-    const dir = join(CLAUDE_DIR, mangled);
-
-    let entries: string[];
-    try {
-      entries = readdirSync(dir);
-    } catch {
-      return []; // Directory doesn't exist
-    }
-
+  detect(projectPaths: string[]): DetectedSession[] {
     const sessions: DetectedSession[] = [];
-    for (const entry of entries) {
-      if (!entry.endsWith(".jsonl")) continue;
+    const seen = new Set<string>();
 
-      const filePath = join(dir, entry);
+    for (const projectPath of projectPaths) {
+      const mangled = manglePath(projectPath);
+      const dir = join(CLAUDE_DIR, mangled);
+
+      let entries: string[];
       try {
-        const stat = statSync(filePath);
-        if (!stat.isFile()) continue;
+        entries = readdirSync(dir);
       } catch {
-        continue;
+        continue; // Directory doesn't exist for this candidate path
       }
 
-      const meta = getSessionMetadata(filePath);
-      if (!meta) continue;
+      for (const entry of entries) {
+        if (!entry.endsWith(".jsonl")) continue;
 
-      // Skip trivially small sessions (< 3 messages)
-      if (meta.messageCount < 3) continue;
+        const filePath = join(dir, entry);
+        // Dedupe across candidate paths (mangled dirs are distinct per path,
+        // but guard anyway).
+        if (seen.has(filePath)) continue;
 
-      const dateStr = new Date(meta.startedAt).toISOString().slice(0, 10);
-      sessions.push({
-        id: filePath,
-        label: `${dateStr} (${meta.messageCount} messages)`,
-        startedAt: meta.startedAt,
-        lastActivityAt: meta.lastActivityAt,
-        estimatedTokens: meta.estimatedTokens,
-        messageCount: meta.messageCount,
-      });
+        try {
+          const stat = statSync(filePath);
+          if (!stat.isFile()) continue;
+        } catch {
+          continue;
+        }
+
+        const meta = getSessionMetadata(filePath);
+        if (!meta) continue;
+
+        // Skip trivially small sessions (< 3 messages)
+        if (meta.messageCount < 3) continue;
+
+        seen.add(filePath);
+        const dateStr = new Date(meta.startedAt).toISOString().slice(0, 10);
+        sessions.push({
+          id: filePath,
+          label: `${dateStr} (${meta.messageCount} messages)`,
+          startedAt: meta.startedAt,
+          lastActivityAt: meta.lastActivityAt,
+          estimatedTokens: meta.estimatedTokens,
+          messageCount: meta.messageCount,
+        });
+      }
     }
 
     // Sort by most recent first

--- a/packages/core/src/import/providers/cline.ts
+++ b/packages/core/src/import/providers/cline.ts
@@ -250,44 +250,49 @@ const clineProvider: AgentHistoryProvider = {
   name: "cline",
   displayName: "Cline",
 
-  detect(projectPath: string): DetectedSession[] {
+  detect(projectPaths: string[]): DetectedSession[] {
     const sessions: DetectedSession[] = [];
+    const seen = new Set<string>();
     const storageDirs = findGlobalStorageDirs();
 
     for (const storageDir of storageDirs) {
-      const tasks = loadTaskHistory(storageDir, projectPath);
+      for (const projectPath of projectPaths) {
+        const tasks = loadTaskHistory(storageDir, projectPath);
 
-      for (const task of tasks) {
-        const taskDir = join(storageDir, "tasks", task.id);
-        if (!existsSync(taskDir)) continue;
+        for (const task of tasks) {
+          const taskDir = join(storageDir, "tasks", task.id);
+          if (seen.has(taskDir)) continue;
+          if (!existsSync(taskDir)) continue;
 
-        // Quick count of messages
-        const messages = readConversation(taskDir);
-        if (messages.length < 3) continue;
+          // Quick count of messages
+          const messages = readConversation(taskDir);
+          if (messages.length < 3) continue;
 
-        const dateStr = new Date(task.ts).toISOString().slice(0, 10);
-        const label = task.task
-          ? `${dateStr} - ${truncate(task.task, 60)} (${messages.length} messages)`
-          : `${dateStr} (${messages.length} messages)`;
+          const dateStr = new Date(task.ts).toISOString().slice(0, 10);
+          const label = task.task
+            ? `${dateStr} - ${truncate(task.task, 60)} (${messages.length} messages)`
+            : `${dateStr} (${messages.length} messages)`;
 
-        // Estimate tokens from file size
-        const historyFile = join(taskDir, "api_conversation_history.json");
-        let estimatedTokens = messages.length * 500;
-        try {
-          const stat = statSync(historyFile);
-          estimatedTokens = Math.ceil(stat.size / 5);
-        } catch {
-          // Use the message-count-based estimate
+          // Estimate tokens from file size
+          const historyFile = join(taskDir, "api_conversation_history.json");
+          let estimatedTokens = messages.length * 500;
+          try {
+            const stat = statSync(historyFile);
+            estimatedTokens = Math.ceil(stat.size / 5);
+          } catch {
+            // Use the message-count-based estimate
+          }
+
+          seen.add(taskDir);
+          sessions.push({
+            id: taskDir,
+            label,
+            startedAt: task.ts,
+            lastActivityAt: task.ts,
+            estimatedTokens,
+            messageCount: messages.length,
+          });
         }
-
-        sessions.push({
-          id: taskDir,
-          label,
-          startedAt: task.ts,
-          lastActivityAt: task.ts,
-          estimatedTokens,
-          messageCount: messages.length,
-        });
       }
     }
 

--- a/packages/core/src/import/providers/codex.ts
+++ b/packages/core/src/import/providers/codex.ts
@@ -245,8 +245,10 @@ const codexProvider: AgentHistoryProvider = {
   name: "codex",
   displayName: "Codex",
 
-  detect(projectPath: string): DetectedSession[] {
+  detect(projectPaths: string[]): DetectedSession[] {
     const sessions: DetectedSession[] = [];
+    const pathSet = new Set(projectPaths);
+    const seen = new Set<string>();
 
     // Scan both active and archived sessions
     const allFiles = [
@@ -258,11 +260,16 @@ const codexProvider: AgentHistoryProvider = {
       const meta = getSessionMeta(filePath);
       if (!meta) continue;
 
-      // Match by CWD — the session must have been started in this project
-      if (meta.cwd !== projectPath) continue;
+      // Match by CWD — the session must have been started in one of the
+      // project's paths (main checkout or a sibling worktree/clone).
+      if (!pathSet.has(meta.cwd)) continue;
 
       // Skip trivially small sessions
       if (meta.messageCount < 3) continue;
+
+      // Dedupe by file path (candidate paths may overlap).
+      if (seen.has(filePath)) continue;
+      seen.add(filePath);
 
       const ts = new Date(meta.timestamp).getTime();
       const estimatedTokens = Math.ceil(meta.fileSize / 5);

--- a/packages/core/src/import/providers/continue.ts
+++ b/packages/core/src/import/providers/continue.ts
@@ -190,6 +190,11 @@ const continueProvider: AgentHistoryProvider = {
     const pathSet = new Set(projectPaths);
     const index = loadSessionIndex();
 
+    // No explicit `seen` set is needed for dedup: a session has exactly one
+    // `workspaceDirectory`, so the `pathSet.has()` filter yields each session
+    // at most once even when candidate paths overlap. The fallback scan below
+    // additionally guards against re-adding an already-indexed session via
+    // `existingIds`.
     for (const meta of index) {
       // Filter by workspace directory (main checkout or a sibling worktree).
       if (!meta.workspaceDirectory || !pathSet.has(meta.workspaceDirectory))

--- a/packages/core/src/import/providers/continue.ts
+++ b/packages/core/src/import/providers/continue.ts
@@ -185,13 +185,15 @@ const continueProvider: AgentHistoryProvider = {
   name: "continue",
   displayName: "Continue",
 
-  detect(projectPath: string): DetectedSession[] {
+  detect(projectPaths: string[]): DetectedSession[] {
     const sessions: DetectedSession[] = [];
+    const pathSet = new Set(projectPaths);
     const index = loadSessionIndex();
 
     for (const meta of index) {
-      // Filter by workspace directory
-      if (meta.workspaceDirectory !== projectPath) continue;
+      // Filter by workspace directory (main checkout or a sibling worktree).
+      if (!meta.workspaceDirectory || !pathSet.has(meta.workspaceDirectory))
+        continue;
 
       // Load the full session to count messages
       const session = loadSession(meta.sessionId);
@@ -236,7 +238,11 @@ const continueProvider: AgentHistoryProvider = {
 
         const session = loadSession(sessionId);
         if (!session) continue;
-        if (session.workspaceDirectory !== projectPath) continue;
+        if (
+          !session.workspaceDirectory ||
+          !pathSet.has(session.workspaceDirectory)
+        )
+          continue;
         if (!session.history || session.history.length < 3) continue;
 
         const dateStr = session.title

--- a/packages/core/src/import/providers/opencode.ts
+++ b/packages/core/src/import/providers/opencode.ts
@@ -111,7 +111,7 @@ const opencodeProvider: AgentHistoryProvider = {
   name: "opencode",
   displayName: "OpenCode",
 
-  detect(projectPath: string): DetectedSession[] {
+  detect(projectPaths: string[]): DetectedSession[] {
     const database = openDB();
     if (!database) return [];
 
@@ -125,11 +125,18 @@ const opencodeProvider: AgentHistoryProvider = {
         return [];
       }
 
-      // Find the project by worktree path
-      const project = database
-        .query("SELECT id FROM project WHERE worktree = ?")
-        .get(projectPath) as { id: string } | null;
-      if (!project) return [];
+      if (projectPaths.length === 0) return [];
+
+      // Find the project(s) by worktree path — a repo's history may live under
+      // the main checkout or any sibling worktree/clone path.
+      const projPlaceholders = projectPaths.map(() => "?").join(", ");
+      const projectRows = database
+        .query(`SELECT id FROM project WHERE worktree IN (${projPlaceholders})`)
+        .all(...projectPaths) as Array<{ id: string }>;
+      if (projectRows.length === 0) return [];
+
+      const projectIds = projectRows.map((r) => r.id);
+      const sessPlaceholders = projectIds.map(() => "?").join(", ");
 
       // Get sessions with message counts
       const sessions = database
@@ -137,10 +144,10 @@ const opencodeProvider: AgentHistoryProvider = {
           `SELECT s.id, s.title, s.time_created, s.time_updated,
                   (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) as msg_count
            FROM session s
-           WHERE s.project_id = ? AND s.parent_id IS NULL
+           WHERE s.project_id IN (${sessPlaceholders}) AND s.parent_id IS NULL
            ORDER BY s.time_updated DESC`,
         )
-        .all(project.id) as Array<{
+        .all(...projectIds) as Array<{
         id: string;
         title: string;
         time_created: number;
@@ -149,9 +156,13 @@ const opencodeProvider: AgentHistoryProvider = {
       }>;
 
       const results: DetectedSession[] = [];
+      const seen = new Set<string>();
       for (const sess of sessions) {
         // Skip trivially small sessions
         if (sess.msg_count < 3) continue;
+        // Dedupe by session id (defensive — sessions are per-project).
+        if (seen.has(sess.id)) continue;
+        seen.add(sess.id);
 
         // Estimate tokens from message count (rough: ~500 tokens/message avg)
         const estimatedTokens = sess.msg_count * 500;

--- a/packages/core/src/import/providers/pi.ts
+++ b/packages/core/src/import/providers/pi.ts
@@ -211,39 +211,46 @@ const piProvider: AgentHistoryProvider = {
   name: "pi",
   displayName: "Pi",
 
-  detect(projectPath: string): DetectedSession[] {
-    const encoded = encodeCwd(projectPath);
-    const dir = join(PI_DIR, encoded);
-
-    let entries: string[];
-    try {
-      entries = readdirSync(dir);
-    } catch {
-      return []; // Directory doesn't exist
-    }
-
+  detect(projectPaths: string[]): DetectedSession[] {
     const sessions: DetectedSession[] = [];
-    for (const entry of entries) {
-      if (!entry.endsWith(".jsonl")) continue;
+    const seen = new Set<string>();
 
-      const filePath = join(dir, entry);
-      const meta = getSessionMeta(filePath);
-      if (!meta) continue;
+    for (const projectPath of projectPaths) {
+      const encoded = encodeCwd(projectPath);
+      const dir = join(PI_DIR, encoded);
 
-      // Skip trivially small sessions
-      if (meta.messageCount < 3) continue;
+      let entries: string[];
+      try {
+        entries = readdirSync(dir);
+      } catch {
+        continue; // Directory doesn't exist for this candidate path
+      }
 
-      const dateStr = new Date(meta.timestamp).toISOString().slice(0, 10);
-      const estimatedTokens = Math.ceil(meta.fileSize / 5);
+      for (const entry of entries) {
+        if (!entry.endsWith(".jsonl")) continue;
 
-      sessions.push({
-        id: filePath,
-        label: `${dateStr} (${meta.messageCount} messages)`,
-        startedAt: meta.timestamp,
-        lastActivityAt: meta.timestamp,
-        estimatedTokens,
-        messageCount: meta.messageCount,
-      });
+        const filePath = join(dir, entry);
+        if (seen.has(filePath)) continue;
+
+        const meta = getSessionMeta(filePath);
+        if (!meta) continue;
+
+        // Skip trivially small sessions
+        if (meta.messageCount < 3) continue;
+
+        seen.add(filePath);
+        const dateStr = new Date(meta.timestamp).toISOString().slice(0, 10);
+        const estimatedTokens = Math.ceil(meta.fileSize / 5);
+
+        sessions.push({
+          id: filePath,
+          label: `${dateStr} (${meta.messageCount} messages)`,
+          startedAt: meta.timestamp,
+          lastActivityAt: meta.timestamp,
+          estimatedTokens,
+          messageCount: meta.messageCount,
+        });
+      }
     }
 
     return sessions.sort((a, b) => b.lastActivityAt - a.lastActivityAt);

--- a/packages/core/src/import/scope.ts
+++ b/packages/core/src/import/scope.ts
@@ -1,0 +1,88 @@
+/**
+ * scope.ts — Worktree-aware path enumeration for conversation import.
+ *
+ * Agent history (Codex/Claude/Pi/OpenCode/...) is keyed by the directory the
+ * agent actually ran in. A single git repo's history is therefore spread across
+ * its main checkout and every worktree/clone path. lore's runtime project
+ * resolution already collapses those to one project (git remote +
+ * `project_path_aliases`), but import historically matched only `process.cwd()`,
+ * so it silently missed every session recorded under a sibling worktree.
+ *
+ * `projectSearchPaths()` computes the union of:
+ *   1. the current project path (always first),
+ *   2. every worktree path reported by `git worktree list --porcelain`, and
+ *   3. every path lore already associates with this project in its DB.
+ *
+ * All branches fail open: any git/DB error degrades to `[projectPath]` and never
+ * throws. In hosted mode the git subprocess is skipped entirely (never run git
+ * against a client-controlled cwd — mirrors `getGitRemote`).
+ */
+import { execSync } from "node:child_process";
+import { resolve } from "node:path";
+import { isHostedMode } from "../hosted";
+import { projectKnownPaths } from "../db";
+
+/**
+ * Enumerate all filesystem paths that should be treated as the same project as
+ * `projectPath` for conversation import. The returned array is deduplicated and
+ * always begins with the resolved `projectPath`.
+ *
+ * @param projectPath  The directory import was invoked for (typically cwd).
+ * @param opts.worktrees  When `false`, restrict to `projectPath` only (plus DB
+ *                        aliases are also skipped — the caller asked for cwd
+ *                        scope). Defaults to `true`.
+ */
+export function projectSearchPaths(
+  projectPath: string,
+  opts?: { worktrees?: boolean },
+): string[] {
+  const base = resolve(projectPath);
+  const ordered: string[] = [base];
+
+  // `--no-worktrees` restricts to the current directory only.
+  if (opts?.worktrees === false) return ordered;
+
+  // 1. git worktrees for the repo containing `base`.
+  for (const p of gitWorktreePaths(base)) ordered.push(p);
+
+  // 2. DB-known paths (main path + aliases) for the resolved project.
+  try {
+    for (const p of projectKnownPaths(base)) ordered.push(resolve(p));
+  } catch {
+    // fail open — DB unavailable / project unknown
+  }
+
+  // Dedupe, preserving order (base guaranteed first).
+  return [...new Set(ordered)];
+}
+
+/**
+ * Return the worktree paths reported by `git worktree list --porcelain`,
+ * resolved to absolute paths. Returns `[]` on any failure (not a repo, git
+ * missing, timeout) and in hosted mode.
+ */
+function gitWorktreePaths(cwd: string): string[] {
+  // Never run git subprocesses against a client-controlled cwd on a hosted
+  // gateway (same invariant as getGitRemote()).
+  if (isHostedMode()) return [];
+
+  try {
+    const output = execSync("git worktree list --porcelain", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"], // suppress stderr
+    });
+    const paths: string[] = [];
+    for (const line of output.split("\n")) {
+      // Porcelain format: each worktree stanza starts with `worktree <path>`.
+      if (line.startsWith("worktree ")) {
+        const p = line.slice("worktree ".length).trim();
+        if (p) paths.push(resolve(p));
+      }
+    }
+    return paths;
+  } catch {
+    return [];
+  }
+}

--- a/packages/core/src/import/scope.ts
+++ b/packages/core/src/import/scope.ts
@@ -36,24 +36,29 @@ export function projectSearchPaths(
   projectPath: string,
   opts?: { worktrees?: boolean },
 ): string[] {
-  const base = resolve(projectPath);
-  const ordered: string[] = [base];
-
-  // `--no-worktrees` restricts to the current directory only.
-  if (opts?.worktrees === false) return ordered;
-
-  // 1. git worktrees for the repo containing `base`.
-  for (const p of gitWorktreePaths(base)) ordered.push(p);
-
-  // 2. DB-known paths (main path + aliases) for the resolved project.
   try {
-    for (const p of projectKnownPaths(base)) ordered.push(resolve(p));
-  } catch {
-    // fail open — DB unavailable / project unknown
-  }
+    const base = resolve(projectPath);
+    const ordered: string[] = [base];
 
-  // Dedupe, preserving order (base guaranteed first).
-  return [...new Set(ordered)];
+    // `--no-worktrees` restricts to the current directory only.
+    if (opts?.worktrees === false) return ordered;
+
+    // 1. git worktrees for the repo containing `base`.
+    for (const p of gitWorktreePaths(base)) ordered.push(p);
+
+    // 2. DB-known paths (main path + aliases) for the resolved project.
+    try {
+      for (const p of projectKnownPaths(base)) ordered.push(resolve(p));
+    } catch {
+      // fail open — DB unavailable / project unknown
+    }
+
+    // Dedupe, preserving order (base guaranteed first).
+    return [...new Set(ordered)];
+  } catch {
+    // Fail open: never let path resolution / DB access break import detection.
+    return [projectPath];
+  }
 }
 
 /**

--- a/packages/core/src/import/types.ts
+++ b/packages/core/src/import/types.ts
@@ -68,11 +68,17 @@ export interface AgentHistoryProvider {
 
   /**
    * Detect whether this agent has conversation history for the given
-   * project path. Should be a fast check — avoid reading full file contents.
+   * project paths. Should be a fast check — avoid reading full file contents.
+   *
+   * A session matches if the directory it was recorded under equals ANY of the
+   * supplied paths. `projectPaths[0]` is the primary project path (cwd); the
+   * remaining entries are sibling worktree/clone paths for the same repo (see
+   * `projectSearchPaths`). Implementations MUST deduplicate returned sessions
+   * (e.g. by their `id`) so overlapping candidate paths never yield duplicates.
    *
    * @returns Array of detected sessions, or empty array if none found.
    */
-  detect(projectPath: string): DetectedSession[];
+  detect(projectPaths: string[]): DetectedSession[];
 
   /**
    * Read conversation text from specific sessions, chunked for LLM

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,7 @@ export {
   projectId,
   projectName,
   projectPath,
+  projectKnownPaths,
   projectGitRemote,
   projectScope,
   setProjectScope,

--- a/packages/core/test/import/aider.test.ts
+++ b/packages/core/test/import/aider.test.ts
@@ -21,7 +21,7 @@ describe("Aider provider", () => {
 
   describe("detect", () => {
     test("returns empty for directory without .aider.chat.history.md", () => {
-      const sessions = provider.detect("/nonexistent/path");
+      const sessions = provider.detect(["/nonexistent/path"]);
       expect(sessions).toEqual([]);
     });
 
@@ -34,7 +34,7 @@ describe("Aider provider", () => {
         join(tmp, ".aider.chat.history.md"),
       );
 
-      const sessions = provider.detect(tmp);
+      const sessions = provider.detect([tmp]);
       expect(sessions.length).toBe(1);
       expect(sessions[0].id).toBe(join(tmp, ".aider.chat.history.md"));
       expect(sessions[0].messageCount).toBe(6); // 3 user + 3 assistant
@@ -45,7 +45,7 @@ describe("Aider provider", () => {
       mkdirSync(tmp, { recursive: true });
       writeFileSync(join(tmp, ".aider.chat.history.md"), "");
 
-      const sessions = provider.detect(tmp);
+      const sessions = provider.detect([tmp]);
       expect(sessions).toEqual([]);
     });
 
@@ -57,8 +57,56 @@ describe("Aider provider", () => {
         "#### user\nHello\n\n#### assistant\nHi!\n",
       );
 
-      const sessions = provider.detect(tmp);
+      const sessions = provider.detect([tmp]);
       expect(sessions).toEqual([]); // Only 2 messages, need >= 3
+    });
+
+    test("matches sessions from any of multiple candidate paths (worktree fix)", () => {
+      // Regression for the git-worktree import bug: a repo's history is spread
+      // across its main checkout and each worktree (agent history is keyed by
+      // the cwd it ran in). detect() must find sessions under ANY candidate.
+      const main = join(tmpdir(), `lore-aider-main-${Date.now()}`);
+      const worktree = join(tmpdir(), `lore-aider-wt-${Date.now()}`);
+      mkdirSync(main, { recursive: true });
+      mkdirSync(worktree, { recursive: true });
+      copyFileSync(
+        join(FIXTURES, "aider-history.md"),
+        join(main, ".aider.chat.history.md"),
+      );
+      copyFileSync(
+        join(FIXTURES, "aider-history.md"),
+        join(worktree, ".aider.chat.history.md"),
+      );
+
+      // Importing from the main checkout with the worktree as a sibling
+      // candidate must surface BOTH history files.
+      const sessions = provider.detect([main, worktree]);
+      const ids = sessions.map((s) => s.id).sort();
+      expect(ids).toEqual(
+        [
+          join(main, ".aider.chat.history.md"),
+          join(worktree, ".aider.chat.history.md"),
+        ].sort(),
+      );
+
+      // A session recorded ONLY under the worktree is still found when the
+      // main path is listed first (the exact reported scenario).
+      const worktreeOnly = provider
+        .detect([main, worktree])
+        .filter((s) => s.id === join(worktree, ".aider.chat.history.md"));
+      expect(worktreeOnly.length).toBe(1);
+    });
+
+    test("deduplicates when the same path appears twice", () => {
+      const tmp = join(tmpdir(), `lore-aider-dupe-${Date.now()}`);
+      mkdirSync(tmp, { recursive: true });
+      copyFileSync(
+        join(FIXTURES, "aider-history.md"),
+        join(tmp, ".aider.chat.history.md"),
+      );
+
+      const sessions = provider.detect([tmp, tmp]);
+      expect(sessions.length).toBe(1);
     });
   });
 

--- a/packages/core/test/import/claude-code.test.ts
+++ b/packages/core/test/import/claude-code.test.ts
@@ -20,7 +20,9 @@ describe("Claude Code provider", () => {
 
   describe("detect", () => {
     test("returns empty for nonexistent project", () => {
-      const sessions = provider.detect("/nonexistent/path/that/does/not/exist");
+      const sessions = provider.detect([
+        "/nonexistent/path/that/does/not/exist",
+      ]);
       expect(sessions).toEqual([]);
     });
   });

--- a/packages/core/test/import/cline.test.ts
+++ b/packages/core/test/import/cline.test.ts
@@ -22,7 +22,9 @@ describe("Cline provider", () => {
   describe("detect", () => {
     test("returns empty for nonexistent project", () => {
       // Cline detect looks in VS Code globalStorage, which won't have this path
-      const sessions = provider.detect("/nonexistent/path/that/does/not/exist");
+      const sessions = provider.detect([
+        "/nonexistent/path/that/does/not/exist",
+      ]);
       expect(sessions).toEqual([]);
     });
   });

--- a/packages/core/test/import/codex.test.ts
+++ b/packages/core/test/import/codex.test.ts
@@ -19,7 +19,9 @@ describe("Codex provider", () => {
 
   describe("detect", () => {
     test("returns empty for nonexistent project", () => {
-      const sessions = provider.detect("/nonexistent/path/that/does/not/exist");
+      const sessions = provider.detect([
+        "/nonexistent/path/that/does/not/exist",
+      ]);
       expect(sessions).toEqual([]);
     });
   });

--- a/packages/core/test/import/continue.test.ts
+++ b/packages/core/test/import/continue.test.ts
@@ -21,7 +21,9 @@ describe("Continue provider", () => {
 
   describe("detect", () => {
     test("returns empty for nonexistent project", () => {
-      const sessions = provider.detect("/nonexistent/path/that/does/not/exist");
+      const sessions = provider.detect([
+        "/nonexistent/path/that/does/not/exist",
+      ]);
       expect(sessions).toEqual([]);
     });
 
@@ -60,14 +62,27 @@ describe("Continue provider", () => {
       const original = process.env.CONTINUE_GLOBAL_DIR;
       process.env.CONTINUE_GLOBAL_DIR = tmp;
       try {
-        const sessions = provider.detect("/test/continue-project");
+        const sessions = provider.detect(["/test/continue-project"]);
         expect(sessions.length).toBe(1);
         expect(sessions[0].id).toBe("sess-continue-1");
         expect(sessions[0].messageCount).toBe(4);
 
         // Should not find sessions for other project
-        const otherSessions = provider.detect("/test/other-project");
+        const otherSessions = provider.detect(["/test/other-project"]);
         expect(otherSessions).toEqual([]);
+
+        // Worktree fix: listing both workspace dirs as candidates finds the
+        // matching session regardless of which one is the cwd.
+        const bothA = provider.detect([
+          "/test/continue-project",
+          "/test/other-project",
+        ]);
+        expect(bothA.map((s) => s.id)).toContain("sess-continue-1");
+        const bothB = provider.detect([
+          "/test/other-project",
+          "/test/continue-project",
+        ]);
+        expect(bothB.map((s) => s.id)).toContain("sess-continue-1");
       } finally {
         if (original !== undefined) {
           process.env.CONTINUE_GLOBAL_DIR = original;

--- a/packages/core/test/import/detect.test.ts
+++ b/packages/core/test/import/detect.test.ts
@@ -111,4 +111,25 @@ describe("detectAll", () => {
     const results = detectAll("/some/path");
     expect(results[0].totalTokens).toBe(3000);
   });
+
+  test("forwards the widened candidate path set to provider.detect", () => {
+    // With worktrees disabled, detection collapses to just the cwd — so the
+    // provider must receive an array containing (at minimum) the resolved cwd.
+    let received: string[] | null = null;
+    registerProvider({
+      name: "spy",
+      displayName: "Spy",
+      detect: (paths: string[]) => {
+        received = paths;
+        return [makeSession()];
+      },
+      readChunks: () => [],
+    });
+
+    detectAll("/some/path", { worktrees: false });
+    expect(received).not.toBeNull();
+    expect(Array.isArray(received)).toBe(true);
+    // cwd is always present and first.
+    expect((received as unknown as string[])[0]).toBe("/some/path");
+  });
 });

--- a/packages/core/test/import/detect.test.ts
+++ b/packages/core/test/import/detect.test.ts
@@ -50,14 +50,14 @@ describe("detectAll", () => {
   });
 
   test("returns empty when no providers are registered", () => {
-    const results = detectAll("/some/path");
+    const results = detectAll("/some/path", { worktrees: false });
     expect(results).toEqual([]);
   });
 
   test("returns empty when no providers have sessions", () => {
     registerProvider(makeProvider("agent-a", []));
     registerProvider(makeProvider("agent-b", []));
-    const results = detectAll("/some/path");
+    const results = detectAll("/some/path", { worktrees: false });
     expect(results).toEqual([]);
   });
 
@@ -72,7 +72,7 @@ describe("detectAll", () => {
       ]),
     );
 
-    const results = detectAll("/some/path");
+    const results = detectAll("/some/path", { worktrees: false });
     expect(results.length).toBe(2);
     // Sorted by totalMessages descending
     expect(results[0].agentName).toBe("agent-b");
@@ -95,7 +95,7 @@ describe("detectAll", () => {
       makeProvider("working", [makeSession({ messageCount: 5 })]),
     );
 
-    const results = detectAll("/some/path");
+    const results = detectAll("/some/path", { worktrees: false });
     expect(results.length).toBe(1);
     expect(results[0].agentName).toBe("working");
   });
@@ -108,7 +108,7 @@ describe("detectAll", () => {
       ]),
     );
 
-    const results = detectAll("/some/path");
+    const results = detectAll("/some/path", { worktrees: false });
     expect(results[0].totalTokens).toBe(3000);
   });
 

--- a/packages/core/test/import/pi.test.ts
+++ b/packages/core/test/import/pi.test.ts
@@ -19,7 +19,9 @@ describe("Pi provider", () => {
 
   describe("detect", () => {
     test("returns empty for nonexistent project", () => {
-      const sessions = provider.detect("/nonexistent/path/that/does/not/exist");
+      const sessions = provider.detect([
+        "/nonexistent/path/that/does/not/exist",
+      ]);
       expect(sessions).toEqual([]);
     });
   });

--- a/packages/core/test/import/scope.test.ts
+++ b/packages/core/test/import/scope.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { projectSearchPaths } from "../../src/import/scope";
+import { db, ensureProject, projectKnownPaths } from "../../src/db";
+
+/**
+ * Register a filesystem path as an alias of an existing project. Mirrors the
+ * INSERT ensureProject() performs on a git-remote/worktree match, without
+ * needing a real git repo in the test sandbox.
+ */
+function addAlias(path: string, projectId: string): void {
+  db()
+    .query(
+      "INSERT OR IGNORE INTO project_path_aliases (path, project_id) VALUES (?, ?)",
+    )
+    .run(path, projectId);
+}
+
+describe("projectSearchPaths", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "lore-scope-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("returns just the resolved cwd for a non-git directory", () => {
+    // A fresh temp dir is not a git repo → no worktrees, not in the DB.
+    const paths = projectSearchPaths(tmp);
+    expect(paths).toEqual([resolve(tmp)]);
+  });
+
+  test("cwd is always the first element", () => {
+    const paths = projectSearchPaths(tmp);
+    expect(paths[0]).toBe(resolve(tmp));
+  });
+
+  test("worktrees:false restricts to cwd only (no DB union)", () => {
+    // Seed a project + alias, then confirm --no-worktrees ignores both.
+    const main = join(tmp, "main");
+    const alias = join(tmp, "worktree-x");
+    const id = ensureProject(main);
+    addAlias(alias, id);
+
+    const paths = projectSearchPaths(main, { worktrees: false });
+    expect(paths).toEqual([resolve(main)]);
+  });
+
+  test("unions DB-known alias paths for the project", () => {
+    const main = join(tmp, "main");
+    const alias = join(tmp, "worktree-x");
+    const id = ensureProject(main);
+    addAlias(alias, id);
+
+    const paths = projectSearchPaths(main);
+    expect(paths).toContain(resolve(main));
+    expect(paths).toContain(resolve(alias));
+  });
+
+  test("finds sibling paths when invoked from an alias path", () => {
+    // The reported bug: importing from a worktree should still surface the
+    // main checkout's history (and vice-versa). projectKnownPaths resolves the
+    // shared project from either path.
+    const main = join(tmp, "main");
+    const alias = join(tmp, "worktree-x");
+    const id = ensureProject(main);
+    addAlias(alias, id);
+
+    const fromAlias = projectSearchPaths(alias);
+    expect(fromAlias[0]).toBe(resolve(alias)); // cwd first
+    expect(fromAlias).toContain(resolve(main)); // sibling surfaced
+  });
+
+  test("deduplicates overlapping candidate paths", () => {
+    const main = join(tmp, "main");
+    const id = ensureProject(main);
+    // Register the main path itself as an alias (overlap with projects.path).
+    addAlias(main, id);
+
+    const paths = projectSearchPaths(main);
+    const unique = new Set(paths);
+    expect(unique.size).toBe(paths.length);
+  });
+
+  test("degrades to [] extra paths when the project is unknown", () => {
+    // projectKnownPaths returns [] for a path the DB has never seen.
+    expect(projectKnownPaths(join(tmp, "never-seen"))).toEqual([]);
+  });
+});

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -82,10 +82,12 @@ Data subcommands:
   Clear flags: --knowledge, --temporal, --distillations, --all
 
 Import options:
-  --yes / -y                    Skip confirmation prompt
+  --yes / -y                    Skip confirmation prompt (import all agents)
   --agent <name>                Import from specific agent only
                                 (claude-code, codex, opencode, cline, continue, pi, aider)
   --project <path>              Target project (default: cwd)
+  --no-worktrees                Only scan the current directory, not sibling
+                                git worktrees / clones of the same repo
   --dry-run                     Show what would be imported, no LLM calls
 
 Agent arguments:
@@ -164,9 +166,10 @@ Examples:
   lore data list knowledge      # List knowledge entries for current project
   lore data clear --project .   # Clear all data for the current project
   lore data clear --all         # Wipe the entire database
-  lore import                   # Import knowledge from prior AI conversations
+  lore import                   # Pick agents to import (all by default)
   lore import --dry-run         # Show what would be imported
   lore import --agent claude-code  # Import from Claude Code only
+  lore import --no-worktrees    # Only this directory, skip sibling worktrees
   lore logs                     # Show recent log entries
   lore logs -f                  # Follow log output in real-time
   lore logs -n 100              # Show last 100 lines

--- a/packages/gateway/src/cli/import-auto.ts
+++ b/packages/gateway/src/cli/import-auto.ts
@@ -62,8 +62,9 @@ export async function maybeAutoImport(
     return; // Can't determine project — skip
   }
 
-  // Detect conversation history across all known agents.
-  let results = detectAll(projectPath);
+  // Detect conversation history across all known agents. Worktree-aware:
+  // finds sessions recorded under the repo's main checkout and any worktree.
+  let results = detectAll(projectPath, { worktrees: true });
   if (results.length === 0) return;
 
   // PER-AGENT GATE (apply FIRST): only consider agents we've never handled

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -60,6 +60,88 @@ async function confirm(message: string, defaultYes = true): Promise<boolean> {
   });
 }
 
+/**
+ * Read a single line from the given prompt. Returns "" for non-TTY input so
+ * callers can apply their own default. Injectable reader for testing.
+ */
+type LineReader = (prompt: string) => Promise<string>;
+
+const readLine: LineReader = (prompt: string) =>
+  new Promise<string>((resolve) => {
+    if (!process.stdin.isTTY) {
+      resolve("");
+      return;
+    }
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stderr,
+    });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+
+/**
+ * Parse a comma/space-separated list of 1-based indices into 0-based indices.
+ *
+ * Accepts:
+ *   - "" / "a" / "all"  → all indices [0..count)
+ *   - "1,3" / "1 3"     → [0, 2]
+ * Invalid/out-of-range tokens cause a return of `null` (caller re-prompts).
+ * Duplicates are collapsed; result is sorted ascending.
+ */
+export function parseIndexSelection(
+  input: string,
+  count: number,
+): number[] | null {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed === "" || trimmed === "a" || trimmed === "all") {
+    return Array.from({ length: count }, (_, i) => i);
+  }
+
+  const tokens = trimmed.split(/[\s,]+/).filter(Boolean);
+  const picked = new Set<number>();
+  for (const tok of tokens) {
+    if (!/^\d+$/.test(tok)) return null;
+    const n = Number.parseInt(tok, 10);
+    if (n < 1 || n > count) return null;
+    picked.add(n - 1);
+  }
+  if (picked.size === 0) return null;
+  return [...picked].sort((a, b) => a - b);
+}
+
+/**
+ * Prompt the user to pick a subset of items by number. Returns the selected
+ * 0-based indices. Non-TTY (and no injected reader) → all. After `maxTries`
+ * invalid attempts → all.
+ */
+export async function selectIndices(
+  count: number,
+  opts: { reader?: LineReader; maxTries?: number } = {},
+): Promise<number[]> {
+  const reader = opts.reader ?? readLine;
+  const maxTries = opts.maxTries ?? 3;
+  const all = () => Array.from({ length: count }, (_, i) => i);
+  // Without an injected reader, only prompt on a real TTY; otherwise import all.
+  if (!opts.reader && !process.stdin.isTTY) return all();
+
+  for (let attempt = 0; attempt < maxTries; attempt++) {
+    const answer = await reader(
+      "[lore] Select agents (comma-separated numbers, or 'a' for all): ",
+    );
+    const parsed = parseIndexSelection(answer, count);
+    if (parsed) return parsed;
+    console.error(
+      "[lore] Invalid selection — enter e.g. '1,3' or 'a' for all.",
+    );
+  }
+  // Fall back to importing everything after repeated invalid input.
+  console.error("[lore] Defaulting to all agents.");
+  return all();
+}
+
 // ---------------------------------------------------------------------------
 // Command entry point
 // ---------------------------------------------------------------------------
@@ -72,6 +154,8 @@ export async function commandImport(
   const dryRun = flags["dry-run"] === true || flags.dryRun === true;
   const yes = flags.yes === true || flags.y === true;
   const agentFilter = (flags.agent as string) ?? null;
+  const noWorktrees =
+    flags["no-worktrees"] === true || flags.noWorktrees === true;
   const projectFlag = flags.project as string | undefined;
   const projectPath = projectFlag ? resolve(projectFlag) : process.cwd();
 
@@ -90,7 +174,7 @@ export async function commandImport(
   // Detect conversation history (local filesystem scan — always local)
   console.log("[lore] Scanning for conversation history...\n");
 
-  let results = detectAll(projectPath);
+  let results = detectAll(projectPath, { worktrees: !noWorktrees });
 
   if (agentFilter) {
     results = results.filter((r) => r.agentName === agentFilter);
@@ -180,13 +264,20 @@ export async function commandImport(
     return;
   }
 
-  // Show detection summary
-  const totalMessages = results.reduce((s, r) => s + r.totalMessages, 0);
-  const totalSessions = results.reduce((s, r) => s + r.sessions.length, 0);
+  // Show detection summary. When more than one agent was detected and we can
+  // prompt interactively (TTY, no --agent filter, not --yes/--dry-run), offer a
+  // numbered multi-select so the user can import a subset.
+  const canSelect =
+    results.length > 1 &&
+    !agentFilter &&
+    !yes &&
+    !dryRun &&
+    process.stdin.isTTY;
 
   console.log("Found prior conversations for this project:\n");
-  for (const result of results) {
-    console.log(`  ${result.agentDisplayName}`);
+  results.forEach((result, i) => {
+    const prefix = canSelect ? `  ${i + 1}. ` : "  ";
+    console.log(`${prefix}${result.agentDisplayName}`);
     console.log(
       `    ${result.sessions.length} sessions, ~${result.totalMessages} messages`,
     );
@@ -195,7 +286,21 @@ export async function commandImport(
       console.log(`    Most recent: ${formatDate(latest.lastActivityAt)}`);
     }
     console.log();
+  });
+
+  // Interactive agent selection (subset). Non-TTY / --yes / --agent → all.
+  if (canSelect) {
+    const chosen = await selectIndices(results.length);
+    results = chosen.map((i) => results[i]);
+    if (results.length === 0) {
+      console.log("[lore] No agents selected — import cancelled.");
+      return;
+    }
   }
+
+  // Recompute totals over the (possibly narrowed) selection.
+  const totalMessages = results.reduce((s, r) => s + r.totalMessages, 0);
+  const totalSessions = results.reduce((s, r) => s + r.sessions.length, 0);
 
   // Estimate LLM calls (one per ~12K token chunk)
   const totalTokens = results.reduce((s, r) => s + r.totalTokens, 0);

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -110,6 +110,9 @@ const OPTIONS = {
   json: { type: "boolean" as const },
   "dry-run": { type: "boolean" as const },
   "no-children": { type: "boolean" as const },
+  // `lore import` flag — restrict detection to the current directory only
+  // (skip sibling git worktrees / clone paths of the same repo).
+  "no-worktrees": { type: "boolean" as const },
   "min-confidence": { type: "string" as const },
   "no-backup": { type: "boolean" as const },
   // `lore data clear` flags

--- a/packages/gateway/test/import-select.test.ts
+++ b/packages/gateway/test/import-select.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, vi } from "vitest";
+import { parseIndexSelection, selectIndices } from "../src/cli/import";
+
+describe("parseIndexSelection", () => {
+  test("empty / 'a' / 'all' select everything", () => {
+    expect(parseIndexSelection("", 3)).toEqual([0, 1, 2]);
+    expect(parseIndexSelection("  ", 3)).toEqual([0, 1, 2]);
+    expect(parseIndexSelection("a", 3)).toEqual([0, 1, 2]);
+    expect(parseIndexSelection("all", 3)).toEqual([0, 1, 2]);
+    expect(parseIndexSelection("ALL", 3)).toEqual([0, 1, 2]);
+  });
+
+  test("comma-separated 1-based indices map to 0-based", () => {
+    expect(parseIndexSelection("1,3", 3)).toEqual([0, 2]);
+    expect(parseIndexSelection("2", 3)).toEqual([1]);
+  });
+
+  test("accepts whitespace and mixed separators", () => {
+    expect(parseIndexSelection("1 3", 3)).toEqual([0, 2]);
+    expect(parseIndexSelection(" 1 , 2 ", 3)).toEqual([0, 1]);
+  });
+
+  test("collapses duplicates and sorts ascending", () => {
+    expect(parseIndexSelection("3,1,3,1", 3)).toEqual([0, 2]);
+  });
+
+  test("rejects out-of-range indices", () => {
+    expect(parseIndexSelection("0", 3)).toBeNull(); // 1-based, 0 invalid
+    expect(parseIndexSelection("4", 3)).toBeNull();
+    expect(parseIndexSelection("1,9", 3)).toBeNull();
+  });
+
+  test("rejects non-numeric tokens", () => {
+    expect(parseIndexSelection("x", 3)).toBeNull();
+    expect(parseIndexSelection("1,x", 3)).toBeNull();
+    expect(parseIndexSelection("1.5", 3)).toBeNull();
+  });
+});
+
+describe("selectIndices", () => {
+  test("returns parsed selection from the injected reader", async () => {
+    const reader = vi.fn(async () => "1,3");
+    const result = await selectIndices(3, { reader });
+    expect(result).toEqual([0, 2]);
+    expect(reader).toHaveBeenCalledTimes(1);
+  });
+
+  test("empty answer selects all", async () => {
+    const reader = vi.fn(async () => "");
+    const result = await selectIndices(2, { reader });
+    expect(result).toEqual([0, 1]);
+  });
+
+  test("re-prompts on invalid input then accepts", async () => {
+    const answers = ["nope", "9", "2"];
+    let i = 0;
+    const reader = vi.fn(async () => answers[i++]);
+    const result = await selectIndices(3, { reader, maxTries: 3 });
+    expect(result).toEqual([1]);
+    expect(reader).toHaveBeenCalledTimes(3);
+  });
+
+  test("falls back to all after exhausting invalid attempts", async () => {
+    const reader = vi.fn(async () => "bogus");
+    const result = await selectIndices(3, { reader, maxTries: 2 });
+    expect(result).toEqual([0, 1, 2]);
+    expect(reader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -83,6 +83,7 @@ export default defineConfig({
             { label: "Configuration", slug: "docs/configuration" },
             { label: "Environment variables", slug: "docs/environment" },
             { label: "Setup command", slug: "docs/setup" },
+            { label: "Import conversations", slug: "docs/import" },
           ],
         },
       ],

--- a/packages/website/src/content/docs/docs/import.md
+++ b/packages/website/src/content/docs/docs/import.md
@@ -1,0 +1,75 @@
+---
+title: Import conversations
+description: Use `lore import` to bootstrap project memory from your existing Claude Code, Codex, OpenCode, Pi, Aider, Cline, and Continue conversations.
+sidebar:
+  order: 6
+---
+
+`lore import` scans your machine for prior AI coding conversations, extracts long-term knowledge from them via the curator, and writes it into your project's memory — so Lore starts with context from day one instead of a blank slate.
+
+It is **idempotent**: already-imported sessions are skipped, so it is safe to run multiple times.
+
+## When to use `lore import`
+
+- **Onboarding an existing project** — you have months of Claude Code / Codex / OpenCode history for a repo and want Lore to learn from it immediately.
+- **Adding a new agent** — you switched (or added) a coding agent and want its history folded into the same project memory.
+- **After working in a git worktree** — conversations you had in a worktree are picked up alongside the main checkout (see [Worktrees & monorepos](#worktrees--monorepos)).
+
+If you start your agent through `lore run`, you will also be offered a one-time auto-import for each newly detected agent — `lore import` is the explicit, re-runnable version of that.
+
+## Usage
+
+```bash
+lore import                      # Detect agents, pick which to import (all by default)
+lore import --agent claude-code  # Import from one agent only (non-interactive)
+lore import --dry-run            # Show what would be imported — no LLM calls
+lore import --no-worktrees       # Only scan the current directory
+lore import --project <path>     # Import for a specific project (default: cwd)
+lore import --yes                # Skip prompts and import everything
+```
+
+## Supported agents
+
+| Agent | Where history is read from |
+| --- | --- |
+| Claude Code | `~/.claude/projects/<project>/*.jsonl` |
+| Codex | `~/.codex/sessions/**` and `~/.codex/archived_sessions/**` |
+| OpenCode | OpenCode's SQLite database |
+| Pi | `~/.pi/agent/sessions/<project>/*.jsonl` |
+| Aider | `<project>/.aider.chat.history.md` |
+| Cline | VS Code globalStorage (Cline extension) |
+| Continue | `~/.continue/sessions/**` |
+
+## Selecting agents
+
+When more than one agent has history for the project, `lore import` prints a numbered list and prompts you to choose:
+
+```
+Found prior conversations for this project:
+
+  1. Codex
+     12 sessions, ~3400 messages
+     Most recent: 2026-07-14 09:12
+
+  2. Claude Code
+     5 sessions, ~900 messages
+     Most recent: 2026-07-13 18:40
+
+[lore] Select agents (comma-separated numbers, or 'a' for all):
+```
+
+Enter `1,2` to import a subset, or `a` (or just press Enter) for all. Use `--agent <name>` to skip the prompt and import a single agent, or `--yes` to import everything without prompting.
+
+## Worktrees & monorepos
+
+Each agent records conversations under the **directory it ran in**. Since git worktrees don't copy untracked directories, a repo's history ends up split across its main checkout (e.g. `~/code/app`) and each worktree (e.g. `~/worktrees/app/feature-x`).
+
+`lore import` resolves the full set of paths that belong to the same repository — using `git worktree list` plus the paths Lore already associates with the project — and finds sessions recorded under **any** of them. So running `lore import` from the main checkout also picks up conversations you had in a worktree, and vice-versa.
+
+Pass `--no-worktrees` to restrict detection to the current directory only.
+
+## Next steps
+
+- [Install Lore](/docs/install/) — get the gateway running first.
+- [Setup command](/docs/setup/) — configure an agent to route through Lore.
+- [Configuration](/docs/configuration/) — tune distillation and knowledge extraction.

--- a/packages/website/src/content/docs/docs/install.md
+++ b/packages/website/src/content/docs/docs/install.md
@@ -45,4 +45,6 @@ Lore can import previous coding conversations so a new project memory does not s
 lore import
 ```
 
-Imported history feeds the same distillation and knowledge pipeline as live sessions.
+Imported history feeds the same distillation and knowledge pipeline as live sessions. `lore import` detects Claude Code, Codex, OpenCode, Pi, Aider, Cline, and Continue, lets you pick which agents to import, and finds conversations across all of a repo's git worktrees.
+
+→ See the full [Import conversations](/docs/import/) guide.


### PR DESCRIPTION
## Summary

Fixes two `lore import` gaps a new user hit while importing multi-agent history, and improves the docs.

### 1. Worktree bug (root cause)
Agent history is keyed by the **directory the agent ran in**. Git worktrees don't copy untracked dirs, so a repo's conversations are split across its main checkout and each worktree. `detect()` previously matched only `process.cwd()`, so import silently missed everything recorded under a sibling path.

Now detection is worktree-aware:
- New `packages/core/src/import/scope.ts` → `projectSearchPaths()` unions `git worktree list --porcelain` paths with lore's DB `project_path_aliases` (via new read-only `projectKnownPaths()` in `db.ts`).
- `detect(projectPath)` → `detect(projectPaths: string[])` across **all 7 providers** (codex, claude-code, pi, opencode, aider, cline, continue); matches sessions under any candidate path, dedupes by id.
- Applied to both explicit `lore import` and `lore run` auto-import. `--no-worktrees` restricts to cwd.
- **Fails open**: any git/DB error degrades to `[cwd]`, never throws; git subprocess is skipped in hosted mode (never run git against a client-controlled cwd).

### 2. Multi-agent selection
When >1 agent is detected, `lore import` shows a numbered list and lets you pick a subset (`1,3` or `a`/Enter for all). Non-TTY / `--yes` / `--agent` import all as before. Built on `node:readline` — no new dependency.

### 3. Docs
New website page `docs/import.md` (Reference sidebar), expanded README import section, and a link from the install guide.

## Why tests missed it
Previous provider tests only ever passed a single path or `/nonexistent`. Added `scope.test.ts`, a `detectAll` path-forwarding test, an **aider sibling-worktree regression test** (session under a worktree found from main), and a continue multi-path test — closing the class of bug.

## Verification
- `pnpm run typecheck` — clean (all packages)
- `pnpm run lint` — exit 0 (no new warnings in changed files)
- `pnpm test` — **5899 passed**, 0 failures
- `pnpm run build` — clean