### PR TITLE
fix(distill): preserve leading user prose during blob reduction (#1343 follow-up)

### DIFF
--- a/packages/core/src/blob-select.ts
+++ b/packages/core/src/blob-select.ts
@@ -234,6 +234,15 @@ export interface ReduceBlobOptions {
    * Empty/whitespace entries are ignored; a trailing display "…" is tolerated.
    */
   pinnedLines?: string[];
+  /**
+   * Chars of the leading prose prefix always kept verbatim, before any scoring.
+   * A user writes their own words (instruction + casual asides / stated facts)
+   * at the head of a message and pastes the bulk blob after; that prose is
+   * signal even when it scores low against the current objective. Leading
+   * segments are force-kept until the first paste-junk segment or this budget is
+   * reached. 0 (or omitted) disables head preservation. #1343 follow-up.
+   */
+  headChars?: number;
 }
 
 export interface ReduceBlobResult {
@@ -293,11 +302,44 @@ export async function reduceBlob(
     pinSpans.some(([s, e]) => seg.start < e && s < seg.end);
   const pinnedFlag = all.map(overlapsPin);
 
+  // Head preservation: force-keep the leading prose prefix — the user's own
+  // words (instruction + any casual asides / stated facts) that precede a pasted
+  // bulk blob. Walk from the top, keeping segments until the first paste-junk
+  // segment (the blob has begun) or the headChars budget is exhausted. Treated
+  // identically to a pin thereafter, so head prose survives relevance scoring,
+  // the segment cap, and the keepChars budget. #1343 follow-up: a low-salience
+  // fact stated at the head of an oversized message must not be elided before
+  // the distiller ever sees it.
+  //
+  // Segment-count clamp: head segments bypass the maxSegments sampling like pins,
+  // but — unlike pins (bounded by MAX_PINNED_ASSERTIONS) — they're bounded only by
+  // headChars, which has no relation to segment size. A misconfigured large
+  // headChars could otherwise force-embed the whole body, reintroducing the
+  // #1343 unbounded-embed cost. Cap the head at half the embed budget so at least
+  // half of maxSegments is always reserved for relevance sampling of the body.
+  const headBudget = opts.headChars ?? 0;
+  const maxHeadSegments = Math.max(1, Math.floor(opts.maxSegments / 2));
+  const headFlag = all.map(() => false);
+  if (headBudget > 0) {
+    let headUsed = 0;
+    let headCount = 0;
+    for (let i = 0; i < all.length; i++) {
+      if (looksLikePasteJunk(all[i].text)) break; // blob started — stop
+      if (headUsed >= headBudget || headCount >= maxHeadSegments) break;
+      headFlag[i] = true;
+      headUsed += all[i].text.length;
+      headCount++;
+    }
+  }
+  // A segment is force-kept if it is a pin OR part of the preserved head.
+  const keptFlag = all.map((_, i) => pinnedFlag[i] || headFlag[i]);
+
   // Stage 1: drop paste-junk before spending any embed — but never drop a pinned
-  // segment (a directive can look "junky" if wrapped in a noisy blob).
+  // or head-preserved segment (a directive/aside can look "junky" if wrapped in a
+  // noisy blob, and the head is always kept).
   const proseIdx: number[] = [];
   for (let i = 0; i < all.length; i++) {
-    if (pinnedFlag[i] || !looksLikePasteJunk(all[i].text)) proseIdx.push(i);
+    if (keptFlag[i] || !looksLikePasteJunk(all[i].text)) proseIdx.push(i);
   }
   const junkDropped = all.length - proseIdx.length;
 
@@ -314,8 +356,8 @@ export async function reduceBlob(
   // whole body.
   let cappedIdx: number[];
   if (proseIdx.length > opts.maxSegments) {
-    const pinnedIdx = proseIdx.filter((i) => pinnedFlag[i]);
-    const nonPinnedIdx = proseIdx.filter((i) => !pinnedFlag[i]);
+    const pinnedIdx = proseIdx.filter((i) => keptFlag[i]);
+    const nonPinnedIdx = proseIdx.filter((i) => !keptFlag[i]);
     const sampleBudget = Math.max(0, opts.maxSegments - pinnedIdx.length);
     // sampleBudget === 0 (pins alone meet/exceed the cap) → keep ZERO non-pinned,
     // never all of them (#1343 S3).
@@ -344,21 +386,22 @@ export async function reduceBlob(
     idx: i,
     text: all[i].text,
     score: opts.cosine(queryVec, segVecs[k]),
-    pinned: pinnedFlag[i],
+    pinned: keptFlag[i],
   }));
 
   const keepIdx = new Set<number>();
   let used = 0;
-  // Pinned segments are kept unconditionally (bypass the budget) so a directive
-  // can never be elided. The number of pins is bounded by the caller
-  // (MAX_PINNED_ASSERTIONS), so this cannot blow the budget unboundedly.
+  // Force-kept segments (pins + preserved head) are kept unconditionally (bypass
+  // the keepChars budget) so a directive/aside can never be elided. Both are
+  // bounded: pins by the caller (MAX_PINNED_ASSERTIONS) and head segments by
+  // maxHeadSegments (≤ maxSegments/2), so this cannot blow the budget unboundedly.
   for (const s of scored) {
     if (s.pinned) {
       keepIdx.add(s.idx);
       used += s.text.length;
     }
   }
-  // Fill the remaining budget with the highest-scoring non-pinned segments.
+  // Fill the remaining budget with the highest-scoring non-forced segments.
   const byScore = scored
     .filter((s) => !s.pinned)
     .sort((a, b) => b.score - a.score);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -246,6 +246,23 @@ export const LoreConfig = z.object({
         .describe(
           "Max blob segments embedded during user-blob reduction. Default: 48.",
         ),
+      /** Chars of the leading prose prefix of an oversized user message that are
+       *  ALWAYS kept verbatim during reduction, before any relevance scoring. A
+       *  user typically writes their own words (the instruction plus any casual
+       *  asides / stated facts) at the head of the message and then pastes the
+       *  bulk blob after. That leading prose is signal even when it scores low
+       *  against the current coding objective (e.g. "our orders ride the
+       *  WHOLESALE channel…"), so it must survive reduction — otherwise a buried
+       *  fact is lost before the distiller ever sees it. Kept until the first
+       *  paste-junk segment OR this budget is reached, whichever comes first. Set
+       *  to 0 to disable head preservation. Default: 1500. */
+      userBlobHeadChars: z
+        .number()
+        .min(0)
+        .default(1_500)
+        .describe(
+          "Chars of the leading user-prose prefix always kept during blob reduction. Set to 0 to disable. Default: 1500.",
+        ),
       /** Number of most-recent gen-0 segments to keep un-archived when
        *  meta-distillation fires. These segments retain full detail in the
        *  context prefix while older segments are consolidated. Default: 5.
@@ -267,6 +284,7 @@ export const LoreConfig = z.object({
       userBlobMaxChars: 12_000,
       userBlobKeepChars: 6_000,
       userBlobMaxSegments: 48,
+      userBlobHeadChars: 1_500,
       recentSegmentsToKeep: 5,
     })
     .describe(

--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -439,6 +439,7 @@ export async function messagesToTextReduced(
             query,
             keepChars: cfg.userBlobKeepChars,
             maxSegments: cfg.userBlobMaxSegments,
+            headChars: cfg.userBlobHeadChars,
             pinnedLines,
           });
           body = result.output;

--- a/packages/core/test/blob-select.test.ts
+++ b/packages/core/test/blob-select.test.ts
@@ -485,4 +485,106 @@ describe("reduceBlob", () => {
 
     expect(result.output).toContain(fullLine);
   });
+
+  test("headChars: leading prose prefix is kept even at zero relevance", async () => {
+    // The user's own words (instruction + a casual aside stating facts) lead the
+    // message; a large low-relevance blob follows. The aside scores 0 against the
+    // coding query, so ONLY head preservation can keep it. #1343 follow-up.
+    const aside =
+      "Starting the orderkit project. (Aside, nothing to act on: our orders " +
+      "ride the WHOLESALE channel out of the EMEA region, ship from WH-07, and " +
+      "we keep status values like SUBMITTED uppercase.) Just the stock_level fn.";
+    const blob = Array.from(
+      { length: 60 },
+      (_, i) => `irrelevant reference spec paragraph number ${i} with filler`,
+    ).join("\n\n");
+    const body = `${aside}\n\n${blob}`;
+
+    const result = await reduceBlob(body, {
+      // Nothing matches "SIGNAL" → every segment (incl. the aside) scores 0.
+      embed: stubEmbed("SIGNAL"),
+      cosine: dot,
+      query: "SIGNAL unrelated coding objective",
+      keepChars: 40, // tiny: relevance budget cannot rescue the aside
+      maxSegments: 48,
+      headChars: 400,
+    });
+
+    for (const fact of ["WHOLESALE", "EMEA", "WH-07", "SUBMITTED"]) {
+      expect(result.output).toContain(fact);
+    }
+  });
+
+  test("headChars=0 disables head preservation (aside is elided at zero relevance)", async () => {
+    // Mutation guard: with head preservation off, the same zero-relevance aside
+    // is dropped — proving the test above is non-vacuous.
+    const aside =
+      "Starting the orderkit project. (Aside: WHOLESALE channel, EMEA region, " +
+      "WH-07 warehouse, SUBMITTED uppercase status.) Just the stock_level fn.";
+    const blob = Array.from(
+      { length: 60 },
+      (_, i) => `irrelevant reference spec paragraph number ${i} with filler`,
+    ).join("\n\n");
+    const body = `${aside}\n\n${blob}`;
+
+    const result = await reduceBlob(body, {
+      embed: stubEmbed("SIGNAL"),
+      cosine: dot,
+      query: "SIGNAL unrelated coding objective",
+      keepChars: 40,
+      maxSegments: 48,
+      headChars: 0,
+    });
+
+    expect(result.output).not.toContain("WHOLESALE");
+  });
+
+  test("headChars: head segments are clamped to maxSegments/2 (cost bound holds)", async () => {
+    // A large headChars must NOT let the head force-embed the whole body — that
+    // would reintroduce the #1343 unbounded-embed cost. The head is clamped to
+    // maxSegments/2 so at least half the embed budget stays for body sampling.
+    // Build a body that is ALL prose (no paste-junk boundary) so nothing stops
+    // the head walk except the clamp.
+    const paras = Array.from(
+      { length: 40 },
+      (_, i) =>
+        `genuine prose paragraph number ${i} with enough words to be a real segment here`,
+    );
+    const body = paras.join("\n\n");
+
+    const result = await reduceBlob(body, {
+      embed: stubEmbed("SIGNAL"),
+      cosine: dot,
+      query: "SIGNAL unrelated",
+      keepChars: 200,
+      maxSegments: 10, // clamp head to floor(10/2) = 5
+      headChars: 1_000_000, // absurdly large: only the segment clamp can bound it
+    });
+
+    // embedded is capped at maxSegments; head cannot exceed maxSegments/2, so the
+    // total embed count never blows past the configured cap.
+    expect(result.embedded).toBeLessThanOrEqual(10);
+  });
+
+  test("headChars: head walk stops at the first paste-junk segment", async () => {
+    // The head prefix ends where the pasted blob begins. A junk segment after the
+    // prose head must terminate the head walk (blob started), so junk is never
+    // force-kept as "head".
+    const prose = "Real instruction prose at the very top of the message here.";
+    const junk = "aGVsbG8=".repeat(400); // base64-like paste junk, one big segment
+    const body = `${prose}\n\n${junk}`;
+
+    const result = await reduceBlob(body, {
+      embed: stubEmbed("SIGNAL"),
+      cosine: dot,
+      query: "SIGNAL unrelated",
+      keepChars: 40,
+      maxSegments: 48,
+      headChars: 1_000_000, // huge — only the junk boundary stops the head walk
+    });
+
+    // The prose head is kept; the junk is NOT force-kept as head (it's elided).
+    expect(result.output).toContain("Real instruction prose");
+    expect(result.output).not.toContain(junk);
+  });
 });

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -110,6 +110,7 @@ Distillation pipeline tuning (segment size, thresholds, tool-output truncation).
 | `userBlobMaxChars` | number | `12000` | min 0 | Trigger threshold (chars) for embedding-based user-blob reduction. Set to 0 to disable. Default: 12000. |
 | `userBlobKeepChars` | number | `6000` | min 0 | Chars kept after reducing an oversized user blob. Default: 6000. |
 | `userBlobMaxSegments` | number | `48` | min 1 | Max blob segments embedded during user-blob reduction. Default: 48. |
+| `userBlobHeadChars` | number | `1500` | min 0 | Chars of the leading user-prose prefix always kept during blob reduction. Set to 0 to disable. Default: 1500. |
 | `recentSegmentsToKeep` | number | `5` | min 0 | Number of most-recent gen-0 segments to keep un-archived when meta-distillation fires. Default: 5. |
 
 


### PR DESCRIPTION
## Summary
Fixes a memory-retention failure discovered while auditing the #961 eval: facts a user states as a casual aside at the **head** of an oversized message are dropped from durable memory before the distiller ever sees them.

## Root cause
The #1351 blob reducer (`reduceBlob`) segments an oversized user message and keeps only the top-N segments by cosine relevance to the distillation query. When a user writes their own words (instruction + asides / stated facts) at the head of a message and pastes a large blob after, that leading prose competes with the blob on relevance and — being low-relevance to the current coding task — gets elided. The fact never reaches distillations/knowledge.

Confirmed empirically: in a Sonnet long-session eval, the turn-1 aside `(…our orders ride the WHOLESALE channel out of EMEA, ship from WH-07, keep status uppercase…)` is segment index 0, non-junk, yet dropped whenever the relevance budget is tight — so the distillations captured the API-spec blob but none of the 4 probe facts, even in a run that happened to score 4/4 (that pass came from the raw conversation window, not memory).

## Fix
Force-keep the leading prose prefix (until the first paste-junk segment or a bounded budget) exactly like a pinned assertion:
- New config `knowledge.distillation.userBlobHeadChars` (default **1500**, 0 disables).
- `reduceBlob` marks leading non-junk segments as head-kept; they bypass relevance scoring, the segment cap, and the keepChars budget.
- Bounded by design, so a pure blob with no prose prefix still reduces normally — #1343's cost intent is preserved.

## Validation
- With a **zero-relevance fake embedder**, all 4 facts survive purely on head preservation (independent of relevance score).
- Mutation test (`headChars=0`) confirms the new regression test is non-vacuous.
- `blob-select` 38/38, `distillation` 122/122, `config` 33/33, tsc clean.

Follow-up to #1343 / part of #961.