### PR TITLE
feat(distillation): reduce oversized user blobs by embedding relevance

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -168,6 +168,9 @@
 <!-- lore:019f05e3-1abc-7c77-944b-bc9e7ae25bb1 -->
 * **Switched from plan mode to build mode (read-write**: switched from plan to build mode (read-only lifted; file changes,
 
+<!-- lore:019f6bb3-6ee8-7b56-bfba-67fa27cab162 -->
+* **Switched from Python to TypeScript**: switched from Python to TypeScript.
+
 <!-- lore:019f65ca-91c3-71f9-9f8a-bb8a803ce3e4 -->
 * **Switched from Python to TypeScript for the project (no longer using Python)**: switched from Python to TypeScript for the project (no longer using Python)
 
@@ -441,6 +444,9 @@
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
 * **Always a remote gateway — it has no shared filesystem with its clients**: User stated: 'Always a remote gateway — it has no shared filesystem with its clients'. This is a directive preference.
 
+<!-- lore:019f6ba4-041e-7712-b0cc-80307b7f4b2f -->
+* **Always add regression tests for identified bugs**: After identifying and fixing bugs (especially blockers like B1), the user consistently adds specific regression tests to prevent recurrence. The tests target the exact failure conditions, such as boundary cases (e.g., 'directive straddling hard window boundary') and verify the fix maintains correct behavior. This pattern applies whenever bugs are discovered during code reviews or testing.
+
 <!-- lore:019f6b30-43e0-7bba-a001-3f8766141466 -->
 * **Always confirm PR is CLEAN and MERGEABLE before merging**: The user consistently requires verification that a pull request is in a CLEAN state with MERGEABLE status before proceeding with merging. This includes checking that all CI checks pass, there are no blocking review comments, and the PR is ready for merge without conflicts. The assistant should always confirm these conditions are met before executing the merge operation.
 
@@ -452,9 +458,6 @@
 
 <!-- lore:019f6b3c-63a8-7e71-ba5b-d041929383c8 -->
 * **Always enforce read-only adversarial reviews with throwaway worktree mutation testing**: The user consistently requires adversarial code reviews to be performed in a strictly read-only manner on the main working tree. Any mutation testing must occur in a separate, throwaway git worktree (typically under /tmp), with verification that the main tree remains byte-identical (via git status/sha256) and the temporary worktree is cleaned up afterward. Reviews must focus on correctness bugs categorized by severity, with explicit scrutiny areas and test verification requirements.
-
-<!-- lore:019f6b0d-388f-7da5-b60a-b04c9636837b -->
-* **Always enforce read-only review workflow with throwaway worktrees**: User consistently mandates a strict read-only review process where the main working repository must never be modified. All testing, mutation analysis, and temporary file operations must occur in isolated throwaway worktrees (typically under /tmp/). The assistant must verify that no tracked files in the main repository are ever touched during review activities. This pattern applies to both pre-merge and post-merge code reviews.
 
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
 * **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
@@ -474,11 +477,8 @@
 <!-- lore:019f6b9f-3931-7f18-962a-e9a68aa5ccd6 -->
 * **Always provide comprehensive test results and code references**: The user consistently provides detailed test results, source code references, and specific implementation details when discussing code changes or issues. They demonstrate a pattern of thorough verification, often including multiple test cases, mutation tests, and explicit code snippets to illustrate their points. This indicates a strong preference for evidence-based discussion and rigorous testing practices.
 
-<!-- lore:019f6aef-f8b3-7b61-9be1-33904f8bca6e -->
-* **Always provide detailed tool results and session context**: The user consistently provides extensive technical context including specific implementation details, system constraints, and environmental factors. This includes API credentials, port numbers, file paths, database configurations, model specifications, and performance characteristics. The user expects this context to be understood and respected when implementing solutions or running evaluations.
-
 <!-- lore:019f6b0d-6019-7af7-bd69-c776e0b1913d -->
-* **Always provide tool results for verification after edits**: The user consistently provides tool results (test outputs, typecheck results, coverage reports, etc.) immediately after applying edits. This demonstrates a strong preference for verifying that changes work as expected before proceeding. The pattern shows the user values concrete feedback and validation at each step of the development process.
+* **Always provide tool results for verification after edits**: The user consistently provides tool results (test outputs, diff scopes, migration details, etc.) immediately after applying code changes. This pattern shows the user expects verification of changes through concrete evidence from development tools, rather than just accepting that changes were made. The assistant should be prepared to analyze and confirm these tool results as part of the development workflow.
 
 <!-- lore:019f66b3-cdb2-7605-9908-3135589ec555 -->
 * **Always record auth failure**: Always record the auth failure so the worker-health ladder sees it.

--- a/.lore.md
+++ b/.lore.md
@@ -106,7 +106,7 @@
 * **Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes. (PR #1277 final commits: 0993b690 tooling, f11f2e4b reformat+autofix, a3486c5f**: Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes.
 
 <!-- lore:019f51ec-9e29-759e-a82c-e06c5485b7b2 -->
-* **Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables)**: Switched to synchronous mode for future calls. User switched to synchronous mode for future calls. This is a declarative preference.
+* **Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables)**: Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables). Never marked incapable and the failure ladder escalated forever with a misleading "auth stale" warning.
 
 <!-- lore:019f3974-7c6a-7091-8602-b4ec0bb763a4 -->
 * **Chose next task: knowledge\_meta seed-order alignment (self-contained, low-risk, completes value-ranked seed coherence work started with knowledge #1189 and entities #1194) — over #1191b (continuous top-N eviction)**: Completed value-ranked seed coherence work in sequence: #1189 (knowledge seed value-ranking) → PR #1194 (entity-graph seed: entities ranked by knowledge\_entity\_refs count DESC then recency; entity\_relations by recency; entity\_aliases by created\_at DESC) → PR #1196 (knowledge\_meta seed aligned to knowledge's ORDER BY: confidence DESC, COALESCE(last\_reinforced\_at, updated\_at) DESC, logical\_id tiebreak). Deferred #1191b (continuous top-N eviction for remote) as a separate larger/riskier task needing a design doc first (remote eviction, cap discovery, thrash guards, concurrency) — not suitable for autonomous same-session implementation. Follow-up issue #1197 filed for a known non-blocking edge case: a deleted high-confidence entry's orphaned knowledge\_meta row can outrank a live entry's meta row under the cap (self-healing, not data loss).
@@ -264,7 +264,7 @@
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
 
 <!-- lore:019efa7b-7094-7654-87f4-0d5b7066beaa -->
-* **node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner**: The judge should never be imported outside driver. This is a directive preference.
+* **node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner**: Trap: node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner. Fix: All SQLite access must go through the #db/driver subpath import map.
 
 <!-- lore:019f6b15-46a7-7b64-be23-364265e1132e -->
 * **Non-OpenRouter providers must never see the provider.sort block**: Trap: non-OpenRouter providers must never see the provider.sort block looks correct because the worker model is cheap. Fix: non-OpenRouter providers must never see the provider.sort block. Non-OpenRouter providers must never see the provider.sort block.
@@ -385,9 +385,6 @@
 <!-- lore:019f1e66-a06c-7c58-b5ec-6d7cb21eddc3 -->
 * **backfillTemporalEmbeddings: per-row checkpoint + backlog/progress logging (PR #1104)**: PR #1104 (\`fix/temporal-rechunk-checkpoint\`) changes two behaviors in \`backfillTemporalEmbeddings\`: 1. \*\*Per-row checkpoint\*\*: \`setKV(TEMPORAL\_RECHUNK\_CURSOR\_KEY, retryFrom ?? cursor)\` moved INSIDE the row loop (was per-page). Crash mid-pass now resumes from last completed row, not start of last page. \`retryFrom ?? cursor\` uses nullish (not \`||\`) — when first row fails, \`retryFrom = ''\` and \`'' ?? cursor\` → \`''\`, correctly resuming at \`id > ''\`. 2. \*\*Backlog + heartbeat logging\*\*: upfront \`SELECT COUNT(\*)\` logs \`'temporal re-chunk: N messages to scan (resuming)'\`; \`PROGRESS\_INTERVAL\_MS = 30\_000\` replaces count-based \`PROGRESS\_INTERVAL = 1000\`; heartbeat shows \`processed re-chunked, scanned scanned…\`. Mutations: per-row checkpoint test and backlog-log test both killed independently. Merged \`25a04e22\` at 2026-07-01T17:30:31Z.
 
-<!-- lore:019f6807-9895-777a-9b94-5e0465c7d512 -->
-* **Batch provider resolution**: Batch provider resolution: Batch LLM client resolves providers at flush time: groups items by \`(authKey, providerID)\`. Only \`anthropic\` and \`openai\` providerIDs get batch providers; others (NVIDIA, OpenRouter) fall back to synchronous processing. \`disabledBatchSessions\` and \`disabledBatchProviders\` sets track permanent batch API access failures.
-
 <!-- lore:019f00ae-c762-7067-8197-83d9b70d8dd9 -->
 * **cache-warmer evidence gate (Bug C): always fund first probe, never fund second+ cycle with zero lifetime hits**: 🔴 Directive: ALWAYS fund the first warmup of a break (\`cyclesSpent === 0\` — the probe that learns if this slow tool returns within TTL), but NEVER fund a second-or-later cycle for a session that has produced zero confirmed hits over its lifetime. Implementation: \`if (cyclesSpent >= 1 && (state.warmup?.warmupHits ?? 0) < TOOL\_CALL\_MIN\_HITS\_FOR\_CONTINUATION) return false\`. \`warmupHits\` is lifetime/durable across breaks; \`warmupCount\` (cyclesSpent) is per-break (reset on return in pipeline.ts). Rationale: 66 of 74 zero-hit warmups occurred at ≤5 lifetime warmups, below \`MIN\_WARMUPS\_FOR\_ROI\_CHECK\`, so hit-rate guard never engaged.
 
@@ -453,14 +450,26 @@
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
 * **Always a remote gateway — it has no shared filesystem with its clients**: Always a remote gateway — it has no shared filesystem with its clients. This is a directive preference.
 
+<!-- lore:019f6b30-43e0-7bba-a001-3f8766141466 -->
+* **Always confirm PR is CLEAN and MERGEABLE before merging**: The user consistently requires verification that a pull request is in a CLEAN state with MERGEABLE status before proceeding with merging. This includes checking that all CI checks pass, there are no blocking review comments, and the PR is ready for merge without conflicts. The assistant should always confirm these conditions are met before executing the merge operation.
+
+<!-- lore:019f6b84-15cd-78d4-9a24-ca95bdd3ebd5 -->
+* **Always emphasize security invariants with 'never' statements**: The user consistently uses strong 'never' statements to define critical security invariants and constraints. These statements appear in multiple contexts: when reviewing code, designing features, and specifying requirements. The user expects these invariants to be strictly enforced in the implementation. Examples include: 'server never holds plaintext DEK', 'ephemeral secret never reaches server', 'DEK wraps are always re-wrapped to prevent self-lockout', 'joining member must NEVER mint fresh DEK'.
+
 <!-- lore:019f6b1c-7cd6-76b1-a3c4-f4bda879566c -->
 * **Always enforce cryptographic safety invariants**: User consistently emphasizes and enforces critical cryptographic safety invariants throughout the design and implementation process. Key patterns include: 1) Server never holds plaintext DEK, 2) Tokens never contain plaintext secrets, 3) Invitee hints are never resolved/verified by server, 4) Invites never downgrade existing roles, 5) Ephemeral keys never touch server, 6) mint:false is a divergence-safety guard not access control, 7) DEK wraps are always re-wrapped to prevent self-lockout. User provides tool results to verify these invariants are maintained in code and database schemas.
+
+<!-- lore:019f6b3c-63a8-7e71-ba5b-d041929383c8 -->
+* **Always enforce read-only adversarial reviews with throwaway worktree mutation testing**: The user consistently requires adversarial code reviews to be performed in a strictly read-only manner on the main working tree. Any mutation testing must occur in a separate, throwaway git worktree (typically under /tmp), with verification that the main tree remains byte-identical (via git status/sha256) and the temporary worktree is cleaned up afterward. Reviews must focus on correctness bugs categorized by severity, with explicit scrutiny areas and test verification requirements.
 
 <!-- lore:019f6b0d-388f-7da5-b60a-b04c9636837b -->
 * **Always enforce read-only review workflow with throwaway worktrees**: User consistently mandates a strict read-only review process where the main working repository must never be modified. All testing, mutation analysis, and temporary file operations must occur in isolated throwaway worktrees (typically under /tmp/). The assistant must verify that no tracked files in the main repository are ever touched during review activities. This pattern applies to both pre-merge and post-merge code reviews.
 
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
 * **Always fail — wrong credentials**: Always fail — wrong credentials. This is a directive preference.
+
+<!-- lore:019f6b49-3efa-7ec7-b4f8-9d522462dd6c -->
+* **Always implement user signal preservation rules in blob reduction**: The user consistently emphasizes strict rules for preserving user signal during blob reduction. Key requirements include: never blunt-truncating user content, always preserving pinned assertions and directives, preventing signal loss at window boundaries, and maintaining non-Latin character integrity. The user provides detailed implementation guidance, test requirements, and configuration parameters to enforce these rules. Any blob reduction implementation must prioritize these signal preservation constraints over other considerations.
 
 <!-- lore:019f6af7-ff50-7c4c-920b-cc3c2dfd6aeb -->
 * **Always match when importing from the worktree (and vice-versa)**: User consistently requests matching when importing from the worktree and vice-versa across multiple sessions.
@@ -478,19 +487,16 @@
 * **Always provide tool results for verification after edits**: The user consistently provides tool results (test outputs, typecheck results, coverage reports, etc.) immediately after applying edits. This demonstrates a strong preference for verifying that changes work as expected before proceeding. The pattern shows the user values concrete feedback and validation at each step of the development process.
 
 <!-- lore:019f66b3-cdb2-7605-9908-3135589ec555 -->
-* **Always record auth failure**: Always record auth failure. Always record the auth failure so the worker-health ladder sees it. This is a directive preference.
+* **Always record auth failure**: Always record the auth failure so the worker-health ladder sees it.
 
-<!-- lore:019f6af0-dce9-7e09-b0f3-b970e990013c -->
-* **Always specify exact implementation constraints and edge case handling**: The user consistently provides detailed implementation requirements, including specific error handling, edge case considerations, and behavioral constraints. They emphasize what should 'never' happen, what should 'always' be true, and how systems should behave under failure conditions. The user focuses on precise technical specifications rather than high-level descriptions.
+<!-- lore:019f6b42-329f-7b38-9633-a57efc66cb95 -->
+* **Always run comprehensive test suites after code changes**: The user consistently runs extensive test suites after making code modifications. This includes running specific test files, filtered test groups, and full integration test suites. The user pays close attention to test results, including pass/fail counts and coverage reports, and uses this information to validate that changes haven't introduced regressions. This pattern demonstrates a strong preference for thorough testing to ensure code quality and stability.
+
+<!-- lore:019f6b34-c188-7e21-93da-2d0a7bfbcf5c -->
+* **Always specify exact technical constraints and requirements**: The user consistently provides highly detailed technical specifications, including exact API credentials, model names, token counts, file paths, and system configurations. They expect implementations to adhere precisely to these constraints, including ignore-lists, timeout values, and specific provider requirements. The user demonstrates deep technical awareness and expects solutions to account for real-world limitations like rate limits, authentication requirements, and system performance characteristics.
 
 <!-- lore:019f6b1e-018e-7377-a9f2-828d44c0fdc2 -->
 * **Always specify negative constraints with 'never' statements**: The user consistently uses imperative 'never' statements to define critical negative constraints and invariants. These statements appear in multiple contexts: code behavior (e.g., 'never silently land on api', 'never goes through this builder'), system design (e.g., 'never the live conversation', 'never open the failure circuit'), and security boundaries (e.g., 'never shoved into', 'never collides'). The pattern indicates the user expects these constraints to be strictly enforced and verified through testing and code review.
-
-<!-- lore:019f6aff-0196-75c4-8a72-f9c75d1ec85c -->
-* **Always verify changes through systematic testing and validation**: The user consistently demonstrates a pattern of thorough verification after making changes. They request multiple validation steps including: running type checks (tsc), executing targeted tests, performing broader test sweeps, checking documentation generation, verifying file states and commit contents, confirming CI status, and examining diffs. This applies after code changes, configuration updates, or documentation edits. The user expects assistants to systematically validate that changes are correct, complete, and haven't introduced regressions before considering work complete.
-
-<!-- lore:019f6af6-b078-776d-845d-2f470609e535 -->
-* **Always verify CI checks and coverage metrics before merging**: The user consistently checks CI status, Codecov coverage metrics, and Seer review comments before approving PRs for merge. They require confirmation that all required checks pass, coverage meets targets, and there are no blocking comments. The user also verifies the exact coverage percentages and file changes to ensure quality standards are met.
 
 <!-- lore:019f6b0a-798e-7f3f-b7fa-78cc6b2570bc -->
 * **Always verify implementation details with concrete test cases**: The user consistently requests verification of implementation details through concrete test cases and tool outputs. They provide specific examples and edge cases to validate that the solution works as expected, particularly focusing on adversarial scenarios and potential failure points. The user expects the assistant to demonstrate correctness through empirical evidence rather than theoretical explanations alone.
@@ -526,13 +532,13 @@
 * **Knowledge file (.lore.md) should be ignored in evaluations**: The knowledge file (.lore.md) should be added to an ignore-list for evaluations. This is a directive preference.
 
 <!-- lore:019f650e-1593-72e3-8c34-fdbf17c32560 -->
-* **Never a skip/conflict**: Never a skip/conflict. Never a skip/conflict: User stated never a skip/conflict. This is a directive preference.
+* **Never a skip/conflict**: Never a skip/conflict: User stated never a skip/conflict.
 
 <!-- lore:019f66a7-6355-761d-ac7a-3050e24a86bf -->
 * **Never accumulate to 30/60 minutes of sustained outage**: User stated never accumulate to 30/60 minutes of sustained outage.
 
 <!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
-* **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access. This is a directive preference.
+* **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
 
 <!-- lore:019f66e9-5fde-7103-a386-f9e5db82613a -->
 * **Never compacts -> errors instead**: User stated never compacts -> errors instead.
@@ -544,7 +550,7 @@
 * **Never falls through to the real defaults 3207/5673**: User stated never falls through to the real defaults 3207/5673.
 
 <!-- lore:019f65ca-91fb-7140-b01f-aeb90540b80d -->
-* **Never from within another transaction**: Never from within another transaction. User stated never from within another transaction. This is a directive preference.
+* **Never from within another transaction**: User stated never from within another transaction.
 
 <!-- lore:019f66a2-591b-7b5d-a0b3-886f650b755f -->
 * **Never marked incapable after 3 consecutive curator empties**: Never marked incapable after 3 consecutive curator empties — reset streak per-worker.
@@ -553,22 +559,22 @@
 * **Never marks a model incapable**: User stated never marks a model incapable.
 
 <!-- lore:019f62e7-b68c-7a51-87d5-d0771009efc6 -->
-* **Never penalizes (neutral) 2ms**: Never penalize entries with latency over 2ms. This is a directive preference.
+* **Never penalizes (neutral) 2ms**: Never penalize entries with latency over 2ms.
 
 <!-- lore:019f66e9-5fc3-72b6-9430-e7ae1dc4498e -->
 * **Never promoted to knowledge**: User stated NEVER promoted to knowledge.
 
 <!-- lore:019f65ca-9216-7d70-9a22-1eea846e704d -->
-* **Never pushed — enqueuing them would create outbox**: Never pushed — enqueuing them would create outbox. User stated never pushed — enqueuing them would create outbox. This is a directive preference.
+* **Never pushed — enqueuing them would create outbox**: User stated never pushed — enqueuing them would create outbox.
 
 <!-- lore:019f66e9-59bb-7472-904b-a861e340f64c -->
 * **Never puts in AGENTS**: Never run git subprocesses against a client-controlled cwd on a hosted gateway. Always degrade to \[cwd] / \[] when git operations are disabled.
 
 <!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
-* **Never re-read — so excluded**: Never re-read — so excluded. User stated never re-read — so excluded. This is a directive preference.
+* **Never re-read — so excluded**: User stated never re-read — so excluded.
 
 <!-- lore:019f65ca-9231-7baf-a27a-65ee4b6c3a4b -->
-* **Never reach the remote**: Never reach the remote. User stated never reach the remote. This is a directive preference.
+* **Never reach the remote**: User stated never reach the remote.
 
 <!-- lore:019f67f1-f15f-75ff-a20a-7b94e316e457 -->
 * **Never run git subprocesses against a client-controlled cwd on a hosted gateway**: User stated to never run git subprocesses against a client-controlled cwd on a hosted gateway.

--- a/.lore.md
+++ b/.lore.md
@@ -106,7 +106,7 @@
 * **Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes. (PR #1277 final commits: 0993b690 tooling, f11f2e4b reformat+autofix, a3486c5f**: Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes.
 
 <!-- lore:019f51ec-9e29-759e-a82c-e06c5485b7b2 -->
-* **Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables)**: Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables). Never marked incapable and the failure ladder escalated forever with a misleading "auth stale" warning.
+* **Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables)**: Switched to synchronous mode for future calls. User switched to synchronous mode for future calls. This is a declarative preference.
 
 <!-- lore:019f3974-7c6a-7091-8602-b4ec0bb763a4 -->
 * **Chose next task: knowledge\_meta seed-order alignment (self-contained, low-risk, completes value-ranked seed coherence work started with knowledge #1189 and entities #1194) — over #1191b (continuous top-N eviction)**: Completed value-ranked seed coherence work in sequence: #1189 (knowledge seed value-ranking) → PR #1194 (entity-graph seed: entities ranked by knowledge\_entity\_refs count DESC then recency; entity\_relations by recency; entity\_aliases by created\_at DESC) → PR #1196 (knowledge\_meta seed aligned to knowledge's ORDER BY: confidence DESC, COALESCE(last\_reinforced\_at, updated\_at) DESC, logical\_id tiebreak). Deferred #1191b (continuous top-N eviction for remote) as a separate larger/riskier task needing a design doc first (remote eviction, cap discovery, thrash guards, concurrency) — not suitable for autonomous same-session implementation. Follow-up issue #1197 filed for a known non-blocking edge case: a deleted high-confidence entry's orphaned knowledge\_meta row can outrank a live entry's meta row under the cap (self-healing, not data loss).
@@ -185,6 +185,9 @@
 <!-- lore:019f6b00-0d6b-787a-8490-b9f21b1d8cce -->
 * **Base64 encoded information in distillations**: Trap: Dropping base64 encoded information from distillations looks like data loss. Fix: Full raw message stored in temporal\_messages.content, indexed by temporal\_fts\_insert trigger using new.content, completely decoupled from distillation. Retrieval modalities: FTS/BM25 indexes full content (base64 theoretically retrievable via substring search), vector/semantic recall already loses base64 due to tool body dropping and truncation in buildEmbeddingUnits. Dropping base64 from distillation loses nothing usable, as bytes remain in temporal\_messages + FTS, and un-recoverable binary was never going to survive as text memory.
 
+<!-- lore:019f6b15-467b-73cd-9958-3f291d09a37a -->
+* **Bearer credential must never be shoved into api-key header**: Trap: bearer credential must never be shoved into api-key header looks correct because the worker model is cheap. Fix: bearer credential must never be shoved into api-key header. Bearer credential must never be shoved into api-key header.
+
 <!-- lore:019ef346-6e54-7f76-bae5-a73af003074c -->
 * **Bedrock worker 403: markAuthStale must NOT be called — no client credential to invalidate**: Trap: calling \`markAuthStale\`/\`markGlobalAuthStale\` on a Bedrock worker 403 looks correct — 403 usually means bad credentials. Fix: Bedrock workers authenticate via SigV4 (AWS IAM), not client API keys. There is no client credential to invalidate. Calling \`markAuthStale\` on a Bedrock 403 would incorrectly stale the Anthropic API key. Guard: skip \`markAuthStale\`/\`markGlobalAuthStale\` when \`effectiveProtocol === 'bedrock'\`. Same invariant applies to \`executeWarmup\` — Bedrock warmup never sends \`x-api-key\` or \`anthropic-version\`. Tests: llm-adapter.test.ts 'bedrock worker 403 does NOT mark client credential stale'; bedrock-warmup.test.ts 'a 403 does NOT mark the client credential stale (SigV4 has none)'. Both verified non-vacuous via swap-fail-restore.
 
@@ -261,10 +264,13 @@
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
 
 <!-- lore:019efa7b-7094-7654-87f4-0d5b7066beaa -->
-* **node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner**: Trap: node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner. Fix: All SQLite access must go through the #db/driver subpath import map.
+* **node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner**: The judge should never be imported outside driver. This is a directive preference.
 
 <!-- lore:019f6b15-46a7-7b64-be23-364265e1132e -->
 * **Non-OpenRouter providers must never see the provider.sort block**: Trap: non-OpenRouter providers must never see the provider.sort block looks correct because the worker model is cheap. Fix: non-OpenRouter providers must never see the provider.sort block. Non-OpenRouter providers must never see the provider.sort block.
+
+<!-- lore:019f60a6-ddca-789e-bd84-2769b6b537fb -->
+* **normalize erases operators/punctuation**: normalize erases operators/punctuation: Trap: stripping ALL non-alphanumeric chars collapses \`>= floor\` and \`> floor\` to \`floor\`, \`x == y\` and \`x != y\` to \`x y\`, etc. — suppressing material edits in code/config-heavy entries. Fix: replace 'strip everything non-alphanumeric' with 'strip a specific set of cosmetic characters, collapse whitespace.'
 
 <!-- lore:019f5e0a-59a7-7ee7-8ec1-5b7c7c721853 -->
 * **OpenAI-protocol cache hit rate issue**: Trap: OpenAI-protocol requests to OpenRouter show 100% cache miss rate because OpenRouter honors Anthropic-style breakpoints on OpenAI Chat Completions API but not on OpenAI requests. Fix: add Anthropic-style \`cache\_control\` breakpoints.
@@ -379,6 +385,9 @@
 <!-- lore:019f1e66-a06c-7c58-b5ec-6d7cb21eddc3 -->
 * **backfillTemporalEmbeddings: per-row checkpoint + backlog/progress logging (PR #1104)**: PR #1104 (\`fix/temporal-rechunk-checkpoint\`) changes two behaviors in \`backfillTemporalEmbeddings\`: 1. \*\*Per-row checkpoint\*\*: \`setKV(TEMPORAL\_RECHUNK\_CURSOR\_KEY, retryFrom ?? cursor)\` moved INSIDE the row loop (was per-page). Crash mid-pass now resumes from last completed row, not start of last page. \`retryFrom ?? cursor\` uses nullish (not \`||\`) — when first row fails, \`retryFrom = ''\` and \`'' ?? cursor\` → \`''\`, correctly resuming at \`id > ''\`. 2. \*\*Backlog + heartbeat logging\*\*: upfront \`SELECT COUNT(\*)\` logs \`'temporal re-chunk: N messages to scan (resuming)'\`; \`PROGRESS\_INTERVAL\_MS = 30\_000\` replaces count-based \`PROGRESS\_INTERVAL = 1000\`; heartbeat shows \`processed re-chunked, scanned scanned…\`. Mutations: per-row checkpoint test and backlog-log test both killed independently. Merged \`25a04e22\` at 2026-07-01T17:30:31Z.
 
+<!-- lore:019f6807-9895-777a-9b94-5e0465c7d512 -->
+* **Batch provider resolution**: Batch provider resolution: Batch LLM client resolves providers at flush time: groups items by \`(authKey, providerID)\`. Only \`anthropic\` and \`openai\` providerIDs get batch providers; others (NVIDIA, OpenRouter) fall back to synchronous processing. \`disabledBatchSessions\` and \`disabledBatchProviders\` sets track permanent batch API access failures.
+
 <!-- lore:019f00ae-c762-7067-8197-83d9b70d8dd9 -->
 * **cache-warmer evidence gate (Bug C): always fund first probe, never fund second+ cycle with zero lifetime hits**: 🔴 Directive: ALWAYS fund the first warmup of a break (\`cyclesSpent === 0\` — the probe that learns if this slow tool returns within TTL), but NEVER fund a second-or-later cycle for a session that has produced zero confirmed hits over its lifetime. Implementation: \`if (cyclesSpent >= 1 && (state.warmup?.warmupHits ?? 0) < TOOL\_CALL\_MIN\_HITS\_FOR\_CONTINUATION) return false\`. \`warmupHits\` is lifetime/durable across breaks; \`warmupCount\` (cyclesSpent) is per-break (reset on return in pipeline.ts). Rationale: 66 of 74 zero-hit warmups occurred at ≤5 lifetime warmups, below \`MIN\_WARMUPS\_FOR\_ROI\_CHECK\`, so hit-rate guard never engaged.
 
@@ -430,6 +439,9 @@
 <!-- lore:019f6803-de7b-7fb8-a01a-d8e5478112f7 -->
 * **Worktree-aware conversation detection**: Worktree-aware conversation detection: \`projectSearchPaths(projectPath, opts?)\` unions: resolved cwd (always first), \`git worktree list --porcelain\` output, and \`git rev-parse --git-dir\` parent directories. Deduplicates paths. \`detectAll()\` uses these paths to find agent sessions across worktrees.
 
+<!-- lore:019f6823-01d2-753d-a832-d426a3cb85d1 -->
+* **Worktree-aware import detection**: Worktree-aware import detection: Project search paths must include: resolved cwd (always first), git worktree paths, and DB aliases. Providers must deduplicate sessions by ID. Empty path arrays should degrade gracefully.
+
 ### Preference
 
 <!-- lore:019f6b0f-ba41-73a2-9c6e-566099faa175 -->
@@ -439,31 +451,16 @@
 * **Adversarial correctness review focus**: When reviewing code changes, focus ONLY on real bugs: logic errors, race conditions, incorrect assumptions, edge cases, security issues, and broken invariants. Categorize findings by severity: BLOCKER, SHOULD-FIX, NIT/MINOR. Do NOT nitpick style. Verify claims by reading actual code.
 
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
-* **Always a remote gateway — it has no shared filesystem with its clients**: User stated: 'Always a remote gateway — it has no shared filesystem with its clients'. This is a directive preference.
-
-<!-- lore:019f6ba4-041e-7712-b0cc-80307b7f4b2f -->
-* **Always add regression tests for identified bugs**: After identifying and fixing bugs (especially blockers like B1), the user consistently adds specific regression tests to prevent recurrence. The tests target the exact failure conditions, such as boundary cases (e.g., 'directive straddling hard window boundary') and verify the fix maintains correct behavior. This pattern applies whenever bugs are discovered during code reviews or testing.
-
-<!-- lore:019f6b30-43e0-7bba-a001-3f8766141466 -->
-* **Always confirm PR is CLEAN and MERGEABLE before merging**: The user consistently requires verification that a pull request is in a CLEAN state with MERGEABLE status before proceeding with merging. This includes checking that all CI checks pass, there are no blocking review comments, and the PR is ready for merge without conflicts. The assistant should always confirm these conditions are met before executing the merge operation.
-
-<!-- lore:019f6b84-15cd-78d4-9a24-ca95bdd3ebd5 -->
-* **Always emphasize security invariants with 'never' statements**: The user consistently uses strong 'never' statements to define critical security invariants and constraints. These statements appear in multiple contexts: when reviewing code, designing features, and specifying requirements. The user expects these invariants to be strictly enforced in the implementation. Examples include: 'server never holds plaintext DEK', 'ephemeral secret never reaches server', 'DEK wraps are always re-wrapped to prevent self-lockout', 'joining member must NEVER mint fresh DEK'.
+* **Always a remote gateway — it has no shared filesystem with its clients**: Always a remote gateway — it has no shared filesystem with its clients. This is a directive preference.
 
 <!-- lore:019f6b1c-7cd6-76b1-a3c4-f4bda879566c -->
 * **Always enforce cryptographic safety invariants**: User consistently emphasizes and enforces critical cryptographic safety invariants throughout the design and implementation process. Key patterns include: 1) Server never holds plaintext DEK, 2) Tokens never contain plaintext secrets, 3) Invitee hints are never resolved/verified by server, 4) Invites never downgrade existing roles, 5) Ephemeral keys never touch server, 6) mint:false is a divergence-safety guard not access control, 7) DEK wraps are always re-wrapped to prevent self-lockout. User provides tool results to verify these invariants are maintained in code and database schemas.
-
-<!-- lore:019f6b3c-63a8-7e71-ba5b-d041929383c8 -->
-* **Always enforce read-only adversarial reviews with throwaway worktree mutation testing**: The user consistently requires adversarial code reviews to be performed in a strictly read-only manner on the main working tree. Any mutation testing must occur in a separate, throwaway git worktree (typically under /tmp), with verification that the main tree remains byte-identical (via git status/sha256) and the temporary worktree is cleaned up afterward. Reviews must focus on correctness bugs categorized by severity, with explicit scrutiny areas and test verification requirements.
 
 <!-- lore:019f6b0d-388f-7da5-b60a-b04c9636837b -->
 * **Always enforce read-only review workflow with throwaway worktrees**: User consistently mandates a strict read-only review process where the main working repository must never be modified. All testing, mutation analysis, and temporary file operations must occur in isolated throwaway worktrees (typically under /tmp/). The assistant must verify that no tracked files in the main repository are ever touched during review activities. This pattern applies to both pre-merge and post-merge code reviews.
 
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
-* **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
-
-<!-- lore:019f6b49-3efa-7ec7-b4f8-9d522462dd6c -->
-* **Always implement user signal preservation rules in blob reduction**: The user consistently emphasizes strict rules for preserving user signal during blob reduction. Key requirements include: never blunt-truncating user content, always preserving pinned assertions and directives, preventing signal loss at window boundaries, and maintaining non-Latin character integrity. The user provides detailed implementation guidance, test requirements, and configuration parameters to enforce these rules. Any blob reduction implementation must prioritize these signal preservation constraints over other considerations.
+* **Always fail — wrong credentials**: Always fail — wrong credentials. This is a directive preference.
 
 <!-- lore:019f6af7-ff50-7c4c-920b-cc3c2dfd6aeb -->
 * **Always match when importing from the worktree (and vice-versa)**: User consistently requests matching when importing from the worktree and vice-versa across multiple sessions.
@@ -474,29 +471,32 @@
 <!-- lore:019f6b1a-2ec1-7e28-b546-73535a7d38db -->
 * **Always preserve user text verbatim without truncation**: The user consistently requires that all user-provided text (messages, comments, code) be preserved verbatim in distillations. This includes never truncating user content, even when it exceeds length limits applied to other content types. The user explicitly states 'User text is always signal — never truncate' in code comments and enforces this through implementation patterns that bypass truncation logic for user-generated content.
 
-<!-- lore:019f6b9f-3931-7f18-962a-e9a68aa5ccd6 -->
-* **Always provide comprehensive test results and code references**: The user consistently provides detailed test results, source code references, and specific implementation details when discussing code changes or issues. They demonstrate a pattern of thorough verification, often including multiple test cases, mutation tests, and explicit code snippets to illustrate their points. This indicates a strong preference for evidence-based discussion and rigorous testing practices.
-
 <!-- lore:019f6aef-f8b3-7b61-9be1-33904f8bca6e -->
 * **Always provide detailed tool results and session context**: The user consistently provides extensive technical context including specific implementation details, system constraints, and environmental factors. This includes API credentials, port numbers, file paths, database configurations, model specifications, and performance characteristics. The user expects this context to be understood and respected when implementing solutions or running evaluations.
 
 <!-- lore:019f6b0d-6019-7af7-bd69-c776e0b1913d -->
-* **Always provide tool results for verification after edits**: The user consistently provides tool results (test outputs, diff scopes, migration details, etc.) immediately after applying code changes. This pattern shows the user expects verification of changes through concrete evidence from development tools, rather than just accepting that changes were made. The assistant should be prepared to analyze and confirm these tool results as part of the development workflow.
+* **Always provide tool results for verification after edits**: The user consistently provides tool results (test outputs, typecheck results, coverage reports, etc.) immediately after applying edits. This demonstrates a strong preference for verifying that changes work as expected before proceeding. The pattern shows the user values concrete feedback and validation at each step of the development process.
 
 <!-- lore:019f66b3-cdb2-7605-9908-3135589ec555 -->
-* **Always record auth failure**: Always record the auth failure so the worker-health ladder sees it.
+* **Always record auth failure**: Always record auth failure. Always record the auth failure so the worker-health ladder sees it. This is a directive preference.
 
-<!-- lore:019f6b42-329f-7b38-9633-a57efc66cb95 -->
-* **Always run comprehensive test suites after code changes**: The user consistently runs extensive test suites after making code modifications. This includes running specific test files, filtered test groups, and full integration test suites. The user pays close attention to test results, including pass/fail counts and coverage reports, and uses this information to validate that changes haven't introduced regressions. This pattern demonstrates a strong preference for thorough testing to ensure code quality and stability.
-
-<!-- lore:019f6b34-c188-7e21-93da-2d0a7bfbcf5c -->
-* **Always specify exact technical constraints and requirements**: The user consistently provides highly detailed technical specifications, including exact API credentials, model names, token counts, file paths, and system configurations. They expect implementations to adhere precisely to these constraints, including ignore-lists, timeout values, and specific provider requirements. The user demonstrates deep technical awareness and expects solutions to account for real-world limitations like rate limits, authentication requirements, and system performance characteristics.
+<!-- lore:019f6af0-dce9-7e09-b0f3-b970e990013c -->
+* **Always specify exact implementation constraints and edge case handling**: The user consistently provides detailed implementation requirements, including specific error handling, edge case considerations, and behavioral constraints. They emphasize what should 'never' happen, what should 'always' be true, and how systems should behave under failure conditions. The user focuses on precise technical specifications rather than high-level descriptions.
 
 <!-- lore:019f6b1e-018e-7377-a9f2-828d44c0fdc2 -->
 * **Always specify negative constraints with 'never' statements**: The user consistently uses imperative 'never' statements to define critical negative constraints and invariants. These statements appear in multiple contexts: code behavior (e.g., 'never silently land on api', 'never goes through this builder'), system design (e.g., 'never the live conversation', 'never open the failure circuit'), and security boundaries (e.g., 'never shoved into', 'never collides'). The pattern indicates the user expects these constraints to be strictly enforced and verified through testing and code review.
 
-<!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
-* **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
+<!-- lore:019f6aff-0196-75c4-8a72-f9c75d1ec85c -->
+* **Always verify changes through systematic testing and validation**: The user consistently demonstrates a pattern of thorough verification after making changes. They request multiple validation steps including: running type checks (tsc), executing targeted tests, performing broader test sweeps, checking documentation generation, verifying file states and commit contents, confirming CI status, and examining diffs. This applies after code changes, configuration updates, or documentation edits. The user expects assistants to systematically validate that changes are correct, complete, and haven't introduced regressions before considering work complete.
+
+<!-- lore:019f6af6-b078-776d-845d-2f470609e535 -->
+* **Always verify CI checks and coverage metrics before merging**: The user consistently checks CI status, Codecov coverage metrics, and Seer review comments before approving PRs for merge. They require confirmation that all required checks pass, coverage meets targets, and there are no blocking comments. The user also verifies the exact coverage percentages and file changes to ensure quality standards are met.
+
+<!-- lore:019f6b0a-798e-7f3f-b7fa-78cc6b2570bc -->
+* **Always verify implementation details with concrete test cases**: The user consistently requests verification of implementation details through concrete test cases and tool outputs. They provide specific examples and edge cases to validate that the solution works as expected, particularly focusing on adversarial scenarios and potential failure points. The user expects the assistant to demonstrate correctness through empirical evidence rather than theoretical explanations alone.
+
+<!-- lore:019f6aff-01f7-716e-b066-92ced18b2b72 -->
+* **Always verify system behavior through direct code inspection and testing**: The user consistently demonstrates a pattern of verifying system behavior through direct code inspection, testing, and validation. When discussing system capabilities or limitations, the user asks for verification of specific behaviors, requests code-level explanations, and expects confirmation through testing or tool-assisted analysis. The user prefers to see concrete evidence from the codebase rather than relying on assumptions or high-level descriptions.
 
 <!-- lore:019f666d-4d29-7800-821a-db71f2686b1b -->
 * **Architecture: context never wiped and rebuilt from lossy summary**: Architecture: context never wiped and rebuilt from lossy summary. Switching to Mastra's observer/reflector architecture with plain-text timestamped observation logs was the breakthrough. The switch from structured JSON to timestamped observation logs made v2 work.
@@ -516,9 +516,6 @@
 <!-- lore:019f666d-4c13-79cf-a6b9-221b19f68d9d -->
 * **Documentation style: README pattern with annotated bash blocks**: Documentation style: README pattern with annotated bash blocks. CLI commands in README.md use annotated bash blocks with \`#\` comments explaining each flag and argument. Website documentation uses frontmatter/H2 sections/Starlight directives. Guides use imperative titles like 'With OpenCode'.
 
-<!-- lore:019f6b92-246b-7f76-9995-e7cdb0dee186 -->
-* **Enforceable invariant filter: prescriptive keyword AND (code reference OR strong code-token signal)**: User stated: 'always or explicit enforce: opt-in) to the judge'. Refined to require prescriptive keyword AND (code reference OR strong code-token signal) to eliminate false keeps and correct skips. This is a directive preference.
-
 <!-- lore:019f666d-4c83-73d0-94ce-549b70d0bf3e -->
 * **Importers: supported list for lore import**: Importers: supported list for lore import: Supported importers consistently mentioned: Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi.
 
@@ -529,13 +526,13 @@
 * **Knowledge file (.lore.md) should be ignored in evaluations**: The knowledge file (.lore.md) should be added to an ignore-list for evaluations. This is a directive preference.
 
 <!-- lore:019f650e-1593-72e3-8c34-fdbf17c32560 -->
-* **Never a skip/conflict**: Never a skip/conflict: User stated never a skip/conflict.
+* **Never a skip/conflict**: Never a skip/conflict. Never a skip/conflict: User stated never a skip/conflict. This is a directive preference.
 
 <!-- lore:019f66a7-6355-761d-ac7a-3050e24a86bf -->
 * **Never accumulate to 30/60 minutes of sustained outage**: User stated never accumulate to 30/60 minutes of sustained outage.
 
 <!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
-* **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
+* **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access. This is a directive preference.
 
 <!-- lore:019f66e9-5fde-7103-a386-f9e5db82613a -->
 * **Never compacts -> errors instead**: User stated never compacts -> errors instead.
@@ -547,7 +544,7 @@
 * **Never falls through to the real defaults 3207/5673**: User stated never falls through to the real defaults 3207/5673.
 
 <!-- lore:019f65ca-91fb-7140-b01f-aeb90540b80d -->
-* **Never from within another transaction**: User stated never from within another transaction.
+* **Never from within another transaction**: Never from within another transaction. User stated never from within another transaction. This is a directive preference.
 
 <!-- lore:019f66a2-591b-7b5d-a0b3-886f650b755f -->
 * **Never marked incapable after 3 consecutive curator empties**: Never marked incapable after 3 consecutive curator empties — reset streak per-worker.
@@ -556,22 +553,22 @@
 * **Never marks a model incapable**: User stated never marks a model incapable.
 
 <!-- lore:019f62e7-b68c-7a51-87d5-d0771009efc6 -->
-* **Never penalizes (neutral) 2ms**: Never penalize entries with latency over 2ms.
+* **Never penalizes (neutral) 2ms**: Never penalize entries with latency over 2ms. This is a directive preference.
 
 <!-- lore:019f66e9-5fc3-72b6-9430-e7ae1dc4498e -->
 * **Never promoted to knowledge**: User stated NEVER promoted to knowledge.
 
 <!-- lore:019f65ca-9216-7d70-9a22-1eea846e704d -->
-* **Never pushed — enqueuing them would create outbox**: User stated never pushed — enqueuing them would create outbox.
+* **Never pushed — enqueuing them would create outbox**: Never pushed — enqueuing them would create outbox. User stated never pushed — enqueuing them would create outbox. This is a directive preference.
 
 <!-- lore:019f66e9-59bb-7472-904b-a861e340f64c -->
 * **Never puts in AGENTS**: Never run git subprocesses against a client-controlled cwd on a hosted gateway. Always degrade to \[cwd] / \[] when git operations are disabled.
 
 <!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
-* **Never re-read — so excluded**: User stated never re-read — so excluded.
+* **Never re-read — so excluded**: Never re-read — so excluded. User stated never re-read — so excluded. This is a directive preference.
 
 <!-- lore:019f65ca-9231-7baf-a27a-65ee4b6c3a4b -->
-* **Never reach the remote**: User stated never reach the remote.
+* **Never reach the remote**: Never reach the remote. User stated never reach the remote. This is a directive preference.
 
 <!-- lore:019f67f1-f15f-75ff-a20a-7b94e316e457 -->
 * **Never run git subprocesses against a client-controlled cwd on a hosted gateway**: User stated to never run git subprocesses against a client-controlled cwd on a hosted gateway.

--- a/.lore.md
+++ b/.lore.md
@@ -498,12 +498,6 @@
 <!-- lore:019f6b1e-018e-7377-a9f2-828d44c0fdc2 -->
 * **Always specify negative constraints with 'never' statements**: The user consistently uses imperative 'never' statements to define critical negative constraints and invariants. These statements appear in multiple contexts: code behavior (e.g., 'never silently land on api', 'never goes through this builder'), system design (e.g., 'never the live conversation', 'never open the failure circuit'), and security boundaries (e.g., 'never shoved into', 'never collides'). The pattern indicates the user expects these constraints to be strictly enforced and verified through testing and code review.
 
-<!-- lore:019f6b0a-798e-7f3f-b7fa-78cc6b2570bc -->
-* **Always verify implementation details with concrete test cases**: The user consistently requests verification of implementation details through concrete test cases and tool outputs. They provide specific examples and edge cases to validate that the solution works as expected, particularly focusing on adversarial scenarios and potential failure points. The user expects the assistant to demonstrate correctness through empirical evidence rather than theoretical explanations alone.
-
-<!-- lore:019f6aff-01f7-716e-b066-92ced18b2b72 -->
-* **Always verify system behavior through direct code inspection and testing**: The user consistently demonstrates a pattern of verifying system behavior through direct code inspection, testing, and validation. When discussing system capabilities or limitations, the user asks for verification of specific behaviors, requests code-level explanations, and expects confirmation through testing or tool-assisted analysis. The user prefers to see concrete evidence from the codebase rather than relying on assumptions or high-level descriptions.
-
 <!-- lore:019f666d-4d29-7800-821a-db71f2686b1b -->
 * **Architecture: context never wiped and rebuilt from lossy summary**: Architecture: context never wiped and rebuilt from lossy summary. Switching to Mastra's observer/reflector architecture with plain-text timestamped observation logs was the breakthrough. The switch from structured JSON to timestamped observation logs made v2 work.
 

--- a/.lore.md
+++ b/.lore.md
@@ -185,9 +185,6 @@
 <!-- lore:019f6b00-0d6b-787a-8490-b9f21b1d8cce -->
 * **Base64 encoded information in distillations**: Trap: Dropping base64 encoded information from distillations looks like data loss. Fix: Full raw message stored in temporal\_messages.content, indexed by temporal\_fts\_insert trigger using new.content, completely decoupled from distillation. Retrieval modalities: FTS/BM25 indexes full content (base64 theoretically retrievable via substring search), vector/semantic recall already loses base64 due to tool body dropping and truncation in buildEmbeddingUnits. Dropping base64 from distillation loses nothing usable, as bytes remain in temporal\_messages + FTS, and un-recoverable binary was never going to survive as text memory.
 
-<!-- lore:019f6b15-467b-73cd-9958-3f291d09a37a -->
-* **Bearer credential must never be shoved into api-key header**: Trap: bearer credential must never be shoved into api-key header looks correct because the worker model is cheap. Fix: bearer credential must never be shoved into api-key header. Bearer credential must never be shoved into api-key header.
-
 <!-- lore:019ef346-6e54-7f76-bae5-a73af003074c -->
 * **Bedrock worker 403: markAuthStale must NOT be called — no client credential to invalidate**: Trap: calling \`markAuthStale\`/\`markGlobalAuthStale\` on a Bedrock worker 403 looks correct — 403 usually means bad credentials. Fix: Bedrock workers authenticate via SigV4 (AWS IAM), not client API keys. There is no client credential to invalidate. Calling \`markAuthStale\` on a Bedrock 403 would incorrectly stale the Anthropic API key. Guard: skip \`markAuthStale\`/\`markGlobalAuthStale\` when \`effectiveProtocol === 'bedrock'\`. Same invariant applies to \`executeWarmup\` — Bedrock warmup never sends \`x-api-key\` or \`anthropic-version\`. Tests: llm-adapter.test.ts 'bedrock worker 403 does NOT mark client credential stale'; bedrock-warmup.test.ts 'a 403 does NOT mark the client credential stale (SigV4 has none)'. Both verified non-vacuous via swap-fail-restore.
 
@@ -268,9 +265,6 @@
 
 <!-- lore:019f6b15-46a7-7b64-be23-364265e1132e -->
 * **Non-OpenRouter providers must never see the provider.sort block**: Trap: non-OpenRouter providers must never see the provider.sort block looks correct because the worker model is cheap. Fix: non-OpenRouter providers must never see the provider.sort block. Non-OpenRouter providers must never see the provider.sort block.
-
-<!-- lore:019f60a6-ddca-789e-bd84-2769b6b537fb -->
-* **normalize erases operators/punctuation**: normalize erases operators/punctuation: Trap: stripping ALL non-alphanumeric chars collapses \`>= floor\` and \`> floor\` to \`floor\`, \`x == y\` and \`x != y\` to \`x y\`, etc. — suppressing material edits in code/config-heavy entries. Fix: replace 'strip everything non-alphanumeric' with 'strip a specific set of cosmetic characters, collapse whitespace.'
 
 <!-- lore:019f5e0a-59a7-7ee7-8ec1-5b7c7c721853 -->
 * **OpenAI-protocol cache hit rate issue**: Trap: OpenAI-protocol requests to OpenRouter show 100% cache miss rate because OpenRouter honors Anthropic-style breakpoints on OpenAI Chat Completions API but not on OpenAI requests. Fix: add Anthropic-style \`cache\_control\` breakpoints.
@@ -436,9 +430,6 @@
 <!-- lore:019f6803-de7b-7fb8-a01a-d8e5478112f7 -->
 * **Worktree-aware conversation detection**: Worktree-aware conversation detection: \`projectSearchPaths(projectPath, opts?)\` unions: resolved cwd (always first), \`git worktree list --porcelain\` output, and \`git rev-parse --git-dir\` parent directories. Deduplicates paths. \`detectAll()\` uses these paths to find agent sessions across worktrees.
 
-<!-- lore:019f6823-01d2-753d-a832-d426a3cb85d1 -->
-* **Worktree-aware import detection**: Worktree-aware import detection: Project search paths must include: resolved cwd (always first), git worktree paths, and DB aliases. Providers must deduplicate sessions by ID. Empty path arrays should degrade gracefully.
-
 ### Preference
 
 <!-- lore:019f6b0f-ba41-73a2-9c6e-566099faa175 -->
@@ -448,7 +439,7 @@
 * **Adversarial correctness review focus**: When reviewing code changes, focus ONLY on real bugs: logic errors, race conditions, incorrect assumptions, edge cases, security issues, and broken invariants. Categorize findings by severity: BLOCKER, SHOULD-FIX, NIT/MINOR. Do NOT nitpick style. Verify claims by reading actual code.
 
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
-* **Always a remote gateway — it has no shared filesystem with its clients**: Always a remote gateway — it has no shared filesystem with its clients. This is a directive preference.
+* **Always a remote gateway — it has no shared filesystem with its clients**: User stated: 'Always a remote gateway — it has no shared filesystem with its clients'. This is a directive preference.
 
 <!-- lore:019f6b30-43e0-7bba-a001-3f8766141466 -->
 * **Always confirm PR is CLEAN and MERGEABLE before merging**: The user consistently requires verification that a pull request is in a CLEAN state with MERGEABLE status before proceeding with merging. This includes checking that all CI checks pass, there are no blocking review comments, and the PR is ready for merge without conflicts. The assistant should always confirm these conditions are met before executing the merge operation.
@@ -466,7 +457,7 @@
 * **Always enforce read-only review workflow with throwaway worktrees**: User consistently mandates a strict read-only review process where the main working repository must never be modified. All testing, mutation analysis, and temporary file operations must occur in isolated throwaway worktrees (typically under /tmp/). The assistant must verify that no tracked files in the main repository are ever touched during review activities. This pattern applies to both pre-merge and post-merge code reviews.
 
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
-* **Always fail — wrong credentials**: Always fail — wrong credentials. This is a directive preference.
+* **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
 
 <!-- lore:019f6b49-3efa-7ec7-b4f8-9d522462dd6c -->
 * **Always implement user signal preservation rules in blob reduction**: The user consistently emphasizes strict rules for preserving user signal during blob reduction. Key requirements include: never blunt-truncating user content, always preserving pinned assertions and directives, preventing signal loss at window boundaries, and maintaining non-Latin character integrity. The user provides detailed implementation guidance, test requirements, and configuration parameters to enforce these rules. Any blob reduction implementation must prioritize these signal preservation constraints over other considerations.
@@ -479,6 +470,9 @@
 
 <!-- lore:019f6b1a-2ec1-7e28-b546-73535a7d38db -->
 * **Always preserve user text verbatim without truncation**: The user consistently requires that all user-provided text (messages, comments, code) be preserved verbatim in distillations. This includes never truncating user content, even when it exceeds length limits applied to other content types. The user explicitly states 'User text is always signal — never truncate' in code comments and enforces this through implementation patterns that bypass truncation logic for user-generated content.
+
+<!-- lore:019f6b9f-3931-7f18-962a-e9a68aa5ccd6 -->
+* **Always provide comprehensive test results and code references**: The user consistently provides detailed test results, source code references, and specific implementation details when discussing code changes or issues. They demonstrate a pattern of thorough verification, often including multiple test cases, mutation tests, and explicit code snippets to illustrate their points. This indicates a strong preference for evidence-based discussion and rigorous testing practices.
 
 <!-- lore:019f6aef-f8b3-7b61-9be1-33904f8bca6e -->
 * **Always provide detailed tool results and session context**: The user consistently provides extensive technical context including specific implementation details, system constraints, and environmental factors. This includes API credentials, port numbers, file paths, database configurations, model specifications, and performance characteristics. The user expects this context to be understood and respected when implementing solutions or running evaluations.
@@ -498,6 +492,9 @@
 <!-- lore:019f6b1e-018e-7377-a9f2-828d44c0fdc2 -->
 * **Always specify negative constraints with 'never' statements**: The user consistently uses imperative 'never' statements to define critical negative constraints and invariants. These statements appear in multiple contexts: code behavior (e.g., 'never silently land on api', 'never goes through this builder'), system design (e.g., 'never the live conversation', 'never open the failure circuit'), and security boundaries (e.g., 'never shoved into', 'never collides'). The pattern indicates the user expects these constraints to be strictly enforced and verified through testing and code review.
 
+<!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
+* **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
+
 <!-- lore:019f666d-4d29-7800-821a-db71f2686b1b -->
 * **Architecture: context never wiped and rebuilt from lossy summary**: Architecture: context never wiped and rebuilt from lossy summary. Switching to Mastra's observer/reflector architecture with plain-text timestamped observation logs was the breakthrough. The switch from structured JSON to timestamped observation logs made v2 work.
 
@@ -515,6 +512,9 @@
 
 <!-- lore:019f666d-4c13-79cf-a6b9-221b19f68d9d -->
 * **Documentation style: README pattern with annotated bash blocks**: Documentation style: README pattern with annotated bash blocks. CLI commands in README.md use annotated bash blocks with \`#\` comments explaining each flag and argument. Website documentation uses frontmatter/H2 sections/Starlight directives. Guides use imperative titles like 'With OpenCode'.
+
+<!-- lore:019f6b92-246b-7f76-9995-e7cdb0dee186 -->
+* **Enforceable invariant filter: prescriptive keyword AND (code reference OR strong code-token signal)**: User stated: 'always or explicit enforce: opt-in) to the judge'. Refined to require prescriptive keyword AND (code reference OR strong code-token signal) to eliminate false keeps and correct skips. This is a directive preference.
 
 <!-- lore:019f666d-4c83-73d0-94ce-549b70d0bf3e -->
 * **Importers: supported list for lore import**: Importers: supported list for lore import: Supported importers consistently mentioned: Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi.

--- a/packages/core/src/blob-select.ts
+++ b/packages/core/src/blob-select.ts
@@ -138,30 +138,78 @@ export function looksLikePasteJunk(segment: string): boolean {
   return false;
 }
 
+/** A segment of the original body, carrying its char offsets so callers can map
+ *  positions (e.g. detected-directive spans) back to segments regardless of how
+ *  the body was split. `[start, end)` are indices into the original body. */
+export interface Segment {
+  text: string;
+  start: number;
+  end: number;
+}
+
 /**
  * Split a body into coherent segments: on the part terminator (tool envelopes
- * stored in the message) and blank lines (paragraphs). Oversized paragraphs and
- * single-giant-line dumps (minified JSON / one-line logs) fall back to fixed
- * char windows so a pathological one-line megablob still segments.
+ * stored in the message) and blank lines (paragraphs). Oversized paragraphs are
+ * split on line boundaries first (so a directive on its own line stays intact);
+ * only a genuinely unbroken giant line (minified JSON / one-line log) falls back
+ * to fixed char windows. Each segment carries its `[start, end)` offset into the
+ * original body.
  */
 export function segmentBody(
   body: string,
   segmentChars = SEGMENT_CHARS,
-): string[] {
+): Segment[] {
+  const segments: Segment[] = [];
+  const push = (text: string, start: number) => {
+    if (text.trim()) segments.push({ text, start, end: start + text.length });
+  };
+
+  // Walk the body span-by-span so every segment keeps a true offset. We split on
+  // the part terminator, then blank lines, then (for oversized paragraphs) lines,
+  // then (for oversized lines) fixed char windows.
+  const emitChunk = (chunk: string, base: number) => {
+    if (chunk.length <= segmentChars * 2) {
+      push(chunk, base);
+      return;
+    }
+    // Oversized: split on line boundaries, preserving offsets. A line that is
+    // itself oversized is hard-windowed (the only case that can split a directive
+    // — but a directive on its own line is preserved).
+    let cursor = 0;
+    const lines = chunk.split("\n");
+    for (let li = 0; li < lines.length; li++) {
+      const line = lines[li];
+      const lineBase = base + cursor;
+      if (line.length <= segmentChars * 2) {
+        push(line, lineBase);
+      } else {
+        for (let i = 0; i < line.length; i += segmentChars) {
+          push(line.slice(i, i + segmentChars), lineBase + i);
+        }
+      }
+      cursor += line.length + 1; // +1 for the consumed "\n"
+    }
+  };
+
+  // Split into parts on the terminator while tracking offsets.
+  let partBase = 0;
   const parts = body.includes(CHUNK_TERMINATOR)
     ? body.split(CHUNK_SEPARATOR)
     : [body];
-  const segments: string[] = [];
-  for (const part of parts) {
-    for (const paragraph of part.split(/\n\s*\n/)) {
-      if (paragraph.length <= segmentChars * 2) {
-        if (paragraph.trim()) segments.push(paragraph);
-        continue;
-      }
-      for (let i = 0; i < paragraph.length; i += segmentChars) {
-        segments.push(paragraph.slice(i, i + segmentChars));
-      }
+  for (let pi = 0; pi < parts.length; pi++) {
+    const part = parts[pi];
+    // Paragraph split within the part (blank lines). Use a matched-offset walk so
+    // paragraph offsets stay accurate through variable-width blank-line runs.
+    const paraRe = /\n\s*\n/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = paraRe.exec(part)) !== null) {
+      emitChunk(part.slice(last, m.index), partBase + last);
+      last = m.index + m[0].length;
     }
+    emitChunk(part.slice(last), partBase + last);
+    // Advance past this part plus the separator that split() consumed.
+    partBase += part.length + CHUNK_SEPARATOR.length;
   }
   return segments;
 }
@@ -179,9 +227,11 @@ export interface ReduceBlobOptions {
   maxSegments: number;
   /**
    * High-priority text snippets (e.g. detected user assertions/directives) that
-   * MUST survive reduction. Any segment containing one of these as a substring is
-   * force-kept regardless of relevance score or budget — a directive buried in an
-   * oversized blob must never be elided. Empty/whitespace entries are ignored.
+   * MUST survive reduction. Located by offset in the original body; every segment
+   * overlapping a match is force-kept regardless of relevance score, budget, or
+   * Stage-1 classification — a directive buried in an oversized blob must never
+   * be elided, even when segmentation splits it across a window boundary.
+   * Empty/whitespace entries are ignored; a trailing display "…" is tolerated.
    */
   pinnedLines?: string[];
 }
@@ -219,69 +269,89 @@ export async function reduceBlob(
   const all = segmentBody(body);
   const pins = (opts.pinnedLines ?? [])
     // Callers may pass display-truncated snippets (e.g. a 200-char cap with a
-    // trailing "…"); strip a trailing ellipsis/whitespace so substring matching
-    // works against the verbatim segment text.
+    // trailing "…"); strip a trailing ellipsis/whitespace so matching works
+    // against the verbatim body text.
     .map((p) => p.replace(/\s*…\s*$/u, "").trim())
     .filter((p) => p.length > 0);
-  // A segment is pinned if it contains any high-priority snippet verbatim. Pinned
-  // segments are force-kept even if Stage-1 would drop them or they'd fall
-  // outside the sampled/budgeted set — a directive must never be elided.
-  const isPinned = (seg: string) => pins.some((p) => seg.includes(p));
+
+  // Locate each pin's char span(s) in the ORIGINAL body, then mark every segment
+  // whose offset range overlaps a pin span as pinned. Matching by body offset —
+  // not by `segment.includes(pin)` — is what makes a directive survive even when
+  // segmentation splits it across a window boundary (both overlapping windows are
+  // force-kept). #1343 B1.
+  const pinSpans: Array<[number, number]> = [];
+  for (const p of pins) {
+    let from = 0;
+    for (;;) {
+      const idx = body.indexOf(p, from);
+      if (idx < 0) break;
+      pinSpans.push([idx, idx + p.length]);
+      from = idx + p.length;
+    }
+  }
+  const overlapsPin = (seg: Segment) =>
+    pinSpans.some(([s, e]) => seg.start < e && s < seg.end);
+  const pinnedFlag = all.map(overlapsPin);
 
   // Stage 1: drop paste-junk before spending any embed — but never drop a pinned
   // segment (a directive can look "junky" if wrapped in a noisy blob).
-  const prose = all.filter((s) => isPinned(s) || !looksLikePasteJunk(s));
-  const junkDropped = all.length - prose.length;
+  const proseIdx: number[] = [];
+  for (let i = 0; i < all.length; i++) {
+    if (pinnedFlag[i] || !looksLikePasteJunk(all[i].text)) proseIdx.push(i);
+  }
+  const junkDropped = all.length - proseIdx.length;
 
-  if (prose.length === 0) {
+  if (proseIdx.length === 0) {
     // Entire blob was non-prose (e.g. a pure base64/binary paste). Nothing worth
     // embedding — annotate the whole thing as elided.
-    return {
-      output: elision(body.length),
-      junkDropped,
-      embedded: 0,
-      kept: 0,
-    };
+    return { output: elision(body.length), junkDropped, embedded: 0, kept: 0 };
   }
 
-  // Cap segment count to bound embed cost; uniformly sample so coverage spans the
-  // whole surviving body rather than just its head. Pinned segments are always
-  // included in the sample so they can never be dropped by the cap.
-  let capped: string[];
-  if (prose.length > opts.maxSegments) {
-    const pinned = prose.filter(isPinned);
-    const sampleBudget = Math.max(0, opts.maxSegments - pinned.length);
-    const nonPinned = prose.filter((s) => !isPinned(s));
+  // Cap segment count to bound embed cost — operating on INDICES so duplicate
+  // segment text can never inflate the count past maxSegments (#1343 S2; Seer
+  // r3596091130). Pinned segments are always included; the remaining budget is
+  // uniformly sampled across the non-pinned survivors so coverage still spans the
+  // whole body.
+  let cappedIdx: number[];
+  if (proseIdx.length > opts.maxSegments) {
+    const pinnedIdx = proseIdx.filter((i) => pinnedFlag[i]);
+    const nonPinnedIdx = proseIdx.filter((i) => !pinnedFlag[i]);
+    const sampleBudget = Math.max(0, opts.maxSegments - pinnedIdx.length);
+    // sampleBudget === 0 (pins alone meet/exceed the cap) → keep ZERO non-pinned,
+    // never all of them (#1343 S3).
     const sampled =
-      sampleBudget > 0 && nonPinned.length > sampleBudget
-        ? Array.from(
-            { length: sampleBudget },
-            (_, i) =>
-              nonPinned[Math.floor((i * nonPinned.length) / sampleBudget)],
-          )
-        : nonPinned;
-    // Re-select from `prose` in original order to preserve ordering, keeping any
-    // segment that is pinned or made the non-pinned sample.
-    const keepSet = new Set([...pinned, ...sampled]);
-    capped = prose.filter((s) => keepSet.has(s));
+      sampleBudget === 0
+        ? []
+        : nonPinnedIdx.length > sampleBudget
+          ? Array.from(
+              { length: sampleBudget },
+              (_, k) =>
+                nonPinnedIdx[
+                  Math.floor((k * nonPinnedIdx.length) / sampleBudget)
+                ],
+            )
+          : nonPinnedIdx;
+    const keep = new Set<number>([...pinnedIdx, ...sampled]);
+    cappedIdx = proseIdx.filter((i) => keep.has(i));
   } else {
-    capped = prose;
+    cappedIdx = proseIdx;
   }
 
   // Stage 2: embed query + segments, score by cosine, greedily fill the budget.
   const [queryVec] = await opts.embed([opts.query]);
-  const segVecs = await opts.embed(capped);
-  const scored = capped.map((text, idx) => ({
-    text,
-    idx,
-    score: opts.cosine(queryVec, segVecs[idx]),
-    pinned: isPinned(text),
+  const segVecs = await opts.embed(cappedIdx.map((i) => all[i].text));
+  const scored = cappedIdx.map((i, k) => ({
+    idx: i,
+    text: all[i].text,
+    score: opts.cosine(queryVec, segVecs[k]),
+    pinned: pinnedFlag[i],
   }));
 
   const keepIdx = new Set<number>();
   let used = 0;
   // Pinned segments are kept unconditionally (bypass the budget) so a directive
-  // can never be elided.
+  // can never be elided. The number of pins is bounded by the caller
+  // (MAX_PINNED_ASSERTIONS), so this cannot blow the budget unboundedly.
   for (const s of scored) {
     if (s.pinned) {
       keepIdx.add(s.idx);
@@ -299,25 +369,42 @@ export async function reduceBlob(
   }
 
   // Reassemble in original order, collapsing dropped runs into one annotation.
-  const outParts: string[] = [];
+  // Iterate over ALL segments (not just embedded ones) so junk-dropped and
+  // cap-dropped regions are accounted for in the elision totals. Kept segments
+  // that were contiguous in the original body (adjacent hard-window pieces of one
+  // line: prevEnd === start) rejoin with NO separator so a mid-word window split
+  // is byte-exact; otherwise segments join with "\n".
+  let output = "";
   let elided = 0;
-  for (const s of scored) {
-    if (keepIdx.has(s.idx)) {
-      if (elided > 0) {
-        outParts.push(elision(elided));
-        elided = 0;
-      }
-      outParts.push(s.text);
+  let prevKeptEnd = -1;
+  let wroteAnything = false;
+  const flushElision = () => {
+    if (elided > 0) {
+      if (wroteAnything) output += "\n";
+      output += elision(elided);
+      wroteAnything = true;
+      elided = 0;
+    }
+  };
+  for (let i = 0; i < all.length; i++) {
+    const seg = all[i];
+    if (keepIdx.has(i)) {
+      flushElision();
+      if (wroteAnything) output += prevKeptEnd === seg.start ? "" : "\n";
+      output += seg.text;
+      prevKeptEnd = seg.end;
+      wroteAnything = true;
     } else {
-      elided += s.text.length;
+      elided += seg.text.length;
+      prevKeptEnd = -1;
     }
   }
-  if (elided > 0) outParts.push(elision(elided));
+  flushElision();
 
   return {
-    output: outParts.join("\n"),
+    output,
     junkDropped,
-    embedded: capped.length,
+    embedded: cappedIdx.length,
     kept: keepIdx.size,
   };
 }

--- a/packages/core/src/blob-select.ts
+++ b/packages/core/src/blob-select.ts
@@ -1,0 +1,323 @@
+// Embedding-based relevance selection for oversized user message blobs (#1343).
+//
+// The segment distiller feeds user-message content verbatim to the worker LLM —
+// "user text is always signal". That holds for prose/directives but NOT for large
+// pasted blobs (logs, dumped files, data exports, base64, minified JSON). Those
+// are bulk, not signal: the observer reads 85K tokens to emit ~500. This module
+// reduces such blobs BEFORE they reach the worker, keeping only the portions that
+// are relevant to what the distiller actually cares about.
+//
+// The design is a TWO-STAGE filter (validated against real production blobs in
+// #1343 — see .opencode/plans):
+//
+//   Stage 1 — cheap lexical pre-filter (FREE, no embeddings). Drops non-prose
+//     "paste junk" (base64, repeated garbage bytes, minified dumps) with pure
+//     string arithmetic. This is the biggest cost lever: a hostile blob never
+//     reaches the embedder. Script-aware so it never drops non-Latin prose.
+//
+//   Stage 2 — embedding relevance. Embeds the surviving prose/code segments and
+//     the caller's relevance query, keeps the top-scoring segments up to a char
+//     budget. Elided runs are annotated so the observer knows content was removed.
+//
+// Fail-open: the CALLER decides what to do when embeddings are unavailable — this
+// module only runs Stage 2 when given an `embed`. `reduceBlob` throwing/rejecting
+// must be caught by the caller, which leaves the body verbatim (never blunt-
+// truncated: dropping user signal is worse than paying for it once).
+//
+// Dependency-free leaf (like embedding-units.ts): takes `embed`/`cosine` as
+// injected functions so it can be unit-tested without the ONNX worker.
+
+/** ASCII Unit Separator — mirrors CHUNK_TERMINATOR in temporal.ts. */
+const CHUNK_TERMINATOR = "\x1f";
+const CHUNK_SEPARATOR = `\n${CHUNK_TERMINATOR}`;
+
+/** Target segment size in chars. Paragraphs larger than 2× this are windowed. */
+const SEGMENT_CHARS = 800;
+
+/**
+ * Segments shorter than this are never judged as junk (too little to classify —
+ * keep, the safe direction). Also the floor below which a whole blob isn't worth
+ * reducing.
+ */
+const MIN_JUDGE_CHARS = 40;
+
+/**
+ * Non-Latin linguistic scripts. Presence in bulk signals human prose. Space-
+ * optional scripts (Han/Kana/Hangul/Thai) are here too — they legitimately lack
+ * word spaces, so the Latin space/word structural test must NOT be applied to
+ * them. `u` flag required for `\p{Script=…}` (used elsewhere: search.ts,
+ * instruction-detect.ts; works on Node + Bun).
+ */
+const NON_LATIN_LINGUISTIC =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Cyrillic}\p{Script=Greek}\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Devanagari}]/gu;
+
+/** Latin letters carrying diacritics (Turkish ç ş ğ ı ö ü, accented Latin). */
+const LATIN_DIACRITICS = /[\u00C0-\u024F\u1E00-\u1EFF]/gu;
+
+/** Any Unicode letter. */
+const ANY_LETTER = /\p{L}/gu;
+
+/**
+ * Fraction of a segment that must be a non-Latin linguistic script before it
+ * takes the language-script branch (skip space/word test, apply entropy test).
+ * 30% (not a mere sprinkle) so a 10%-CJK / 90%-junk mix can't whitewash garbage.
+ */
+const NON_LATIN_DOMINANT = 0.3;
+
+/** More than this many Latin diacritics → treat as accented-Latin prose. */
+const DIACRITIC_MIN = 3;
+
+/**
+ * Distinct-character ratio ceiling for the language-script branch. Real
+ * CJK/JP/KR prose reuses common characters (dcr ≈ 0.6–0.73); random CJK/binary
+ * noise spans its block uniformly (dcr ≈ 0.99). Above this → noise, drop.
+ * Alphabetic scripts sit far below (Cyrillic ≈ 0.23, Arabic ≈ 0.28).
+ */
+const LANG_DCR_MAX = 0.85;
+
+/**
+ * For ASCII-dominant segments: average token length above this (with few
+ * letters) marks a base64/minified dump — enormous unbroken tokens.
+ */
+const ASCII_AVG_TOKEN_MAX = 40;
+const ASCII_LETTER_RATIO_MAX = 0.5;
+
+/**
+ * Trigram distinct ratio floor for ASCII-dominant segments. Repeated garbage
+ * bytes produce very few distinct trigrams. Below this → drop.
+ */
+const ASCII_TRIGRAM_RATIO_MIN = 0.15;
+
+/** Distinct-character ratio over a string. */
+function distinctCharRatio(t: string): number {
+  return new Set(t).size / t.length;
+}
+
+/** Distinct-trigram ratio (sequence-level repetition signal). */
+function trigramRatio(t: string): number {
+  const distinct = new Set<string>();
+  for (let i = 0; i + 3 <= t.length; i += 3) distinct.add(t.slice(i, i + 3));
+  return distinct.size / Math.max(1, Math.floor(t.length / 3));
+}
+
+/**
+ * Stage 1: is this segment non-prose "paste junk" that should be dropped before
+ * spending an embed? Pure string arithmetic — no model, no I/O.
+ *
+ * 🔴 Tuning invariant: a false POSITIVE (dropping real prose) violates "user
+ * text is signal" and is unacceptable; a false NEGATIVE (keeping junk) only
+ * costs a few embeds that Stage 2 ranks low. Tuned conservatively — when in
+ * doubt, keep.
+ */
+export function looksLikePasteJunk(segment: string): boolean {
+  const t = segment.trim();
+  if (t.length < MIN_JUDGE_CHARS) return false; // too short to judge → keep
+
+  const nonLatin = (t.match(NON_LATIN_LINGUISTIC) ?? []).length;
+  const diacritics = (t.match(LATIN_DIACRITICS) ?? []).length;
+
+  // Language-script branch: dominant non-Latin script OR accented Latin. Skip the
+  // space/word test (non-space scripts lack word spaces) but STILL require
+  // language-like character statistics — this is what stops binary garbage whose
+  // bytes happen to decode into CJK/other linguistic code points.
+  if (nonLatin / t.length > NON_LATIN_DOMINANT || diacritics > DIACRITIC_MIN) {
+    return distinctCharRatio(t) > LANG_DCR_MAX; // too many unique chars = noise
+  }
+
+  // ASCII / Latin-dominant branch: structural dump signals.
+  const letters = (t.match(ANY_LETTER) ?? []).length;
+  const letterRatio = letters / t.length;
+  const words = t.split(/\s+/);
+  const avgToken = t.length / words.length;
+
+  if (words.length < 3) return true; // one giant unbroken token = dump
+  if (avgToken > ASCII_AVG_TOKEN_MAX && letterRatio < ASCII_LETTER_RATIO_MAX) {
+    return true; // base64 / minified: enormous tokens, few letters
+  }
+  if (trigramRatio(t) < ASCII_TRIGRAM_RATIO_MIN) return true; // repeated garbage
+  return false;
+}
+
+/**
+ * Split a body into coherent segments: on the part terminator (tool envelopes
+ * stored in the message) and blank lines (paragraphs). Oversized paragraphs and
+ * single-giant-line dumps (minified JSON / one-line logs) fall back to fixed
+ * char windows so a pathological one-line megablob still segments.
+ */
+export function segmentBody(
+  body: string,
+  segmentChars = SEGMENT_CHARS,
+): string[] {
+  const parts = body.includes(CHUNK_TERMINATOR)
+    ? body.split(CHUNK_SEPARATOR)
+    : [body];
+  const segments: string[] = [];
+  for (const part of parts) {
+    for (const paragraph of part.split(/\n\s*\n/)) {
+      if (paragraph.length <= segmentChars * 2) {
+        if (paragraph.trim()) segments.push(paragraph);
+        continue;
+      }
+      for (let i = 0; i < paragraph.length; i += segmentChars) {
+        segments.push(paragraph.slice(i, i + segmentChars));
+      }
+    }
+  }
+  return segments;
+}
+
+export interface ReduceBlobOptions {
+  /** Embed a batch of texts. Injected so this leaf is testable without ONNX. */
+  embed: (texts: string[]) => Promise<Float32Array[]>;
+  /** Cosine similarity of two L2-normalized vectors (dot product). */
+  cosine: (a: Float32Array, b: Float32Array) => number;
+  /** What the kept segments are scored against (assertions + prior obs + turn). */
+  query: string;
+  /** Max chars of blob to keep after selection. */
+  keepChars: number;
+  /** Max segments to embed (bounds cost); surviving segments sampled down. */
+  maxSegments: number;
+  /**
+   * High-priority text snippets (e.g. detected user assertions/directives) that
+   * MUST survive reduction. Any segment containing one of these as a substring is
+   * force-kept regardless of relevance score or budget — a directive buried in an
+   * oversized blob must never be elided. Empty/whitespace entries are ignored.
+   */
+  pinnedLines?: string[];
+}
+
+export interface ReduceBlobResult {
+  /** The reduced body, original order, with elided runs annotated. */
+  output: string;
+  /** Segments dropped by Stage-1 pre-filter (no embed spent). */
+  junkDropped: number;
+  /** Segments embedded in Stage 2. */
+  embedded: number;
+  /** Segments kept in the output. */
+  kept: number;
+}
+
+/** Format an elided run marker. */
+function elision(chars: number): string {
+  return `[… ${chars} chars elided (low-relevance) …]`;
+}
+
+/**
+ * Reduce an oversized user blob to its query-relevant portions.
+ *
+ * Two-stage: Stage-1 lexical pre-filter drops paste-junk for free; Stage-2 embeds
+ * the survivors and keeps the top-scoring segments up to `keepChars`, preserving
+ * original order and annotating elided runs.
+ *
+ * Throws if `embed` rejects — the caller must catch and leave the body verbatim
+ * (fail-open; never blunt-truncate user signal).
+ */
+export async function reduceBlob(
+  body: string,
+  opts: ReduceBlobOptions,
+): Promise<ReduceBlobResult> {
+  const all = segmentBody(body);
+  const pins = (opts.pinnedLines ?? [])
+    // Callers may pass display-truncated snippets (e.g. a 200-char cap with a
+    // trailing "…"); strip a trailing ellipsis/whitespace so substring matching
+    // works against the verbatim segment text.
+    .map((p) => p.replace(/\s*…\s*$/u, "").trim())
+    .filter((p) => p.length > 0);
+  // A segment is pinned if it contains any high-priority snippet verbatim. Pinned
+  // segments are force-kept even if Stage-1 would drop them or they'd fall
+  // outside the sampled/budgeted set — a directive must never be elided.
+  const isPinned = (seg: string) => pins.some((p) => seg.includes(p));
+
+  // Stage 1: drop paste-junk before spending any embed — but never drop a pinned
+  // segment (a directive can look "junky" if wrapped in a noisy blob).
+  const prose = all.filter((s) => isPinned(s) || !looksLikePasteJunk(s));
+  const junkDropped = all.length - prose.length;
+
+  if (prose.length === 0) {
+    // Entire blob was non-prose (e.g. a pure base64/binary paste). Nothing worth
+    // embedding — annotate the whole thing as elided.
+    return {
+      output: elision(body.length),
+      junkDropped,
+      embedded: 0,
+      kept: 0,
+    };
+  }
+
+  // Cap segment count to bound embed cost; uniformly sample so coverage spans the
+  // whole surviving body rather than just its head. Pinned segments are always
+  // included in the sample so they can never be dropped by the cap.
+  let capped: string[];
+  if (prose.length > opts.maxSegments) {
+    const pinned = prose.filter(isPinned);
+    const sampleBudget = Math.max(0, opts.maxSegments - pinned.length);
+    const nonPinned = prose.filter((s) => !isPinned(s));
+    const sampled =
+      sampleBudget > 0 && nonPinned.length > sampleBudget
+        ? Array.from(
+            { length: sampleBudget },
+            (_, i) =>
+              nonPinned[Math.floor((i * nonPinned.length) / sampleBudget)],
+          )
+        : nonPinned;
+    // Re-select from `prose` in original order to preserve ordering, keeping any
+    // segment that is pinned or made the non-pinned sample.
+    const keepSet = new Set([...pinned, ...sampled]);
+    capped = prose.filter((s) => keepSet.has(s));
+  } else {
+    capped = prose;
+  }
+
+  // Stage 2: embed query + segments, score by cosine, greedily fill the budget.
+  const [queryVec] = await opts.embed([opts.query]);
+  const segVecs = await opts.embed(capped);
+  const scored = capped.map((text, idx) => ({
+    text,
+    idx,
+    score: opts.cosine(queryVec, segVecs[idx]),
+    pinned: isPinned(text),
+  }));
+
+  const keepIdx = new Set<number>();
+  let used = 0;
+  // Pinned segments are kept unconditionally (bypass the budget) so a directive
+  // can never be elided.
+  for (const s of scored) {
+    if (s.pinned) {
+      keepIdx.add(s.idx);
+      used += s.text.length;
+    }
+  }
+  // Fill the remaining budget with the highest-scoring non-pinned segments.
+  const byScore = scored
+    .filter((s) => !s.pinned)
+    .sort((a, b) => b.score - a.score);
+  for (const s of byScore) {
+    if (used + s.text.length > opts.keepChars) continue;
+    keepIdx.add(s.idx);
+    used += s.text.length;
+  }
+
+  // Reassemble in original order, collapsing dropped runs into one annotation.
+  const outParts: string[] = [];
+  let elided = 0;
+  for (const s of scored) {
+    if (keepIdx.has(s.idx)) {
+      if (elided > 0) {
+        outParts.push(elision(elided));
+        elided = 0;
+      }
+      outParts.push(s.text);
+    } else {
+      elided += s.text.length;
+    }
+  }
+  if (elided > 0) outParts.push(elision(elided));
+
+  return {
+    output: outParts.join("\n"),
+    junkDropped,
+    embedded: capped.length,
+    kept: keepIdx.size,
+  };
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -211,6 +211,41 @@ export const LoreConfig = z.object({
         .describe(
           "Max chars per tool output for distillation input. Set to 0 to disable truncation. Default: 4000.",
         ),
+      /** Trigger threshold for embedding-based user-blob reduction (#1343). A user
+       *  message body longer than this is treated as a potential pasted blob
+       *  (logs, dumped files, data exports) and reduced to its query-relevant
+       *  portions before being sent to the distiller worker, instead of being fed
+       *  verbatim. Ordinary prose/directives stay well under this and pass through
+       *  untouched. Set to 0 to disable blob reduction entirely. Default: 12000. */
+      userBlobMaxChars: z
+        .number()
+        .min(0)
+        .default(12_000)
+        .describe(
+          "Trigger threshold (chars) for embedding-based user-blob reduction. Set to 0 to disable. Default: 12000.",
+        ),
+      /** Char budget kept after reducing an oversized user blob. The highest-
+       *  relevance segments (scored against the distillation objective) are kept
+       *  up to this budget; the rest are elided with an annotation. The full raw
+       *  message is always retained in temporal_messages + FTS, so elided bulk
+       *  stays recall-searchable. Default: 6000. */
+      userBlobKeepChars: z
+        .number()
+        .min(0)
+        .default(6_000)
+        .describe(
+          "Chars kept after reducing an oversized user blob. Default: 6000.",
+        ),
+      /** Max blob segments embedded during reduction. Bounds the local-embedding
+       *  cost per oversized message; surviving segments are uniformly sampled down
+       *  to this count so coverage still spans the whole body. Default: 48. */
+      userBlobMaxSegments: z
+        .number()
+        .min(1)
+        .default(48)
+        .describe(
+          "Max blob segments embedded during user-blob reduction. Default: 48.",
+        ),
       /** Number of most-recent gen-0 segments to keep un-archived when
        *  meta-distillation fires. These segments retain full detail in the
        *  context prefix while older segments are consolidated. Default: 5.
@@ -229,6 +264,9 @@ export const LoreConfig = z.object({
       maxSegmentTokens: 16384,
       metaThreshold: 20,
       toolOutputMaxChars: 4_000,
+      userBlobMaxChars: 12_000,
+      userBlobKeepChars: 6_000,
+      userBlobMaxSegments: 48,
       recentSegmentsToKeep: 5,
     })
     .describe(

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -431,7 +431,10 @@ export async function messagesToTextReduced(
       if (canReduce && m.content.length > blobTrigger) {
         try {
           const result = await reduceBlob(m.content, {
-            embed: (texts) => embedding.embed(texts, "document"),
+            // Route through the token-area sub-batcher (not raw embed()) so a
+            // batch of segments never posts one oversized padded tensor to the
+            // worker — mirrors every other batch embed path (#1072).
+            embed: (texts) => embedding.embedInTokenBatches(texts, "document"),
             cosine: embedding.cosineSimilarity,
             query,
             keepChars: cfg.userBlobKeepChars,

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -22,6 +22,7 @@ import {
   recursiveUser,
 } from "./prompt";
 import { toolStripAnnotation } from "./gradient";
+import { reduceBlob } from "./blob-select";
 import { workerSessionIDs } from "./worker";
 import { distillLimiter } from "./session-limiter";
 import type { LLMClient } from "./types";
@@ -385,6 +386,76 @@ export function messagesToText(
       return `[${m.role}] (${formatTime(m.created_at)}) ${body}`;
     })
     .join("\n\n");
+}
+
+/**
+ * Async sibling of {@link messagesToText} that additionally reduces oversized
+ * USER message bodies via embedding-based relevance selection (#1343).
+ *
+ * User bodies below `userBlobMaxChars` (or when reduction is disabled / the
+ * embedder is unavailable) pass through verbatim — the "always signal" rule
+ * holds for ordinary prose. A body above the threshold is treated as a potential
+ * pasted blob (logs, dumped file, data export): its query-relevant portions are
+ * kept and the bulk is elided, instead of feeding the whole thing to the worker
+ * LLM. The full raw message stays in `temporal_messages` + FTS, so elided bulk
+ * remains recall-searchable.
+ *
+ * Fail-open: any error during reduction (embed rejects, provider gone) leaves the
+ * body verbatim — dropping user signal is worse than paying to distill it once.
+ * Never blunt-truncates.
+ *
+ * @param query  What kept segments are scored against — built by the caller from
+ *               pinned assertions + prior observations + adjacent assistant turn.
+ * @param pinnedLines  High-priority snippets (detected user directives) that must
+ *               survive reduction verbatim — a segment containing one is force-kept.
+ */
+export async function messagesToTextReduced(
+  messages: TemporalMessage[],
+  query: string,
+  pinnedLines?: string[],
+): Promise<string> {
+  const cfg = config().distillation;
+  const cap = cfg.toolOutputMaxChars;
+  const blobTrigger = cfg.userBlobMaxChars;
+  const canReduce =
+    blobTrigger > 0 && embedding.isAvailable() && query.trim().length > 0;
+
+  const rendered = await Promise.all(
+    messages.map(async (m) => {
+      if (m.role !== "user") {
+        const body = truncateToolOutputsInContent(m.content, cap);
+        return `[${m.role}] (${formatTime(m.created_at)}) ${body}`;
+      }
+      // User body: reduce only oversized ones; short prose is always verbatim.
+      let body = m.content;
+      if (canReduce && m.content.length > blobTrigger) {
+        try {
+          const result = await reduceBlob(m.content, {
+            embed: (texts) => embedding.embed(texts, "document"),
+            cosine: embedding.cosineSimilarity,
+            query,
+            keepChars: cfg.userBlobKeepChars,
+            maxSegments: cfg.userBlobMaxSegments,
+            pinnedLines,
+          });
+          body = result.output;
+          log.info(
+            `reduced oversized user blob: ${m.content.length}→${body.length} chars ` +
+              `(${result.junkDropped} junk-dropped, ${result.embedded} embedded, ${result.kept} kept)`,
+          );
+        } catch (err) {
+          // Fail-open: leave the body verbatim rather than risk dropping signal.
+          log.warn(
+            `user-blob reduction failed, keeping verbatim: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+      return `[${m.role}] (${formatTime(m.created_at)}) ${body}`;
+    }),
+  );
+  return rendered.join("\n\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -1045,9 +1116,9 @@ async function distillSegment(input: {
   metadata?: KnowledgeMetadata;
 }): Promise<DistillationResult | null> {
   const prior = latestObservations(input.projectPath, input.sessionID);
-  const text = messagesToText(input.messages);
   // Pre-scan for high-priority user assertions that might be lost in a
-  // large segment dominated by routine code or tool output.
+  // large segment dominated by routine code or tool output. Run this BEFORE
+  // rendering so the assertion text can seed the blob-reduction relevance query.
   const assertions = detectAssertions(input.messages);
   const pinnedAssertions =
     assertions.length > 0
@@ -1058,6 +1129,28 @@ async function distillSegment(input: {
       `pinned ${assertions.length} user assertion(s) in segment of ${input.messages.length} msgs`,
     );
   }
+  // Relevance query for embedding-based user-blob reduction (#1343): what the
+  // distiller cares about — the running session narrative (prior observations),
+  // the user's explicit directives (pinned assertions), and what the assistant
+  // did in this segment (adjacent assistant turns). Oversized user blobs are
+  // scored against this so only their relevant portions are kept.
+  const blobQuery = [
+    prior ?? "",
+    assertions.map((a) => a.text).join("\n"),
+    input.messages
+      .filter((m) => m.role === "assistant")
+      .map((m) => m.content)
+      .join("\n")
+      .slice(0, 4000),
+    "user request, directives, decisions, errors, key facts",
+  ]
+    .filter((s) => s.trim().length > 0)
+    .join("\n");
+  const text = await messagesToTextReduced(
+    input.messages,
+    blobQuery,
+    assertions.map((a) => a.text),
+  );
   // Pre-scan structured tool failures in this segment's time window so the
   // observer surfaces recurring obstacles instead of dropping them as noise.
   const toolFailures = detectToolFailures(

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2201,7 +2201,7 @@ export const MAX_TEMPORAL_CHUNKS_PER_MESSAGE = 64;
  * in any batch rejects before the caller stores, so a partial chunk set is never
  * written (storeTemporalChunks DELETEs-then-INSERTs the complete set).
  */
-async function embedInTokenBatches(
+export async function embedInTokenBatches(
   texts: string[],
   inputType: "document" | "query",
 ): Promise<Float32Array[]> {

--- a/packages/core/test/blob-select.test.ts
+++ b/packages/core/test/blob-select.test.ts
@@ -1,0 +1,348 @@
+import { describe, test, expect } from "vitest";
+import {
+  looksLikePasteJunk,
+  segmentBody,
+  reduceBlob,
+} from "../src/blob-select";
+
+// ─── Stage 1: looksLikePasteJunk ───────────────────────────────────────────
+//
+// 🔴 Invariant: a false POSITIVE (dropping real prose) is unacceptable; a false
+// NEGATIVE (keeping junk) only costs a few embeds. Tests below assert 0 false
+// positives across many scripts and correct drops on adversarial garbage.
+
+describe("looksLikePasteJunk — keeps real prose (no false positives)", () => {
+  const prose: [string, string][] = [
+    [
+      "english",
+      "a failure on claude code. it has happened a couple of times to me. brand new conversation and it says compaction failed?",
+    ],
+    [
+      "turkish-diacritics",
+      "Bir de yazı AI ile yazılmış duruyor bazı kısımlar. Başlangıç kısmı uzun. Onlar iyileştirilebilir çünkü asıl argüman güçlü.",
+    ],
+    [
+      "turkish-romanized",
+      "Bir de yazi AI ile yazilmis duruyor bazi kisimlar. Baslangic kismi uzun. Onlar iyilestirilebilir.",
+    ],
+    [
+      "cjk",
+      "这是一个关于内存管理的讨论。我们需要一个更智能的方法来处理大型输入。也许我们可以使用嵌入来获得更好的信号。这个想法很有趣。",
+    ],
+    [
+      "japanese",
+      "これはメモリ管理に関する議論です。単純に切り詰めるのではなく、大きな入力を処理するより賢い方法が必要です。埋め込みを使うといいかもしれません。",
+    ],
+    [
+      "korean",
+      "이것은 메모리 관리에 대한 논의입니다. 단순히 잘라내는 대신 큰 입력을 처리하는 더 스마트한 방법이 필요합니다.",
+    ],
+    [
+      "cyrillic",
+      "Это обсуждение управления памятью. Нам нужен более разумный способ обработки больших входных данных вместо простого усечения.",
+    ],
+    [
+      "arabic",
+      "هذه مناقشة حول إدارة الذاكرة. نحتاج إلى طريقة أكثر ذكاءً لمعالجة المدخلات الكبيرة بدلاً من الاقتطاع البسيط.",
+    ],
+    [
+      "code-ts",
+      "export function messagesToText(messages, cap) { return messages.map(m => `[${m.role}] ${m.content}`).join('\\n\\n'); }",
+    ],
+    [
+      "json-config",
+      '{ "userBlobMaxChars": 12000, "userBlobKeepChars": 6000, "maxSegments": 48, "enabled": true }',
+    ],
+  ];
+  for (const [name, text] of prose) {
+    test(`keeps ${name}`, () => {
+      expect(looksLikePasteJunk(text)).toBe(false);
+    });
+  }
+});
+
+describe("looksLikePasteJunk — drops paste junk (including adversarial)", () => {
+  const randomBinary = (n: number) => {
+    let s = "";
+    for (let i = 0; i < n; i++)
+      s += String.fromCharCode(Math.floor(Math.random() * 65536));
+    return s;
+  };
+  const cjkNoise = (n: number) => {
+    let s = "";
+    for (let i = 0; i < n; i++)
+      s += String.fromCharCode(0x4e00 + Math.floor(Math.random() * 20000));
+    return s;
+  };
+  const mixed = (n: number) => {
+    let s = "";
+    for (let i = 0; i < n; i++)
+      s +=
+        Math.random() < 0.1
+          ? String.fromCharCode(0x4e00 + Math.floor(Math.random() * 20000))
+          : String.fromCharCode(33 + Math.floor(Math.random() * 94));
+    return s;
+  };
+
+  const junk: [string, string][] = [
+    [
+      "base64-png",
+      "iVBORw0KGgoAAAANSUhEUgAAB9AAAAO6CAYAAADHGMxWAAbOYklEQVR4Ae3AA6AkWZbG8f937o3IzKdyS2Oubdu2bWmMnpZKr54yMyLu",
+    ],
+    [
+      "repeated-garbage",
+      "VVV1111VVXXXXVVVddddVVV1111VVXXUXlqquuuuqqq6666qqrrrrqqquuuuqqq6666qqrrrrqqquuuuqqq66ictVVV1111VVXXXXVVV",
+    ],
+    [
+      "minified",
+      '{"a":1,"b":2,"c":[1,2,3,4,5,6,7,8,9],"k":"averylongvaluewithnospaces1234567890abcdefghijklmnopqrstuvwxyz0987"}',
+    ],
+    ["random-utf16-binary", randomBinary(400)],
+    ["random-cjk-noise", cjkNoise(400)],
+    ["10pct-cjk-90pct-junk", mixed(400)],
+    [
+      "base64-with-stray-cyrillic",
+      "iVBORw0KGgoAAAANSUhEUgAAB9ЖAAAO6CAYAAADHGMxWAAbOYklEQДVR4Ae3AA6AkWZbG8f937o3IжKdyS2Oubdu2bWmMnpЯr54yMyLu",
+    ],
+  ];
+  for (const [name, text] of junk) {
+    test(`drops ${name}`, () => {
+      expect(looksLikePasteJunk(text)).toBe(true);
+    });
+  }
+});
+
+test("looksLikePasteJunk keeps short segments (too short to judge)", () => {
+  // Below the 40-char judge floor → always kept (safe direction).
+  expect(looksLikePasteJunk("VVVXXXddd111")).toBe(false);
+});
+
+// ─── segmentBody ───────────────────────────────────────────────────────────
+
+describe("segmentBody", () => {
+  test("splits paragraphs on blank lines", () => {
+    const segs = segmentBody("first para\n\nsecond para\n\nthird para");
+    expect(segs).toEqual(["first para", "second para", "third para"]);
+  });
+
+  test("windows a single giant line (one-line megablob)", () => {
+    const giant = "x".repeat(5000);
+    const segs = segmentBody(giant, 800);
+    // 5000 / 800 = 7 windows (last partial), none exceeding the window size.
+    expect(segs.length).toBe(Math.ceil(5000 / 800));
+    for (const s of segs) expect(s.length).toBeLessThanOrEqual(800);
+  });
+
+  test("splits on the part terminator (tool envelopes)", () => {
+    const body = `[tool:read] a.ts\n\x1f[tool:read] b.ts`;
+    const segs = segmentBody(body);
+    expect(segs.length).toBe(2);
+  });
+
+  test("drops empty/whitespace-only paragraphs", () => {
+    const segs = segmentBody("real content here\n\n   \n\nmore content");
+    expect(segs).toEqual(["real content here", "more content"]);
+  });
+});
+
+// ─── Stage 2 + integration: reduceBlob ─────────────────────────────────────
+//
+// Deterministic stubbed embedder: assigns each text a 2-D vector so we control
+// exactly which segment scores highest against the query. No ONNX worker needed.
+
+/** Build a stub embed that maps specific substrings to specific unit vectors. */
+function stubEmbed(match: string) {
+  // query and any segment containing `match` → [1,0]; everything else → [0,1].
+  return async (texts: string[]): Promise<Float32Array[]> =>
+    texts.map((t) =>
+      t.includes(match) ? new Float32Array([1, 0]) : new Float32Array([0, 1]),
+    );
+}
+const dot = (a: Float32Array, b: Float32Array) => a[0] * b[0] + a[1] * b[1];
+
+describe("reduceBlob", () => {
+  test("keeps the query-relevant segment, elides low-relevance bulk", async () => {
+    const body = [
+      "SIGNAL: the compaction failed error is here",
+      ...Array.from(
+        { length: 20 },
+        (_, i) => `irrelevant filler paragraph ${i}`,
+      ),
+    ].join("\n\n");
+
+    const result = await reduceBlob(body, {
+      embed: stubEmbed("SIGNAL"),
+      cosine: dot,
+      query: "SIGNAL relevance query",
+      keepChars: 60,
+      maxSegments: 48,
+    });
+
+    expect(result.output).toContain("SIGNAL: the compaction failed error");
+    expect(result.output).toMatch(/\[… \d+ chars elided \(low-relevance\) …\]/);
+    expect(result.kept).toBe(1);
+  });
+
+  test("Stage-1 drops paste-junk before embedding (junk never embedded)", async () => {
+    const junk = Array.from(
+      { length: 30 },
+      () =>
+        "VVV1111VVXXXXVVVddddVVV1111VVXXUXlqquuuuqqq6666qqrrrrqqquuuuqqq6666qqrrrr",
+    ).join("\n\n");
+    const body = `SIGNAL real prose about the actual bug we are hunting down today\n\n${junk}`;
+
+    let embedCalls = 0;
+    const countingEmbed = async (texts: string[]) => {
+      embedCalls += texts.length;
+      return texts.map((t) =>
+        t.includes("SIGNAL")
+          ? new Float32Array([1, 0])
+          : new Float32Array([0, 1]),
+      );
+    };
+
+    const result = await reduceBlob(body, {
+      embed: countingEmbed,
+      cosine: dot,
+      query: "SIGNAL",
+      keepChars: 200,
+      maxSegments: 48,
+    });
+
+    expect(result.junkDropped).toBe(30);
+    // Only the 1 prose segment (+ the query) is embedded, not the 30 junk ones.
+    expect(result.embedded).toBe(1);
+    // embedCalls = 1 (query) + 1 (prose segment) = 2.
+    expect(embedCalls).toBe(2);
+    expect(result.output).toContain("SIGNAL real prose");
+  });
+
+  test("all-junk body: nothing embedded, whole body elided", async () => {
+    const junk = Array.from(
+      { length: 10 },
+      () =>
+        "iVBORw0KGgoAAAANSUhEUgAAB9AAAAO6CAYAAADHGMxWAAbOYklEQVR4Ae3AA6AkWZbG8f937o3IzKdyS2Oubdu2bWm",
+    ).join("\n\n");
+    let embedCalls = 0;
+    const result = await reduceBlob(junk, {
+      embed: async (texts) => {
+        embedCalls += texts.length;
+        return texts.map(() => new Float32Array([0, 1]));
+      },
+      cosine: dot,
+      query: "anything",
+      keepChars: 200,
+      maxSegments: 48,
+    });
+    expect(embedCalls).toBe(0);
+    expect(result.embedded).toBe(0);
+    expect(result.kept).toBe(0);
+    expect(result.output).toMatch(/^\[… \d+ chars elided/);
+  });
+
+  test("caps embedded segments at maxSegments", async () => {
+    const body = Array.from(
+      { length: 100 },
+      (_, i) => `prose paragraph number ${i} with real words in it`,
+    ).join("\n\n");
+    const result = await reduceBlob(body, {
+      embed: async (texts) => texts.map(() => new Float32Array([0, 1])),
+      cosine: dot,
+      query: "query",
+      keepChars: 100000,
+      maxSegments: 10,
+    });
+    expect(result.embedded).toBe(10);
+  });
+
+  test("propagates embed rejection (caller handles fail-open)", async () => {
+    const body = Array.from(
+      { length: 20 },
+      (_, i) => `prose paragraph number ${i} with real words`,
+    ).join("\n\n");
+    await expect(
+      reduceBlob(body, {
+        embed: async () => {
+          throw new Error("provider gone");
+        },
+        cosine: dot,
+        query: "query",
+        keepChars: 200,
+        maxSegments: 48,
+      }),
+    ).rejects.toThrow("provider gone");
+  });
+
+  test("force-keeps a pinned directive even when it scores lowest", async () => {
+    // The directive scores [0,1] (irrelevant to the query) but must survive.
+    const directive = "never truncate user signal in distillation";
+    const body = [
+      `SIGNAL relevant to the query goes here`,
+      ...Array.from({ length: 20 }, (_, i) => `filler paragraph ${i}`),
+      `IMPORTANT: ${directive} — please remember this`,
+    ].join("\n\n");
+
+    const result = await reduceBlob(body, {
+      // Only the "SIGNAL" segment scores high; the directive scores low.
+      embed: stubEmbed("SIGNAL"),
+      cosine: dot,
+      query: "SIGNAL relevance query",
+      keepChars: 40, // tight budget: without pinning the directive would be elided
+      pinnedLines: [directive],
+      maxSegments: 48,
+    });
+
+    expect(result.output).toContain(directive);
+  });
+
+  test("pinned directive survives Stage-1 junk drop", async () => {
+    // A directive can be embedded in a segment that Stage-1 classifies as junk
+    // (very low trigram variety). Pinning must override the Stage-1 drop.
+    const directive = "always use tabs not spaces";
+    // Long low-variety tail → trigram ratio well below the junk floor (0.15).
+    const junkyWithPin = `${directive} ${"ab".repeat(400)}`;
+    // Sanity: confirm this segment IS junk without the pin.
+    expect(looksLikePasteJunk(junkyWithPin)).toBe(true);
+
+    const body = [
+      junkyWithPin,
+      ...Array.from({ length: 5 }, (_, i) => `normal prose paragraph ${i}`),
+    ].join("\n\n");
+
+    const result = await reduceBlob(body, {
+      embed: async (texts) => texts.map(() => new Float32Array([0, 1])),
+      cosine: dot,
+      query: "query",
+      keepChars: 2000,
+      pinnedLines: [directive],
+      maxSegments: 48,
+    });
+
+    expect(result.output).toContain(directive);
+    // Without the pin this segment would have been counted as junk-dropped.
+    expect(result.junkDropped).toBe(0);
+  });
+
+  test("pinned matching tolerates a display-truncated snippet (trailing …)", async () => {
+    const fullLine =
+      "the user explicitly said we must always keep the exact migration name intact";
+    const body = [
+      "some relevant signal here for the query",
+      ...Array.from({ length: 15 }, (_, i) => `filler ${i}`),
+      fullLine,
+    ].join("\n\n");
+    // Caller passes a 40-char-capped snippet with a trailing ellipsis.
+    const truncatedPin = `${fullLine.slice(0, 40)}…`;
+
+    const result = await reduceBlob(body, {
+      embed: stubEmbed("signal"),
+      cosine: dot,
+      query: "signal query",
+      keepChars: 40,
+      pinnedLines: [truncatedPin],
+      maxSegments: 48,
+    });
+
+    expect(result.output).toContain(fullLine);
+  });
+});

--- a/packages/core/test/blob-select.test.ts
+++ b/packages/core/test/blob-select.test.ts
@@ -176,6 +176,25 @@ describe("segmentBody", () => {
       "more content",
     ]);
   });
+
+  test("every segment's offsets slice back to its exact text (tricky paths)", () => {
+    // Offset arithmetic is load-bearing for pin overlap detection. Lock it in
+    // across the paths that use variable-width separators / windowing.
+    const bodies = [
+      "para one\n\n\npara two\n\n\n\npara three", // multi-blank-line runs
+      "line a\r\nline b\r\n\r\nline c", // CRLF
+      "   leading ws para\n\ntrailing ws para   ", // leading/trailing whitespace
+      `first tool\n\x1fsecond tool\n\x1fthird tool`, // terminators
+      `${"x".repeat(2000)}\n\x1f${"y".repeat(50)}`, // giant line + terminator
+      `head para\n\n${"z".repeat(2100)}\n\ntail para`, // oversized middle paragraph
+      "a\n\x1f\n\x1fb", // consecutive terminators (empty middle part)
+    ];
+    for (const body of bodies) {
+      for (const seg of segmentBody(body)) {
+        expect(body.slice(seg.start, seg.end)).toBe(seg.text);
+      }
+    }
+  });
 });
 
 // ─── Stage 2 + integration: reduceBlob ─────────────────────────────────────
@@ -424,6 +443,24 @@ describe("reduceBlob", () => {
     // Only the pinned segment is embedded/kept; non-pinned are not all re-admitted.
     expect(result.embedded).toBe(1);
     expect(result.output).toContain(directive);
+  });
+
+  test("keeps a \\n between two adjacent kept paragraphs (no fusion)", async () => {
+    // Two distinct paragraphs both score high and are both kept with NO elision
+    // run between them. They were separated by a blank line in the body (offsets
+    // non-adjacent), so reassembly must restore a "\n" — never fuse them into one
+    // run (which would only be correct for contiguous hard-window pieces).
+    const body = "SIGNAL alpha paragraph\n\nSIGNAL beta paragraph";
+    const result = await reduceBlob(body, {
+      embed: stubEmbed("SIGNAL"), // both paragraphs score [1,0]
+      cosine: dot,
+      query: "SIGNAL",
+      keepChars: 10000, // both fit → both kept, no elision between them
+      maxSegments: 48,
+    });
+    expect(result.kept).toBe(2);
+    expect(result.output).toBe("SIGNAL alpha paragraph\nSIGNAL beta paragraph");
+    expect(result.output).not.toContain("elided");
   });
 
   test("pinned matching tolerates a display-truncated snippet (trailing …)", async () => {

--- a/packages/core/test/blob-select.test.ts
+++ b/packages/core/test/blob-select.test.ts
@@ -120,9 +120,16 @@ test("looksLikePasteJunk keeps short segments (too short to judge)", () => {
 // ─── segmentBody ───────────────────────────────────────────────────────────
 
 describe("segmentBody", () => {
-  test("splits paragraphs on blank lines", () => {
-    const segs = segmentBody("first para\n\nsecond para\n\nthird para");
-    expect(segs).toEqual(["first para", "second para", "third para"]);
+  test("splits paragraphs on blank lines, carrying offsets", () => {
+    const body = "first para\n\nsecond para\n\nthird para";
+    const segs = segmentBody(body);
+    expect(segs.map((s) => s.text)).toEqual([
+      "first para",
+      "second para",
+      "third para",
+    ]);
+    // Offsets must point back into the original body verbatim.
+    for (const s of segs) expect(body.slice(s.start, s.end)).toBe(s.text);
   });
 
   test("windows a single giant line (one-line megablob)", () => {
@@ -130,18 +137,44 @@ describe("segmentBody", () => {
     const segs = segmentBody(giant, 800);
     // 5000 / 800 = 7 windows (last partial), none exceeding the window size.
     expect(segs.length).toBe(Math.ceil(5000 / 800));
-    for (const s of segs) expect(s.length).toBeLessThanOrEqual(800);
+    for (const s of segs) expect(s.text.length).toBeLessThanOrEqual(800);
+    // Windows are contiguous and cover the whole body.
+    expect(segs.map((s) => s.text).join("")).toBe(giant);
   });
 
-  test("splits on the part terminator (tool envelopes)", () => {
+  test("splits an oversized paragraph on line boundaries (keeps lines intact)", () => {
+    // A 2000-char paragraph made of short lines must split BETWEEN lines, never
+    // mid-line, so a directive on its own line is never cut.
+    const lines = Array.from(
+      { length: 60 },
+      (_, i) => `line ${i} with a good number of real words in it here now`,
+    );
+    const body = lines.join("\n");
+    expect(body.length).toBeGreaterThan(1600); // triggers oversized path
+    const segs = segmentBody(body, 800);
+    // Every produced segment is a whole line (or run of lines), never a partial.
+    for (const s of segs) {
+      expect(body.slice(s.start, s.end)).toBe(s.text);
+    }
+    // Each original line appears verbatim in some segment.
+    for (const line of lines) {
+      expect(segs.some((s) => s.text.includes(line))).toBe(true);
+    }
+  });
+
+  test("splits on the part terminator (tool envelopes), offsets accurate", () => {
     const body = `[tool:read] a.ts\n\x1f[tool:read] b.ts`;
     const segs = segmentBody(body);
     expect(segs.length).toBe(2);
+    for (const s of segs) expect(body.slice(s.start, s.end)).toBe(s.text);
   });
 
   test("drops empty/whitespace-only paragraphs", () => {
     const segs = segmentBody("real content here\n\n   \n\nmore content");
-    expect(segs).toEqual(["real content here", "more content"]);
+    expect(segs.map((s) => s.text)).toEqual([
+      "real content here",
+      "more content",
+    ]);
   });
 });
 
@@ -321,6 +354,76 @@ describe("reduceBlob", () => {
     expect(result.output).toContain(directive);
     // Without the pin this segment would have been counted as junk-dropped.
     expect(result.junkDropped).toBe(0);
+  });
+
+  test("pinned directive survives a hard window-boundary split (#1343 B1)", async () => {
+    // A single unbroken line (no blank lines, no \n) longer than 2×segmentChars
+    // is hard-windowed at char boundaries. A directive that straddles a boundary
+    // is split across two segments — offset-based pin matching must force-keep
+    // BOTH overlapping windows so the directive is never elided.
+    const SEG = 800;
+    const filler = "log noise ".repeat(74); // ~740 chars, no newlines
+    const directive =
+      "always redact tokens from these logs before sharing them with anyone";
+    // Place the directive so it straddles the 800 boundary, then a long tail.
+    const body = filler + directive + " tail " + "x".repeat(3000);
+    // Precondition: the directive is genuinely split (present in no single window).
+    const rawWindows: string[] = [];
+    for (let i = 0; i < body.length; i += SEG)
+      rawWindows.push(body.slice(i, i + SEG));
+    expect(rawWindows.some((w) => w.includes(directive))).toBe(false);
+
+    const result = await reduceBlob(body, {
+      // Everything scores low — only the pin should keep the directive.
+      embed: async (texts) => texts.map(() => new Float32Array([0, 1])),
+      cosine: dot,
+      query: "unrelated query",
+      keepChars: 100, // tight: non-pinned tail cannot fill it
+      pinnedLines: [directive],
+      maxSegments: 48,
+    });
+
+    // The full directive survives byte-exact: contiguous hard-window pieces of
+    // the same line rejoin with no separator, so a mid-word split is seamless.
+    // Strip only the elision markers (which sit between non-contiguous runs).
+    const kept = result.output.replace(/\[… \d+ chars elided[^\]]*…\]/gu, "");
+    expect(kept).toContain(directive);
+  });
+
+  test("caps embedded segments despite duplicate segment text (#1343 S2)", async () => {
+    // 100 IDENTICAL prose paragraphs. A Set<string> would collapse them and
+    // re-admit all copies; index-based capping must hold the maxSegments limit.
+    const body = Array.from(
+      { length: 100 },
+      () => "the exact same repeated prose paragraph with words",
+    ).join("\n\n");
+    const result = await reduceBlob(body, {
+      embed: async (texts) => texts.map(() => new Float32Array([0, 1])),
+      cosine: dot,
+      query: "query",
+      keepChars: 100000,
+      maxSegments: 10,
+    });
+    expect(result.embedded).toBeLessThanOrEqual(10);
+  });
+
+  test("sampleBudget 0 (pins fill the cap) keeps no extra non-pinned (#1343 S3)", async () => {
+    const directive = "always keep this exact directive";
+    const body = [
+      directive,
+      ...Array.from({ length: 50 }, (_, i) => `filler paragraph number ${i}`),
+    ].join("\n\n");
+    const result = await reduceBlob(body, {
+      embed: async (texts) => texts.map(() => new Float32Array([0, 1])),
+      cosine: dot,
+      query: "query",
+      keepChars: 100000,
+      pinnedLines: [directive],
+      maxSegments: 1, // one pin exactly fills the cap → zero non-pinned sampled
+    });
+    // Only the pinned segment is embedded/kept; non-pinned are not all re-admitted.
+    expect(result.embedded).toBe(1);
+    expect(result.output).toContain(directive);
   });
 
   test("pinned matching tolerates a display-truncated snippet (trailing …)", async () => {

--- a/packages/core/test/distillation.test.ts
+++ b/packages/core/test/distillation.test.ts
@@ -11,6 +11,7 @@ import {
   maxAllowedExpansion,
   detectAssertions,
   detectToolFailures,
+  messagesToTextReduced,
   run,
   settleBackgroundWork,
 } from "../src/distillation";
@@ -360,7 +361,39 @@ describe("messagesToText", () => {
   });
 });
 
-// ─── Round-trip via partsToText ────────────────────────────────────────
+// ─── messagesToTextReduced (#1343) ─────────────────────────────────────
+//
+// Async sibling that reduces oversized USER blobs via embedding relevance.
+// The reduction logic itself is covered exhaustively by blob-select.test.ts
+// with a stubbed embedder; here we pin the distillation wiring: short bodies
+// and non-user roles behave exactly like messagesToText, and reduction only
+// engages above the size threshold.
+
+describe("messagesToTextReduced", () => {
+  test("passes short user messages through verbatim", async () => {
+    const msgs = [msg("user", "a normal short directive from the user")];
+    const out = await messagesToTextReduced(msgs, "query");
+    expect(out).toContain("a normal short directive from the user");
+    expect(out).not.toContain("elided");
+  });
+
+  test("empty query disables reduction (oversized body verbatim)", async () => {
+    // With no relevance query there's nothing to score against, so even an
+    // oversized body must pass through untouched rather than be reduced.
+    const huge = "x".repeat(20_000);
+    const msgs = [msg("user", huge)];
+    const out = await messagesToTextReduced(msgs, "   ");
+    expect(out).toContain(huge);
+  });
+
+  test("still truncates oversized tool output on non-user roles", async () => {
+    const big = "a".repeat(5_000);
+    const msgs = [msg("assistant", `[tool:grep] ${big}`)];
+    const out = await messagesToTextReduced(msgs, "query");
+    expect(out).toContain("[output omitted — grep:");
+  });
+});
+
 //
 // Pin the producer/consumer contract end-to-end: a LorePart[] containing
 // arbitrary content (including payloads that look like envelopes) flows

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -107,6 +107,9 @@ Distillation pipeline tuning (segment size, thresholds, tool-output truncation).
 | `maxSegmentTokens` | number | `16384` | min 256 | Maximum tokens per distillation segment before splitting. Default: 16384. |
 | `metaThreshold` | number | `20` | min 3 | Number of gen-0 segments that triggers meta-distillation. Default: 20. |
 | `toolOutputMaxChars` | number | `4000` | min 0 | Max chars per tool output for distillation input. Set to 0 to disable truncation. Default: 4000. |
+| `userBlobMaxChars` | number | `12000` | min 0 | Trigger threshold (chars) for embedding-based user-blob reduction. Set to 0 to disable. Default: 12000. |
+| `userBlobKeepChars` | number | `6000` | min 0 | Chars kept after reducing an oversized user blob. Default: 6000. |
+| `userBlobMaxSegments` | number | `48` | min 1 | Max blob segments embedded during user-blob reduction. Default: 48. |
 | `recentSegmentsToKeep` | number | `5` | min 0 | Number of most-recent gen-0 segments to keep un-archived when meta-distillation fires. Default: 5. |
 
 


### PR DESCRIPTION
## Why

The segment distiller feeds user-message content verbatim to the worker LLM on the principle that "user text is always signal." That holds for prose and directives, but breaks down for large pasted blobs — logs, dumped files, data exports, base64. In one eval run a single ~85K-token paste cost ~200K input tokens to distill while the observer emitted ~500 tokens back: we paid to read bulk that was never memory-worthy. Tool outputs were already capped; user bodies were the last uncapped path and had become the dominant distillation cost.

Blunt head-keep truncation is the obvious fix but the wrong one — the signal in a pasted blob (the one error line, the changed value) can be anywhere, so truncation drops it at random. Instead we spend cheap **local** embeddings — effectively free next to the paid worker call — to pick which expensive tokens are worth sending.

## Approach

Two-stage reducer, tuned so a false positive (dropping real prose) is unacceptable while a false negative only wastes a few embeds:

- **Stage 1** — a free, script-aware lexical pre-filter drops paste-junk *before any embedding*. Biggest lever: a hostile blob never reaches the embedder. It classifies writing systems via Unicode script escapes so it never mistakes CJK/Cyrillic/Turkish prose for garbage, and still requires language-like statistics inside a script so binary bytes that decode into linguistic ranges don't slip through.
- **Stage 2** — embeds the survivors and keeps the segments most relevant to what the distiller cares about: the running session narrative, the user's directives, and what the assistant did with the blob.

Reduction only engages above a size threshold; ordinary messages are untouched. Detected user directives are force-kept verbatim so a buried instruction can never be elided. **Fails open** — any embedder error leaves the body verbatim rather than risk losing signal, never blunt-truncating. Elided bulk stays in `temporal_messages` + FTS, so nothing becomes unrecoverable (it remains recall-searchable, and was never semantically recallable anyway).

Validated against real production blobs: **98–99% token reduction** with signal preserved.

Closes #1343