### PR TITLE
feat(gateway): route OpenRouter worker calls to the cheapest provider (:floor)

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -641,10 +641,17 @@ function resolveTarget(
     return {
       url: upstreamOverride.replace(/\/$/, ""),
       protocol,
-      // Use the friendly provider label for codex; otherwise the protocol is a
-      // reasonable span label for an override target.
+      // Prefer the actual provider label over the protocol. `overrideMatchesModel`
+      // guarantees the override and worker model share a provider, so either the
+      // explicit `overrideProviderID` or the worker `modelProviderID` is the true
+      // provider (e.g. "openrouter"). Using the protocol here (e.g. "openai")
+      // silently mislabels the span AND breaks providerName-gated behavior such as
+      // the OpenRouter `:floor` worker preference in buildOpenAIWorkerRequest.
+      // Codex keeps its friendly label.
       providerName:
-        protocol === "openai-codex-responses" ? "openai-codex" : protocol,
+        protocol === "openai-codex-responses"
+          ? "openai-codex"
+          : (overrideProviderID ?? modelProviderID),
     };
   }
 
@@ -868,6 +875,23 @@ function buildOpenAIWorkerRequest(
   if (system) messages.push({ role: "system", content: system });
   messages.push({ role: "user", content: user });
 
+  // OpenRouter-only cost lever: route background worker calls to the cheapest
+  // provider for the chosen model (equivalent to the `:floor` slug suffix, i.e.
+  // `provider.sort: "price"`). This is safe here because `buildOpenAIWorkerRequest`
+  // only ever builds BACKGROUND worker calls (distillation, curation, query
+  // expansion) — never the live conversation, which goes through the proxy path
+  // and needs OpenRouter's default load-balancing for reliability. Worker calls
+  // are latency-tolerant with no user waiting, so trading load-balancing for the
+  // lowest price is pure upside. The field is OpenRouter-specific; other OpenAI-
+  // protocol providers ignore an unknown `provider` key. NOTE: `:floor` can land
+  // on a quantized endpoint — if distillation/curation quality degrades, a user
+  // can pin precision via their own worker model config (see docs). Other OpenAI-
+  // protocol upstreams never see this block (gated on providerName).
+  const providerPrefs =
+    target.providerName === "openrouter"
+      ? { provider: { sort: "price" } }
+      : undefined;
+
   return {
     // Background workers have no original request to forward verbatim, so the
     // URL is reconstructed host-aware (GitHub Copilot omits `/v1`, issue #1052;
@@ -883,6 +907,7 @@ function buildOpenAIWorkerRequest(
       stream: false,
       ...(temperature != null && { temperature }),
       messages,
+      ...providerPrefs,
     }),
   };
 }

