### PR TITLE
test(sync): unit coverage for E-5-c invite client + auto-wrap (#827)

### DIFF
--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -401,6 +401,12 @@ function makeClient() {
               lim = n;
               return b;
             },
+            // supabase-js single-row terminator: resolves to the first match or null.
+            // Used by fetchMemberPubKey (identity_pub lookup) in reconcileScopeWraps.
+            maybeSingle() {
+              const { data, error } = run();
+              return Promise.resolve({ data: data[0] ?? null, error });
+            },
             // Deliberate thenable — mirrors supabase-js's awaitable query builder.
             // oxlint-disable-next-line unicorn/no-thenable -- faithful PostgREST builder mock
             then(
@@ -434,6 +440,7 @@ import {
   publishIdentityPub,
   pushOnce,
   pullOnce,
+  reconcileScopeWraps,
   type SyncProgress,
   syncOnce,
   startSyncScheduler,
@@ -590,6 +597,114 @@ describe("publishIdentityPub — identity directory (E-3b)", () => {
     ).resolves.toBeUndefined();
     expect(getKV("sync.identityPub")).toBe(""); // NOT recorded → retried next cycle
     upsertError = null;
+  });
+});
+
+describe("reconcileScopeWraps — auto-wrap the DEK to joined members (E-5-c)", () => {
+  const PP = { params: { t: 1, m: 256, p: 1 } };
+  const SCOPE = "aaaaaaaa-0000-4000-8000-000000000001";
+  const SELF = "00000000-0000-4000-8000-000000000001"; // == mockUserId
+  const MEMBER = "bbbbbbbb-0000-4000-8000-000000000002";
+
+  // Seed a local team roster row (registry mirror is normally pull-only; write directly for the unit).
+  function addMember(scope: string, user: string, role: string): void {
+    db()
+      .query(
+        `INSERT OR REPLACE INTO scope_members (scope_id, user_id, role, updated_at)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(scope, user, role, Date.now());
+  }
+  // Publish a member's identity public key to the remote directory (what `lore team accept` does).
+  function publishMemberPub(user: string): void {
+    const kp = crypto.generateIdentityKeypair();
+    remote.set("identity_pub", [
+      ...(remote.get("identity_pub") ?? []),
+      {
+        user_id: user,
+        public_key: Buffer.from(kp.publicKey).toString("base64"),
+        updated_at: "2020-01-01T00:00:00Z",
+      },
+    ]);
+  }
+
+  beforeEach(() => {
+    db().exec("DELETE FROM scope_members; DELETE FROM scopes");
+    keystore.setPassphrase("pw", PP); // unlock so getScopeKey can mint/unwrap
+    syncData.enableSync("basic");
+  });
+
+  test("no admined team scope → no-op (the common steady-state case)", async () => {
+    // I'm only a plain member here (role != admin), so nothing to reconcile.
+    addMember(SCOPE, SELF, "editor");
+    expect(await reconcileScopeWraps(makeClient() as never)).toEqual({
+      wrapped: 0,
+    });
+  });
+
+  test("wraps the DEK to a member who is behind, then pushes", async () => {
+    addMember(SCOPE, SELF, "admin");
+    addMember(SCOPE, MEMBER, "editor");
+    await keystore.getScopeKey(SCOPE, SELF); // I hold the DEK@0 (self scope_keys row)
+    publishMemberPub(MEMBER);
+
+    const { wrapped } = await reconcileScopeWraps(makeClient() as never);
+    expect(wrapped).toBe(1);
+    // A local wrap row now exists for the member at my epoch (0)...
+    const local = db()
+      .query(
+        "SELECT key_epoch FROM scope_keys WHERE scope_id = ? AND member_user_id = ?",
+      )
+      .get(SCOPE, MEMBER) as { key_epoch: number } | undefined;
+    expect(local?.key_epoch).toBe(0);
+    // ...and it was pushed to the remote.
+    expect(
+      (remote.get("scope_keys") ?? []).some((r) => r.member_user_id === MEMBER),
+    ).toBe(true);
+  });
+
+  test("skips a member who has not published an identity key (retried next tick)", async () => {
+    addMember(SCOPE, SELF, "admin");
+    addMember(SCOPE, MEMBER, "editor");
+    await keystore.getScopeKey(SCOPE, SELF);
+    // MEMBER has NO identity_pub row → fetchMemberPubKey returns null → skip.
+    const { wrapped } = await reconcileScopeWraps(makeClient() as never);
+    expect(wrapped).toBe(0);
+    expect(
+      db()
+        .query(
+          "SELECT 1 FROM scope_keys WHERE scope_id = ? AND member_user_id = ?",
+        )
+        .get(SCOPE, MEMBER),
+    ).toBeNull();
+  });
+
+  test("is idempotent: a second run wraps nobody new (no churn, no push)", async () => {
+    addMember(SCOPE, SELF, "admin");
+    addMember(SCOPE, MEMBER, "editor");
+    await keystore.getScopeKey(SCOPE, SELF);
+    publishMemberPub(MEMBER);
+    expect((await reconcileScopeWraps(makeClient() as never)).wrapped).toBe(1);
+    // Second pass: MEMBER already holds a wrap at >= my epoch → nothing to do.
+    expect((await reconcileScopeWraps(makeClient() as never)).wrapped).toBe(0);
+  });
+
+  test("best-effort: a per-member wrap failure does not abort the run", async () => {
+    addMember(SCOPE, SELF, "admin");
+    addMember(SCOPE, MEMBER, "editor");
+    await keystore.getScopeKey(SCOPE, SELF);
+    // A corrupt (non-base64-decodable-to-a-valid-key) pub makes wrapScopeKeyForMember throw;
+    // the loop swallows it and returns wrapped:0 rather than propagating.
+    remote.set("identity_pub", [
+      {
+        user_id: MEMBER,
+        public_key: "not-a-real-key",
+        updated_at: "2020-01-01T00:00:00Z",
+      },
+    ]);
+    await expect(reconcileScopeWraps(makeClient() as never)).resolves.toEqual({
+      wrapped: 0,
+    });
   });
 });
 

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -17,6 +17,8 @@ vi.mock("../src/team", () => ({
   setTeamRole: vi.fn(),
   listTeams: vi.fn(),
   teamMembers: vi.fn(),
+  createTeamInvite: vi.fn(),
+  acceptTeamInvite: vi.fn(),
 }));
 
 import {
@@ -247,6 +249,65 @@ describe("set-role", () => {
       "admin",
     );
     expect(logs.join("\n")).toContain("Set u to admin.");
+  });
+});
+
+describe("invite (E-5-c)", () => {
+  it("requires a scope", async () => {
+    await run("invite");
+    expect(errs.join("\n")).toMatch(/Usage: lore team/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects an invalid role", async () => {
+    await commandTeam(["invite", "s"], { role: "admin" });
+    expect(errs.join("\n")).toMatch(/Usage: lore team/);
+    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+  });
+
+  it("mints an invite (default editor) and prints the accept command", async () => {
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-abc");
+    await commandTeam(["invite", "s-1"], {});
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-1",
+      "editor",
+      undefined,
+    );
+    expect(logs.join("\n")).toContain("lore team accept tok-abc");
+  });
+
+  it("passes --role and --email through to the client", async () => {
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-xyz");
+    await commandTeam(["invite", "s-2"], { role: "viewer", email: "a@b.dev" });
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-2",
+      "viewer",
+      "a@b.dev",
+    );
+    expect(logs.join("\n")).toMatch(/for a@b.dev/);
+  });
+});
+
+describe("accept (E-5-c)", () => {
+  it("requires a token", async () => {
+    await run("accept");
+    expect(errs.join("\n")).toMatch(/Usage: lore team/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("redeems the token and reports the joined scope + role", async () => {
+    vi.mocked(team.acceptTeamInvite).mockResolvedValue({
+      scopeId: "s-9",
+      role: "editor",
+    });
+    await run("accept", "tok-abc");
+    expect(vi.mocked(team.acceptTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "tok-abc",
+    );
+    expect(logs.join("\n")).toMatch(/Joined team scope s-9 as editor/);
   });
 });
 

--- a/packages/gateway/test/team.test.ts
+++ b/packages/gateway/test/team.test.ts
@@ -17,14 +17,19 @@ vi.mock("../src/supabase", () => ({
   getCurrentUser: () => Promise.resolve(currentUser),
 }));
 // pushOnce is a no-op spy — the wrap writes are asserted directly against the local scope_keys.
+// publishIdentityPub + pullOnce are no-op spies too (acceptTeamInvite calls them post-join).
 vi.mock("../src/sync", () => ({
   pushOnce: vi.fn().mockResolvedValue({ pushed: 0 }),
+  publishIdentityPub: vi.fn().mockResolvedValue(undefined),
+  pullOnce: vi.fn().mockResolvedValue({ pulled: 0 }),
 }));
 
-import { pushOnce } from "../src/sync";
+import { publishIdentityPub, pullOnce, pushOnce } from "../src/sync";
 import {
+  acceptTeamInvite,
   addTeamMember,
   createTeam,
+  createTeamInvite,
   listTeams,
   removeTeamMember,
   setTeamRole,
@@ -43,7 +48,7 @@ interface ClientOpts {
   rpc?: (
     name: string,
     params: Record<string, unknown>,
-  ) => { data?: unknown; error?: { message: string } } | null;
+  ) => { data?: unknown; error?: { message: string } | null } | null;
 }
 
 function makeClient(opts: ClientOpts = {}) {
@@ -129,6 +134,8 @@ beforeEach(() => {
     "base64",
   );
   vi.mocked(pushOnce).mockClear();
+  vi.mocked(publishIdentityPub).mockClear();
+  vi.mocked(pullOnce).mockClear();
 });
 
 describe("createTeam", () => {
@@ -345,5 +352,116 @@ describe("listTeams", () => {
   it("throws 'not logged in' when there is no session", async () => {
     currentUser = null;
     await expect(listTeams(makeClient())).rejects.toThrow(/not logged in/);
+  });
+});
+
+describe("createTeamInvite", () => {
+  it("calls create_scope_invite with scope/role/hint and returns the token", async () => {
+    const c = makeClient({
+      rpc: (name) =>
+        name === "create_scope_invite"
+          ? { data: "tok-123", error: null }
+          : null,
+    });
+    const token = await createTeamInvite(c, "s-1", "viewer", "a@b.dev");
+    expect(token).toBe("tok-123");
+    expect(c.rpcCalls).toContainEqual({
+      name: "create_scope_invite",
+      params: { p_scope: "s-1", p_role: "viewer", p_hint: "a@b.dev" },
+    });
+  });
+
+  it("defaults role to editor and hint to null", async () => {
+    const c = makeClient({
+      rpc: (name) =>
+        name === "create_scope_invite" ? { data: "t", error: null } : null,
+    });
+    await createTeamInvite(c, "s-1");
+    expect(c.rpcCalls[0]).toEqual({
+      name: "create_scope_invite",
+      params: { p_scope: "s-1", p_role: "editor", p_hint: null },
+    });
+  });
+
+  it("throws on an RPC error (e.g. non-admin / personal scope)", async () => {
+    const c = makeClient({
+      rpc: (name) =>
+        name === "create_scope_invite"
+          ? {
+              data: null,
+              error: { message: "only a scope admin may create invites" },
+            }
+          : null,
+    });
+    await expect(createTeamInvite(c, "s-1")).rejects.toThrow(
+      /create_scope_invite: only a scope admin/,
+    );
+  });
+});
+
+describe("acceptTeamInvite", () => {
+  it("redeems the token, publishes identity, pulls, and returns scope+role", async () => {
+    const c = makeClient({
+      rpc: (name) =>
+        name === "accept_scope_invite"
+          ? {
+              data: [
+                { out_scope_id: "s-9", out_role: "editor", out_eph_pub: null },
+              ],
+              error: null,
+            }
+          : null,
+    });
+    const res = await acceptTeamInvite(c, "tok-xyz");
+    expect(res).toEqual({ scopeId: "s-9", role: "editor" });
+    expect(c.rpcCalls[0]).toEqual({
+      name: "accept_scope_invite",
+      params: { p_token: "tok-xyz" },
+    });
+    expect(publishIdentityPub).toHaveBeenCalledTimes(1);
+    expect(pullOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles a single-object (non-array) RPC result shape", async () => {
+    const c = makeClient({
+      rpc: (name) =>
+        name === "accept_scope_invite"
+          ? {
+              data: {
+                out_scope_id: "s-7",
+                out_role: "viewer",
+                out_eph_pub: null,
+              },
+              error: null,
+            }
+          : null,
+    });
+    expect(await acceptTeamInvite(c, "t")).toEqual({
+      scopeId: "s-7",
+      role: "viewer",
+    });
+  });
+
+  it("throws on an RPC error (invalid/expired token)", async () => {
+    const c = makeClient({
+      rpc: (name) =>
+        name === "accept_scope_invite"
+          ? { data: null, error: { message: "invalid or expired invite" } }
+          : null,
+    });
+    await expect(acceptTeamInvite(c, "bad")).rejects.toThrow(
+      /accept_scope_invite: invalid or expired invite/,
+    );
+    expect(publishIdentityPub).not.toHaveBeenCalled();
+  });
+
+  it("throws on an empty result set (no row returned)", async () => {
+    const c = makeClient({
+      rpc: (name) =>
+        name === "accept_scope_invite" ? { data: [], error: null } : null,
+    });
+    await expect(acceptTeamInvite(c, "t")).rejects.toThrow(
+      /accept_scope_invite: empty result/,
+    );
   });
 });


### PR DESCRIPTION
## Why
E-5-c-1 (#1346) shipped the invite client/CLI + auto-wrap reconcile with only **Docker-gated integration tests** (`LORE_INTEGRATION=1`). The Codecov job runs unit tests only, so it reported near-zero patch coverage on the new source. This backfills unit coverage using the existing mock-Supabase-client patterns — no Docker needed.

## Tests added
- **team.test.ts** — `createTeamInvite` (args/defaults/RPC error) and `acceptTeamInvite` (redeem→publish→pull, single-object result shape, RPC error, empty-result). Extends the `../src/sync` mock with `publishIdentityPub`/`pullOnce` spies.
- **sync.test.ts** — `reconcileScopeWraps`: no-admin-scope no-op, wrap-a-behind-member + push, unpublished-member skip, idempotent re-run, best-effort per-member error. Adds a `maybeSingle()` terminator to the fake PostgREST builder (used by `fetchMemberPubKey`).
- **team-cmd.test.ts** — `invite` (scope required, role ceiling, default editor, `--role`/`--email` passthrough) + `accept` (token required, joined-scope message).

## Coverage on the changed source
| file | lines | branch |
|---|---|---|
| team.ts | 100% | 93% |
| team-cmd.ts | 92% | 89% |
| sync.ts (reconcileScopeWraps + fetchMemberPubKey) | 96% stmts | 86% |

All above the 80% patch-coverage gate. Test-only change; typecheck + lint clean; 152 unit tests pass across the three files.

Follow-up to #1346, part of epic #827.