### PR TITLE
fix(gateway): defer lore-run auto-import until a credential is available

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -417,6 +417,9 @@
 <!-- lore:019f70ff-1287-727d-8ebb-a6611f8eef4b -->
 * **Always use 'never' and 'always' to specify strict behavioral constraints**: The user consistently employs 'never' and 'always' to define strict behavioral requirements in code comments, test names, and technical discussions. This pattern appears when specifying invariants, safety properties, and boundary conditions that must be maintained. The assistant should recognize these as hard constraints that require rigorous implementation and verification through tests.
 
+<!-- lore:019f7115-87fa-7c87-be34-f8af5a5de67f -->
+* **Always use absolute 'never' statements for technical constraints**: User consistently uses strong 'never' statements to define technical constraints and boundaries. This pattern appears across multiple contexts: GitHub Actions should never fail builds (always exit 0), sync operations should never lower local values or cause conflicts, and security functions should never be recreated in-place. The user employs these absolute statements to communicate non-negotiable requirements clearly and concisely.
+
 <!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
 * **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
 

--- a/.lore.md
+++ b/.lore.md
@@ -414,6 +414,9 @@
 <!-- lore:019f70a4-9381-77f1-bc0d-1485c1e9fbcd -->
 * **Always signal — never truncate user's actual prose/instructions**: User stated: 'Never blunt-truncates.' This is a directive preference indicating that user's actual prose/instructions should never be crudely truncated.
 
+<!-- lore:019f70ff-1287-727d-8ebb-a6611f8eef4b -->
+* **Always use 'never' and 'always' to specify strict behavioral constraints**: The user consistently employs 'never' and 'always' to define strict behavioral requirements in code comments, test names, and technical discussions. This pattern appears when specifying invariants, safety properties, and boundary conditions that must be maintained. The assistant should recognize these as hard constraints that require rigorous implementation and verification through tests.
+
 <!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
 * **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
 

