### PR TITLE
test(import): raise commandImport patch coverage to 100%

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -435,17 +435,35 @@
 <!-- lore:019f6838-2a3c-7cf7-9796-e4f07c5055c6 -->
 * **Always enforce strict crypto safety rules**: Always enforce strict crypto safety rules: 'server never holds plaintext DEK', 'never auto-create identity on fresh device', 'never repopulate with stale keys', 'never encrypt with non-recoverable keys'. Document as comments, enforce via fail-closed designs and convergence mechanisms. Prevent divergence, self-lockout, plaintext exposure.
 
+<!-- lore:019f6a75-16eb-70a6-9f1e-f472cf2f92c9 -->
+* **Always enforce strict pre-merge review gates with explicit safety invariants**: The user consistently mandates adversarial pre-merge reviews for critical changes, specifying explicit safety invariants that must be verified. They provide detailed context about the system's architecture and constraints, clearly distinguish between related but separate concerns that must not interfere, and specify exact files/lines under review. The user expects verification that core safety properties are maintained, often with read-only constraints to prevent accidental modifications during review.
+
+<!-- lore:019f6aa4-83ef-7f83-88a2-1b86e228085f -->
+* **Always enforce strict routing boundaries and failure modes**: The user consistently requires that routing logic must never allow fallbacks to unintended endpoints. This includes: 1) Worker providers must always fail closed rather than falling back to direct endpoints, 2) Foreign providers must never silently route to default providers like api.openai.com, 3) Routing gates must be non-vacuous and verified through mutation testing. The user expects these routing boundaries to be strictly enforced and tested to prevent unintended provider routing.
+
 <!-- lore:019f681e-6ded-7243-bc68-1098bd07a18c -->
 * **Always enforce strict security reviews for crypto implementations**: Always enforce strict security reviews for crypto implementations: Formal, read-only security reviews for cryptographic work. 'Flaw' criteria: key leaks, data loss bugs, divergence issues. Workflows: no direct modifications during review, mutation testing only in isolated environments, verification of main codebase integrity.
 
 <!-- lore:019f6804-7980-7756-8329-b223cc38dde3 -->
 * **Always investigate cost optimization opportunities in distillation**: Always investigate cost optimization opportunities in distillation: Scrutinize distillation costs, seek optimization opportunities. Ask detailed questions about batch processing, call types, cost implications. Expect thorough investigation: tracing call propagation, examining environment variables, analyzing timing constraints. Disclose cost-related caveats, explore production-representative cost scenarios.
 
+<!-- lore:019f68ab-0b0c-7804-86bc-b8041a460eff -->
+* **Always perform adversarial code reviews before merging PRs**: The user consistently requires adversarial code reviews as a mandatory pre-merge gate for all pull requests, regardless of size or CI status. This includes: 1) Read-only analysis of migration correctness, test discrimination, and security implications; 2) Mutation testing in isolated throwaway worktrees to verify test coverage; 3) Verification that the main repository remains byte-identical after review; 4) Structured verdicts addressing specific review points. The user enforces this workflow strictly, treating it as a blocker that must be completed before any merge occurs.
+
 <!-- lore:019f6877-27c0-7a00-b889-14ec6eac930a -->
 * **Always perform comprehensive testing and validation after code changes**: The user consistently demonstrates a pattern of thorough testing and validation after implementing code changes. This includes: 1) Running comprehensive test suites (unit, integration, security) and reporting detailed pass/fail results, 2) Performing linting and type checking to catch non-functional issues, 3) Investigating and diagnosing test failures through detailed analysis and debugging, 4) Making iterative fixes based on test results and retesting until all tests pass, 5) Performing regression testing to ensure changes don't break existing functionality. This pattern shows the user values code quality and reliability, and expects assistants to support this rigorous testing process.
 
 <!-- lore:019f66e9-6a37-7aa0-b281-de68fd4089de -->
 * **Always prefers dataclasses over bare dicts**: Always prefer dataclasses over bare dicts for structured data. This provides better type safety and documentation.
