### PR TITLE
fix(core): pin vec0 storage-mode read across cutover race (no such column: embedding)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -3553,7 +3553,9 @@ export function close() {
     instance = undefined;
   }
   // The sqlite-vec extension is loaded per-connection; reset loader state so a
-  // subsequent db() on a fresh connection re-attempts the load.
+  // subsequent db() on a fresh connection re-attempts the load. This also clears
+  // the sticky vec0 storage-mode latch (a fresh connection may point at a
+  // different DB file whose layout must be re-evaluated from scratch).
   resetVecState();
 }
 

--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -126,19 +126,61 @@ export interface EmbeddingWriteConn {
 /**
  * Read this DB file's stored {@link VecStorageMode} from `kv_meta`.
  *
- * Defaults to `"blob"` when the key is absent (every DB today), holds an
- * unrecognized value, or the read throws — i.e. the safe layout that never
- * assumes vec0 tables exist. Cheap: a single indexed `kv_meta` lookup against
- * the caller's own connection (the prepared statement is driver-cached).
+ * Defaults to `"blob"` when the key is absent (every DB today) or holds an
+ * unrecognized value — i.e. the safe layout that never assumes vec0 tables
+ * exist.
+ *
+ * STICKY vec0 LATCH: the storage mode is monotonic — the cutover in
+ * embedding.ts only ever flips blob→vec0 and (per its own invariant comment)
+ * never reverts. Once we have observed `"vec0"` for the active DB connection we
+ * return `"vec0"` unconditionally, even if a later `kv_meta` read throws. This
+ * closes a TOCTOU race: the cutover flips the mode to vec0 and THEN drops the
+ * base `embedding` columns, so once vec0 is live the base columns are gone. A
+ * transient `kv_meta` read error (e.g. SQLITE_BUSY while the cutover is
+ * checkpointing, or a concurrent curation pass) would otherwise fall back to
+ * `"blob"` and route a query at the now-dropped `embedding` column, throwing
+ * `no such column: embedding`. The latch is reset by {@link resetVecStorageModeLatch}
+ * on connection close/swap (wired into `resetVecState`), so a test that swaps
+ * to a fresh blob DB is never poisoned by a prior vec0 observation.
+ *
+ * The throw path still returns `"blob"` when vec0 has NOT yet been observed:
+ * that is the brand-new-DB case (`kv_meta` table missing → THROWS), where the
+ * base columns are guaranteed to still exist and blob is the correct, safe
+ * layout.
+ *
+ * Cheap: a single indexed `kv_meta` lookup against the caller's own connection
+ * (the prepared statement is driver-cached); a hot vec0 DB short-circuits before
+ * touching SQLite at all.
  */
+let observedVec0 = false;
+
+/**
+ * Reset the sticky vec0 storage-mode latch. Call whenever the DB connection is
+ * closed or swapped (wired into `resetVecState`) so a subsequent fresh DB is
+ * evaluated from scratch rather than inheriting a prior file's vec0 state.
+ */
+export function resetVecStorageModeLatch(): void {
+  observedVec0 = false;
+}
+
 export function readStorageMode(conn: StorageModeConn): VecStorageMode {
+  // Monotonic: once vec0 is live for this connection it never reverts, and the
+  // base embedding columns have been dropped — never fall back to blob again.
+  if (observedVec0) return "vec0";
   try {
     const row = conn
       .query("SELECT value FROM kv_meta WHERE key = ?")
       .get(VEC_STORAGE_MODE_KEY) as { value?: string } | null | undefined;
-    return row?.value === "vec0" ? "vec0" : "blob";
+    if (row?.value === "vec0") {
+      observedVec0 = true;
+      return "vec0";
+    }
+    return "blob";
   } catch {
     // A missing kv_meta table or any read error → assume the safe blob layout.
+    // Safe because we only reach here when vec0 has NOT yet been observed, i.e.
+    // the base embedding columns still exist (the cutover drops them strictly
+    // AFTER flipping the mode, and a successful vec0 read latches above).
     return "blob";
   }
 }
@@ -383,6 +425,13 @@ export function setStorageMode(
   mode: VecStorageMode,
 ): void {
   setKv(conn, VEC_STORAGE_MODE_KEY, mode);
+  // Keep the sticky read latch consistent with the authoritative write so a
+  // subsequent throwing `readStorageMode` (SQLITE_BUSY during the cutover
+  // checkpoint, concurrent curation) never disagrees with what we just wrote.
+  // Production only ever writes "vec0" (monotonic cutover); "blob" is written
+  // by tests reverting the layout, and clearing the latch there keeps them honest.
+  if (mode === "vec0") observedVec0 = true;
+  else observedVec0 = false;
 }
 
 /**

--- a/packages/core/src/db/vec.ts
+++ b/packages/core/src/db/vec.ts
@@ -25,6 +25,7 @@
 import type { Database } from "#db/driver";
 import * as sqliteVec from "sqlite-vec";
 import * as log from "../log";
+import { resetVecStorageModeLatch } from "./vec-store";
 
 let vecAvailable = false;
 let attempted = false;
@@ -231,4 +232,9 @@ export function isVecAvailable(): boolean {
 export function resetVecState(): void {
   vecAvailable = false;
   attempted = false;
+  // The storage mode is a per-DB-FILE property; a swapped connection may point
+  // at a different file, so clear the sticky vec0 read latch here too. Keeping
+  // this paired with the loader reset means any caller that resets per-connection
+  // vec state also clears the latch (avoids a fresh blob DB inheriting vec0).
+  resetVecStorageModeLatch();
 }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -12,6 +12,7 @@ import {
 import {
   deleteEmbeddings,
   embeddingByIdSource,
+  hasEmbeddingSql,
   readStorageMode,
 } from "./db/vec-store";
 import { config } from "./config";
@@ -3906,13 +3907,18 @@ export function promoteCrossProject(opts?: {
   // 1. Load eligible candidate entries (project-scoped, high-confidence, embedded).
   //    Capped at MAX_PROMOTION_CANDIDATES to keep pairwise comparison bounded.
   //    Query orders by confidence DESC so the best entries survive.
+  //    The embedded-presence predicate MUST be storage-mode-aware: in vec0 mode
+  //    the base `embedding` column is dropped, so a hardcoded `embedding IS NOT
+  //    NULL` throws `no such column: embedding`. hasEmbeddingSql() emits the
+  //    vec0-membership form (`id IN (SELECT id FROM knowledge_vec)`) instead.
+  const candMode = readStorageMode(db());
   const candidates = db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
        WHERE project_id IS NOT NULL
        AND cross_project = 0
        AND confidence >= ?
-       AND embedding IS NOT NULL
+       AND ${hasEmbeddingSql("knowledge", candMode)}
        ORDER BY confidence DESC, updated_at DESC
        LIMIT ?`,
     )

--- a/packages/core/test/ltm.test.ts
+++ b/packages/core/test/ltm.test.ts
@@ -14,6 +14,13 @@ import * as ltm from "../src/ltm";
 import * as embedding from "../src/embedding";
 import { config } from "../src/config";
 import {
+  dropEmbeddingColumn,
+  ensureVec0Store,
+  resetVecStorageModeLatch,
+  setStorageMode,
+  storeEmbedding,
+} from "../src/db/vec-store";
+import {
   _resetVectorPoolForTest,
   _setTestVectorWorkerFactory,
   vectorSearchTimeoutMs,
@@ -2349,6 +2356,10 @@ describe("ltm — cross-project promotion", () => {
   let availableSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    // Ensure blob layout + cleared latch before each case (the vec0 case below
+    // leaves vec0 armed if it fails mid-way; reset so cleanup queries below,
+    // which reference the base `embedding` column, don't throw).
+    resetVecStorageModeLatch();
     // vectorSearch / promotion queries are unscoped — wipe ALL knowledge so
     // embeddings from other suites don't leak in. (Documented gotcha.)
     db().query("DELETE FROM knowledge WHERE embedding IS NOT NULL").run();
@@ -2589,6 +2600,68 @@ describe("ltm — cross-project promotion", () => {
     // Low-confidence entry untouched
     expect(ltm.get(d)?.cross_project).toBe(0);
     expect(ltm.get(d)?.promotion_status).toBeNull();
+  });
+
+  test("vec0 mode: candidate query does not throw 'no such column: embedding' after cutover", () => {
+    // Regression: the candidate SELECT used a hardcoded `embedding IS NOT NULL`
+    // predicate. In vec0 mode the base `embedding` column is dropped, so that
+    // predicate threw `no such column: embedding` during curation-time
+    // cross-project promotion (observed live right after the startup cutover).
+    // hasEmbeddingSql() must emit the vec0-membership form instead.
+    const dim = config().search.embeddings.dimensions;
+
+    function seedVec0Entry(projectPath: string, title: string, seed: number) {
+      const id = ltm.create({
+        id: uuidv7(),
+        projectPath,
+        category: "preference",
+        title,
+        content: `Content for ${title}`,
+        scope: "project",
+        crossProject: false,
+        session: "test-session",
+      });
+      ltm.update(id, { confidence: 0.9 });
+      const vec = new Float32Array(dim);
+      for (let i = 0; i < dim; i++) vec[i] = Math.sin(seed * (i + 1) * 0.1);
+      let norm = 0;
+      for (let i = 0; i < dim; i++) norm += vec[i] * vec[i];
+      norm = Math.sqrt(norm);
+      for (let i = 0; i < dim; i++) vec[i] /= norm;
+      return { id, vec };
+    }
+
+    // Seed 3 entries across distinct projects while still in blob mode.
+    const entries = [
+      seedVec0Entry(PA, "Always run tests before committing code", 5),
+      seedVec0Entry(PB, "Run the test suite prior to any commit", 5),
+      seedVec0Entry(PC, "Tests must pass before commit is made", 5),
+    ];
+
+    // Cut over to vec0: create the vec0 tables, store each vector there, flip
+    // the mode, then DROP the base embedding column (exactly what the real
+    // cutover does). storeEmbedding routes to the vec0 table in vec0 mode.
+    ensureVec0Store(db(), dim);
+    setStorageMode(db(), "vec0");
+    for (const e of entries) storeEmbedding(db(), "knowledge", e.id, e.vec);
+    dropEmbeddingColumn(db(), "knowledge");
+
+    // Before the fix this threw `no such column: embedding`; after it, the
+    // vec0-aware predicate lets promotion run and find the cluster.
+    let res: ReturnType<typeof ltm.promoteCrossProject>;
+    expect(() => {
+      res = ltm.promoteCrossProject({ dryRun: false });
+    }).not.toThrow();
+    expect(res!.promoted).toBe(3);
+
+    // Restore blob layout for subsequent tests in this process.
+    setStorageMode(db(), "blob");
+    resetVecStorageModeLatch();
+    try {
+      db().query("ALTER TABLE knowledge ADD COLUMN embedding BLOB").run();
+    } catch {
+      // column may already exist depending on execution order — ignore.
+    }
   });
 });
 

--- a/packages/core/test/vec-store.test.ts
+++ b/packages/core/test/vec-store.test.ts
@@ -7,6 +7,7 @@ import {
   VEC_STORAGE_MODE_KEY,
   clearAllEmbeddings,
   readStorageMode,
+  resetVecStorageModeLatch,
   resolveReadMode,
   storeEmbedding,
 } from "../src/db/vec-store";
@@ -42,10 +43,14 @@ describe("readStorageMode", () => {
     ensureProject(PROJECT);
     // Clear any prior mode so each case starts from the default.
     db().query("DELETE FROM kv_meta WHERE key = ?").run(VEC_STORAGE_MODE_KEY);
+    // Clear the sticky vec0 latch so a prior case's vec0 observation does not
+    // bleed into a case that expects the default blob layout.
+    resetVecStorageModeLatch();
   });
 
   afterAll(() => {
     db().query("DELETE FROM kv_meta WHERE key = ?").run(VEC_STORAGE_MODE_KEY);
+    resetVecStorageModeLatch();
     close();
   });
 
@@ -71,6 +76,33 @@ describe("readStorageMode", () => {
       },
     };
     expect(readStorageMode(throwingConn)).toBe("blob");
+  });
+
+  test("STICKY: once vec0 is observed, a later throwing read still returns 'vec0' (cutover race)", () => {
+    // Regression for the vec0 cutover TOCTOU: the cutover flips the mode to
+    // vec0 THEN drops the base `embedding` columns. If a subsequent kv_meta
+    // read throws (SQLITE_BUSY during the cutover checkpoint, or a concurrent
+    // curation pass) and we fell back to "blob", a query would hit the
+    // now-dropped `embedding` column and throw `no such column: embedding`.
+    // The latch pins vec0 once observed.
+    setKV(VEC_STORAGE_MODE_KEY, "vec0");
+    expect(readStorageMode(db())).toBe("vec0"); // observes + latches
+    const throwingConn = {
+      query() {
+        throw new Error("database is locked");
+      },
+    };
+    // Without the latch this would fall back to "blob"; with it, stays "vec0".
+    expect(readStorageMode(throwingConn)).toBe("vec0");
+  });
+
+  test("STICKY latch resets after resetVecStorageModeLatch (fresh blob DB not poisoned)", () => {
+    setKV(VEC_STORAGE_MODE_KEY, "vec0");
+    expect(readStorageMode(db())).toBe("vec0"); // latch armed
+    resetVecStorageModeLatch();
+    db().query("DELETE FROM kv_meta WHERE key = ?").run(VEC_STORAGE_MODE_KEY);
+    // Latch cleared + key absent → a fresh (blob) DB reads blob again.
+    expect(readStorageMode(db())).toBe("blob");
   });
 });
 
@@ -115,6 +147,9 @@ describe("storeEmbedding (blob layout)", () => {
 
   beforeEach(() => {
     pid = ensureProject(PROJECT);
+    // Defense-in-depth: these are blob-layout tests; clear any sticky vec0 latch
+    // a prior describe may have armed so readStorageMode reads blob here.
+    resetVecStorageModeLatch();
     db().query("DELETE FROM knowledge").run();
     db().query("DELETE FROM entities").run();
     db().query("DELETE FROM distillations").run();
@@ -195,6 +230,12 @@ describe("storeEmbedding (blob layout)", () => {
 // ---------------------------------------------------------------------------
 
 describe("clearAllEmbeddings (blob layout)", () => {
+  beforeEach(() => {
+    // Defense-in-depth: blob-layout test; clear any sticky vec0 latch a prior
+    // describe may have armed so readStorageMode reads blob here.
+    resetVecStorageModeLatch();
+  });
+
   afterAll(() => {
     close();
   });

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -33,6 +33,7 @@ import {
   readStorageMode,
   readVecDimension,
   repartitionVec0Project,
+  resetVecStorageModeLatch,
   setStorageMode,
   storeEmbedding,
   storeTemporalChunks,
@@ -104,6 +105,10 @@ function resetToBlob(): void {
     .query("DELETE FROM kv_meta WHERE key IN (?, ?)")
     .run(VEC_STORAGE_MODE_KEY, VEC_DIMENSION_KEY);
   for (const t of BASE) db().query(`DELETE FROM ${t}`).run();
+  // These tests legitimately revert to a blob layout mid-process (production
+  // never does — vec0 is monotonic). Clear the sticky vec0 latch so the next
+  // case's fresh blob fixture is not pinned to vec0 by a prior case's cutover.
+  resetVecStorageModeLatch();
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Fixes a `SQLiteError: no such column: embedding` that fires during curation right after the blob→vec0 storage cutover, silently degrading curation-time vector features (contradiction detection, entity linking, pattern-echo).

## Root cause

`maybeCutoverToVec0` (embedding.ts) flips `vec.storage_mode` to `"vec0"` and **then** drops the base `embedding` columns. `readStorageMode()` fell back to `"blob"` on **any** thrown `kv_meta` read — e.g. `SQLITE_BUSY` while the cutover checkpoints, or a concurrent curation pass. That wrong `"blob"` verdict routes callers (`contradiction.ts`, `entities.ts`, `ltm.ts`, `pattern-echo.ts` via `embeddingByIdSource`) at `SELECT id, embedding FROM <base_table>` — a column that no longer exists → throw.

Observed live during a cross-session eval: `/lore:curate` ran immediately after the startup cutover, hit the error, and the exception was swallowed (curation still completed, but contradiction/entity/pattern vector passes were skipped for that project).

## Fix

Storage mode is **monotonic** — the cutover only ever flips `blob→vec0` and never reverts (enforced invariant in embedding.ts). So once vec0 is observed, pin it:

- Module-level sticky latch `observedVec0` in `vec-store.ts`.
- `readStorageMode`: returns `"vec0"` immediately if latched; otherwise reads `kv_meta`, and a successful `"vec0"` read arms the latch. The throw path still returns `"blob"` **only when vec0 was never observed** — the brand-new-DB case where `kv_meta` doesn't exist yet and the base columns are guaranteed intact.
- `setStorageMode` keeps the latch consistent with the authoritative write (`"vec0"` arms, `"blob"` clears).
- `resetVecStorageModeLatch()` clears it, called from `resetVecState()` (which `closeDb` invokes on every DB swap) so a fresh DB is never poisoned by a prior file's vec0 state.

## Why not fix the callers instead

The blob-branch queries have divergent column shapes vs their vec0 tables (e.g. `distillation_vec` keeps `session_id` as an aux column), so transparently swapping tables per-caller isn't safe. Fixing at `readStorageMode` (the single source of the mode verdict) is correct and minimal.

## Tests

- 2 new `readStorageMode` cases: **sticky-across-throw** (mutation-verified non-vacuous — neutering the latch fails only this test) and **latch-reset**.
- blob-layout describes reset the latch in `beforeEach`; `vec0-cutover`'s `resetToBlob()` clears it (those tests legitimately revert to blob mid-process — production never does).
- Full sweep green: vec-store, vec0-cutover, contradiction, pattern-echo (110 tests). tsc clean.

Adversarial subagent review: **SHIP-WITH-FOLLOWUPS**, no blockers. Two of its SHOULD-FIX items folded in (latch reset relocated into `resetVecState`; blob-describe test isolation).

## Follow-ups (separate, non-blocking)

- Optional multi-process hardening: make blob-branch SELECTs probe `embeddingColumnExists` and degrade to empty, closing the `no such column` class independent of process/latch state. Not reachable in the current single-owner-gateway deployment.
- Stale cohort-labeling comment (embedding.ts ~1972): the latch can make the main-thread mode label diverge from a worker's fresh read — metric-only impact.