--- a/.lore.md
+++ b/.lore.md
@@ -99,9 +99,6 @@
 <!-- lore:019f5692-6771-7577-965f-da25f1e11f6d -->
 * **Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes. (PR #1277 final commits: 0993b690 tooling, f11f2e4b reformat+autofix, a3486c5f**: Adopted three-commit strategy: commit 1 = tooling/config, commit 2 = mechanical reformat + safe autofixes, commit 3 = manual semantic (async-safety) fixes.
 
-<!-- lore:019f51ec-9e29-759e-a82c-e06c5485b7b2 -->
-* **Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables)**: Chose knowledge\_meta table (non-evicting, raises 23514 on cap overflow) over knowledge/entities/entity\_aliases/entity\_relations (evicting tables). Never marked incapable and the failure ladder escalated forever with a misleading "auth stale" warning.
-
 <!-- lore:019f3974-7c6a-7091-8602-b4ec0bb763a4 -->
 * **Chose next task: knowledge\_meta seed-order alignment (self-contained, low-risk, completes value-ranked seed coherence work started with knowledge #1189 and entities #1194) — over #1191b (continuous top-N eviction)**: Completed value-ranked seed coherence work in sequence: #1189 (knowledge seed value-ranking) → PR #1194 (entity-graph seed: entities ranked by knowledge\_entity\_refs count DESC then recency; entity\_relations by recency; entity\_aliases by created\_at DESC) → PR #1196 (knowledge\_meta seed aligned to knowledge's ORDER BY: confidence DESC, COALESCE(last\_reinforced\_at, updated\_at) DESC, logical\_id tiebreak). Deferred #1191b (continuous top-N eviction for remote) as a separate larger/riskier task needing a design doc first (remote eviction, cap discovery, thrash guards, concurrency) — not suitable for autonomous same-session implementation. Follow-up issue #1197 filed for a known non-blocking edge case: a deleted high-confidence entry's orphaned knowledge\_meta row can outrank a live entry's meta row under the cap (self-healing, not data loss).
 
@@ -170,8 +167,8 @@
 <!-- lore:019ef645-24ae-7562-ace6-3b0d343cdb3f -->
 * **applyRemoteMetaCrdt uses Date.now() for updated\_at — corrupts remote timestamp semantics**: Trap: \`applyRemoteMetaCrdt\` passes \`Date.now()\` as \`updated\_at\` when merging remote CRDT row — looks fine because sync advances cursors anyway. Fix: remote \`row\` already contains correct \`updated\_at\` (epoch ms); using local \`Date.now()\` loses the actual change timestamp, corrupting \`updated\_at\` semantic meaning (though not breaking CRDT merge or cursor advancement). Fix: pass \`Number(row.updated\_at ?? 0)\` instead. Confirmed in PR #1126 fix commit \`36173a7\`.
 
-<!-- lore:019f6d35-e66f-719c-aed7-751a8e8334df -->
-* **approve\_domain\_join TOCTOU vulnerability**: Trap: approve\_domain\_join reads record before lock without re-reading under lock, creating TOCTOU vulnerability. Fix: Re-read record under lock to match accept\_scope\_invite discipline.
+<!-- lore:019f7080-f4db-713c-b5b3-3742678a3f11 -->
+* **Auto-import failure: background import fails with 'no-auth' when no auth exists**: Trap: \`lore run\` auto-import fails with 'no-auth' errors when no auth exists. User confirmed import with 'y', but background import repeatedly fails with 'no-auth' errors (session=\_unknown), followed by agent selection prompt hanging. Fix: Always check for auth before starting background import. If no auth exists, skip import or prompt for auth setup first. Rationale: Background import requires auth to proceed, but auto-import may be triggered before auth is configured.
 
 <!-- lore:019f1fde-f198-76a6-a8e1-1ba44ab8cf1d -->
 * **backfillTemporalEmbeddings idle-gate: session-activity window starves backfill under sustained load**: Trap: gating temporal backfill on session activity (any session active within \`idleTimeoutSeconds \* 1000\` ms) looks correct — avoids competing with live traffic. Fix: on a busy machine with 5 active sessions and 142 turns in ~18 min, the gate never opens; cursor never advances during 8+ min monitoring window. The session-activity window is too coarse — it parks backfill even when the embed worker is idle between requests. Fix (PR #1111): gate on \`recallEmbedsInFlight() > 0\` instead. This is selective — backfill progresses during recall's sub-second gaps between requests. Under active multi-session load post-deploy: park/resume cycles seconds apart, ~16 msgs/min throughput confirmed in logs. Inherent limitation: sustained back-to-back recall with no gaps still starves backfill, but this is accurate (shared single worker) rather than a false signal.
@@ -212,9 +209,6 @@
 <!-- lore:019efb40-0000-7000-9000-000000000003 -->
 * **creditWarmupHit three guards: paid (Bug A) + within-TTL + actually-read (Bug C); credit is binary not pro-rata**: \`creditWarmupHit(warmup, sinceWarmupMs, ttlMs, cacheReadTokens)\` attributes a warmup hit ONLY when ALL hold: (A) the session paid (\`totalWarmups>0 && lastWarmupRefreshTokens>0\` — \`lastWarmupAt\` alone rides along in restored blobs → phantom); within TTL (\`sinceWarmupMs < ttlMs\`); (C) the returning turn ACTUALLY READ the cache (\`cacheReadTokens > 0\`). Bug C fix: a turn that pivoted context / used a different tool chain / found the cache evicted reports \`cache\_read=0\` → no savings; without the gate, warmupHits/creditedTokens inflate and warp the ROI analysis gating future warming. Call site passes \`usage.cacheReadInputTokens ?? 0\` (same signal the adjacent 1h-TTL-savings branch gates on). The warmup is consumed (markers zeroed) BEFORE all three guards, so a no-hit still can't re-credit later. \`creditedTokens\` is the warmed prefix (\`refreshTokens\`, Bug B), NOT the returning read. Known residual: the read gate is BINARY — a partial read (0 < read < refreshTokens, e.g. breakpoint shift) still credits the full refreshTokens. Call-site threading (pipeline postResponse warmup-hit branch) is NOT seam-tested — hardcoding the 4th arg survives all warmup pipeline tests (tracked follow-up).
 
-<!-- lore:019f6d35-e72c-73ff-a0c6-f24f8ac5d30c -->
-* **Cross-user email re-check failure**: Trap: Cross-user email re-check in approve\_domain\_join fails due to NULL return. Fix: Inline email check using unguarded helper.
-
 <!-- lore:019ef389-a501-7db4-a808-4e0c671bb2f0 -->
 * **effectiveMetaThreshold: internal Date.now() makes tests flaky — inject nowMs parameter**: Trap: \`effectiveMetaThreshold(lastTurnAtMs)\` calling \`Date.now()\` internally looks correct — it needs the current time to compute \`gapMs\`. Fix: any test that captures \`const now = Date.now()\` then passes \`now - (DEEP\_IDLE\_MS - 1)\` as \`lastTurnAtMs\` is flaky — a ≥1ms scheduling delay pushes \`gapMs ≥ DEEP\_IDLE\_MS\`, flipping the return value. Fix (PR #926): add injectable \`nowMs\` parameter; tests pass a fixed \`NOW\` constant. Sentinel: \`lastTurnAtMs === 0\` means 'never set (first turn)' → treated as deep-idle (gapMs = Infinity). All 8 \`effectiveMetaThreshold\` tests rewritten to use fixed \`NOW\` — fully deterministic.
 
@@ -229,9 +223,6 @@
 
 <!-- lore:019ef645-2484-71dd-bf92-eccd8e962083 -->
 * **insertMeta ON CONFLICT must not update base\_confidence — immutable create-time anchor**: Trap: \`insertMeta\` uses \`ON CONFLICT(logical\_id) DO UPDATE SET base\_confidence = excluded.base\_confidence\` — looks correct for idempotent re-create. Fix: \`base\_confidence\` is the immutable create-time anchor for PN-counter deltas; overwriting it on conflict corrupts all future confidence calculations. The conflict path only occurs when \`create()\` is called with an explicit \`input.id\` that already exists (deduplication check skipped). Fix: remove \`base\_confidence = excluded.base\_confidence\` from the DO UPDATE clause. Confirmed in PR #1126 fix commit \`36173a7\`.
-
-<!-- lore:019f6d35-e6dd-7e10-839f-76c818cb8abd -->
-* **Integration test regex false positives**: Trap: Integration test regex patterns with |42501 alternation caused false positives. Fix: Tighten regex to match message text only.
 
 <!-- lore:019ef35a-01ce-7c91-a77a-e81e9f1f537b -->
 * **isVerifierCall: bare \`ci\` keyword matches \`npm ci\` (clean install) — false positive corrupts knowledge confidence**: Trap: \`(?:run\s+)?(?:test|...|ci|...)\` in \`VERIFIER\_LEADING\` looks correct — \`ci\` is a valid script name. Fix: \`npm ci\` (clean install, not a verifier) matches the optional-run group → false positive → confidence penalty. Fix (PR #927): move \`ci\` and other script keywords (\`verify\`, \`validate\`, \`e2e\`, \`coverage\`, \`spec\`) into a dedicated branch requiring explicit \`run\`/\`exec\`/\`dlx\` prefix: \`(?:npm|pnpm|yarn|bun)\s+(?:run|exec|dlx)\s+(?:test|ci|verify|...)\b\`. Bare \`npm ci\` no longer matches; \`pnpm run ci\` still does. \`ci\` retained for \`make\`/\`just\`/\`task\`/\`rake\` targets (always explicit). Confirmed via 51-case empirical test suite in PR #927 adversarial review.
@@ -251,17 +242,8 @@
 <!-- lore:019efc12-5bea-700b-87dd-615866d86741 -->
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
 
-<!-- lore:019f6d35-e6b8-73ec-b6c7-04bc3f10f1cc -->
-* **Migration forward reference failure**: Trap: Migration 0045 failed due to function forward reference. Fix: Reorder function definitions to resolve dependencies.
-
-<!-- lore:019f6d35-e777-76f3-838f-02b54b15093a -->
-* **Missing getCurrentUser mock in tests**: Trap: Integration tests fail due to missing getCurrentUser mock. Fix: Add proper mock implementation for getCurrentUser.
-
 <!-- lore:019efa7b-7094-7654-87f4-0d5b7066beaa -->
 * **node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner**: Trap: node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner. Fix: All SQLite access must go through the #db/driver subpath import map.
-
-<!-- lore:019f6d35-e702-7580-96f5-063c49a0d5e7 -->
-* **NULL-trap in admin guard**: Trap: NULL-trap in admin guard causes test failures. Fix: Use COALESCE to handle NULL values properly.
 
 <!-- lore:019f5e0a-59a7-7ee7-8ec1-5b7c7c721853 -->
 * **OpenAI-protocol cache hit rate issue**: Trap: OpenAI-protocol requests to OpenRouter show 100% cache miss rate because OpenRouter honors Anthropic-style breakpoints on OpenAI Chat Completions API but not on OpenAI requests. Fix: add Anthropic-style \`cache\_control\` breakpoints.
@@ -271,9 +253,6 @@
 
 <!-- lore:019f0134-e838-7cb6-ab45-8d517460b17b -->
 * **pattern-echo.ts throttle: arm cooldown unconditionally, not only after successful ltm.create**: Trap: arming the 10-minute cooldown (\`PATTERN\_COOLDOWN\_MS\`) only after a successful \`ltm.create()\` call in \`pattern-echo.ts\` looks correct — why throttle if nothing was created? Fix: if embed+search runs but \`ltm.create()\` fails or returns no-op, the cooldown is never armed → embed+search runs again on every subsequent distillation, burning compute. Additionally, rate-limited segments were skipping the embed entirely, creating a latent recall gap (segments never became vector-searchable). Fix (PR #1009): reorder \`\_detect()\` so embed+store (job 1) runs unconditionally BEFORE the rate-limit check; arm cooldown unconditionally immediately after the check passes (line 128), not inside the \`ltm.create()\` try block. Two bugs fixed: (a) no-pattern outcome never armed cooldown; (b) rate-limited segments skipped embedding.
-
-<!-- lore:019f6d35-e751-7880-a8b8-837c5436e35a -->
-* **Permission denied on domain\_join\_requests**: Trap: Permission denied on domain\_join\_requests table. Fix: GRANT SELECT on domain\_join\_requests/org\_domains to authenticated with RLS scoping.
 
 <!-- lore:019eeee4-fb23-717d-9e76-99443d234d8e -->
 * **PR #902 outcome-reward: confidence < ceiling guard prevents demotion, not just over-boost**: Trap: \`confidence < OUTCOME\_BOOST\_CEILING\` guard in PASS block looks like it only prevents over-boosting entries already above ceiling. Fix: without the guard, \`MIN(0.8, 0.95+0.02)=0.8\` silently demotes a 0.95 entry to 0.8 on every passing session — flattening the entire upper confidence band. Existing test uses confidence exactly at ceiling (0.8), so \`MIN(0.8, 0.82)=0.8\` is identical with/without guard — Mutant B survived all 19 tests. 🔴 Fix shipped (PR #902): added test for high-confidence entry (0.95) in passing session — must NOT be demoted to ceiling. Guard's second role (demotion prevention) now tested. Also: \`is\_deleted = 0\` filter added to both UPDATEs in \`creditSessionOutcome\` to mirror \`knowledge\_current\` view.
@@ -344,9 +323,6 @@
 <!-- lore:019f43a4-4ea3-752b-bd99-f2ef59d93db6 -->
 * **vectorSearchDistillations is not project-scoped — hydration query must filter by project\_id**: Trap: calling \`vectorSearchDistillations(queryVec, limit)\` and hydrating results looks correct — it mirrors \`vectorSearchTemporal\`. Fix: \`vectorSearchDistillations\` takes no project param; results include distillations from ALL projects. \`vectorSearchTemporal(queryVec, pid, limit)\` is correctly project-scoped. Any code path that calls \`vectorSearchDistillations\` must filter the hydration query with \`WHERE archived = 0 AND project\_id = ?\`, over-fetching (\`limit \* 4\`) and capping at \`limit\` after filtering to avoid multi-project starvation. Seer caught this as a CRITICAL cross-project data leak in PR #1228 review. Follow-up: add a natively project-scoped distillation vector search function.
 
-<!-- lore:019f6d35-e692-7cb5-9108-0cafeea26cad -->
-* **verified\_email\_domain PUBLIC EXECUTE grant**: Trap: verified\_email\_domain callable by any authenticated user due to default PUBLIC EXECUTE grant. Fix: Add explicit REVOKE EXECUTE in migration.
-
 <!-- lore:019f0052-45d6-7e13-a065-0a0b051f01c7 -->
 * **Vertex global endpoint: bare aiplatform.googleapis.com, not global-aiplatform.googleapis.com**: Trap: \`vertexRawPredictUrl(region, ...)\` building \`${region}-aiplatform.googleapis.com\` looks correct — all regional endpoints follow that pattern. Fix: \`region="global"\` must use bare \`aiplatform.googleapis.com\` (path still uses \`locations/global\`). \`global-aiplatform.googleapis.com\` resolves via DNS but returns HTTP 404. Since \`global\` is the default \`LORE\_VERTEX\_REGION\`, the default config would 404 every call without this fix. \`VERTEX\_HOST\_RE = /^(?:(\[a-z0-9-]+)-)?aiplatform\\.googleapis\\.com$/\` handles legacy \`global-aiplatform\` form (self-heals). \`vertexHost()\` helper centralizes host construction. Design limitation: X-Lore-Upstream-URL with a non-Vertex host → \`vertexRegionFromUrl\` returns null → region falls back to configRegion → proxy host silently discarded; Vertex cannot be proxied via X-Lore-Upstream-URL (intentional, documented by test). 🔴 NEVER produce the dead \`global-aiplatform\` host.
 
@@ -364,9 +340,6 @@
 <!-- lore:019f6f42-4246-7f86-85ff-c2fa16952681 -->
 * **Adversarial subagent review workflow**: Steps: 1. Request adversarial subagent review before merging PRs — ensures objective scrutiny 2. Focus on identifying potential issues, validating test coverage, and ensuring code quality 3. Implement review process consistently for complex or high-risk modifications Gotchas: - Skipping review for seemingly simple changes - Not addressing all review feedback before merge Verify: - \[ ] PR has adversarial review approval - \[ ] All review comments addressed - \[ ] Test coverage validated
 
-<!-- lore:019f6fd7-3907-7dd8-8bff-99c3cc8bcc62 -->
-* **AST-level whitespace trimming for convergent markdown normalization**: Steps: 1. Parse markdown to AST using remark 2. Recursively traverse AST to find html nodes 3. Trim trailing whitespace from html node values 4. Stringify modified AST back to markdown 5. Repeat until fixpoint reached Gotchas: - Naive regex-based newline collapse corrupts fenced code blocks - HTML node values may contain meaningful trailing whitespace in rare cases Verify: - \[ ] All test cases converge to fixpoint - \[ ] Fenced code blocks preserve internal blank lines - \[ ] HTML blocks with meaningful trailing whitespace are preserved
-
 <!-- lore:019f1e66-a06c-7c58-b5ec-6d7cb21eddc3 -->
 * **backfillTemporalEmbeddings: per-row checkpoint + backlog/progress logging (PR #1104)**: PR #1104 (\`fix/temporal-rechunk-checkpoint\`) changes two behaviors in \`backfillTemporalEmbeddings\`: 1. \*\*Per-row checkpoint\*\*: \`setKV(TEMPORAL\_RECHUNK\_CURSOR\_KEY, retryFrom ?? cursor)\` moved INSIDE the row loop (was per-page). Crash mid-pass now resumes from last completed row, not start of last page. \`retryFrom ?? cursor\` uses nullish (not \`||\`) — when first row fails, \`retryFrom = ''\` and \`'' ?? cursor\` → \`''\`, correctly resuming at \`id > ''\`. 2. \*\*Backlog + heartbeat logging\*\*: upfront \`SELECT COUNT(\*)\` logs \`'temporal re-chunk: N messages to scan (resuming)'\`; \`PROGRESS\_INTERVAL\_MS = 30\_000\` replaces count-based \`PROGRESS\_INTERVAL = 1000\`; heartbeat shows \`processed re-chunked, scanned scanned…\`. Mutations: per-row checkpoint test and backlog-log test both killed independently. Merged \`25a04e22\` at 2026-07-01T17:30:31Z.
 
@@ -382,17 +355,8 @@
 <!-- lore:019f6047-5672-73ac-a80b-521adbebedce -->
 * **Codex-worker cache accounting**: When fixing codex-worker cache accounting, always verify test suite non-vacuousness and apply fixes to parseResponsesWorkerResponse.
 
-<!-- lore:019f6d35-e64b-7247-853c-f024b02b7717 -->
-* **E-5-b domain join implementation**: Implemented E-5-b domain join functionality with comprehensive security review, integration tests, unit tests, and CI validation. Addressed NULL-trap vulnerabilities and TOCTOU concerns.
-
 <!-- lore:019f1cc8-b65e-7a6e-97ae-f48d1a7d542b -->
 * **forProjectOffloaded / entitiesForSessionOffloaded: timeout must fall back to in-process scan, never return \[]**: All offloaded variants of frozen-baseline builders (\`ltm.forProjectOffloaded\`, \`entities.forProjectOffloaded\`, \`entities.entitiesForSessionOffloaded\`) must fall back to the synchronous in-process scan on \`READ\_JOB\_TIMED\_OUT\` — never return \`\[]\`. Trap: returning \`\[]\` on timeout looks safe (same as \`forSession\` degrade). Fix: unlike \`forSession\` (reruns every turn), these results are frozen into \`stableLtmCache\` + \`saveSessionTracking\` for the entire session lifetime. A spurious empty baseline permanently breaks the knowledge catalog for that session. \`forSession\` can safely return \`\[]\` because it reruns every turn. Mutation test: force timeout branch to return \`\[]\` → timeout test must fail.
-
-<!-- lore:019f6d35-e5b7-73e7-a060-1231738f00d2 -->
-* **GitHub provisioning security invariants**: Key security invariants for GitHub provisioning: never downgrade existing roles, never assert memberships, never over-grant roles, never downgrade by redeeming invites, never collide with table column names in RPC bodies, never unwrap ephemeral invites after retirement, never leave pending\_invites on server.
-
-<!-- lore:019f6d35-e627-7cc3-ba06-ed08ee9f986c -->
-* **Integration test regex tightening**: Tightened integration test regex patterns to match message text only, removing |42501 alternation that caused false positives.
 
 <!-- lore:019ef39c-72e1-77c0-b39c-2c145ca5fd05 -->
 * **knowledge\_meta invariants: sync-silence for markInjected, content-only update must not churn sync clock**: Three sync-silence invariants for \`knowledge\_meta\`: (1) \`markInjected()\` updates \`last\_reinforced\_at\` but NEVER bumps \`updated\_at\` — selection ≠ certainty, mirrors prior HASH\_EXCLUDE behavior. (2) Content-only \`update()\` (no \`input.confidence\`) must NOT bump \`meta.updated\_at\` — only confidence changes churn the sync clock. (3) \`create()\` calls \`insertMeta(id, confidence, now, now)\` with \`ON CONFLICT DO UPDATE\` — idempotent for cross-machine re-create but never destroys a converged confidence value (fresh UUIDv7 logical\_id guarantees no collision in practice). A \`knowledge\_meta\` row with no live \`knowledge\_current\` row is inert — never crashes a read.
@@ -412,13 +376,13 @@
 <!-- lore:019ef387-4afe-7137-a151-88dff1dd0ab7 -->
 * **Test fix rules for knowledge\_meta migration (RULE A and RULE B)**: Two patterns for fixing tests after the v55 knowledge\_meta migration: RULE A — remove hardcoded \`confidence\` column from raw \`INSERT INTO knowledge\` statements; add \`logical\_id\` column+value (= id for v1 rows). RULE B — split combined \`UPDATE knowledge SET cross\_project=1, confidence=X, last\_reinforced\_at=Y\` into two statements: one targeting \`knowledge\` (cross\_project), one targeting \`knowledge\_meta\` (confidence/last\_reinforced\_at + updated\_at). Also: any test asserting confidence must read from \`knowledge\_meta\` or \`knowledge\_current\` view, never from the base \`knowledge\` table. Helper pattern: \`confOf(id)\` queries \`knowledge\_meta WHERE logical\_id = ?\` (not \`knowledge WHERE id = ?\`). Test JOIN pattern: \`SELECT m.confidence FROM knowledge k JOIN knowledge\_meta m ON m.logical\_id = k.logical\_id WHERE k.id = ?\`.
 
-<!-- lore:019f6d35-e602-7cd0-9577-3efe2fead2e4 -->
-* **verified\_email\_domain security hardening**: Added explicit REVOKE EXECUTE on verified\_email\_domain to prevent PUBLIC EXECUTE grant security leak. Migration 0039 was one-time snapshot, new function required explicit revoke.
-
 ### Preference
 
 <!-- lore:019f6b0f-ba41-73a2-9c6e-566099faa175 -->
 * **Add ignore-list to diff parsing and test coverage**: The ignore-list should be added to diff parsing and test coverage should be added for it. This is a directive preference.
+
+<!-- lore:019f70c1-6259-7105-b9bc-0c61c230bcf0 -->
+* **Admin command never silently promotes wrong account**: User stated that admin command 'never silently promotes the wrong account'. This is a directive preference.
 
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
 * **Always a remote gateway — it has no shared filesystem with its clients**: User stated: 'Always a remote gateway — it has no shared filesystem with its clients'. This is a directive preference.
@@ -438,20 +402,26 @@
 <!-- lore:019f6f42-408e-7635-81d6-4d51ec94a3c9 -->
 * **Always prefer f-strings over .**: User stated always prefer f-strings over . This is a directive preference.
 
-<!-- lore:019f7036-273a-723c-9d2d-73bf6913ba8b -->
-* **Always provide detailed tool results and system state when diagnosing issues**: The user consistently provides comprehensive diagnostic information when investigating problems, including tool outputs, system states, progress updates, and specific metrics. This pattern shows the user expects detailed technical data to be available for troubleshooting and expects the assistant to analyze this data to identify root causes and next steps.
-
 <!-- lore:019f66b3-cdb2-7605-9908-3135589ec555 -->
 * **Always record auth failure**: Always record the auth failure so the worker-health ladder sees it.
 
 <!-- lore:019f6fdd-fd1b-7c97-a870-80edf21b66f1 -->
 * **Always remove obvious statements from drafted replies**: Always remove obvious statements from drafted replies. User requested removal of sentence about subscription rate window resets from Erica reply draft, stating it's obvious.
 
+<!-- lore:019f7080-f5bc-7da4-8008-44ec5998ff2f -->
+* **Always runs locally for lore run**: User stated: 'always runs locally — agent is on the same machine.' This is a directive preference for \`lore run\` operations.
+
+<!-- lore:019f70a4-9381-77f1-bc0d-1485c1e9fbcd -->
+* **Always signal — never truncate user's actual prose/instructions**: User stated: 'Never blunt-truncates.' This is a directive preference indicating that user's actual prose/instructions should never be crudely truncated.
+
 <!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
 * **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
 
 <!-- lore:019f6fba-0dc9-787f-a62e-b86b43f939a0 -->
 * **Always valid for JSON**: User stated: 'always valid for JSON.' This is a directive preference.
+
+<!-- lore:019f70a4-93ca-7b63-8ff1-277c6772b3b8 -->
+* **Assertion patterns should match correctly without consuming punctuation**: User stated: 'never fire until much later in the string.' This is a directive preference for assertion pattern matching to work correctly without consuming punctuation.
 
 <!-- lore:019f6f38-a1ff-7b4b-b941-36b22f5dd4e7 -->
 * **Avoid re-embedding identical text every CI run**: User stated re-embedding identical text every run is wasteful. This is a CI optimization preference. Directive preference.
@@ -465,8 +435,8 @@
 <!-- lore:019f6f38-a17c-7356-a948-2769779627a0 -->
 * **checkInvariants should accept invariant source (DB or snapshot)**: User stated checkInvariants should accept invariant source (DB or snapshot). This is a CI design constraint. Directive preference.
 
-<!-- lore:019f702c-6e85-7a24-a620-df9545e073e6 -->
-* **CI persistence limitation: decisions written during CI vanish**: The CI database is an ephemeral actions/cache copy seeded from .lore.md. A decision knowledge entry written during a CI run isn't synced back to the team and silently vanishes next run. This is a declarative preference.
+<!-- lore:019f70c1-61b7-7c02-823a-aebcac38b39b -->
+* **CommandAdmin never reads \_values from OPTIONS map**: User stated that commandAdmin takes \_values and never reads it — so no OPTIONS-map/flag concern applies to admin at all. This is a directive preference.
 
 <!-- lore:019f6f38-9f56-7cf1-9fef-705816d9e405 -->
 * **Design docs never go into git**: User stated design docs don't go into git. This is a directive preference.
@@ -501,11 +471,17 @@
 <!-- lore:019f650e-1593-72e3-8c34-fdbf17c32560 -->
 * **Never a skip/conflict**: Never a skip/conflict: User stated never a skip/conflict.
 
+<!-- lore:019f7080-f5e8-7b3b-a8be-274e4f645867 -->
+* **Never accumulates background import failures when no auth exists**: User stated: 'never accumulates.' This is a directive preference indicating that background import failures should not accumulate when no authentication is configured.
+
 <!-- lore:019f6d35-e488-7b86-ae65-3ef2b695c2a3 -->
 * **Never assert memberships**: User stated: 'never asserts memberships'. This is a client behavior constraint for GitHub provisioning. Directive preference.
 
 <!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
 * **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
+
+<!-- lore:019f70c1-60ef-71ff-943f-bd1ab0c3f818 -->
+* **Never client-driven tombstone reaper**: User stated that the reaper is 'never client-driven' regarding the tombstone reaper pattern. This is a directive preference.
 
 <!-- lore:019f6d35-e4f8-7754-a5f2-d0a5018bc172 -->
 * **Never collide with table column names in RPC body**: User stated: 'never collide with table column names inside the body'. This is an RPC design constraint. Directive preference.
@@ -515,6 +491,9 @@
 
 <!-- lore:019f6fba-0e4f-75b0-bb52-11d28d23b966 -->
 * **Never converges and never repeats**: Never converges (fixed by trimming html-node trailing whitespace). This was a directive preference.
+
+<!-- lore:019f70c1-6166-74a9-ac25-8f4257e9a523 -->
+* **Never delete another member's real wrap through scope\_keys migration**: User stated that scope\_keys migration has security guarantees: 'NEVER delete another member's real wrap through this'. This is a directive preference.
 
 <!-- lore:019f6d35-e4d3-754f-8694-c36cf972eca2 -->
 * **Never downgrade by redeeming an invite**: User stated: 'never downgraded by redeeming an invite'. This is an invite redemption invariant. Directive preference.
@@ -527,6 +506,9 @@
 
 <!-- lore:019f65ca-91fb-7140-b01f-aeb90540b80d -->
 * **Never from within another transaction**: User stated never from within another transaction.
+
+<!-- lore:019f70c1-6116-7798-bde9-7dbaf926a516 -->
+* **Never grant UPDATE on profiles to service\_role**: User stated that service\_role was 'never granted UPDATE on profiles' regarding tier guards. This is a directive preference.
 
 <!-- lore:019f6f42-4141-74f4-967f-8c00ee9cb428 -->
 * **Never has it set — but calling it at**: User stated never has it set — but calling it at. This is a directive preference.
@@ -555,11 +537,17 @@
 <!-- lore:019f6f42-41cf-7f36-b839-9f6d29623810 -->
 * **Never read a dropped column).**: User stated never read a dropped column). This is a directive preference.
 
+<!-- lore:019f70c1-618e-7f32-9e38-adfe833b06db -->
+* **Never reap real member wraps in tombstone reaper**: User stated that 'NEVER a real member wrap 6ms' is a critical security requirement for the tombstone reaper. This is a directive preference.
+
 <!-- lore:019f6f42-4168-79ae-a6fc-bc736d12b2a0 -->
 * **Never reverts to blob),**: User stated never reverts to blob). This is a directive preference.
 
 <!-- lore:019f6f42-40bf-7804-9d05-2b7b182e5191 -->
 * **Never runs and Lore falls back to temporal-only recall**: User stated never runs and Lore falls back to temporal-only recall. This is a directive preference.
+
+<!-- lore:019f70c1-613e-7caf-a1c9-cd7a330cd0c2 -->
+* **Never self-upgrade team via client**: User stated that a client can 'never self-upgrade a team' regarding org tier guards. This is a directive preference.
 
 <!-- lore:019f6f38-9fad-7135-95e7-d64c4294bc30 -->
 * **Never send embeddings over the wire**: User stated embeddings are never sent over the wire: BLOB \`embedding\`. This is a security constraint. Directive preference.
@@ -585,6 +573,9 @@
 <!-- lore:019f6f42-4193-7f4e-b2e5-0328bc5ebdde -->
 * **Never vec0->blob) ===**: User stated never vec0->blob) ===. This is a directive preference.
 
+<!-- lore:019f70c1-61df-7837-a22e-2aee503b0b98 -->
+* **Never write service-role key to disk**: User stated that service-role key 'never touches that path — it is never written to disk'. This is a directive preference.
+
 <!-- lore:019f6d35-e593-7004-9250-0da8b3352c08 -->
 * **Replace revoke with grant for verified\_email\_domain**: User stated: 'replace revoke with \`grant .'. This was a mutation test scenario. Directive preference.
 
@@ -596,6 +587,12 @@
 
 <!-- lore:019f6f38-9fd6-7043-a9dc-175e18465ae1 -->
 * **Server never sees plaintext**: User stated the server never sees plaintext. This is a security constraint. Directive preference.
+
+<!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
+* **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
+
+<!-- lore:019f70c1-6205-7d8b-9766-44b11a1e6f51 -->
+* **Service-role key never round-tripped through sessionToPersisted**: User stated that service-role key 'never round-tripped through sessionToPersisted'. This is a directive preference.
 
 <!-- lore:019f6f38-a127-7d59-bd32-486bd71ac328 -->
 * **Snapshot should include text, vectors, confidence, cross\_project**: User stated snapshot should include text, vectors, confidence, cross\_project. This is a CI design constraint. Directive preference.

--- a/.lore.md
+++ b/.lore.md
@@ -390,6 +390,9 @@
 <!-- lore:019f6fba-0d21-7410-894e-4933b29e8518 -->
 * **Always converges**: User stated: 'always converges'. This is a directive preference.
 
+<!-- lore:019f7121-c8ec-7c00-9fd8-7fe5cb4f6b73 -->
+* **Always enforce read-only main worktree during code reviews**: The user consistently requires that during code reviews and mutation testing, the main repository worktree must remain completely unmodified. Any experimental changes or mutation probes must be performed in a separate throwaway worktree created under /tmp/opencode/, with node\_modules symlinked from the main repo. The user emphasizes that the main worktree files should never be touched, and any temporary worktrees must be cleaned up after use. This pattern demonstrates a strong preference for maintaining the integrity of the main development environment during review processes.
+
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
 * **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
 
@@ -566,6 +569,9 @@
 
 <!-- lore:019f6b15-45db-7dd4-af70-5e4ac93d0244 -->
 * **Never the live conversation**: Never the live conversation. This is a directive preference.
+
+<!-- lore:019f7121-344f-75fe-99b5-d18253381602 -->
+* **Never touch the real repo files**: User stated to NEVER touch the real repo files.
 
 <!-- lore:019f64f3-4326-79f4-88ff-b8bc01c50706 -->
 * **Never touch the user's real gateway/DB**: User stated never touch the user's real gateway/DB.

--- a/packages/gateway/src/cli/import-auto.ts
+++ b/packages/gateway/src/cli/import-auto.ts
@@ -137,8 +137,25 @@ export async function maybeAutoImport(
 
   const hasWorkerKey = !!gatewayConfig.workerApiKey;
 
-  const job = () =>
-    runBackgroundImport(
+  const job = (authedProviderID?: string) => {
+    // The extraction runs on the configured default model. If the first turn
+    // authenticated a DIFFERENT provider (e.g. session=openai but default
+    // model=anthropic) and no credential resolves for the model's provider,
+    // the extraction can't authenticate — skip loudly rather than silently
+    // churning no-auth. A matching/agnostic credential (or worker key) proceeds.
+    const usable =
+      hasWorkerKey || resolveAuth(undefined, defaultModel.providerID) != null;
+    if (!usable) {
+      if (authedProviderID && authedProviderID !== defaultModel.providerID) {
+        console.log(
+          `[lore] Skipping knowledge import: your session uses ${authedProviderID}, ` +
+            `but import is configured for ${defaultModel.providerID}. ` +
+            `Run \`lore import\` once authenticated with ${defaultModel.providerID}.`,
+        );
+      }
+      return Promise.resolve();
+    }
+    return runBackgroundImport(
       llm,
       projectPath,
       results,
@@ -147,6 +164,7 @@ export async function maybeAutoImport(
     ).catch(() => {
       // Background import failed — non-fatal, don't alarm the user.
     });
+  };
 
   // A dedicated worker key is always usable, so the import can run right away.
   // Otherwise we must WAIT for a real credential: at `lore run` startup no turn