+
+<!-- lore:019f6a85-edb6-7596-9c37-f39b98a8a830 -->
+* **Always preserve user text verbatim without truncation**: The user consistently emphasizes that user-generated text should never be truncated or modified. They consider user text as essential signal that must be preserved in its original form throughout processing. This applies to all user messages, including those in temporal sequences and distillation observations. Any truncation mechanisms should only target non-user content like tool outputs, while user text must always pass through verbatim.
+
+<!-- lore:019f6a82-7de7-7d5f-a5e3-e8e8cf19964a -->
+* **Always prioritize cheapest provider routing with explicit cost-based selection**: The user consistently emphasizes routing to the cheapest available provider for model execution. They explicitly state preferences like 'always route to the cheapest provider' and 'always pick the cheapest one', and justify this by noting cost advantages like using existing provider credits. This pattern indicates a strong preference for cost-optimized routing that should be implemented through explicit provider selection based on price, rather than defaulting to specific providers.
+
+<!-- lore:019f6aa3-7068-7a95-95ec-3674588ee017 -->
+* **Always prioritize cost efficiency in LLM usage**: The user consistently emphasizes minimizing LLM costs through architectural choices. They prefer using cheaper models for background tasks, implementing cost funnels with multiple filtering stages, and establishing guardrails to prevent expensive model usage. The user expects cost comparisons between models and tiered approaches that use cheap models for initial processing with escalation to stronger models only when necessary.
 
 <!-- lore:019f6800-934c-7f17-bd4e-16227242a02d -->
 * **Always provide complete git diffs for code changes**: Always provide complete git diffs for code changes: Provide detailed git diffs showing exact code changes across multiple files. Include file paths, line numbers, specific code modifications. Prefer precise, verifiable code changes over verbal descriptions.
@@ -455,6 +473,9 @@
 
 <!-- lore:019f6850-73b9-75d7-b999-7963f892231c -->
 * **Always request adversarial security reviews for cross-user write paths**: The user consistently requests comprehensive adversarial security reviews whenever new cross-user write paths are introduced. These reviews focus on correctness, logic, and security implications, with specific scrutiny points provided. The user mandates read-only reviews using throwaway worktrees for any mutation testing, with strict verification and cleanup procedures. This pattern applies to security-sensitive changes like team lifecycle RPCs, scope membership modifications, and data sharing mechanisms.
+
+<!-- lore:019f6a95-6fd8-7590-9cd0-1261cc1f1dca -->
+* **Always request thorough investigation with file:line references before implementation**: The user consistently requires detailed research and evidence gathering before approving or implementing changes. This includes: (1) thorough investigation of codebases with exact file:line references, (2) verbatim code/text quotes to support findings, (3) clear documentation of current system behavior, and (4) evaluation of impact before proceeding. The user treats these phases as read-only by default and expects comprehensive analysis before any modifications are made.
 
 <!-- lore:019f681c-074e-79f9-a2e5-9dd137761257 -->
 * **Always specify invariants and security constraints during code reviews**: Always specify invariants and security constraints during code reviews: Provide detailed invariants, security requirements, edge case considerations. Specify fail-open behavior, git subprocess restrictions, deduplication requirements, SQL injection prevention, signature migration completeness. Provide context: git diffs, file contents, test results.

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -17,6 +17,8 @@ import {
   setLastImportAt,
   load,
 } from "@loreai/core";
+type DetectionResult =
+  import("@loreai/core").conversationImport.DetectionResult;
 import { createGatewayLLMClient } from "../llm-adapter";
 import { resolveAuth } from "../auth";
 import { exportLoreFile } from "@loreai/core";
@@ -142,6 +144,90 @@ export async function selectIndices(
   return all();
 }
 
