### PR TITLE
feat(sync): domain auto-join (Model B: verified-admin claim + approve-on-join) (E-5-b, #827)

### DIFF
--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -253,4 +253,17 @@ describe("server-internal tables are intentionally NOT synced", () => {
         `pending_invites must NOT be in SYNCED_TABLES.${tier} — it is a server-internal, RPC-only table (deny-all RLS, no local mirror). Syncing it would wedge the outbox prune floor.`,
       ).toBeUndefined();
   });
+
+  // org_domains / domain_join_requests (E-5-b, #827): same rationale as pending_invites — written/read
+  // only via SECURITY DEFINER RPCs (claim/request/approve/reject_domain_join), no local mirror, and
+  // (for writes) deny-all under RLS. They MUST stay out of SYNCED_TABLES or the client-unpushable
+  // rows would pin the outbox prune floor at 0 for every table (#828 wedge).
+  test("domain auto-join tables are absent from every tier's registry", () => {
+    for (const tier of ["basic", "pro", "max"] as const)
+      for (const table of ["org_domains", "domain_join_requests"])
+        expect(
+          SYNCED_TABLES[tier].find((m) => m.table === table),
+          `${table} must NOT be in SYNCED_TABLES.${tier} — server-internal, RPC-only (no local mirror). Syncing it would wedge the outbox prune floor.`,
+        ).toBeUndefined();
+  });
 });

--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -17,16 +17,21 @@ import { getAuthedClient, getCurrentUser } from "../supabase";
 import {
   addTeamMember,
   acceptTeamInvite,
+  approveDomainJoin,
+  claimOrgDomain,
   createTeam,
   createTeamInvite,
+  listDomainJoinRequests,
   listTeams,
+  rejectDomainJoin,
   removeTeamMember,
+  requestDomainJoin,
   setTeamRole,
   teamMembers,
 } from "../team";
 
 const USAGE =
-  "Usage: lore team [list | members <scope> | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite <scope> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>]]";
+  "Usage: lore team [list | members <scope> | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite <scope> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>] | domain <claim <org> <domain> [--role member] | request <org> <domain> | requests <org> | approve <request-id> | reject <request-id>>]";
 
 export async function commandTeam(
   positionals: string[],
@@ -280,6 +285,68 @@ export async function commandTeam(
         }
         setProjectPromotionPolicy(pid, policy);
         console.log(`Set this project's team-promotion policy to ${policy}.`);
+        break;
+      }
+      case "domain": {
+        // Org-level domain auto-join (E-5-b). No DEK/encryption — pure org membership.
+        const verb = positionals[1];
+        switch (verb) {
+          case "claim": {
+            const org = positionals[2];
+            const domain = positionals[3];
+            if (!org || !domain) return usage();
+            const joinRole = (values.role as string) ?? "member";
+            if (
+              joinRole !== "manager" &&
+              joinRole !== "billing" &&
+              joinRole !== "member"
+            )
+              return usage();
+            await claimOrgDomain(client, org, domain, joinRole);
+            console.log(
+              `Claimed ${domain} for org ${org}. Members with a verified @${domain} email can now request to join (role: ${joinRole}).`,
+            );
+            break;
+          }
+          case "request": {
+            const org = positionals[2];
+            const domain = positionals[3];
+            if (!org || !domain) return usage();
+            const id = await requestDomainJoin(client, org, domain);
+            console.log(
+              `Join request submitted (${id}). An org admin must approve it.`,
+            );
+            break;
+          }
+          case "requests": {
+            const org = positionals[2];
+            if (!org) return usage();
+            const reqs = await listDomainJoinRequests(client, org);
+            if (reqs.length === 0) {
+              console.log("No pending join requests.");
+              break;
+            }
+            for (const r of reqs)
+              console.log(`${r.id}  ${r.userId}  @${r.domain}`);
+            break;
+          }
+          case "approve": {
+            const id = positionals[2];
+            if (!id) return usage();
+            await approveDomainJoin(client, id);
+            console.log(`Approved join request ${id}.`);
+            break;
+          }
+          case "reject": {
+            const id = positionals[2];
+            if (!id) return usage();
+            await rejectDomainJoin(client, id);
+            console.log(`Rejected join request ${id}.`);
+            break;
+          }
+          default:
+            return usage();
+        }
         break;
       }
       default:

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -319,3 +319,89 @@ export async function acceptTeamInvite(
   }
   return { scopeId, role };
 }