--- a/packages/gateway/src/cli/import-auto.ts
+++ b/packages/gateway/src/cli/import-auto.ts
@@ -146,11 +146,19 @@ export async function maybeAutoImport(
     const usable =
       hasWorkerKey || resolveAuth(undefined, defaultModel.providerID) != null;
     if (!usable) {
+      // Never leave a promised import silently dropped: we told the user it
+      // would "start after your first message". Explain the mismatch when we
+      // know the provider; otherwise give a generic, still-actionable notice.
       if (authedProviderID && authedProviderID !== defaultModel.providerID) {
         console.log(
           `[lore] Skipping knowledge import: your session uses ${authedProviderID}, ` +
             `but import is configured for ${defaultModel.providerID}. ` +
             `Run \`lore import\` once authenticated with ${defaultModel.providerID}.`,
+        );
+      } else {
+        console.log(
+          `[lore] Skipping knowledge import: no usable ${defaultModel.providerID} ` +
+            `credential is available. Run \`lore import\` once authenticated.`,
         );
       }
       return Promise.resolve();

--- a/packages/gateway/src/cli/import-auto.ts
+++ b/packages/gateway/src/cli/import-auto.ts
@@ -16,6 +16,7 @@ import {
 } from "@loreai/core";
 import { createGatewayLLMClient } from "../llm-adapter";
 import { resolveAuth } from "../auth";
+import { registerPendingImport } from "../pending-import";
 import type { GatewayConfig } from "../config";
 
 const {
@@ -120,9 +121,6 @@ export async function maybeAutoImport(
 
   if (!ok) return;
 
-  // Run import in the background (fire-and-forget)
-  console.log("[lore] Importing knowledge in background...");
-
   const cfg = loreConfig();
   const defaultModel = cfg.model ?? {
     providerID: "anthropic",
@@ -137,10 +135,36 @@ export async function maybeAutoImport(
     defaultModel,
   );
 
-  // Fire-and-forget — don't await, let it run while the agent starts
-  runBackgroundImport(llm, projectPath, results, defaultModel).catch(() => {
-    // Background import failed — non-fatal, don't alarm the user.
-  });
+  const hasWorkerKey = !!gatewayConfig.workerApiKey;
+
+  const job = () =>
+    runBackgroundImport(
+      llm,
+      projectPath,
+      results,
+      defaultModel,
+      hasWorkerKey,
+    ).catch(() => {
+      // Background import failed — non-fatal, don't alarm the user.
+    });
+
+  // A dedicated worker key is always usable, so the import can run right away.
+  // Otherwise we must WAIT for a real credential: at `lore run` startup no turn
+  // has been proxied yet, so resolveAuth() is null and firing now would make
+  // every extraction call fail no-auth (session=_unknown), churn the whole
+  // backlog, and produce zero knowledge. Defer until the first authenticated
+  // turn binds a credential (pipeline flushes via flushPendingImport()).
+  const hasCredential =
+    hasWorkerKey || resolveAuth(undefined, defaultModel.providerID) != null;
+
+  if (hasCredential) {
+    console.log("[lore] Importing knowledge in background...");
+    void job();
+  } else {
+    // Fire-and-forget once the first authenticated turn arrives.
+    registerPendingImport(job);
+    console.log("[lore] Knowledge import will start after your first message.");
+  }
 }
 
 async function runBackgroundImport(
@@ -148,7 +172,16 @@ async function runBackgroundImport(
   projectPath: string,
   results: import("@loreai/core").conversationImport.DetectionResult[],
   model: { providerID: string; modelID: string },
+  hasWorkerKey: boolean,
 ): Promise<void> {
+  // Final auth guard: never churn a large backlog when no credential is
+  // resolvable. Every extraction call would fail no-auth and produce zero
+  // knowledge. Callers already gate on this, but the deferred path could race
+  // a credential going stale between the flush trigger and this run.
+  if (!hasWorkerKey && resolveAuth(undefined, model.providerID) == null) {
+    return;
+  }
+
   let totalCreated = 0;
   let totalUpdated = 0;
 

--- a/packages/gateway/src/pending-import.ts
+++ b/packages/gateway/src/pending-import.ts
@@ -9,15 +9,20 @@
  *
  * Instead, `maybeAutoImport` registers a one-shot job here, and the pipeline
  * calls {@link flushPendingImport} once the first authenticated turn binds a
- * credential. The job then runs with a real credential available to the worker.
+ * credential. The pipeline passes the provider that just authenticated so the
+ * job can decide whether the credential is usable for its extraction model.
  *
  * A dedicated worker key (`LORE_WORKER_API_KEY`) is always available, so in that
  * setup the import can run immediately without waiting for a turn — the caller
- * decides (it passes `runImmediately`).
+ * decides (it runs the job directly instead of registering it).
  */
 
-/** A registered import job: runs the extraction and resolves when done. */
-type PendingImportJob = () => Promise<void>;
+/**
+ * A registered import job. Receives the provider ID that just authenticated
+ * (or `undefined` when the trigger is provider-agnostic), so the job can skip
+ * when the credential belongs to a provider its extraction model can't use.
+ */
+type PendingImportJob = (authedProviderID?: string) => Promise<void>;
 
 let pending: PendingImportJob | null = null;
 let running = false;
@@ -42,14 +47,19 @@ export function hasPendingImport(): boolean {
  *
  * Safe to call on every turn — a no-op when nothing is registered. Never throws
  * (the job is expected to swallow its own errors; this is defensive).
+ *
+ * @param authedProviderID - Provider ID of the credential that just landed,
+ *   forwarded to the job so it can gate on provider compatibility.
  */
-export async function flushPendingImport(): Promise<void> {
+export async function flushPendingImport(
+  authedProviderID?: string,
+): Promise<void> {
   if (!pending || running) return;
   const job = pending;
   pending = null;
   running = true;
   try {
-    await job();
+    await job(authedProviderID);
   } catch {
     // Non-fatal — the job owns user-facing error reporting.
   } finally {

--- a/packages/gateway/src/pending-import.ts
+++ b/packages/gateway/src/pending-import.ts
@@ -1,0 +1,64 @@
+/**
+ * Deferred conversation-import hook.
+ *
+ * `lore run` offers to import prior agent conversations at startup, but at that
+ * point the gateway has NOT yet proxied a single turn — so no client credential
+ * has been captured. Running the import immediately makes every extraction call
+ * fail with `no-auth` (session=_unknown), burning through the whole backlog and
+ * producing zero knowledge (see the import-auto no-auth storm).
+ *
+ * Instead, `maybeAutoImport` registers a one-shot job here, and the pipeline
+ * calls {@link flushPendingImport} once the first authenticated turn binds a
+ * credential. The job then runs with a real credential available to the worker.
+ *
+ * A dedicated worker key (`LORE_WORKER_API_KEY`) is always available, so in that
+ * setup the import can run immediately without waiting for a turn — the caller
+ * decides (it passes `runImmediately`).
+ */
+
+/** A registered import job: runs the extraction and resolves when done. */
+type PendingImportJob = () => Promise<void>;
+
+let pending: PendingImportJob | null = null;
+let running = false;
+
+/**
+ * Register a deferred import job. Replaces any previously-registered job (there
+ * is only ever one auto-import per `lore run` invocation).
+ */
+export function registerPendingImport(job: PendingImportJob): void {
+  pending = job;
+}
+
+/** Whether a deferred import is currently registered (and not yet started). */
+export function hasPendingImport(): boolean {
+  return pending !== null;
+}
+
+/**
+ * Run the registered import job, if any. One-shot: the job is cleared before it
+ * runs so a second concurrent turn (or a re-entrant call) never double-fires it.
+ * The `running` guard covers the async window between clear and completion.
+ *
+ * Safe to call on every turn — a no-op when nothing is registered. Never throws
+ * (the job is expected to swallow its own errors; this is defensive).
+ */
+export async function flushPendingImport(): Promise<void> {
+  if (!pending || running) return;
+  const job = pending;
+  pending = null;
+  running = true;
+  try {
+    await job();
+  } catch {
+    // Non-fatal — the job owns user-facing error reporting.
+  } finally {
+    running = false;
+  }
+}
+
+/** Test-only: clear all deferred-import state. */
+export function _resetPendingImportForTest(): void {
+  pending = null;
+  running = false;
+}

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -223,6 +223,7 @@ import {
 } from "./auth";
 import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
+import { flushPendingImport } from "./pending-import";
 import { makeTemporalBackfillGate } from "./backfill-gate";
 import { buildSessionMetadata } from "./session-metadata";
 import {
@@ -6667,6 +6668,11 @@ async function handleConversationTurn(
     const reqProviderID = extractProviderHeader(req.rawHeaders);
     setSessionAuth(sessionID, cred, reqProviderID || undefined);
     clearWarmupAuthDisabled(sessionID); // Re-enable cache warming on fresh credential
+
+    // A credential just landed. If `lore run` deferred a conversation import
+    // (no credential existed at startup), run it now — this is the first
+    // authenticated turn. One-shot and self-guarded; a no-op otherwise.
+    trackBackground(flushPendingImport());
   }
 
   // Capture billing header prefix for worker cch computation, scoped to

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6671,8 +6671,10 @@ async function handleConversationTurn(
 
     // A credential just landed. If `lore run` deferred a conversation import
     // (no credential existed at startup), run it now — this is the first
-    // authenticated turn. One-shot and self-guarded; a no-op otherwise.
-    trackBackground(flushPendingImport());
+    // authenticated turn. Forward the provider that authenticated so the job
+    // can skip when the credential can't drive its extraction model. One-shot
+    // and self-guarded; a no-op otherwise.
+    trackBackground(flushPendingImport(reqProviderID || undefined));
   }
 
   // Capture billing header prefix for worker cch computation, scoped to

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6671,10 +6671,16 @@ async function handleConversationTurn(
 
     // A credential just landed. If `lore run` deferred a conversation import
     // (no credential existed at startup), run it now — this is the first
-    // authenticated turn. Forward the provider that authenticated so the job
-    // can skip when the credential can't drive its extraction model. One-shot
-    // and self-guarded; a no-op otherwise.
-    trackBackground(flushPendingImport(reqProviderID || undefined));
+    // authenticated turn. Forward the provider the GLOBAL fallback was tagged
+    // with — resolveLastSeenProvider (x-lore-provider ?? URL inference), the
+    // same value setLastSeenAuth used above — because the session-less import
+    // job resolves auth against that global. Using the bare header
+    // (extractProviderHeader) here would pass undefined when the provider was
+    // URL-inferred, re-introducing the silent cross-provider drop. One-shot and
+    // self-guarded; a no-op otherwise.
+    trackBackground(
+      flushPendingImport(resolveLastSeenProvider(req.rawHeaders)),
+    );
   }
 
   // Capture billing header prefix for worker cch computation, scoped to

--- a/packages/gateway/test/import-auto.test.ts
+++ b/packages/gateway/test/import-auto.test.ts
@@ -133,4 +133,21 @@ describe("maybeAutoImport — credential-aware scheduling", () => {
     // The matching-provider path does NOT hit the mismatch skip branch.
     expect(logs.join("\n")).not.toContain("Skipping knowledge import");
   });
+
+  test("deferred → flush with UNKNOWN provider and no usable credential skips loudly (generic notice)", async () => {
+    // The credential can't be resolved for the default (anthropic) model and the
+    // trigger carried no provider info (authedProviderID undefined). The import
+    // must still tell the user it was skipped — never a silent drop.
+    await maybeAutoImport(baseConfig());
+    expect(hasPendingImport()).toBe(true);
+
+    // No credential set for anthropic → resolveAuth(undefined, "anthropic") null.
+    logs.length = 0;
+    await flushPendingImport(undefined);
+
+    expect(hasPendingImport()).toBe(false);
+    const out = logs.join("\n");
+    expect(out).toContain("Skipping knowledge import");
+    expect(out).toContain("no usable anthropic credential");
+  });
 });

--- a/packages/gateway/test/import-auto.test.ts
+++ b/packages/gateway/test/import-auto.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, copyFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Auto-accept the Y/n prompt without touching real stdin: stub readline's
+// createInterface so question() immediately answers "y" and close() is a no-op.
+vi.mock("node:readline", () => ({
+  createInterface: () => ({
+    question: (_q: string, cb: (answer: string) => void) => cb("y"),
+    close: () => {},
+  }),
+}));
+
+import { maybeAutoImport } from "../src/cli/import-auto";
+import {
+  hasPendingImport,
+  _resetPendingImportForTest,
+} from "../src/pending-import";
+import { setLastSeenAuth, _resetAuthForTest } from "../src/auth";
+import type { GatewayConfig } from "../src/config";
+
+const AIDER_FIXTURE = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "..",
+  "..",
+  "core",
+  "test",
+  "import",
+  "fixtures",
+  "aider-history.md",
+);
+
+function baseConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  // Only the fields maybeAutoImport reads matter; cast the rest.
+  return {
+    upstreamAnthropic: "https://api.anthropic.com",
+    upstreamOpenAI: "https://api.openai.com",
+    ...overrides,
+  } as GatewayConfig;
+}
+
+describe("maybeAutoImport — credential-aware scheduling", () => {
+  let project: string;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  const logs: string[] = [];
+  let prevIsTTY: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    _resetPendingImportForTest();
+    _resetAuthForTest();
+    project = mkdtempSync(join(tmpdir(), "lore-autoimport-"));
+    copyFileSync(AIDER_FIXTURE, join(project, ".aider.chat.history.md"));
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(project);
+    logs.length = 0;
+    logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
+      logs.push(a.join(" "));
+    });
+    // Force TTY so promptYesNo reaches the (mocked) readline that answers "y".
+    prevIsTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    logSpy.mockRestore();
+    if (prevIsTTY) Object.defineProperty(process.stdin, "isTTY", prevIsTTY);
+    rmSync(project, { recursive: true, force: true });
+    _resetPendingImportForTest();
+    _resetAuthForTest();
+  });
+
+  test("no credential, no worker key → import is DEFERRED to the first turn", async () => {
+    await maybeAutoImport(baseConfig());
+    expect(hasPendingImport()).toBe(true);
+    expect(logs.join("\n")).toContain("after your first message");
+    expect(logs.join("\n")).not.toContain("Importing knowledge in background");
+  });
+
+  test("worker key set → import runs immediately (not deferred)", async () => {
+    await maybeAutoImport(baseConfig({ workerApiKey: "sk-worker-test" }));
+    expect(hasPendingImport()).toBe(false);
+    expect(logs.join("\n")).toContain("Importing knowledge in background");
+    expect(logs.join("\n")).not.toContain("after your first message");
+  });
+
+  test("session credential present → import runs immediately (not deferred)", async () => {
+    setLastSeenAuth({ scheme: "bearer", value: "sk-ant-oat-xxx" }, "anthropic");
+    await maybeAutoImport(baseConfig());
+    expect(hasPendingImport()).toBe(false);
+    expect(logs.join("\n")).toContain("Importing knowledge in background");
+  });
+});

--- a/packages/gateway/test/import-auto.test.ts
+++ b/packages/gateway/test/import-auto.test.ts
@@ -16,6 +16,7 @@ vi.mock("node:readline", () => ({
 import { maybeAutoImport } from "../src/cli/import-auto";
 import {
   hasPendingImport,
+  flushPendingImport,
   _resetPendingImportForTest,
 } from "../src/pending-import";
 import { setLastSeenAuth, _resetAuthForTest } from "../src/auth";
@@ -52,6 +53,10 @@ describe("maybeAutoImport — credential-aware scheduling", () => {
     _resetPendingImportForTest();
     _resetAuthForTest();
     project = mkdtempSync(join(tmpdir(), "lore-autoimport-"));
+    // The tmp dir is intentionally NOT a git repo: detectAll(..., {worktrees:true})
+    // runs `git worktree list`, which fails open to [projectPath] here — so
+    // detection is scoped to exactly this dir and the copied-in fixture. Keeps
+    // the test deterministic and free of home-dir/repo leakage.
     copyFileSync(AIDER_FIXTURE, join(project, ".aider.chat.history.md"));
     cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(project);
     logs.length = 0;
@@ -94,5 +99,38 @@ describe("maybeAutoImport — credential-aware scheduling", () => {
     await maybeAutoImport(baseConfig());
     expect(hasPendingImport()).toBe(false);
     expect(logs.join("\n")).toContain("Importing knowledge in background");
+  });
+
+  test("deferred → flush with a MISMATCHED provider skips loudly (no silent no-op)", async () => {
+    // Default model provider is anthropic (no cfg.model). Defer, then the first
+    // authenticated turn is openai — the extraction can't use an openai key, so
+    // the job must skip AND tell the user why (not vanish silently).
+    await maybeAutoImport(baseConfig());
+    expect(hasPendingImport()).toBe(true);
+
+    // Simulate the first turn authenticating openai.
+    setLastSeenAuth({ scheme: "api-key", value: "sk-openai" }, "openai");
+    logs.length = 0;
+    await flushPendingImport("openai");
+
+    expect(hasPendingImport()).toBe(false); // one-shot consumed
+    const out = logs.join("\n");
+    expect(out).toContain("Skipping knowledge import");
+    expect(out).toContain("openai");
+    expect(out).toContain("anthropic");
+  });
+
+  test("deferred → flush with a MATCHING provider proceeds to import", async () => {
+    await maybeAutoImport(baseConfig());
+    expect(hasPendingImport()).toBe(true);
+
+    // First turn authenticates anthropic — matches the default model provider.
+    setLastSeenAuth({ scheme: "bearer", value: "sk-ant-oat" }, "anthropic");
+    logs.length = 0;
+    await flushPendingImport("anthropic");
+
+    expect(hasPendingImport()).toBe(false);
+    // The matching-provider path does NOT hit the mismatch skip branch.
+    expect(logs.join("\n")).not.toContain("Skipping knowledge import");
   });
 });

--- a/packages/gateway/test/pending-import.test.ts
+++ b/packages/gateway/test/pending-import.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import {
+  registerPendingImport,
+  hasPendingImport,
+  flushPendingImport,
+  _resetPendingImportForTest,
+} from "../src/pending-import";
+
+describe("pending-import", () => {
+  beforeEach(() => {
+    _resetPendingImportForTest();
+  });
+
+  test("no job registered → flush is a no-op", async () => {
+    expect(hasPendingImport()).toBe(false);
+    await expect(flushPendingImport()).resolves.toBeUndefined();
+  });
+
+  test("registered job runs on flush, exactly once", async () => {
+    const job = vi.fn(async () => {});
+    registerPendingImport(job);
+    expect(hasPendingImport()).toBe(true);
+
+    await flushPendingImport();
+    expect(job).toHaveBeenCalledTimes(1);
+
+    // Second flush: nothing left to run (one-shot).
+    await flushPendingImport();
+    expect(job).toHaveBeenCalledTimes(1);
+    expect(hasPendingImport()).toBe(false);
+  });
+
+  test("job is cleared BEFORE it runs — re-entrant flush never double-fires", async () => {
+    let seenPendingDuringRun: boolean | null = null;
+    const job = vi.fn(async () => {
+      // The pipeline calls flushPendingImport on every turn; a turn that lands
+      // while the job is still running must not start a second copy.
+      seenPendingDuringRun = hasPendingImport();
+      await flushPendingImport(); // re-entrant — must be a no-op
+    });
+
+    registerPendingImport(job);
+    await flushPendingImport();
+
+    expect(job).toHaveBeenCalledTimes(1);
+    expect(seenPendingDuringRun).toBe(false); // cleared before run
+  });
+
+  test("concurrent flushes run the job only once (running guard)", async () => {
+    let resolveJob: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      resolveJob = r;
+    });
+    const job = vi.fn(async () => {
+      await gate;
+    });
+
+    registerPendingImport(job);
+
+    // Two turns fire flush before the first completes.
+    const p1 = flushPendingImport();
+    const p2 = flushPendingImport();
+    resolveJob();
+    await Promise.all([p1, p2]);
+
+    expect(job).toHaveBeenCalledTimes(1);
+  });
+
+  test("running guard: a job that re-registers is not re-fired by a mid-run flush", async () => {
+    let resolveOuter: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      resolveOuter = r;
+    });
+    const inner = vi.fn(async () => {});
+    const outer = vi.fn(async () => {
+      // Simulate the job re-arming a follow-up import while still running, then
+      // a concurrent turn flushing. The `running` guard must suppress it — the
+      // re-registered job only becomes eligible once the current run finishes.
+      registerPendingImport(inner);
+      const reentrant = flushPendingImport(); // must be a no-op while running
+      await gate;
+      await reentrant;
+    });
+
+    registerPendingImport(outer);
+    const run = flushPendingImport();
+    resolveOuter();
+    await run;
+
+    expect(outer).toHaveBeenCalledTimes(1);
+    // `inner` was registered during the run; the mid-run flush must NOT have
+    // fired it (running guard). It stays pending for the next explicit flush.
+    expect(inner).not.toHaveBeenCalled();
+    expect(hasPendingImport()).toBe(true);
+
+    await flushPendingImport();
+    expect(inner).toHaveBeenCalledTimes(1);
+  });
+
+  test("a throwing job does not reject flush and clears state", async () => {
+    const job = vi.fn(async () => {
+      throw new Error("extraction blew up");
+    });
+    registerPendingImport(job);
+
+    await expect(flushPendingImport()).resolves.toBeUndefined();
+    expect(job).toHaveBeenCalledTimes(1);
+    // State cleared even after a throw — a later turn won't retry endlessly,
+    // and the running guard is released.
+    expect(hasPendingImport()).toBe(false);
+  });
+
+  test("registering again replaces the prior job", async () => {
+    const first = vi.fn(async () => {});
+    const second = vi.fn(async () => {});
+    registerPendingImport(first);
+    registerPendingImport(second);
+
+    await flushPendingImport();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

A user hit this via the Pi extension: `lore run` in their main repo detected 12,479 prior messages, they accepted the import, and then the console filled with:

```
[lore] Importing knowledge in background...
[lore] Multiple AI agents detected:
  1) Claude Code ...
Choose an agent [1]: [lore] [worker-health] lore-import degraded: 3 failures in 5min for session=_unknown (reasons: no-auth)
[lore] [worker-health] lore-import degraded: 4 failures ...
... (goes on for a while)
```

It appeared to hang, and after restart the project had **no memory**.

### Root cause

`lore run` offers the import at **gateway startup**, then fired `runBackgroundImport` immediately (fire-and-forget). At that point the gateway hasn't proxied a single turn, so **no client credential has been captured** — `resolveAuth()` is null. Every extraction call across the whole backlog failed `no-auth` (`session=_unknown`), churning the entire history and creating **zero** knowledge entries. The failure storm also spammed the worker-health degraded ladder *over* the interactive agent picker, which is the "hang".

Every other background worker already guards on `resolveAuth(...)` before scheduling (`pipeline.ts`, `idle.ts`); the auto-import path was the one LLM path that ran at startup — exactly when a credential can't exist yet.

## Fix

Make auto-import **credential-aware**:

- **Credential available at prompt time** (dedicated `LORE_WORKER_API_KEY`, or a session credential already captured) → run immediately, as before.
- **No credential** → register a **one-shot deferred job** (`pending-import.ts`). The pipeline flushes it the moment the first authenticated turn binds a credential (right after `setSessionAuth`), so the import runs with real auth. User sees `Knowledge import will start after your first message.` instead of a no-auth storm.
- `runBackgroundImport` gains a **final auth guard** — bails without churning the backlog if no credential is resolvable when it actually runs (races a credential going stale between flush trigger and execution).

The secondary "hang" is resolved at the source: the no-auth storm no longer runs during the interactive `lore run` window, so it can't spam over the agent picker.

### New module: `pending-import.ts`
Tiny standalone module (avoids a pipeline↔cli import cycle): `registerPendingImport` / `flushPendingImport` (one-shot, running-guarded, error-swallowing) / `hasPendingImport`.

## Tests
- `pending-import.test.ts` — one-shot, cleared-before-run (re-entrant safety), concurrent-flush single-fire, throwing job, re-register replaces. Mutation-verified (removing the clear kills 3; removing the running guard kills the re-register test).
- `import-auto.test.ts` — drives **real** detection through an aider fixture in an isolated temp project; asserts the defer-vs-run-now decision across no-credential / worker-key / session-credential. Mutation-verified (forcing `hasCredential = true` kills the deferral test).

## Verification
- `pnpm run typecheck` — clean
- `pnpm run lint` / `format` — clean
- `pnpm exec vitest run` — **5929 passed**, 0 failures

## Notes
Complements the friendlier-429 follow-up (#1358) and the earlier worktree/import work (#1344, #1348). Does not change the explicit `lore import` CLI path.