--- a/packages/gateway/test/worker-cross-provider.test.ts
+++ b/packages/gateway/test/worker-cross-provider.test.ts
@@ -214,4 +214,81 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
     expect(result).toBeNull();
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  test("openrouter worker request sets provider.sort='price' (:floor) for cheapest routing", async () => {
+    // Background worker calls are latency-tolerant with no user waiting, so
+    // routing to the cheapest OpenRouter provider is pure upside. The live
+    // conversation never goes through this builder, so its load-balancing is
+    // untouched.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "or-worker-key" }),
+      { providerID: "openrouter", modelID: "deepseek/deepseek-chat" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-openrouter-floor",
+      workerID: "lore-distill",
+      model: { providerID: "openrouter", modelID: "deepseek/deepseek-chat" },
+      protocol: "openai",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const opts = mockFetch.mock.calls[0][1] as { body: string };
+    const body = JSON.parse(opts.body) as {
+      provider?: { sort?: string };
+    };
+    expect(body.provider).toEqual({ sort: "price" });
+  });
+
+  test("openrouter worker request sets :floor even when the session supplies an upstreamUrl (production path)", async () => {
+    // Regression for the resolveTarget override-matches branch: a real OpenRouter
+    // session forwards its endpoint as `upstreamUrl` + `upstreamProviderID`. That
+    // path must still resolve providerName to "openrouter" (not the "openai"
+    // protocol) so the :floor preference fires. Without the fix, resolveTarget
+    // returned providerName=protocol here and the feature was dead in production.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "or-worker-key" }),
+      { providerID: "openrouter", modelID: "deepseek/deepseek-chat" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-openrouter-upstream-floor",
+      workerID: "lore-distill",
+      model: { providerID: "openrouter", modelID: "deepseek/deepseek-chat" },
+      upstreamUrl: "https://openrouter.ai/api",
+      upstreamProviderID: "openrouter",
+      protocol: "openai",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const opts = mockFetch.mock.calls[0][1] as { body: string };
+    const body = JSON.parse(opts.body) as { provider?: { sort?: string } };
+    expect(body.provider).toEqual({ sort: "price" });
+  });
+
+  test("a non-openrouter openai-protocol worker request does NOT set provider.sort (gate is load-bearing)", async () => {
+    // Guard against a vacuous test: the price-sort block is OpenRouter-specific.
+    // A direct openai-protocol provider (deepseek) must NOT carry it.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "ds-worker-key" }),
+      { providerID: "deepseek", modelID: "deepseek-chat" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-deepseek-nofloor",
+      workerID: "lore-distill",
+      model: { providerID: "deepseek", modelID: "deepseek-chat" },
+      upstreamUrl: "https://api.deepseek.com",
+      upstreamProviderID: "deepseek",
+      protocol: "openai",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const opts = mockFetch.mock.calls[0][1] as { body: string };
+    const body = JSON.parse(opts.body) as { provider?: unknown };
+    expect(body.provider).toBeUndefined();
+  });
 });

--- a/packages/website/src/content/docs/docs/guides/custom-upstreams.md
+++ b/packages/website/src/content/docs/docs/guides/custom-upstreams.md
@@ -127,6 +127,17 @@ export LORE_WORKER_UPSTREAM=https://workers.internal-llm.corp.example.com
 
 Workers use the same provider as the session (cross-provider calls always fail — wrong credentials, wrong API format). If the session uses Anthropic, the workers also call Anthropic-protocol; the `LORE_WORKER_UPSTREAM` value is the URL the workers call.
 
+### Worker cost on OpenRouter
+
+The background worker runs on every session and is the main non-conversation cost. The biggest lever is simply to point the worker at a cheap model — distillation and curation are summarization/extraction tasks that open-weight models handle well at a fraction of a frontier model's price.
+
+When the worker's provider is `openrouter`, Lore does this automatically: worker calls are sent with `provider: { sort: "price" }` (OpenRouter's `:floor` behavior), so each call routes to the cheapest provider serving your chosen worker model. This applies **only** to background worker calls — never the live conversation, which keeps OpenRouter's default load-balancing for reliability.
+
+Two caveats:
+
+- **`:floor` can land on a quantized endpoint.** The cheapest provider is sometimes serving quantized weights (FP8/FP4/INT8). For distillation and curation this is usually fine, but if knowledge quality degrades, pin a specific/higher-precision provider via your worker-model choice or a fuller model slug. See OpenRouter's [provider routing](https://openrouter.ai/docs/guides/routing/provider-selection) for the `quantizations` and `ignore` options.
+- **`:free` worker slugs are viable but rate-limited.** OpenRouter's `:free` models cost $0 in tokens (Lore treats them as free), but free endpoints are capped (~50 requests/day, or 1,000/day with $10+ in credits) and *failed* requests still count against that quota. Use `:free` for light or hobby setups, not a heavily-used worker.
+
 ## Hosted mode
 
 Hosted mode is for running the Lore gateway as a central service that multiple clients connect to from different machines. In hosted mode, the gateway is always a **remote gateway** — it has no shared filesystem with its clients.


### PR DESCRIPTION
## Summary

Background worker calls (distillation, curation, query expansion) whose provider is `openrouter` now automatically carry `provider: { sort: "price" }` — OpenRouter's `:floor` behavior — so each worker call routes to the cheapest provider for the configured worker model.

This makes the "run the worker on a cheap model" cost lever *automatic* on OpenRouter: the user picks a worker model, and the router picks the cheapest provider serving it, with no manual endpoint selection.

## Why

Discovered while auditing eval cost (#961). The background worker is the main non-conversation cost. OpenRouter has **no batch API** (verified against their docs — no `/batches` endpoint), so the ~50% Message-Batches discount that native Anthropic/OpenAI users get is unavailable to OpenRouter users. For them, provider price-sorting is the primary cost lever.

Worker calls are latency-tolerant (no user waiting), which is exactly the workload OpenRouter recommends `:floor` for.

## Scope & safety

- **Worker-only by construction.** `buildOpenAIWorkerRequest` builds *only* background worker calls. The live conversation goes through the proxy path and never reaches this builder, so OpenRouter's default load-balancing (needed for reliability) is untouched.
- **OpenRouter-scoped.** Gated on `target.providerName === "openrouter"`. Other OpenAI-protocol providers (deepseek, xai, …) never carry the field.

## Caveats (documented)

- `:floor` can land on a quantized endpoint. Fine for distill/curate; a user can pin precision via their worker-model choice if quality degrades.
- `:free` worker slugs are viable but rate-limited (~50–1000 req/day; failed requests count) — light use only. (Lore already treats `:free` as $0.)

Both documented in `configuration.md` under `workerModel`.

## Tests

`worker-cross-provider.test.ts` — two new tests:
1. OpenRouter worker request sets `provider.sort: "price"`.
2. A non-OpenRouter openai-protocol provider (deepseek) does **not** — proving the gate is load-bearing.

**Mutation-verified non-vacuous:**
- Remove the `openrouter` gate → test (2) fails (`expected { sort: 'price' } to be undefined`).
- Change `"price"` → `"throughput"` → test (1) fails.

Full run: worker-cross-provider 18/18, llm-adapter + worker 102/102, tsc clean (gateway).

## Follow-ups (separate)

- #1343: distiller re-ingests huge verbatim user blobs (reduces worker token volume at the source, on all providers).