+
+// --- Domain auto-join (E-5-b, Model B) ------------------------------------------------------------
+// Org-level membership only (never a team scope / DEK) — thin wrappers over the SECURITY DEFINER RPCs
+// in migration 0045. Verification (verified-email @domain, freemail blocklist, admin gate) is entirely
+// server-side; the client never asserts eligibility.
+
+export interface DomainJoinRequest {
+  id: string;
+  domain: string;
+  userId: string;
+  status: string;
+  requestedAt: string;
+}
+
+/** Claim an auto-join domain for an org (admin/manager; must own a verified email @domain). */
+export async function claimOrgDomain(
+  client: SupabaseClient,
+  orgId: string,
+  domain: string,
+  joinRole: "manager" | "billing" | "member" = "member",
+): Promise<void> {
+  const { error } = await client.rpc("claim_org_domain", {
+    p_org: orgId,
+    p_domain: domain,
+    p_join_role: joinRole,
+  });
+  if (error) throw new Error(`claim_org_domain: ${error.message}`);
+}
+
+/** Request to join an org whose claimed domain matches the caller's verified email. Returns the
+ * request id (admins approve it via approveDomainJoin). */
+export async function requestDomainJoin(
+  client: SupabaseClient,
+  orgId: string,
+  domain: string,
+): Promise<string> {
+  const { data, error } = await client.rpc("request_domain_join", {
+    p_org: orgId,
+    p_domain: domain,
+  });
+  if (error) throw new Error(`request_domain_join: ${error.message}`);
+  return data as string;
+}
+
+/** List pending domain-join requests for an org (admin/manager; RLS scopes to the caller's orgs). */
+export async function listDomainJoinRequests(
+  client: SupabaseClient,
+  orgId: string,
+): Promise<DomainJoinRequest[]> {
+  const { data, error } = await client
+    .from("domain_join_requests")
+    .select("id, domain, user_id, status, requested_at")
+    .eq("org_id", orgId)
+    .eq("status", "pending")
+    .order("requested_at", { ascending: true });
+  if (error) throw new Error(`domain_join_requests: ${error.message}`);
+  return (data ?? []).map((r) => ({
+    id: r.id as string,
+    domain: r.domain as string,
+    userId: r.user_id as string,
+    status: r.status as string,
+    requestedAt: r.requested_at as string,
+  }));
+}
+
+/** Approve a pending join request (admin/manager). Additive — never downgrades an existing role. */
+export async function approveDomainJoin(
+  client: SupabaseClient,
+  requestId: string,
+): Promise<void> {
+  const { error } = await client.rpc("approve_domain_join", {
+    p_request_id: requestId,
+  });
+  if (error) throw new Error(`approve_domain_join: ${error.message}`);
+}
+
+/** Reject a pending join request (admin/manager). */
+export async function rejectDomainJoin(
+  client: SupabaseClient,
+  requestId: string,
+): Promise<void> {
+  const { error } = await client.rpc("reject_domain_join", {
+    p_request_id: requestId,
+  });
+  if (error) throw new Error(`reject_domain_join: ${error.message}`);
+}