+/** A detected session already recorded on the remote gateway. */
+type RemoteImportRecord = {
+  agent_name: string;
+  source_id: string;
+  source_hash: string;
+};
+
+/**
+ * Restrict detection results to a single agent by internal name.
+ *
+ * Returns the filtered results (possibly empty). Pure — no I/O.
+ */
+export function applyAgentFilter(
+  results: DetectionResult[],
+  agentFilter: string | null,
+): DetectionResult[] {
+  if (!agentFilter) return results;
+  return results.filter((r) => r.agentName === agentFilter);
+}
+
+/**
+ * Drop sessions that have already been imported, recompute per-agent totals,
+ * and remove agents left with no new sessions.
+ *
+ * Dedup source depends on mode:
+ *   - remote: match against the remote gateway's import-history rows
+ *   - local:  consult the local import DB via `isImportedLocal`
+ *
+ * Both the hash function and the local-check are injected so this is a pure,
+ * testable transform with no direct filesystem/DB dependency.
+ */
+export function filterAlreadyImported(
+  results: DetectionResult[],
+  opts: {
+    projectPath: string;
+    hashOf: (sess: { messageCount: number; lastActivityAt: number }) => string;
+    remoteImports?: RemoteImportRecord[];
+    isImportedLocal: (
+      projectPath: string,
+      agentName: string,
+      sourceId: string,
+      hash: string,
+    ) => unknown;
+    hasProvider?: (agentName: string) => boolean;
+  },
+): DetectionResult[] {
+  const { projectPath, hashOf, remoteImports, isImportedLocal } = opts;
+  const hasProvider = opts.hasProvider ?? (() => true);
+
+  for (const result of results) {
+    if (!hasProvider(result.agentName)) continue;
+
+    result.sessions = result.sessions.filter((sess) => {
+      const hash = hashOf({
+        messageCount: sess.messageCount,
+        lastActivityAt: sess.lastActivityAt,
+      });
+      if (remoteImports) {
+        // Check against remote import history
+        return !remoteImports.some(
+          (r) =>
+            r.agent_name === result.agentName &&
+            r.source_id === sess.id &&
+            r.source_hash === hash,
+        );
+      }
+      // Local mode: check local DB (truthy record → already imported)
+      return !isImportedLocal(projectPath, result.agentName, sess.id, hash);
+    });
+
+    result.totalMessages = result.sessions.reduce(
+      (s, sess) => s + sess.messageCount,
+      0,
+    );
+    result.totalTokens = result.sessions.reduce(
+      (s, sess) => s + sess.estimatedTokens,
+      0,
+    );
+  }
+
+  // Remove agents with no new sessions
+  return results.filter((r) => r.sessions.length > 0);
+}
+
 // ---------------------------------------------------------------------------
 // Command entry point
 // ---------------------------------------------------------------------------
