### PR TITLE
ci: advisory semantic-linter GitHub Action + workflow

### DIFF
--- a/.github/actions/invariant-check/action.yml
+++ b/.github/actions/invariant-check/action.yml
@@ -1,0 +1,162 @@
+name: "Lore semantic linter (invariant-check)"
+description: >-
+  Advisory-only: surfaces PR changes that contradict a documented invariant in
+  the repo's `.lore.md`. NEVER fails the build — reports findings as annotations
+  and a job summary; humans decide.
+
+inputs:
+  base:
+    description: "Base ref/SHA. Defaults to the PR base (auto-detected)."
+    required: false
+    default: ""
+  head:
+    description: "Head ref/SHA. Defaults to the PR head (auto-detected)."
+    required: false
+    default: ""
+  model:
+    description: "Judge model (provider/id). Defaults to the configured worker model."
+    required: false
+    default: ""
+  worker-api-key:
+    description: >-
+      Dedicated judge credential (sets LORE_WORKER_API_KEY). Required in CI —
+      the gateway has no client session to borrow auth from.
+    required: false
+    default: ""
+  lore-command:
+    description: >-
+      How to invoke the lore CLI. Default `lore` (built binary on PATH). For an
+      un-built checkout, pass e.g. `pnpm tsx packages/gateway/src/cli/bin.ts`.
+    required: false
+    default: "lore"
+  gate:
+    description: >-
+      Opt into blocking mode. When "true", strict findings and un-overridden
+      soft findings FAIL the job (the CLI exits non-zero). Default "false" —
+      advisory only, never fails. Soft findings are cleared by a
+      `lore-override: <invariant> — <reason>` commit trailer; strict cannot be
+      overridden. Even in gate mode, an invariant only reaches strict/soft via
+      explicit `enforce:` metadata, so a repo with no opt-ins gates on nothing.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # ------------------------------------------------------------------
+    # Invariant source (see the coverage note below):
+    #   The check reads invariants from a lore DB at $LORE_DB_PATH. There is no
+    #   local DB in CI, so we DERIVE one from the repo's committed `.lore.md`
+    #   (plaintext title+content) and let the CLI's --import-lore-md embed it
+    #   in-process. That derivation (ONNX embed of ~all entries) is cached via
+    #   actions/cache and only re-runs when the knowledge or the embedding stack
+    #   changes — the cache key is versioned on the model, the onnxruntime-node
+    #   version, AND the .lore.md content hash so a stale embedding space can
+    #   never be silently reused (cosine drift = quiet recall rot).
+    #
+    #   COVERAGE CAVEAT: `.lore.md` omits cross_project=1 entries (global
+    #   invariants that span projects, ~16 in practice). A .lore.md-sourced
+    #   check therefore has slightly narrower coverage than a full local DB.
+    #   Acceptable for the advisory tier; do not rely on it for global rules.
+    # ------------------------------------------------------------------
+    - name: Compute invariant-DB cache key
+      id: key
+      shell: bash
+      env:
+        LORE_IC_MODEL: ${{ inputs.model }}
+      run: |
+        set -euo pipefail
+        ort=$(node -p "require('onnxruntime-node/package.json').version" 2>/dev/null || echo "na")
+        lore_hash=$(git hash-object .lore.md 2>/dev/null || echo "none")
+        model="${LORE_IC_MODEL:-default}"
+        # Slashes in the model id break nothing but read oddly in a key; keep raw.
+        echo "key=lore-invariants-v1-${model}-ort${ort}-${lore_hash}" >> "$GITHUB_OUTPUT"
+        echo "db=${RUNNER_TEMP}/lore-ci/lore.db" >> "$GITHUB_OUTPUT"
+
+    - name: Restore derived invariant DB
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/lore-ci
+        key: ${{ steps.key.outputs.key }}
+
+    - name: Resolve range + run invariant-check
+      id: check
+      shell: bash
+      env:
+        LORE_IC_BASE: ${{ inputs.base }}
+        LORE_IC_HEAD: ${{ inputs.head }}
+        LORE_IC_MODEL: ${{ inputs.model }}
+        LORE_WORKER_API_KEY: ${{ inputs.worker-api-key }}
+        LORE_CMD: ${{ inputs.lore-command }}
+        # Point the whole lore stack (db(), forProject, loadInvariantVecs) at the
+        # cached/derived CI DB instead of ~/.local/share/lore/lore.db.
+        LORE_DB_PATH: ${{ steps.key.outputs.db }}
+        CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        LORE_IC_GATE: ${{ inputs.gate }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$(dirname "$LORE_DB_PATH")"
+
+        # Need full history for merge-base resolution.
+        git fetch --no-tags --prune --depth=200 origin \
+          "+refs/heads/*:refs/remotes/origin/*" 2>/dev/null || true
+
+        base="${LORE_IC_BASE}"
+        head="${LORE_IC_HEAD}"
+        if [ -z "$base" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+          base="origin/${GITHUB_BASE_REF}"
+        fi
+        if [ -z "$head" ]; then
+          head="${GITHUB_SHA}"
+        fi
+
+        args=(invariant-check --json)
+        [ -n "$base" ] && args+=(--base "$base")
+        [ -n "$head" ] && args+=(--head "$head")
+        [ -n "${LORE_IC_MODEL}" ] && args+=(--model "${LORE_IC_MODEL}")
+        # On a cache MISS, seed the DB from .lore.md (imports + embeds, once).
+        # On a HIT the DB already exists; --import-lore-md fast-paths (mtime/hash
+        # match) and is a cheap no-op, so it is always safe to pass.
+        args+=(--import-lore-md)
+        # Blocking mode is opt-in. In gate mode the CLI exits 2 on a blocking
+        # finding; we let that propagate as a job failure below. In advisory
+        # mode (default) the CLI only ever exits non-zero on a TOOLING error.
+        if [ "${LORE_IC_GATE}" = "true" ]; then
+          args+=(--gate)
+        fi
+
+        # Capture the exit so we can classify it. Exit 2 == a GATE BLOCK (a real,
+        # intended failure in gate mode). Any OTHER non-zero == a TOOLING failure
+        # (e.g. no range) which must NEVER fail the build — we log it and pass.
+        set +e
+        # shellcheck disable=SC2086
+        $LORE_CMD "${args[@]}" > /tmp/lore-ic.json 2> /tmp/lore-ic.err
+        rc=$?
+        set -e
+        if [ $rc -eq 2 ] && [ "${LORE_IC_GATE}" = "true" ]; then
+          # Gate block — report findings, then fail the job on purpose.
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "gate_blocked=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if [ $rc -ne 0 ]; then
+          echo "::notice title=Lore invariant-check::skipped (tooling: exit $rc)"
+          cat /tmp/lore-ic.err || true
+          echo "skipped=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "skipped=false" >> "$GITHUB_OUTPUT"
+        echo "gate_blocked=false" >> "$GITHUB_OUTPUT"
+
+    - name: Report findings (annotations + summary)
+      if: steps.check.outputs.skipped == 'false'
+      shell: bash
+      run: node "${{ github.action_path }}/report.mjs" /tmp/lore-ic.json
+
+    - name: Fail on blocking findings (gate mode)
+      if: steps.check.outputs.gate_blocked == 'true'
+      shell: bash
+      run: |
+        echo "::error title=Lore invariant-check::blocking invariant contradiction(s) — see annotations. Override a SOFT finding with a 'lore-override: <invariant> — <reason>' commit trailer; STRICT cannot be overridden."
+        exit 1

--- a/.github/actions/invariant-check/action.yml
+++ b/.github/actions/invariant-check/action.yml
@@ -2,7 +2,9 @@ name: "Lore semantic linter (invariant-check)"
 description: >-
   Advisory-only: surfaces PR changes that contradict a documented invariant in
   the repo's `.lore.md`. NEVER fails the build — reports findings as annotations
-  and a job summary; humans decide.
+  and a job summary; humans decide. Requires the caller to checkout with
+  `fetch-depth: 0` so merge-base resolution against the PR base has full history
+  (a shallow clone can force a noisy tip-to-tip diff instead of the fork-point diff).
 
 inputs:
   base:

--- a/.github/actions/invariant-check/report.mjs
+++ b/.github/actions/invariant-check/report.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 /**
  * Lore invariant-check GHA reporter. Reads the `lore invariant-check --json`
- * output and emits GitHub annotations + a job summary. ADVISORY ONLY: it emits
- * `::warning::` workflow commands (never `::error::`) and ALWAYS exits 0 — the
- * whole point is that this never fails a build. Humans decide.
+ * output and emits GitHub **file annotations** (so findings render in-context on
+ * the PR diff, at the changed line) plus a job summary. The reporter itself
+ * ALWAYS exits 0 — failing a blocked build is a separate action step, never this
+ * script. Annotation level: `::error::` for a gate-blocking finding, `::notice::`
+ * for an overridden one, `::warning::` otherwise (advisory).
  */
 import { readFileSync, appendFileSync } from "node:fs";
 
@@ -13,7 +15,7 @@ if (!path) {
   process.exit(0);
 }
 
-/** @type {{findings: Array<{invariantTitle:string,invariantContent:string,file:string,reason:string|null,severity:string,refHit:boolean,similarity:number}>, hunks:number, invariants:number, candidates:number, judgeCalls:number, model?:string}} */
+/** @type {{findings: Array<{invariantId:string,invariantTitle:string,invariantContent:string,file:string,reason:string|null,severity:string,refHit:boolean,similarity:number,hunk:string}>, hunks:number, invariants:number, candidates:number, judgeCalls:number, model?:string, gate?:object}} */
 let result;
 try {
   result = JSON.parse(readFileSync(path, "utf8"));
@@ -33,6 +35,28 @@ const funnel =
 function esc(s) {
   // Escape for workflow-command message data.
   return String(s ?? "").replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+/** Escape a markdown table cell: neutralize `|` and collapse newlines so a
+ *  finding with a pipe in its title or a multi-line judge reason can't corrupt
+ *  the rendered table. */
+function cell(s) {
+  return String(s ?? "").replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim();
+}
+
+/** Extract the new-file line span from a unified-diff hunk header so the
+ *  annotation lands on the actual changed lines in the PR diff. Header shape:
+ *  `@@ -a,b +c,d @@ ...` → { line: c, endLine: c + d - 1 }. Returns null when the
+ *  header is absent/unparseable (annotation then falls back to file-level). */
+function hunkRange(hunkText) {
+  const m = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(hunkText ?? "");
+  if (!m) return null;
+  const start = Number(m[1]);
+  const count = m[2] === undefined ? 1 : Number(m[2]);
+  if (!Number.isFinite(start) || start < 1) return null;
+  // count 0 (pure deletion hunk) → annotate the single anchor line.
+  const endLine = count > 0 ? start + count - 1 : start;
+  return { line: start, endLine };
 }
 
 if (findings.length === 0) {
@@ -64,7 +88,12 @@ function findingKey(f) {
   return `${f.invariantId}\x1f${f.file}`;
 }
 
-// Annotations. Blocking (gate mode) → error; overridden → notice; else warning.
+// File annotations. Blocking (gate mode) → error; overridden → notice; else
+// warning. A `line`/`endLine` derived from the hunk header makes each annotation
+// render at the changed lines in the PR diff (in-context), falling back to a
+// file-level annotation when the header can't be parsed. EVERY interpolated
+// field (including file) is escaped — an unescaped value can inject a second
+// workflow command.
 for (const f of findings) {
   const key = findingKey(f);
   const isBlocking = gated && blockingIds.has(key);
@@ -79,7 +108,11 @@ for (const f of findings) {
   const msg =
     `${f.reason ?? "possible contradiction"}\n\n` +
     `Invariant: ${f.invariantContent}`;
-  console.log(`::${level} file=${f.file},title=${esc(title)}::${esc(msg)}`);
+  const range = hunkRange(f.hunk);
+  const loc = range
+    ? `file=${esc(f.file)},line=${range.line},endLine=${range.endLine}`
+    : `file=${esc(f.file)}`;
+  console.log(`::${level} ${loc},title=${esc(title)}::${esc(msg)}`);
 }
 
 // Job summary — a readable table + gate status.
@@ -92,7 +125,7 @@ if (summaryFile) {
         : overriddenIds.has(key)
           ? "↪ overridden"
           : "advisory";
-      return `| \`${f.severity}\` | ${state} | ${f.invariantTitle} | \`${f.file}\` | ${(f.reason ?? "").replace(/\|/g, "\\|")} |`;
+      return `| \`${cell(f.severity)}\` | ${state} | ${cell(f.invariantTitle)} | \`${cell(f.file)}\` | ${cell(f.reason)} |`;
     })
     .join("\n");
   const header = gated

--- a/.github/actions/invariant-check/report.mjs
+++ b/.github/actions/invariant-check/report.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Lore invariant-check GHA reporter. Reads the `lore invariant-check --json`
+ * output and emits GitHub annotations + a job summary. ADVISORY ONLY: it emits
+ * `::warning::` workflow commands (never `::error::`) and ALWAYS exits 0 — the
+ * whole point is that this never fails a build. Humans decide.
+ */
+import { readFileSync, appendFileSync } from "node:fs";
+
+const path = process.argv[2];
+if (!path) {
+  console.log("::notice title=Lore invariant-check::no result file");
+  process.exit(0);
+}
+
+/** @type {{findings: Array<{invariantTitle:string,invariantContent:string,file:string,reason:string|null,severity:string,refHit:boolean,similarity:number}>, hunks:number, invariants:number, candidates:number, judgeCalls:number, model?:string}} */
+let result;
+try {
+  result = JSON.parse(readFileSync(path, "utf8"));
+} catch (e) {
+  console.log(`::notice title=Lore invariant-check::unreadable result (${e})`);
+  process.exit(0);
+}
+
+const findings = result.findings ?? [];
+const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+
+const funnel =
+  `${result.hunks} hunks × ${result.invariants} invariants → ` +
+  `${result.candidates} candidates → ${result.judgeCalls} judge calls` +
+  (result.model ? ` · ${result.model}` : "");
+
+function esc(s) {
+  // Escape for workflow-command message data.
+  return String(s ?? "").replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+if (findings.length === 0) {
+  console.log(`::notice title=Lore invariant-check::✓ no suspected invariant violations (${funnel})`);
+  if (summaryFile) {
+    appendFileSync(
+      summaryFile,
+      `## 🧭 Lore semantic linter\n\n✓ No suspected invariant violations.\n\n<sub>${funnel}</sub>\n`,
+    );
+  }
+  process.exit(0);
+}
+
+// Gate classification (present when the CLI computed it). In gate mode a
+// blocking finding is an `::error::`; everything else is a `::warning::`. In
+// advisory mode everything is a warning (the job never fails).
+const gate = result.gate ?? null;
+const gated = gate?.mode === "gate";
+const blockingIds = new Set(
+  (gate?.blocking ?? []).map((f) => `${f.invariantId}\x1f${f.file}`),
+);
+const overriddenIds = new Set(
+  (gate?.overridden ?? []).map(
+    (o) => `${o.finding.invariantId}\x1f${o.finding.file}`,
+  ),
+);
+
+function findingKey(f) {
+  return `${f.invariantId}\x1f${f.file}`;
+}
+
+// Annotations. Blocking (gate mode) → error; overridden → notice; else warning.
+for (const f of findings) {
+  const key = findingKey(f);
+  const isBlocking = gated && blockingIds.has(key);
+  const isOverridden = overriddenIds.has(key);
+  const level = isBlocking ? "error" : isOverridden ? "notice" : "warning";
+  const tag = isBlocking
+    ? "BLOCKING"
+    : isOverridden
+      ? "overridden"
+      : f.severity;
+  const title = `Lore invariant [${tag}]: ${f.invariantTitle}`;
+  const msg =
+    `${f.reason ?? "possible contradiction"}\n\n` +
+    `Invariant: ${f.invariantContent}`;
+  console.log(`::${level} file=${f.file},title=${esc(title)}::${esc(msg)}`);
+}
+
+// Job summary — a readable table + gate status.
+if (summaryFile) {
+  const rows = findings
+    .map((f) => {
+      const key = findingKey(f);
+      const state = gated && blockingIds.has(key)
+        ? "🚫 blocking"
+        : overriddenIds.has(key)
+          ? "↪ overridden"
+          : "advisory";
+      return `| \`${f.severity}\` | ${state} | ${f.invariantTitle} | \`${f.file}\` | ${(f.reason ?? "").replace(/\|/g, "\\|")} |`;
+    })
+    .join("\n");
+  const header = gated
+    ? gate.blocking.length > 0
+      ? `🚫 **${gate.blocking.length} blocking** + ${findings.length - gate.blocking.length} advisory — gate mode. Override a soft finding with a \`lore-override: <invariant> — <reason>\` commit trailer; strict cannot be overridden.`
+      : `✓ Gate passed — ${findings.length} advisory finding${findings.length === 1 ? "" : "s"}, none blocking.`
+    : `⚠ **${findings.length} suspected invariant contradiction${findings.length === 1 ? "" : "s"}** — advisory, review; this check never fails the build.`;
+  appendFileSync(
+    summaryFile,
+    `## 🧭 Lore semantic linter\n\n${header}\n\n` +
+      `| severity | state | invariant | file | why |\n|---|---|---|---|---|\n${rows}\n\n` +
+      `<sub>${funnel}</sub>\n`,
+  );
+}
+
+// The reporter itself always exits 0 — the gate fail is a separate action step.
+
+// ADVISORY: always succeed.
+process.exit(0);

--- a/.github/actions/invariant-check/report.mjs
+++ b/.github/actions/invariant-check/report.mjs
@@ -33,8 +33,16 @@ const funnel =
   (result.model ? ` · ${result.model}` : "");
 
 function esc(s) {
-  // Escape for workflow-command message data.
+  // Escape workflow-command MESSAGE data (the part after `::`). Only %, CR, LF
+  // are special here.
   return String(s ?? "").replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+function escProp(s) {
+  // Escape a workflow-command PROPERTY value (e.g. file=…, title=…). Properties
+  // are comma-separated and key:value, so `,` and `:` must be escaped too or a
+  // value containing them shifts/splits the annotation's parameters.
+  return esc(s).replace(/,/g, "%2C").replace(/:/g, "%3A");
 }
 
 /** Escape a markdown table cell: neutralize `|` and collapse newlines so a
@@ -110,9 +118,9 @@ for (const f of findings) {
     `Invariant: ${f.invariantContent}`;
   const range = hunkRange(f.hunk);
   const loc = range
-    ? `file=${esc(f.file)},line=${range.line},endLine=${range.endLine}`
-    : `file=${esc(f.file)}`;
-  console.log(`::${level} ${loc},title=${esc(title)}::${esc(msg)}`);
+    ? `file=${escProp(f.file)},line=${range.line},endLine=${range.endLine}`
+    : `file=${escProp(f.file)}`;
+  console.log(`::${level} ${loc},title=${escProp(title)}::${esc(msg)}`);
 }
 
 // Job summary — a readable table + gate status.

--- a/.github/actions/invariant-check/report.mjs
+++ b/.github/actions/invariant-check/report.mjs
@@ -20,7 +20,7 @@ let result;
 try {
   result = JSON.parse(readFileSync(path, "utf8"));
 } catch (e) {
-  console.log(`::notice title=Lore invariant-check::unreadable result (${e})`);
+  console.log(`::notice title=Lore invariant-check::unreadable result (${String(e)})`);
   process.exit(0);
 }
 

--- a/.github/actions/invariant-check/report.mjs
+++ b/.github/actions/invariant-check/report.mjs
@@ -35,7 +35,10 @@ const funnel =
 function esc(s) {
   // Escape workflow-command MESSAGE data (the part after `::`). Only %, CR, LF
   // are special here.
-  return String(s ?? "").replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+  return String(s ?? "")
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
 }
 
 function escProp(s) {
@@ -49,7 +52,10 @@ function escProp(s) {
  *  finding with a pipe in its title or a multi-line judge reason can't corrupt
  *  the rendered table. */
 function cell(s) {
-  return String(s ?? "").replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim();
+  return String(s ?? "")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ")
+    .trim();
 }
 
 /** Extract the new-file line span from a unified-diff hunk header so the
@@ -68,7 +74,9 @@ function hunkRange(hunkText) {
 }
 
 if (findings.length === 0) {
-  console.log(`::notice title=Lore invariant-check::✓ no suspected invariant violations (${funnel})`);
+  console.log(
+    `::notice title=Lore invariant-check::✓ no suspected invariant violations (${funnel})`,
+  );
   if (summaryFile) {
     appendFileSync(
       summaryFile,
@@ -128,11 +136,12 @@ if (summaryFile) {
   const rows = findings
     .map((f) => {
       const key = findingKey(f);
-      const state = gated && blockingIds.has(key)
-        ? "🚫 blocking"
-        : overriddenIds.has(key)
-          ? "↪ overridden"
-          : "advisory";
+      const state =
+        gated && blockingIds.has(key)
+          ? "🚫 blocking"
+          : overriddenIds.has(key)
+            ? "↪ overridden"
+            : "advisory";
       return `| \`${cell(f.severity)}\` | ${state} | ${cell(f.invariantTitle)} | \`${cell(f.file)}\` | ${cell(f.reason)} |`;
     })
     .join("\n");

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -1,0 +1,43 @@
+name: Semantic linter (advisory)
+
+# Advisory-only: surfaces PR changes that contradict a documented invariant.
+# NEVER fails the build — reports findings as annotations + a job summary.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Keep only the latest run per PR.
+concurrency:
+  group: semantic-linter-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  invariant-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Advisory: a failure here must never block a PR.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so merge-base against the PR base resolves.
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: pnpm install --frozen-lockfile
+      - name: Run Lore semantic linter
+        uses: ./.github/actions/invariant-check
+        with:
+          # Un-built checkout → run the CLI via tsx.
+          lore-command: "pnpm tsx packages/gateway/src/cli/bin.ts"
+          # Cheap judge; Haiku had the best recall in eval. Configure the key as
+          # a repo secret. Absent → the check no-ops (no auth) and still passes.
+          model: "anthropic/claude-haiku-4.5"
+          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY }}


### PR DESCRIPTION
## Goal

Run the linter (#1362) on every PR and surface contradictions **where the reviewer already is** — as inline annotations on the changed lines of the diff, plus a summary. **Stacked on #1362.**

## Why these choices

- **Never fails the build.** Advisory by default at three layers: the CLI only exits non-zero in opt-in gate mode, the action classifies any other non-zero as a tooling skip, and the job carries `continue-on-error`. A repo turns on blocking deliberately, per-invariant.
- **In-context file annotations.** Findings render at the exact changed lines (parsed from the hunk header), so a contradiction shows up on the diff line that caused it — not buried in a log.
- **`.lore.md` + cached DB is the invariant source, not the sync backend.** The backend can't serve CI: content is end-to-end encrypted on the wire and embeddings aren't synced. So the action derives invariants from the committed `.lore.md` and caches the derived DB, keyed on model + embedding-runtime version + `.lore.md` hash — a mismatched embedding stack can't silently poison recall.

## Known limitation

`.lore.md` omits cross-project (global) invariants, so CI coverage is slightly narrower than a full local DB. Fine for advisory; documented in the action.

## Follow-ups filed

Zero-secret judge via GitHub Models (#1368) and the override→decision write-back (#1365) — both deliberately out of scope here.

## Review

Adversarially reviewed. Follow-up commit fixes an annotation-injection hole (unescaped file path), adds the in-context line annotations, and hardens the summary table against pipes/newlines in finding text.