--- a/packages/gateway/test/helpers/pg-harness.ts
+++ b/packages/gateway/test/helpers/pg-harness.ts
@@ -64,8 +64,9 @@ export interface PgHarness {
   asUser<T>(uid: string, fn: (c: Client) => Promise<T>): Promise<T>;
   asService<T>(fn: (c: Client) => Promise<T>): Promise<T>;
   asAnon<T>(fn: (c: Client) => Promise<T>): Promise<T>;
-  /** Create an auth user (fires handle_new_user → profiles). Returns the uid. */
-  createUser(email?: string): Promise<string>;
+  /** Create an auth user (fires handle_new_user → profiles). Returns the uid. `confirmed` sets
+   * email_confirmed_at (default true — a logged-in Supabase user has a verified email). */
+  createUser(email?: string, confirmed?: boolean): Promise<string>;
   /** PostgREST base URL (only when started with { postgrest: true }). */
   restUrl?: string;
   /** Mint a JWT for a user (role=authenticated, sub=uid). */
@@ -242,10 +243,13 @@ export async function startPgHarness(
         runAs("authenticated", { sub: uid, role: "authenticated" }, fn),
       asService: (fn) => runAs("service_role", { role: "service_role" }, fn),
       asAnon: (fn) => runAs("anon", { role: "anon" }, fn),
-      async createUser(email = `u${randomBytes(4).toString("hex")}@test.dev`) {
+      async createUser(
+        email = `u${randomBytes(4).toString("hex")}@test.dev`,
+        confirmed = true,
+      ) {
         const { rows } = await client.query(
-          "insert into auth.users (email) values ($1) returning id",
-          [email],
+          "insert into auth.users (email, email_confirmed_at) values ($1, $2) returning id",
+          [email, confirmed ? new Date().toISOString() : null],
         );
         return rows[0].id as string;
       },

--- a/packages/gateway/test/helpers/supabase-shim.sql
+++ b/packages/gateway/test/helpers/supabase-shim.sql
@@ -11,6 +11,7 @@ create schema if not exists auth;
 create table if not exists auth.users (
   id                 uuid primary key default gen_random_uuid(),
   email              text,
+  email_confirmed_at timestamptz,
   raw_user_meta_data jsonb not null default '{}'::jsonb,
   created_at         timestamptz not null default now()
 );

--- a/packages/gateway/test/sync-domain-join.integration.test.ts
+++ b/packages/gateway/test/sync-domain-join.integration.test.ts
@@ -1,0 +1,259 @@
+/**
+ * END-TO-END integration for domain auto-join (E-5-b, Model B, #827) against a REAL Postgres +
+ * PostgREST. An org admin CLAIMS a domain (proving control via their own verified email at that
+ * domain, freemail rejected); a user with a matching VERIFIED email REQUESTS to join; an admin
+ * APPROVES (additive, never demote). No silent absorption, no public-domain hijack.
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-domain-join.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  approveDomainJoin,
+  claimOrgDomain,
+  createTeam,
+  listDomainJoinRequests,
+  rejectDomainJoin,
+  requestDomainJoin,
+} from "../src/team";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+// team.ts's selfUserId() calls getCurrentUser(); createTeam needs it to resolve the caller. Mock it
+// to whichever uid the current step acts as (set before each createTeam call).
+let mockUid = "";
+vi.mock("../src/supabase", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/supabase")>()),
+  getCurrentUser: () => Promise.resolve(mockUid ? { user_id: mockUid } : null),
+}));
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+let admin: string; // @acme.dev verified — org owner + domain claimant
+let coworker: string; // @acme.dev verified — eligible to request
+let outsider: string; // @other.dev verified — NOT eligible
+let unverified: string; // @acme.dev but email NOT confirmed — NOT eligible
+let freemailAdmin: string; // @gmail.com verified — cannot claim gmail.com
+
+function clientFor(uid: string): SupabaseClient {
+  const jwt = h.userJwt(uid);
+  const rewriteFetch = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    return fetch(url.replace("/rest/v1", ""), init);
+  };
+  return createClient(h.restUrl as string, jwt, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: {
+      headers: { Authorization: `Bearer ${jwt}` },
+      fetch: rewriteFetch as unknown as typeof fetch,
+    },
+  });
+}
+
+/** admin creates a team org and returns { scope, org }. */
+async function freshOrg(name: string): Promise<{ scope: string; org: string }> {
+  mockUid = admin; // createTeam resolves the caller via getCurrentUser (mocked)
+  const scope = await createTeam(clientFor(admin), name);
+  const org = await h.client
+    .query("select org_id from public.scopes where id=$1", [scope])
+    .then((r) => r.rows[0].org_id as string);
+  return { scope, org };
+}
+async function orgRole(org: string, uid: string): Promise<string | undefined> {
+  return h.client
+    .query(
+      "select role from public.org_members where org_id=$1 and user_id=$2",
+      [org, uid],
+    )
+    .then((r) => (r.rows[0]?.role as string) ?? undefined);
+}
+
+beforeAll(async () => {
+  if (SKIP) return;
+  h = await startPgHarness({ postgrest: true });
+  admin = await h.createUser("boss@acme.dev");
+  coworker = await h.createUser("dev@acme.dev");
+  outsider = await h.createUser("stranger@other.dev");
+  unverified = await h.createUser("ghost@acme.dev", false); // email NOT confirmed
+  freemailAdmin = await h.createUser("someone@gmail.com");
+}, 240_000);
+
+afterAll(async () => {
+  if (!SKIP) await h.stop();
+});
+
+beforeEach(async () => {
+  if (SKIP) return;
+  // Clean org state between tests (FK order: members/requests/domains → scopes → orgs).
+  await h.client.query(
+    "delete from public.domain_join_requests; delete from public.org_domains;" +
+      " delete from public.scope_members; delete from public.org_members where role<>'owner';" +
+      " delete from public.scopes where kind='team'; delete from public.orgs where kind='team'",
+  );
+});
+
+describe.skipIf(SKIP)("domain auto-join (E-5-b, Model B)", () => {
+  it("an admin claims their own verified domain; a coworker requests and is approved (additive)", async () => {
+    const { org } = await freshOrg("Acme");
+    await claimOrgDomain(clientFor(admin), org, "acme.dev", "member");
+
+    // Coworker (verified @acme.dev) requests → pending.
+    const reqId = await requestDomainJoin(clientFor(coworker), org, "acme.dev");
+    expect(reqId).toBeTruthy();
+    const pending = await listDomainJoinRequests(clientFor(admin), org);
+    expect(pending.map((r) => r.userId)).toContain(coworker);
+
+    // Admin approves → coworker becomes an org member at the claim's join_role.
+    await approveDomainJoin(clientFor(admin), reqId);
+    expect(await orgRole(org, coworker)).toBe("member");
+    // Request is decided (no longer pending).
+    expect((await listDomainJoinRequests(clientFor(admin), org)).length).toBe(
+      0,
+    );
+  });
+
+  it("a non-admin cannot claim a domain (42501)", async () => {
+    const { org } = await freshOrg("Acme");
+    await expect(
+      claimOrgDomain(clientFor(coworker), org, "acme.dev"),
+    ).rejects.toThrow(/only an org owner\/manager/i);
+  });
+
+  it("a freemail domain cannot be claimed (22023)", async () => {
+    // freemailAdmin makes their own org and tries to claim gmail.com.
+    mockUid = freemailAdmin;
+    const scope = await createTeam(clientFor(freemailAdmin), "Gmailers");
+    const org = await h.client
+      .query("select org_id from public.scopes where id=$1", [scope])
+      .then((r) => r.rows[0].org_id as string);
+    await expect(
+      claimOrgDomain(clientFor(freemailAdmin), org, "gmail.com"),
+    ).rejects.toThrow(/freemail|public/i);
+  });
+
+  it("an admin cannot claim a domain that is not their own verified email domain (42501)", async () => {
+    const { org } = await freshOrg("Acme");
+    // admin's verified email is @acme.dev, not @other.dev → cannot prove control.
+    await expect(
+      claimOrgDomain(clientFor(admin), org, "other.dev"),
+    ).rejects.toThrow(/verified email must be at the claimed domain/i);
+  });
+
+  it("an outsider whose email is at a DIFFERENT domain cannot request (no oracle)", async () => {
+    const { org } = await freshOrg("Acme");
+    await claimOrgDomain(clientFor(admin), org, "acme.dev");
+    await expect(
+      requestDomainJoin(clientFor(outsider), org, "acme.dev"),
+    ).rejects.toThrow(/no matching claimed domain/i);
+  });
+
+  it("an UNVERIFIED email cannot request even at a claimed domain", async () => {
+    const { org } = await freshOrg("Acme");
+    await claimOrgDomain(clientFor(admin), org, "acme.dev");
+    // `unverified` has ghost@acme.dev but email_confirmed_at IS NULL → email_domain() returns NULL.
+    await expect(
+      requestDomainJoin(clientFor(unverified), org, "acme.dev"),
+    ).rejects.toThrow(/no matching claimed domain/i);
+  });
+
+  it("requesting when no domain is claimed fails with the same error as a domain mismatch", async () => {
+    const { org } = await freshOrg("Acme");
+    // No claim exists → identical error to the mismatch case (no claimed-domain enumeration).
+    await expect(
+      requestDomainJoin(clientFor(coworker), org, "acme.dev"),
+    ).rejects.toThrow(/no matching claimed domain/i);
+  });
+
+  it("approve is admin-only; a non-admin cannot approve (42501)", async () => {
+    const { org } = await freshOrg("Acme");
+    await claimOrgDomain(clientFor(admin), org, "acme.dev");
+    const reqId = await requestDomainJoin(clientFor(coworker), org, "acme.dev");
+    // coworker (not yet a member, certainly not admin) tries to approve their own request.
+    await expect(approveDomainJoin(clientFor(coworker), reqId)).rejects.toThrow(
+      /only an org owner\/manager|no such request/i,
+    );
+    expect(await orgRole(org, coworker)).toBeUndefined();
+  });
+
+  it("approve is additive — a coworker who is already a higher role is not demoted", async () => {
+    const { org } = await freshOrg("Acme");
+    await claimOrgDomain(clientFor(admin), org, "acme.dev", "member");
+    // Make coworker an org MANAGER first (directly, as the fixture).
+    await h.client.query(
+      "insert into public.org_members (org_id, user_id, role) values ($1,$2,'manager')",
+      [org, coworker],
+    );
+    // A stale pending request approved later must NOT downgrade manager → member.
+    await h.client.query(
+      "insert into public.domain_join_requests (org_id, domain, user_id) values ($1,'acme.dev',$2)",
+      [org, coworker],
+    );
+    const reqId = await h.client
+      .query(
+        "select id from public.domain_join_requests where org_id=$1 and user_id=$2",
+        [org, coworker],
+      )
+      .then((r) => r.rows[0].id as string);
+    await approveDomainJoin(clientFor(admin), reqId);
+    expect(await orgRole(org, coworker)).toBe("manager"); // NOT demoted
+  });
+
+  it("reject marks the request rejected and grants no membership", async () => {
+    const { org } = await freshOrg("Acme");
+    await claimOrgDomain(clientFor(admin), org, "acme.dev");
+    const reqId = await requestDomainJoin(clientFor(coworker), org, "acme.dev");
+    await rejectDomainJoin(clientFor(admin), reqId);
+    expect(await orgRole(org, coworker)).toBeUndefined();
+    const status = await h.client
+      .query("select status from public.domain_join_requests where id=$1", [
+        reqId,
+      ])
+      .then((r) => r.rows[0]?.status as string);
+    expect(status).toBe("rejected");
+  });
+
+  it("verified_email_domain is NOT client-callable (no cross-user email-domain oracle)", async () => {
+    // The unguarded helper must be RPC-internal only. A direct authenticated call must be denied.
+    const { error } = await clientFor(coworker).rpc("verified_email_domain", {
+      p_uid: admin,
+    });
+    expect(error).toBeTruthy(); // permission denied / not exposed
+    // The guarded email_domain IS callable but pins a cross-user probe to null.
+    const { data } = await clientFor(coworker).rpc("email_domain", {
+      p_uid: admin, // asking about a DIFFERENT user
+    });
+    expect(data ?? null).toBeNull();
+  });
+});

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -19,6 +19,11 @@ vi.mock("../src/team", () => ({
   teamMembers: vi.fn(),
   createTeamInvite: vi.fn(),
   acceptTeamInvite: vi.fn(),
+  claimOrgDomain: vi.fn(),
+  requestDomainJoin: vi.fn(),
+  listDomainJoinRequests: vi.fn(),
+  approveDomainJoin: vi.fn(),
+  rejectDomainJoin: vi.fn(),
 }));
 
 import {
@@ -324,6 +329,97 @@ describe("accept (E-5-c)", () => {
       "tok-abc",
     );
     expect(logs.join("\n")).toMatch(/Joined team scope s-9 as editor/);
+  });
+});
+
+describe("domain (E-5-b)", () => {
+  it("claim requires org + domain", async () => {
+    await run("domain", "claim", "org-1");
+    expect(errs.join("\n")).toMatch(/Usage: lore team/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("claim rejects an invalid join role", async () => {
+    await commandTeam(["domain", "claim", "org-1", "acme.dev"], {
+      role: "admin",
+    });
+    expect(errs.join("\n")).toMatch(/Usage: lore team/);
+    expect(vi.mocked(team.claimOrgDomain)).not.toHaveBeenCalled();
+  });
+
+  it("claim passes org/domain/default-role through", async () => {
+    await commandTeam(["domain", "claim", "org-1", "acme.dev"], {});
+    expect(vi.mocked(team.claimOrgDomain)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "org-1",
+      "acme.dev",
+      "member",
+    );
+    expect(logs.join("\n")).toMatch(/Claimed acme.dev/);
+  });
+
+  it("request requires org + domain and reports the request id", async () => {
+    vi.mocked(team.requestDomainJoin).mockResolvedValue("req-7");
+    await run("domain", "request", "org-1", "acme.dev");
+    expect(vi.mocked(team.requestDomainJoin)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "org-1",
+      "acme.dev",
+    );
+    expect(logs.join("\n")).toContain("req-7");
+  });
+
+  it("requests lists pending join requests", async () => {
+    vi.mocked(team.listDomainJoinRequests).mockResolvedValue([
+      {
+        id: "req-1",
+        domain: "acme.dev",
+        userId: "u-2",
+        status: "pending",
+        requestedAt: "t",
+      },
+    ]);
+    await run("domain", "requests", "org-1");
+    expect(logs.join("\n")).toContain("req-1");
+    expect(logs.join("\n")).toContain("u-2");
+  });
+
+  it("requests prints a friendly message when there are none", async () => {
+    vi.mocked(team.listDomainJoinRequests).mockResolvedValue([]);
+    await run("domain", "requests", "org-1");
+    expect(logs.join("\n")).toMatch(/No pending join requests/);
+  });
+
+  it("approve requires an id and calls approveDomainJoin", async () => {
+    await run("domain", "approve", "req-9");
+    expect(vi.mocked(team.approveDomainJoin)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "req-9",
+    );
+    expect(logs.join("\n")).toMatch(/Approved join request req-9/);
+  });
+
+  it("reject calls rejectDomainJoin", async () => {
+    await run("domain", "reject", "req-9");
+    expect(vi.mocked(team.rejectDomainJoin)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "req-9",
+    );
+    expect(logs.join("\n")).toMatch(/Rejected join request req-9/);
+  });
+
+  it("an unknown domain verb prints usage", async () => {
+    await run("domain", "bogus");
+    expect(errs.join("\n")).toMatch(/Usage: lore team/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does NOT require encryption/sync (org membership only, no DEK)", async () => {
+    vi.spyOn(keystore, "encryptionState").mockReturnValue("off");
+    vi.spyOn(syncData, "isSyncEnabled").mockReturnValue(false);
+    await run("domain", "requests", "org-1");
+    // No "run `lore sync enable`" guard fired — the RPC path was reached.
+    expect(errs.join("\n")).not.toMatch(/sync enable/);
   });
 });
 

--- a/packages/gateway/test/team.test.ts
+++ b/packages/gateway/test/team.test.ts
@@ -28,10 +28,14 @@ import { publishIdentityPub, pullOnce, pushOnce } from "../src/sync";
 import {
   acceptTeamInvite,
   addTeamMember,
+  approveDomainJoin,
+  claimOrgDomain,
   createTeam,
   createTeamInvite,
   listTeams,
+  rejectDomainJoin,
   removeTeamMember,
+  requestDomainJoin,
   setTeamRole,
   teamMembers,
 } from "../src/team";
@@ -512,5 +516,80 @@ describe("acceptTeamInvite", () => {
     await expect(acceptTeamInvite(c, "cap123.SECRET")).rejects.toThrow(
       /no matching ephemeral key/,
     );
+  });
+});
+
+describe("domain auto-join RPC wrappers (E-5-b)", () => {
+  it("claimOrgDomain calls claim_org_domain with org/domain/role", async () => {
+    const c = makeClient();
+    await claimOrgDomain(c, "org-1", "Acme.dev", "manager");
+    expect(c.rpcCalls[0]).toEqual({
+      name: "claim_org_domain",
+      params: { p_org: "org-1", p_domain: "Acme.dev", p_join_role: "manager" },
+    });
+  });
+
+  it("claimOrgDomain defaults the role to member", async () => {
+    const c = makeClient();
+    await claimOrgDomain(c, "org-1", "acme.dev");
+    expect(c.rpcCalls[0].params).toEqual({
+      p_org: "org-1",
+      p_domain: "acme.dev",
+      p_join_role: "member",
+    });
+  });
+
+  it("claimOrgDomain surfaces the RPC error", async () => {
+    const c = makeClient({
+      rpc: (n) =>
+        n === "claim_org_domain"
+          ? { data: null, error: { message: "freemail" } }
+          : null,
+    });
+    await expect(claimOrgDomain(c, "o", "gmail.com")).rejects.toThrow(
+      /claim_org_domain: freemail/,
+    );
+  });
+
+  it("requestDomainJoin returns the request id", async () => {
+    const c = makeClient({
+      rpc: (n) =>
+        n === "request_domain_join" ? { data: "req-1", error: null } : null,
+    });
+    expect(await requestDomainJoin(c, "org-1", "acme.dev")).toBe("req-1");
+    expect(c.rpcCalls[0]).toEqual({
+      name: "request_domain_join",
+      params: { p_org: "org-1", p_domain: "acme.dev" },
+    });
+  });
+
+  it("requestDomainJoin surfaces the RPC error", async () => {
+    const c = makeClient({
+      rpc: (n) =>
+        n === "request_domain_join"
+          ? { data: null, error: { message: "no matching claimed domain" } }
+          : null,
+    });
+    await expect(requestDomainJoin(c, "o", "x.dev")).rejects.toThrow(
+      /request_domain_join: no matching claimed domain/,
+    );
+  });
+
+  it("approveDomainJoin calls approve_domain_join with the request id", async () => {
+    const c = makeClient();
+    await approveDomainJoin(c, "req-9");
+    expect(c.rpcCalls[0]).toEqual({
+      name: "approve_domain_join",
+      params: { p_request_id: "req-9" },
+    });
+  });
+
+  it("rejectDomainJoin calls reject_domain_join with the request id", async () => {
+    const c = makeClient();
+    await rejectDomainJoin(c, "req-9");
+    expect(c.rpcCalls[0]).toEqual({
+      name: "reject_domain_join",
+      params: { p_request_id: "req-9" },
+    });
   });
 });

--- a/supabase/migrations/0045_org_domains.sql
+++ b/supabase/migrations/0045_org_domains.sql
@@ -1,0 +1,227 @@
+-- Migration 0045 — domain auto-join (Model B: verified-admin-email claim + freemail blocklist +
+-- approve-on-join) (E-5-b, #827).
+--
+-- An org admin/manager may CLAIM an auto-join domain ONLY if their OWN email is verified and at that
+-- domain, and the domain is not a public/freemail domain. A user whose VERIFIED email matches a
+-- claimed domain may REQUEST to join; an org admin approves (additive, never demote). No silent
+-- absorption (that is Model A / DNS-TXT, a later upgrade) and no pure email-match hijack.
+
+-- ---------------------------------------------------------------------------------------------------
+-- Tables
+-- ---------------------------------------------------------------------------------------------------
+create table if not exists public.org_domains (
+  org_id           uuid not null references public.orgs (id) on delete cascade,
+  domain           text not null,                     -- lowercased; the claimant admin's verified domain
+  claimed_by       uuid not null references auth.users (id) on delete cascade,
+  join_role        text not null default 'member' check (join_role in ('manager', 'billing', 'member')),
+  requires_approval boolean not null default true,    -- Model B: always true here (DNS-TXT relaxes later)
+  created_at       timestamptz not null default now(),
+  primary key (org_id, domain)
+);
+
+create table if not exists public.domain_join_requests (
+  id           uuid primary key default gen_random_uuid(),
+  org_id       uuid not null references public.orgs (id) on delete cascade,
+  domain       text not null,
+  user_id      uuid not null references auth.users (id) on delete cascade,
+  status       text not null default 'pending' check (status in ('pending', 'approved', 'rejected')),
+  requested_at timestamptz not null default now(),
+  decided_by   uuid references auth.users (id),
+  decided_at   timestamptz,
+  unique (org_id, user_id)                             -- one live request per (org, user)
+);
+create index if not exists idx_domain_join_requests_org on public.domain_join_requests (org_id);
+
+-- ---------------------------------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------------------------------
+-- The raw (UNGUARDED) verified-email domain of any user. NOT granted to authenticated — it exists so
+-- the admin-gated approve_domain_join RPC (SECURITY DEFINER) can re-verify a DIFFERENT user's email
+-- domain at approval time without tripping email_domain()'s self-only oracle guard. Only reachable
+-- from inside definer functions in this schema (no direct client grant). Defined BEFORE email_domain
+-- since email_domain's SQL body references it.
+create or replace function public.verified_email_domain(p_uid uuid)
+returns text language sql stable security definer set search_path = pg_catalog, public
+as $$
+  select lower(split_part(u.email, '@', 2))
+    from auth.users u
+    where u.id = p_uid
+      and u.email is not null
+      and u.email_confirmed_at is not null
+      and position('@' in u.email) > 0;
+$$;
+-- Postgres grants EXECUTE to PUBLIC by default at CREATE time, and PostgREST exposes any executable
+-- function at /rest/v1/rpc/<name> (the 0039 hazard). This helper is UNGUARDED (no self-only oracle
+-- pin) — it must NEVER be client-callable, or any authenticated user could read any user's verified
+-- email domain. Revoke the blanket PUBLIC/anon grants so it is reachable ONLY from inside the
+-- admin-gated definer RPCs in this schema.
+revoke all on function public.verified_email_domain(uuid) from public, anon, authenticated;
+
+-- The lowercased domain of a user's VERIFIED email, or NULL if unset/unconfirmed. Self-only: a
+-- cross-user probe (p_uid <> auth.uid()) returns NULL unless the caller is service_role — mirrors the
+-- 0032 oracle-guard pins so this can never be used to learn another user's email domain.
+create or replace function public.email_domain(p_uid uuid default auth.uid())
+returns text language sql stable security definer set search_path = pg_catalog, public
+as $$
+  select case
+    when p_uid is distinct from auth.uid() and auth.role() is distinct from 'service_role' then null
+    else public.verified_email_domain(p_uid)
+  end;
+$$;
+grant execute on function public.email_domain(uuid) to authenticated;
+
+-- Public/freemail domains that no single org may claim (they are shared by unrelated people).
+create or replace function public.is_freemail(p_domain text)
+returns boolean language sql immutable set search_path = pg_catalog, public
+as $$
+  select lower(p_domain) in (
+    'gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'live.com', 'msn.com',
+    'yahoo.com', 'ymail.com', 'icloud.com', 'me.com', 'mac.com', 'proton.me', 'protonmail.com',
+    'pm.me', 'aol.com', 'gmx.com', 'gmx.net', 'zoho.com', 'yandex.com', 'mail.com', 'fastmail.com',
+    'hey.com', 'tutanota.com', 'tuta.io', 'qq.com', '163.com', '126.com'
+  );
+$$;
+grant execute on function public.is_freemail(text) to authenticated;
+
+-- ---------------------------------------------------------------------------------------------------
+-- RPCs (SECURITY DEFINER, pinned search_path, org-locked)
+-- ---------------------------------------------------------------------------------------------------
+-- Claim an auto-join domain for an org. Admin/manager-only; the claimant must PROVE control by having
+-- their own VERIFIED email at the domain; freemail domains are rejected.
+create or replace function public.claim_org_domain(
+  p_org uuid, p_domain text, p_join_role text default 'member')
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare v_domain text := lower(trim(p_domain));
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_org::text, 0));
+  if coalesce(public.org_role(p_org), '') not in ('owner', 'manager') then
+    raise exception 'only an org owner/manager may claim a domain' using errcode = '42501';
+  end if;
+  if p_join_role not in ('manager', 'billing', 'member') then
+    raise exception 'join role must be manager/billing/member' using errcode = '22023';
+  end if;
+  if v_domain = '' or position('@' in v_domain) > 0 or position('.' in v_domain) = 0 then
+    raise exception 'invalid domain' using errcode = '22023';
+  end if;
+  if public.is_freemail(v_domain) then
+    raise exception 'public/freemail domains cannot be claimed' using errcode = '22023';
+  end if;
+  -- Proof of control: the claiming admin's OWN verified email must be at this domain.
+  if public.email_domain(auth.uid()) is distinct from v_domain then
+    raise exception 'your verified email must be at the claimed domain' using errcode = '42501';
+  end if;
+  insert into public.org_domains (org_id, domain, claimed_by, join_role)
+    values (p_org, v_domain, auth.uid(), p_join_role)
+    on conflict (org_id, domain) do update set join_role = excluded.join_role;
+end $$;
+grant execute on function public.claim_org_domain(uuid, text, text) to authenticated;
+
+-- Request to join an org whose claimed domain matches the caller's VERIFIED email. Identical error
+-- for "no such claim" and "email does not match" so a claimed-domain list can't be enumerated.
+create or replace function public.request_domain_join(p_org uuid, p_domain text)
+returns uuid language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare v_domain text := lower(trim(p_domain)); v_id uuid;
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_org::text, 0));
+  if not exists (select 1 from public.org_domains where org_id = p_org and domain = v_domain)
+     or public.email_domain(auth.uid()) is distinct from v_domain then
+    raise exception 'no matching claimed domain for your verified email' using errcode = '42501';
+  end if;
+  -- Already a member? Nothing to request.
+  if public.is_org_member(p_org) then
+    raise exception 'already a member of this org' using errcode = '22023';
+  end if;
+  insert into public.domain_join_requests (org_id, domain, user_id)
+    values (p_org, v_domain, auth.uid())
+    on conflict (org_id, user_id) do update set
+      status = 'pending', domain = excluded.domain, requested_at = now(),
+      decided_by = null, decided_at = null
+    returning id into v_id;
+  return v_id;
+end $$;
+grant execute on function public.request_domain_join(uuid, text) to authenticated;
+
+-- Approve a pending join request. Org admin/manager-only. Additive (never downgrades an existing
+-- higher role). Re-verifies the requester's email STILL matches the claimed domain at approval time
+-- (guards against an email change between request and approval).
+create or replace function public.approve_domain_join(p_request_id uuid)
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare rec public.domain_join_requests%rowtype;
+begin
+  select * into rec from public.domain_join_requests where id = p_request_id;
+  if not found then
+    raise exception 'no such request' using errcode = '22023';
+  end if;
+  perform pg_advisory_xact_lock(hashtextextended(rec.org_id::text, 0));
+  -- Re-read under the lock (mirrors accept_scope_invite's discipline): a concurrent approval that
+  -- won the lock first may have already decided this request, so the stale pre-lock rec.status must
+  -- not be trusted for the 'pending' check / audit stamp below.
+  select * into rec from public.domain_join_requests where id = p_request_id;
+  if not found then
+    raise exception 'no such request' using errcode = '22023';
+  end if;
+  if coalesce(public.org_role(rec.org_id), '') not in ('owner', 'manager') then
+    raise exception 'only an org owner/manager may approve join requests' using errcode = '42501';
+  end if;
+  if rec.status <> 'pending' then
+    raise exception 'request already decided' using errcode = '22023';
+  end if;
+  -- The claim must still exist AND the requester's verified email must still match it. Use the
+  -- UNGUARDED verified_email_domain (this RPC is already admin-gated) — email_domain() would return
+  -- NULL for a cross-user (requester ≠ approving admin) probe.
+  if not exists (select 1 from public.org_domains where org_id = rec.org_id and domain = rec.domain)
+     or public.verified_email_domain(rec.user_id) is distinct from rec.domain then
+    raise exception 'requester no longer qualifies for this domain' using errcode = '22023';
+  end if;
+  insert into public.org_members (org_id, user_id, role)
+    select rec.org_id, rec.user_id, coalesce(d.join_role, 'member')
+      from public.org_domains d where d.org_id = rec.org_id and d.domain = rec.domain
+    on conflict (org_id, user_id) do nothing;   -- additive: never downgrade an existing role
+  update public.domain_join_requests
+    set status = 'approved', decided_by = auth.uid(), decided_at = now()
+    where id = p_request_id;
+end $$;
+grant execute on function public.approve_domain_join(uuid) to authenticated;
+
+create or replace function public.reject_domain_join(p_request_id uuid)
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare rec public.domain_join_requests%rowtype;
+begin
+  select * into rec from public.domain_join_requests where id = p_request_id;
+  if not found then
+    raise exception 'no such request' using errcode = '22023';
+  end if;
+  perform pg_advisory_xact_lock(hashtextextended(rec.org_id::text, 0));
+  if coalesce(public.org_role(rec.org_id), '') not in ('owner', 'manager') then
+    raise exception 'only an org owner/manager may reject join requests' using errcode = '42501';
+  end if;
+  update public.domain_join_requests
+    set status = 'rejected', decided_by = auth.uid(), decided_at = now()
+    where id = p_request_id and status = 'pending';
+end $$;
+grant execute on function public.reject_domain_join(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------------------------------
+-- RLS — both tables written ONLY via the RPCs above; reads scoped so a member/admin sees the relevant
+-- rows. No direct DML grant to authenticated (RPC-only), matching pending_invites.
+-- ---------------------------------------------------------------------------------------------------
+alter table public.org_domains enable row level security;
+revoke all on public.org_domains from anon, authenticated;
+grant select on public.org_domains to authenticated;   -- reads only; writes are RPC-only (RLS scopes rows)
+drop policy if exists org_domains_read on public.org_domains;
+create policy org_domains_read on public.org_domains
+  for select using (public.is_org_member(org_id));   -- org members may see their org's claimed domains
+
+alter table public.domain_join_requests enable row level security;
+revoke all on public.domain_join_requests from anon, authenticated;
+grant select on public.domain_join_requests to authenticated;   -- reads only; writes are RPC-only
+drop policy if exists domain_join_requests_read on public.domain_join_requests;
+create policy domain_join_requests_read on public.domain_join_requests
+  for select using (
+    user_id = (select auth.uid())                                   -- a user sees their own request
+    or coalesce(public.org_role(org_id), '') in ('owner', 'manager')-- an admin sees their org's requests
+  );


### PR DESCRIPTION
## What
The second E-5 provisioning mechanism (after E-5-a GitHub Teams and E-5-c email invites). **Model B** domain auto-join:
1. An org admin/manager **claims** an auto-join domain, proving control via their **own verified email** at that domain (freemail domains rejected).
2. A user whose **verified email** matches a claimed domain **requests** to join.
3. An admin **approves** — additive (never demotes an existing higher role).

No silent absorption, no public-domain hijack; pure email-match with no control proof is explicitly rejected. DNS-TXT (Model A) zero-touch is a later upgrade.

## Migration 0045
- `org_domains` + `domain_join_requests` — RPC-only writes (deny-all DML), reads RLS-scoped.
- `email_domain(uid)`: self-only oracle guard (cross-user probe → NULL unless service_role, mirrors 0032). `verified_email_domain(uid)`: unguarded helper for the admin-gated approve re-check — **explicitly REVOKEd from public/anon/authenticated** (the 0039 default-PUBLIC-EXECUTE hazard) so it is never client-callable.
- `is_freemail` blocklist; `claim/request/approve/reject_domain_join` RPCs (SECURITY DEFINER, pinned search_path, org-advisory-locked, admin-gated with `coalesce` to avoid the NULL-`not in` SQL trap; approve re-verifies the requester's email at approval time).

## Client + CLI
- `team.ts` thin RPC wrappers (org membership only — **no DEK/crypto**).
- `lore team domain <claim|request|requests|approve|reject>` — **not** gated behind encryption/sync.

## Test harness
Added `email_confirmed_at` to the auth.users shim + a `confirmed` flag on pg-harness `createUser` (default true).

## Tests
- **sync-domain-join integration (11):** admin-gate / freemail / own-domain-proof on claim; request needs a claim + verified email (identical error → no oracle); unverified email can't request; approve admin-only + additive + re-verify; reject; and `verified_email_domain` is not client-callable while `email_domain` pins a cross-user probe to null.
- **team / team-cmd unit (18):** RPC wrappers + CLI dispatch/validation; domain verbs need neither encryption nor sync.
- **sync-registry-contract:** `org_domains`/`domain_join_requests` stay OUT of SYNCED_TABLES (server-internal; would wedge the prune floor, #828).

Full typecheck/lint/format clean; 156 unit + 11 domain integration pass (133 total integration green). Part of epic #827.