@@ -177,7 +263,7 @@ export async function commandImport(
   let results = detectAll(projectPath, { worktrees: !noWorktrees });
 
   if (agentFilter) {
-    results = results.filter((r) => r.agentName === agentFilter);
+    results = applyAgentFilter(results, agentFilter);
     if (results.length === 0) {
       console.log(
         `[lore] No conversation history found from "${agentFilter}" for this project.`,
@@ -195,9 +281,7 @@ export async function commandImport(
 
   // Filter out already-imported sessions.
   // In remote mode, fetch import history from the remote gateway.
-  let remoteImports:
-    | Array<{ agent_name: string; source_id: string; source_hash: string }>
-    | undefined;
+  let remoteImports: RemoteImportRecord[] | undefined;
   if (remote) {
     try {
       const pq = projectQueryParams(projectPath);
@@ -222,40 +306,17 @@ export async function commandImport(
     }
   }
 
-  for (const result of results) {
-    const provider = getProvider(result.agentName);
-    if (!provider) continue;
-
-    result.sessions = result.sessions.filter((sess) => {
-      const hash = computeHash({
+  results = filterAlreadyImported(results, {
+    projectPath,
+    hashOf: (sess) =>
+      computeHash({
         messageCount: sess.messageCount,
         lastTimestamp: sess.lastActivityAt,
-      });
-      if (remote && remoteImports) {
-        // Check against remote import history
-        return !remoteImports.some(
-          (r) =>
-            r.agent_name === result.agentName &&
-            r.source_id === sess.id &&
-            r.source_hash === hash,
-        );
-      }
-      // Local mode: check local DB
-      return !isImported(projectPath, result.agentName, sess.id, hash);
-    });
-
-    result.totalMessages = result.sessions.reduce(
-      (s, sess) => s + sess.messageCount,
-      0,
-    );
-    result.totalTokens = result.sessions.reduce(
-      (s, sess) => s + sess.estimatedTokens,
-      0,
-    );
-  }
-
-  // Remove agents with no new sessions
-  results = results.filter((r) => r.sessions.length > 0);
+      }),
+    remoteImports,
+    isImportedLocal: isImported,
+    hasProvider: (name) => getProvider(name) != null,
+  });
 
   if (results.length === 0) {
     console.log(

--- a/packages/gateway/test/import-command.test.ts
+++ b/packages/gateway/test/import-command.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, copyFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Mock the gateway-relative remote layer so commandImport runs in "remote mode"
+// (no gateway startup, no real LLM). These mocks work because they target
+// gateway-relative paths, not the aliased @loreai/core barrel.
+const remotePostMock = vi.fn(async () => ({
+  created: 2,
+  updated: 1,
+  deleted: 0,
+  failed: 0,
+  chunks: 3,
+}));
+const remoteGetMock = vi.fn(async () => [] as unknown);
+
+vi.mock("../src/cli/remote", () => ({
+  getRemoteUrl: () => process.env.LORE_REMOTE_URL,
+  projectQueryParams: () => "path=/x",
+  remoteGet: (...a: unknown[]) => remoteGetMock(...(a as [])),
+  remotePost: (...a: unknown[]) => remotePostMock(...(a as [])),
+}));
+
+// commandImport in remote mode never starts a gateway, but guard the import.
+vi.mock("../src/cli/start", () => ({
+  startGateway: vi.fn(async () => {
+    throw new Error("startGateway must not be called in remote mode");
+  }),
+}));
+
+import { commandImport } from "../src/cli/import";
+
+const AIDER_FIXTURE = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "..",
+  "..",
+  "core",
+  "test",
+  "import",
+  "fixtures",
+  "aider-history.md",
+);
+
+describe("commandImport (remote mode)", () => {
+  let project: string;
+  const logs: string[] = [];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  const prevRemote = process.env.LORE_REMOTE_URL;
+
+  beforeEach(() => {
+    project = mkdtempSync(join(tmpdir(), "lore-cmdimport-"));
+    process.env.LORE_REMOTE_URL = "https://gw.example";
+    logs.length = 0;
+    logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
+      logs.push(a.join(" "));
+    });
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    remotePostMock.mockClear();
+    remoteGetMock.mockClear();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    rmSync(project, { recursive: true, force: true });
+    if (prevRemote === undefined) delete process.env.LORE_REMOTE_URL;
+    else process.env.LORE_REMOTE_URL = prevRemote;
+  });
+
+  test("no prior history → early return, no remote call", async () => {
+    await commandImport([], { project, yes: true });
+    expect(logs.join("\n")).toContain("No prior AI conversation history");
+    expect(remotePostMock).not.toHaveBeenCalled();
+  });
+
+  test("--agent with no match → early return", async () => {
+    // An aider history exists, but the user filtered to a different agent.
+    copyFileSync(AIDER_FIXTURE, join(project, ".aider.chat.history.md"));
+    await commandImport([], { project, agent: "codex", yes: true });
+    expect(logs.join("\n")).toContain(
+      'No conversation history found from "codex"',
+    );
+    expect(remotePostMock).not.toHaveBeenCalled();
+  });
+
+  test("detected history → dedup filter runs → delegates to remote", async () => {
+    copyFileSync(AIDER_FIXTURE, join(project, ".aider.chat.history.md"));
+    await commandImport([], { project, agent: "aider", yes: true });
+    // filterAlreadyImported kept the fresh session and we routed to the remote.
+    expect(remoteGetMock).toHaveBeenCalled(); // fetched remote import history
+    expect(remotePostMock).toHaveBeenCalled(); // delegated extraction
+    expect(logs.join("\n")).toContain("Using remote gateway");
+  });
+
+  test("dry-run → summarizes but never calls the remote", async () => {
+    copyFileSync(AIDER_FIXTURE, join(project, ".aider.chat.history.md"));
+    await commandImport([], { project, agent: "aider", "dry-run": true });
+    expect(logs.join("\n")).toContain("Dry run");
+    expect(remotePostMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/test/import-select.test.ts
+++ b/packages/gateway/test/import-select.test.ts
@@ -1,5 +1,45 @@
 import { describe, test, expect, vi } from "vitest";
-import { parseIndexSelection, selectIndices } from "../src/cli/import";
+import {
+  parseIndexSelection,
+  selectIndices,
+  applyAgentFilter,
+  filterAlreadyImported,
+} from "../src/cli/import";
+import type { conversationImport } from "@loreai/core";
+
+type DetectionResult = conversationImport.DetectionResult;
+type DetectedSession = conversationImport.DetectedSession;
+
+function makeSession(
+  overrides: Partial<DetectedSession> = {},
+): DetectedSession {
+  return {
+    id: "sess-1",
+    label: "Test session",
+    startedAt: 1_000,
+    lastActivityAt: 2_000,
+    estimatedTokens: 500,
+    messageCount: 10,
+    ...overrides,
+  };
+}
+
+function makeResult(
+  agentName: string,
+  sessions: DetectedSession[],
+): DetectionResult {
+  return {
+    agentName,
+    agentDisplayName: agentName,
+    sessions,
+    totalMessages: sessions.reduce((s, x) => s + x.messageCount, 0),
+    totalTokens: sessions.reduce((s, x) => s + x.estimatedTokens, 0),
+  };
+}
+
+// A stable hash for tests: encode the two fields we key on.
+const hashOf = (s: { messageCount: number; lastActivityAt: number }) =>
+  `${s.messageCount}:${s.lastActivityAt}`;
 
 describe("parseIndexSelection", () => {
   test("empty / 'a' / 'all' select everything", () => {
@@ -65,5 +105,159 @@ describe("selectIndices", () => {
     const result = await selectIndices(3, { reader, maxTries: 2 });
     expect(result).toEqual([0, 1, 2]);
     expect(reader).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("applyAgentFilter", () => {
+  const results = [
+    makeResult("codex", [makeSession()]),
+    makeResult("claude-code", [makeSession({ id: "c1" })]),
+  ];
+
+  test("returns all results when filter is null", () => {
+    expect(applyAgentFilter(results, null)).toBe(results);
+  });
+
+  test("keeps only the matching agent", () => {
+    const filtered = applyAgentFilter(results, "codex");
+    expect(filtered.map((r) => r.agentName)).toEqual(["codex"]);
+  });
+
+  test("returns empty when no agent matches", () => {
+    expect(applyAgentFilter(results, "nonexistent")).toEqual([]);
+  });
+});
+
+describe("filterAlreadyImported", () => {
+  test("local mode: drops sessions already in the local DB", () => {
+    const dupe = makeSession({
+      id: "dupe",
+      messageCount: 5,
+      lastActivityAt: 9,
+    });
+    const fresh = makeSession({
+      id: "fresh",
+      messageCount: 7,
+      lastActivityAt: 8,
+    });
+    const results = [makeResult("codex", [dupe, fresh])];
+
+    const isImportedLocal = vi.fn(
+      (_p: string, _a: string, sourceId: string) => sourceId === "dupe",
+    );
+
+    const out = filterAlreadyImported(results, {
+      projectPath: "/p",
+      hashOf,
+      isImportedLocal,
+      // remoteImports omitted → local path
+    });
+
+    expect(out.length).toBe(1);
+    expect(out[0].sessions.map((s) => s.id)).toEqual(["fresh"]);
+    // totals recomputed over the surviving session
+    expect(out[0].totalMessages).toBe(7);
+    expect(out[0].totalTokens).toBe(500);
+    expect(isImportedLocal).toHaveBeenCalled();
+  });
+
+  test("local mode: removes an agent left with zero new sessions", () => {
+    const results = [
+      makeResult("codex", [makeSession({ id: "a" })]),
+      makeResult("pi", [makeSession({ id: "b" })]),
+    ];
+    // codex fully imported, pi entirely new
+    const isImportedLocal = (_p: string, agent: string) => agent === "codex";
+
+    const out = filterAlreadyImported(results, {
+      projectPath: "/p",
+      hashOf,
+      isImportedLocal,
+    });
+
+    expect(out.map((r) => r.agentName)).toEqual(["pi"]);
+  });
+
+  test("remote mode: dedups against remote import history, never touches local", () => {
+    const dupe = makeSession({
+      id: "r-dupe",
+      messageCount: 3,
+      lastActivityAt: 4,
+    });
+    const fresh = makeSession({
+      id: "r-fresh",
+      messageCount: 6,
+      lastActivityAt: 5,
+    });
+    const results = [makeResult("claude-code", [dupe, fresh])];
+
+    const isImportedLocal = vi.fn(() => false);
+    const remoteImports = [
+      {
+        agent_name: "claude-code",
+        source_id: "r-dupe",
+        source_hash: hashOf({ messageCount: 3, lastActivityAt: 4 }),
+      },
+    ];
+
+    const out = filterAlreadyImported(results, {
+      projectPath: "/p",
+      hashOf,
+      remoteImports,
+      isImportedLocal,
+    });
+
+    expect(out[0].sessions.map((s) => s.id)).toEqual(["r-fresh"]);
+    // remote path must NOT consult the local DB
+    expect(isImportedLocal).not.toHaveBeenCalled();
+  });
+
+  test("remote mode: a hash mismatch is treated as a new (not-yet-imported) session", () => {
+    const sess = makeSession({ id: "x", messageCount: 3, lastActivityAt: 4 });
+    const results = [makeResult("codex", [sess])];
+    const remoteImports = [
+      {
+        agent_name: "codex",
+        source_id: "x",
+        source_hash: "stale-hash", // same id, different content hash
+      },
+    ];
+
+    const out = filterAlreadyImported(results, {
+      projectPath: "/p",
+      hashOf,
+      remoteImports,
+      isImportedLocal: () => false,
+    });
+
+    expect(out[0].sessions.map((s) => s.id)).toEqual(["x"]);
+  });
+
+  test("skips agents with no registered provider", () => {
+    const results = [makeResult("ghost", [makeSession({ id: "g" })])];
+    const isImportedLocal = vi.fn(() => false);
+
+    const out = filterAlreadyImported(results, {
+      projectPath: "/p",
+      hashOf,
+      isImportedLocal,
+      hasProvider: () => false, // provider missing
+    });
+
+    // Agent skipped entirely — its sessions are left untouched, and since it
+    // still has sessions it survives the empty-filter (matches production:
+    // `getProvider` guard `continue`s, agent kept).
+    expect(out.map((r) => r.agentName)).toEqual(["ghost"]);
+    expect(isImportedLocal).not.toHaveBeenCalled();
+  });
+
+  test("returns empty when every session is already imported", () => {
+    const results = [makeResult("codex", [makeSession({ id: "a" })])];
+    const out = filterAlreadyImported(results, {
+      projectPath: "/p",
+      hashOf,
+      isImportedLocal: () => true,
+    });
+    expect(out).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the merged worktree/multi-agent import PR (#1344), which landed at **51.72% patch coverage** on `packages/gateway/src/cli/import.ts` — Codecov flagged 22 missing lines in the interactive `commandImport` flow.

Root cause: the agent-filter, dedup-filter, and empty-result decision logic was inline in a large function wired to gateway startup, the LLM client, and the DB, so it wasn't unit-testable.

## Changes

**Refactor (behavior-preserving):** extract the pure decision logic into two injectable helpers:
- `applyAgentFilter(results, agentFilter)`
- `filterAlreadyImported(results, { hashOf, remoteImports, isImportedLocal, hasProvider })`

The remote-vs-local dedup semantics are unchanged: remote import history is consulted only when the remote fetch succeeded; otherwise it falls back to the local DB check (same as before).

**Tests:**
- Unit tests for both helpers: agent match / no-match / null, local dedup, remote dedup, remote hash-mismatch → treated as new, missing-provider skip, empty result.
- A `commandImport` remote-mode integration test that mocks the gateway-relative `./remote` and `./start` layers (not the aliased `@loreai/core` barrel) and drives **real** detection via an aider fixture in an isolated temp project — covering the no-history, agent-filter-no-match, delegate-to-remote, and dry-run paths.

## Coverage
Patch coverage on `import.ts`: **45/45 added executable lines (100%)**, up from 51.72%.

## Verification
- `pnpm run typecheck` — clean
- `pnpm run lint` — exit 0
- `pnpm exec vitest run` — **5919 passed**, 0 failures