### PR TITLE
feat(cli): `lore admin grant` operator command for tier promotion (#827)

### DIFF
--- a/packages/gateway/src/cli/admin-cmd.ts
+++ b/packages/gateway/src/cli/admin-cmd.ts
@@ -1,0 +1,121 @@
+/**
+ * `lore admin` — OPERATOR-ONLY commands for the platform maintainer, gated by the
+ * `SUPABASE_SERVICE_ROLE_KEY` env var (which only staff hold; it is never shipped
+ * or persisted). These perform privileged writes the RLS/tier guards deliberately
+ * block for normal users.
+ *
+ *   lore admin grant <email|orgId> <free|pro|team>
+ *
+ * Personal upgrade (an email) flips `profiles.tier`; a team upgrade (an org UUID)
+ * flips `orgs.tier`. `effective_tier()` reads profiles for personal scopes and
+ * orgs for team scopes, so this is the single lever behind entitlement.
+ */
+import { getServiceRoleClient } from "../supabase";
+
+const USAGE =
+  "Usage: lore admin grant <email> <free|pro>   (personal)\n" +
+  "       lore admin grant <orgId> <free|team>  (team org)";
+// Valid tiers per target type. effective_tier() reads profiles.tier for personal scopes (free/pro)
+// and orgs.tier for team scopes (free/team). Cross-pairing (e.g. an email → 'team') writes a tier the
+// client can't act on (currentSyncTier maps only pro/max → pro sync) — so we reject it up front.
+const PERSONAL_TIERS = new Set(["free", "pro"]);
+const TEAM_TIERS = new Set(["free", "team"]);
+// A v4/v7 UUID (org id) vs an email address — decides profiles vs orgs. Anchored: an email that
+// merely CONTAINS a uuid substring must still route to the personal (profiles) path.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function commandAdmin(
+  positionals: string[],
+  _values: Record<string, unknown>,
+): Promise<void> {
+  const sub = positionals[0];
+  if (sub !== "grant") return usage();
+
+  const target = positionals[1];
+  const tier = positionals[2];
+  if (!target || !tier) return usage();
+
+  const isOrg = UUID_RE.test(target);
+  const allowed = isOrg ? TEAM_TIERS : PERSONAL_TIERS;
+  if (!allowed.has(tier)) {
+    console.error(
+      isOrg
+        ? `Team orgs accept free|team, not "${tier}".`
+        : `Personal accounts accept free|pro, not "${tier}".`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const client = getServiceRoleClient();
+  if (!client) {
+    console.error(
+      "This is an operator-only command. Set SUPABASE_SERVICE_ROLE_KEY (staff-only) to use it.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    if (isOrg) {
+      // Team: flip orgs.tier by org id.
+      const { data, error } = await client
+        .from("orgs")
+        .update({ tier })
+        .eq("id", target)
+        .select("id, kind, tier");
+      if (error) throw new Error(error.message);
+      if (!data || data.length === 0) {
+        console.error(`No org found with id ${target}.`);
+        process.exitCode = 1;
+        return;
+      }
+      console.log(`Set org ${target} (${data[0].kind}) tier → ${tier}.`);
+    } else {
+      // Personal: resolve the email → user id via profiles, then flip profiles.tier. Exact match
+      // (.eq, not .ilike) — ilike would treat %/_ in the operator's input as wildcards and could
+      // silently promote a single unintended match. profiles.email is stored lowercased (0001).
+      const email = target.toLowerCase();
+      const { data: prof, error: lookupErr } = await client
+        .from("profiles")
+        .select("id, email")
+        .eq("email", email);
+      if (lookupErr) throw new Error(lookupErr.message);
+      if (!prof || prof.length === 0) {
+        console.error(`No account found for email ${target}.`);
+        process.exitCode = 1;
+        return;
+      }
+      if (prof.length > 1) {
+        console.error(
+          `Multiple accounts match ${target} — refusing to guess. Pass the user's org id instead.`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const { data: updated, error: updErr } = await client
+        .from("profiles")
+        .update({ tier })
+        .eq("id", prof[0].id)
+        .select("id");
+      if (updErr) throw new Error(updErr.message);
+      // Confirm the update hit a row — guards against a silent no-op (profile deleted between the
+      // lookup and the write) printing a misleading success.
+      if (!updated || updated.length === 0) {
+        console.error(`No account found for email ${target}.`);
+        process.exitCode = 1;
+        return;
+      }
+      console.log(`Set ${prof[0].email} (personal) tier → ${tier}.`);
+    }
+  } catch (e) {
+    console.error(`lore admin: ${(e as Error).message}`);
+    process.exitCode = 1;
+  }
+}
+
+function usage(): void {
+  console.error(USAGE);
+  process.exitCode = 1;
+}

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -475,6 +475,12 @@ export async function _cli(): Promise<void> {
         break;
       }
 
+      case "admin": {
+        const { commandAdmin } = await import("./admin-cmd");
+        await commandAdmin(rest, values);
+        break;
+      }
+
       case "logs": {
         const { commandLogs } = await import("./logs");
         await commandLogs(rest, values);
@@ -531,6 +537,7 @@ export async function _cli(): Promise<void> {
               "whoami",
               "sync",
               "team",
+              "admin",
               "logs",
               "import",
               "entity",

--- a/packages/gateway/src/supabase.ts
+++ b/packages/gateway/src/supabase.ts
@@ -164,6 +164,30 @@ export function createSupabaseClient(): SupabaseClient {
 }
 
 /**
+ * Build a SERVICE-ROLE client from the `SUPABASE_SERVICE_ROLE_KEY` env var — an
+ * OPERATOR-ONLY escape hatch (e.g. `lore admin grant`) for privileged writes the
+ * RLS/tier guards deliberately block for normal users. The key bypasses RLS and
+ * is NEVER persisted or shipped: it is read from the environment at call time and
+ * lives only in this in-memory client. Returns null when the env var is unset so
+ * the caller can print a clear "operator-only" message rather than 401.
+ *
+ * SECURITY: this client BYPASSES RLS entirely. It is intentionally scoped to the
+ * operator `lore admin` command (tier writes only). Any NEW caller is a security-
+ * review trigger — do not use it to reach around RLS for ordinary features.
+ */
+export function getServiceRoleClient(): SupabaseClient | null {
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!key) return null;
+  return createClient(SUPABASE_URL, key, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+}
+
+/**
  * Build a client with the persisted session restored (and refreshed if the
  * access token expired). Re-persists the refreshed tokens. Returns null when
  * not logged in or the session could not be restored (expired refresh token,

--- a/packages/gateway/test/admin-cmd.test.ts
+++ b/packages/gateway/test/admin-cmd.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit coverage for the operator-only `lore admin grant` CLI (service-role tier flips).
+ * The service-role client (../supabase) is mocked; we assert the target-type routing
+ * (email → profiles, UUID → orgs), tier validation, the missing-key guard, and the
+ * not-found / ambiguous-email paths.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockClient: unknown = null;
+vi.mock("../src/supabase", () => ({
+  getServiceRoleClient: () => mockClient,
+}));
+
+import { commandAdmin } from "../src/cli/admin-cmd";
+
+let logs: string[];
+let errs: string[];
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logs = [];
+  errs = [];
+  process.exitCode = 0;
+  logSpy = vi
+    .spyOn(console, "log")
+    .mockImplementation((...a: unknown[]) => void logs.push(a.join(" ")));
+  errSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation((...a: unknown[]) => void errs.push(a.join(" ")));
+});
+afterEach(() => {
+  logSpy.mockRestore();
+  errSpy.mockRestore();
+  mockClient = null;
+  process.exitCode = 0;
+});
+
+/**
+ * A tiny chainable Supabase mock. `profilesRows` feeds the email→profiles lookup;
+ * `orgUpdateRows` feeds the org update .select(); update calls are recorded.
+ */
+function makeClient(
+  opts: {
+    profilesRows?: { id: string; email: string }[];
+    orgUpdateRows?: { id: string; kind: string; tier: string }[];
+    profileUpdateRows?: { id: string }[];
+    updateErr?: string;
+  } = {},
+) {
+  const updates: { table: string; patch: Record<string, unknown> }[] = [];
+  const client = {
+    updates,
+    from(table: string) {
+      return {
+        // profiles email lookup: .select().eq()  → awaited
+        select(_cols: string) {
+          return {
+            eq: (_c: string, _v: string) =>
+              Promise.resolve({ data: opts.profilesRows ?? [], error: null }),
+          };
+        },
+        // update path: .update().eq().select()  (orgs) or .update().eq() (profiles)
+        update(patch: Record<string, unknown>) {
+          updates.push({ table, patch });
+          return {
+            eq: (_c: string, _v: string) => {
+              const err = opts.updateErr ? { message: opts.updateErr } : null;
+              // A real Promise with a `.select()` attached — both the orgs and profiles update paths
+              // await `.eq().select()`. Object.assign on a genuine Promise avoids a hand-rolled
+              // thenable (no-thenable lint). orgs → orgUpdateRows; profiles → profileUpdateRows
+              // (defaults to one row so a successful tier flip is confirmed).
+              const rows =
+                table === "orgs"
+                  ? (opts.orgUpdateRows ?? [])
+                  : (opts.profileUpdateRows ?? [{ id: "u-1" }]);
+              const p = Promise.resolve({ data: null, error: err });
+              return Object.assign(p, {
+                select: (_s: string) =>
+                  Promise.resolve({ data: err ? null : rows, error: err }),
+              });
+            },
+          };
+        },
+      };
+    },
+  };
+  return client;
+}
+
+describe("lore admin grant", () => {
+  it("prints usage for a non-grant subcommand", async () => {
+    await commandAdmin(["bogus"], {});
+    expect(errs.join("\n")).toMatch(/Usage: lore admin/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("requires target + tier", async () => {
+    await commandAdmin(["grant", "a@b.dev"], {});
+    expect(errs.join("\n")).toMatch(/Usage: lore admin/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects an unknown tier", async () => {
+    mockClient = makeClient();
+    await commandAdmin(["grant", "a@b.dev", "platinum"], {});
+    expect(errs.join("\n")).toMatch(/free\|pro/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects a team tier for a personal (email) target", async () => {
+    mockClient = makeClient();
+    await commandAdmin(["grant", "dev@acme.dev", "team"], {});
+    expect(errs.join("\n")).toMatch(/Personal accounts accept free\|pro/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects a pro tier for a team (UUID) target", async () => {
+    mockClient = makeClient();
+    await commandAdmin(
+      ["grant", "0192f0aa-1111-7000-8000-000000000000", "pro"],
+      {},
+    );
+    expect(errs.join("\n")).toMatch(/Team orgs accept free\|team/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses without a service-role key (operator-only)", async () => {
+    mockClient = null; // getServiceRoleClient returns null when the env var is unset
+    await commandAdmin(["grant", "a@b.dev", "pro"], {});
+    expect(errs.join("\n")).toMatch(/operator-only|SUPABASE_SERVICE_ROLE_KEY/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("promotes a personal account by email (profiles.tier)", async () => {
+    mockClient = makeClient({
+      profilesRows: [{ id: "u-1", email: "dev@acme.dev" }],
+    });
+    await commandAdmin(["grant", "dev@acme.dev", "pro"], {});
+    const c = mockClient as ReturnType<typeof makeClient>;
+    expect(c.updates).toEqual([{ table: "profiles", patch: { tier: "pro" } }]);
+    expect(logs.join("\n")).toMatch(/dev@acme.dev \(personal\) tier → pro/);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("errors when no account matches the email", async () => {
+    mockClient = makeClient({ profilesRows: [] });
+    await commandAdmin(["grant", "ghost@acme.dev", "pro"], {});
+    expect(errs.join("\n")).toMatch(/No account found/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("refuses an ambiguous email (multiple matches)", async () => {
+    mockClient = makeClient({
+      profilesRows: [
+        { id: "u-1", email: "dev@acme.dev" },
+        { id: "u-2", email: "dev@acme.dev" },
+      ],
+    });
+    await commandAdmin(["grant", "dev@acme.dev", "pro"], {});
+    expect(errs.join("\n")).toMatch(/Multiple accounts match/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("promotes a team org by UUID (orgs.tier)", async () => {
+    mockClient = makeClient({
+      orgUpdateRows: [
+        {
+          id: "0192f0aa-1111-7000-8000-000000000000",
+          kind: "team",
+          tier: "team",
+        },
+      ],
+    });
+    await commandAdmin(
+      ["grant", "0192f0aa-1111-7000-8000-000000000000", "team"],
+      {},
+    );
+    const c = mockClient as ReturnType<typeof makeClient>;
+    expect(c.updates).toEqual([{ table: "orgs", patch: { tier: "team" } }]);
+    expect(logs.join("\n")).toMatch(/Set org .* \(team\) tier → team/);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("errors when no org matches the UUID", async () => {
+    mockClient = makeClient({ orgUpdateRows: [] });
+    await commandAdmin(
+      ["grant", "0192f0aa-2222-7000-8000-000000000000", "team"],
+      {},
+    );
+    expect(errs.join("\n")).toMatch(/No org found/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("routes an email containing an embedded UUID to the personal (profiles) path", async () => {
+    // Anchoring regression: UUID_RE must be ^...$ so an email that merely CONTAINS a uuid
+    // substring is NOT misrouted to the orgs path.
+    mockClient = makeClient({
+      profilesRows: [
+        {
+          id: "u-9",
+          email: "user+0192f0aa-1111-7000-8000-000000000000@acme.dev",
+        },
+      ],
+    });
+    await commandAdmin(
+      ["grant", "user+0192f0aa-1111-7000-8000-000000000000@acme.dev", "pro"],
+      {},
+    );
+    const c = mockClient as ReturnType<typeof makeClient>;
+    expect(c.updates).toEqual([{ table: "profiles", patch: { tier: "pro" } }]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("surfaces a service-role update error", async () => {
+    mockClient = makeClient({
+      profilesRows: [{ id: "u-1", email: "dev@acme.dev" }],
+      updateErr: "permission denied",
+    });
+    await commandAdmin(["grant", "dev@acme.dev", "pro"], {});
+    expect(errs.join("\n")).toMatch(/lore admin: permission denied/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("errors (not misleading success) when the profile update hits no row", async () => {
+    // Lookup finds the account, but the update returns no row (deleted in between) → must NOT
+    // print success. Guards the silent-no-op case (Seer LOW).
+    mockClient = makeClient({
+      profilesRows: [{ id: "u-1", email: "dev@acme.dev" }],
+      profileUpdateRows: [], // update matched nothing
+    });
+    await commandAdmin(["grant", "dev@acme.dev", "pro"], {});
+    expect(logs.join("\n")).not.toMatch(/tier →/);
+    expect(errs.join("\n")).toMatch(/No account found/);
+    expect(process.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## What
An **operator-only** command to promote a personal account or team org to a paid tier — the manual lever behind entitlement, for staff use until billing (Stripe) is wired.

```
lore admin grant <email|orgId> <free|pro|team>
```

- **email** → resolved via `profiles` (service-role read) → flips `profiles.tier` (personal). Refuses on no-match and on **ambiguous** multi-match (never guesses).
- **UUID** → flips `orgs.tier` by org id (team). Refuses on no-match.

`effective_tier()` reads profiles for personal scopes and orgs for team scopes, so this single lever drives entitlement.

## Why service-role
The tier guards (`guard_profile_tier` 0006, `guard_org_tier` 0023) deliberately block clients from self-upgrading — `service_role` is the sole writer. So a manual promotion must go through service-role.

`getServiceRoleClient()` (supabase.ts) builds an **in-memory** client from `SUPABASE_SERVICE_ROLE_KEY` **at call time** — never persisted, never shipped (only the anon key ships; RLS enforces normal users). Returns null when the env var is unset → the command prints a clear "operator-only" message instead of a 401.

`admin` is added to `knownCommands` (recognized, not "did you mean") but kept **out of user-facing help** — a hidden staff command.

## Tests (admin-cmd unit, 10)
usage/arg validation, unknown-tier rejection, missing-key guard, email→profiles promote, UUID→orgs promote, not-found + ambiguous-email + update-error paths.

Typecheck/lint/format clean; 10 unit tests pass. No schema change. Part of epic #827.