### PR TITLE
fix(sync): reap orphaned ephemeral-invite scope_keys rows (#1353)

### DIFF
--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -1538,6 +1538,73 @@ describe.skipIf(gate())("sync migrations — tombstone reaper (#909)", () => {
   });
 });
 
+describe.skipIf(SKIP)(
+  "sync migrations — ephemeral-invite scope_keys reaper (0046, #1353)",
+  () => {
+    const ANCIENT = "2020-01-01T00:00:00Z";
+    const recentTs = () => new Date(Date.now() - 5 * 86_400_000).toISOString();
+
+    // Insert a scope_keys row as the table owner (superuser h.client, which holds the GRANT that
+    // service_role lacks). Reset the request.jwt.claims GUC first so the maintain_usage trigger's
+    // auth.uid() → current_setting('request.jwt.claims')::json doesn't trip on a stale value left on
+    // the shared connection by an earlier asUser/asService test. Explicit created_at controls age.
+    // `member` is either an 'eph:<pub>' capability id or a real user uuid (a normal member wrap the
+    // reaper must NEVER touch).
+    const insKey = async (scope: string, member: string, createdAt: string) => {
+      // Session-level (is_local=false) so it persists across h.client's autocommit statements.
+      // Use '{}' (valid empty JSON) — auth.uid()/auth.role() do current_setting(...)::json, which
+      // trips on a bare '' left by an earlier asUser/asService test.
+      await h.client.query(
+        "select set_config('request.jwt.claims', '{}', false)",
+      );
+      await h.client.query(
+        `insert into public.scope_keys (scope_id, member_user_id, author_id, wrapped_dek, key_epoch, created_at, updated_at)
+         values ($1, $2, $1, 'd3JhcHBlZERFSw==', 0, $3, $3)`,
+        [scope, member, createdAt],
+      );
+    };
+    const remainingKeys = async (scope: string) =>
+      (
+        await h.client.query(
+          "select member_user_id from public.scope_keys where scope_id=$1 order by member_user_id",
+          [scope],
+        )
+      ).rows.map((r) => r.member_user_id as string);
+
+    it("reaps ONLY 'eph:' rows older than the window; keeps recent eph + all real wraps", async () => {
+      const a = await h.createUser();
+      await insKey(a, a, ANCIENT); // a real member wrap, ancient → MUST survive (never reaped)
+      await insKey(a, "eph:OLDPUB", ANCIENT); // stale eph capability → reaped
+      await insKey(a, "eph:NEWPUB", recentTs()); // eph inside the 14d window → kept
+
+      const { rows: rr } = await h.client.query(
+        "select public.reap_ephemeral_scope_keys(14) as n",
+      );
+      expect(Number(rr[0].n)).toBeGreaterThanOrEqual(1); // >= our 1 stale eph (reap is global)
+
+      // Real wrap survives; recent eph survives; stale eph gone.
+      expect(await remainingKeys(a)).toEqual([a, "eph:NEWPUB"]);
+    });
+
+    it("retention_days=0 reaps every eph row but NEVER a real member wrap", async () => {
+      const a = await h.createUser();
+      await insKey(a, a, recentTs()); // real wrap, even recent → never touched
+      await insKey(a, "eph:P", recentTs()); // recent eph, but window 0 → reaped
+      await h.client.query("select public.reap_ephemeral_scope_keys(0)");
+      expect(await remainingKeys(a)).toEqual([a]); // only the real wrap remains
+    });
+
+    it("is not executable by a normal (authenticated) user — system task only", async () => {
+      const a = await h.createUser();
+      await expect(
+        h.asUser(a, (c) =>
+          c.query("select public.reap_ephemeral_scope_keys(14)"),
+        ),
+      ).rejects.toThrow(/permission denied/i);
+    });
+  },
+);
+
 describe.skipIf(gate())("sync migrations — reaper watermark (#909)", () => {
   const nowIso = () => new Date().toISOString();
   // Relative dates keep the tests robust to wall-clock. The cutoff is

--- a/supabase/migrations/0046_reap_ephemeral_scope_keys.sql
+++ b/supabase/migrations/0046_reap_ephemeral_scope_keys.sql
@@ -1,0 +1,61 @@
+-- Migration 0046 — reap orphaned ephemeral-invite scope_keys rows (E-5-c-2 follow-up, #1353).
+--
+-- An `--offline` invite (0044) mints a synthetic scope_keys row keyed `member_user_id = 'eph:<pub>'`
+-- holding the scope DEK wrapped to an ephemeral public key. On accept the invitee RETIRES it (delete
+-- both sides via retire_ephemeral_invite). But if the invite is NEVER accepted, or retirement fails
+-- after adoption (the two steps aren't atomic), the eph row lingers forever — the token's decryption
+-- capability against that row outlives the pending_invites 14-day join window (0042).
+--
+-- Blast radius is bounded (eph rows are is_member-gated on read, so only existing members — who
+-- already hold the DEK — can read them; no leak to non-members). This is hygiene / defense-in-depth,
+-- so a periodic server-side reap keyed off the same 14-day window as the invite expiry is sufficient.
+--
+-- Mirrors reap_tombstones (0018): SECURITY DEFINER, service_role-only, daily pg_cron where available.
+-- NOTE 0018 deliberately EXCLUDES scope_keys from the tombstone reaper (real per-member wraps must
+-- never be background-deleted); this reaper is the narrow complement — it touches ONLY 'eph:%' rows,
+-- never a real member wrap.
+
+create or replace function public.reap_ephemeral_scope_keys(retention_days integer default 14)
+returns bigint
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  cutoff timestamptz := now() - make_interval(days => greatest(retention_days, 0));
+  n      bigint;
+begin
+  -- Only ephemeral capability wraps, and only those older than the retention window. `created_at`
+  -- (not updated_at) is the age basis: an eph row is written once and never updated, and its purpose
+  -- expires with the invite token — a real member wrap (member_user_id = a uuid) is never matched.
+  delete from public.scope_keys
+    where member_user_id like 'eph:%'
+      and created_at < cutoff;
+  get diagnostics n = row_count;
+  return n;
+end;
+$$;
+
+-- System task only — a regular user must never trigger a cross-scope reap (the function is SECURITY
+-- DEFINER and bypasses RLS). pg_cron runs as the owner; a service_role admin may invoke it manually.
+revoke all on function public.reap_ephemeral_scope_keys(integer) from public;
+grant execute on function public.reap_ephemeral_scope_keys(integer) to service_role;
+
+-- Schedule a daily reap, but only where pg_cron exists (Supabase). The stock postgres:16-alpine image
+-- the integration harness uses lacks it, so this whole block is skipped there and the function is
+-- exercised by calling it directly in tests. (The inner cron.* references are only parsed when the
+-- branch runs, so they don't error when the cron schema is absent.)
+do $$
+begin
+  if exists (select 1 from pg_available_extensions where name = 'pg_cron') then
+    create extension if not exists pg_cron;
+    if exists (select 1 from cron.job where jobname = 'reap-ephemeral-scope-keys') then
+      perform cron.unschedule('reap-ephemeral-scope-keys');
+    end if;
+    perform cron.schedule(
+      'reap-ephemeral-scope-keys', '43 3 * * *',
+      'select public.reap_ephemeral_scope_keys(14)'
+    );
+  end if;
+end
+$$;


### PR DESCRIPTION
Closes #1353. E-5-c-2 follow-up from the offline-invite adversarial review.

## Gap
An `--offline` invite mints a synthetic `scope_keys` row keyed `member_user_id = 'eph:<pub>'` holding the scope DEK wrapped to an ephemeral pubkey. The accepting invitee normally **retires** it (deletes both sides), but if the invite is **never accepted** — or retirement fails after adoption (the two steps aren't atomic) — the eph row lingers forever, outliving the `pending_invites` 14-day join window, so the token's decryption capability against that row never expires.

Blast radius is **bounded** (eph rows are `is_member`-gated on read → only existing members, who already hold the DEK, can read them; no leak to non-members), so this is hygiene / defense-in-depth.

## Fix — migration 0046
`reap_ephemeral_scope_keys(retention_days default 14)`: deletes **only** `scope_keys` rows with `member_user_id like 'eph:%'` older than the window (by `created_at`, write-once for eph rows). SECURITY DEFINER, **service_role-only** (revoked from public/authenticated), daily `pg_cron` where available.

Mirrors `reap_tombstones` (0018) — which deliberately **excludes** `scope_keys` from the tombstone reaper (real member wraps must never be background-deleted). This is the narrow complement: it touches **only eph rows, never a real member wrap**.

## Tests (sync-security integration)
- reaps only stale eph rows (keeps recent eph + **all real wraps**);
- `retention_days=0` reaps every eph row but **never** a real member wrap;
- not callable by a normal authenticated user (system task only).

Also fixed a cross-test GUC-contamination bug: reset `request.jwt.claims` to `'{}'` before the owner-context inserts (a bare `''` left by an earlier `asUser` test trips `auth.uid()`'s `::json` cast).

100 sync-security + 37 other integration tests green; typecheck/lint/format clean. Part of epic #827.