### PR TITLE
feat(gateway): friendlier hint for pass-through 429 on OAuth sessions

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -150,6 +150,9 @@
 <!-- lore:019f4e07-af72-709a-9f1a-ce812355e889 -->
 * **Switched from a self-relation to two separate entities (e1**: switched from a self-relation to two separate entities (e1,
 
+<!-- lore:019f718f-9d3f-7637-bd1e-f56a97912261 -->
+* **Switched from claude-sonnet-4.6 to claude-sonnet-5 for consistency with published results**: Switched from claude-sonnet-4.6 to claude-sonnet-5 for consistency with published results.
+
 <!-- lore:019f4e9b-53bd-7506-8413-94d3cecd4213 -->
 * **Switched from forcing a violation to \*\*catalog introspection\*\* — directly querying information\_schema/pg\_constraint to assert content**: Switched from forcing a violation to \*\*catalog introspection\*\* — directly querying information\_schema/pg\_constraint to assert content.
 
@@ -369,11 +372,11 @@
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
 * **Always a remote gateway — it has no shared filesystem with its clients**: User stated: 'Always a remote gateway — it has no shared filesystem with its clients'. This is a directive preference.
 
+<!-- lore:019f7198-ce07-794a-a76b-39db101e2201 -->
+* **Always call plan\_exit to indicate planning completion**: The user consistently requires the assistant to explicitly call plan\_exit at the end of planning sessions. This serves as a clear signal that the planning phase is complete and the user should be notified. The pattern appears in multiple sessions where the user provides explicit instructions to 'always call plan\_exit' during planning activities.
+
 <!-- lore:019f6fba-0d21-7410-894e-4933b29e8518 -->
 * **Always converges**: User stated: 'always converges'. This is a directive preference.
-
-<!-- lore:019f716d-0035-7814-8a96-93b98d738b7a -->
-* **Always enforce strict error classification rules**: The user consistently mandates precise error handling logic, particularly around worker capability classification. They emphasize that transient errors must never mark a capable model as 'worker-incapable', and false positives from regex matching must never permanently mislabel models. The user provides specific implementation rules and design principles to ensure errors are classified correctly, with particular attention to avoiding incorrect 'worker-incapable' states that could cause permanent mislabeling of functional models.
 
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
 * **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
@@ -402,14 +405,14 @@
 <!-- lore:019f70a4-9381-77f1-bc0d-1485c1e9fbcd -->
 * **Always signal — never truncate user's actual prose/instructions**: Always signal — never truncate user's actual prose/instructions. User stated that the leading prose prefix is always kept verbatim during reduction. This is a directive preference.
 
+<!-- lore:019f719b-c5a7-704d-9a34-d2552d266e4d -->
+* **Always use bedrock-mantle with anthropic wire protocol and model remap**: The user consistently implements bedrock-mantle integration using the anthropic wire protocol exclusively. This includes: 1) Using the anthropic wire path for all bedrock-mantle requests, 2) Applying model ID remapping to anthropic format (anthropic.\<name>), 3) Using native Anthropic Messages API with x-api-key authentication and anthropic-version header, 4) Building URLs with the /anthropic base path, and 5) Ensuring the isBedrockMantleDispatch function enforces the anthropic protocol requirement. The user also consistently notes that bedrock-mantle does not support structured outputs.
+
 <!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
 * **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
 
 <!-- lore:019f6fba-0dc9-787f-a62e-b86b43f939a0 -->
 * **Always valid for JSON**: User stated: 'always valid for JSON.' This is a directive preference.
-
-<!-- lore:019f7162-c2a3-7359-8472-63388c997300 -->
-* **Always verify PR merge success despite local cleanup failures**: User consistently merges PRs after confirming mergeable state and passing checks, but frequently encounters local cleanup failures due to background .lore.md modifications. The user expects the assistant to verify the remote merge succeeded on GitHub regardless of local issues, and to handle the local cleanup separately without blocking the merge process.
 
 <!-- lore:019f70a4-93ca-7b63-8ff1-277c6772b3b8 -->
 * **Assertion patterns should match correctly without consuming punctuation**: Assertion patterns should match correctly without consuming punctuation. User stated that the leading prose prefix is always kept during blob reduction. This is a directive preference.

--- a/.lore.md
+++ b/.lore.md
@@ -372,6 +372,9 @@
 <!-- lore:019f6fba-0d21-7410-894e-4933b29e8518 -->
 * **Always converges**: User stated: 'always converges'. This is a directive preference.
 
+<!-- lore:019f716d-0035-7814-8a96-93b98d738b7a -->
+* **Always enforce strict error classification rules**: The user consistently mandates precise error handling logic, particularly around worker capability classification. They emphasize that transient errors must never mark a capable model as 'worker-incapable', and false positives from regex matching must never permanently mislabel models. The user provides specific implementation rules and design principles to ensure errors are classified correctly, with particular attention to avoiding incorrect 'worker-incapable' states that could cause permanent mislabeling of functional models.
+
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
 * **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
 
@@ -383,9 +386,6 @@
 
 <!-- lore:019f6fd7-3931-76ae-93b7-cbcec8c69643 -->
 * **Always normalize to MIGRATIONS.length for database migrations**: Always normalize to MIGRATIONS.length for database migrations to ensure consistency. This was a directive preference.
-
-<!-- lore:019f715f-5bd4-7548-b9b5-06542a50fc86 -->
-* **Always perform read-only research before implementing changes**: The user consistently performs detailed read-only investigation before making any code modifications. They request comprehensive analysis of existing code structure, integration points, and potential implementation approaches without allowing any file modifications. The user expects precise file:line references, code excerpts, and concrete recommendations for the smallest correct implementation path. This pattern applies when adding new features or providers to complex codebases.
 
 <!-- lore:019f6f42-408e-7635-81d6-4d51ec94a3c9 -->
 * **Always prefer f-strings over .**: User stated always prefer f-strings over . This is a directive preference.
@@ -407,6 +407,9 @@
 
 <!-- lore:019f6fba-0dc9-787f-a62e-b86b43f939a0 -->
 * **Always valid for JSON**: User stated: 'always valid for JSON.' This is a directive preference.
+
+<!-- lore:019f7162-c2a3-7359-8472-63388c997300 -->
+* **Always verify PR merge success despite local cleanup failures**: User consistently merges PRs after confirming mergeable state and passing checks, but frequently encounters local cleanup failures due to background .lore.md modifications. The user expects the assistant to verify the remote merge succeeded on GitHub regardless of local issues, and to handle the local cleanup separately without blocking the merge process.
 
 <!-- lore:019f70a4-93ca-7b63-8ff1-277c6772b3b8 -->
 * **Assertion patterns should match correctly without consuming punctuation**: Assertion patterns should match correctly without consuming punctuation. User stated that the leading prose prefix is always kept during blob reduction. This is a directive preference.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -224,6 +224,7 @@ import {
 import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
 import { flushPendingImport } from "./pending-import";
+import { upstreamErrorHint } from "./upstream-error-hint";
 import { makeTemporalBackfillGate } from "./backfill-gate";
 import { buildSessionMetadata } from "./session-metadata";
 import {
@@ -8137,8 +8138,14 @@ async function handleConversationTurn(
 
   if (!upstreamResponse.ok) {
     const errorBody = await upstreamResponse.text();
+    const errorHint = upstreamErrorHint({
+      status: upstreamResponse.status,
+      body: errorBody,
+      protocol: effectiveProtocol,
+      credScheme: resolveAuth(sessionID)?.scheme,
+    });
     log.error(
-      `upstream error: ${upstreamResponse.status} ${errorBody.slice(0, 500)}`,
+      `upstream error: ${upstreamResponse.status} ${errorBody.slice(0, 500)}${errorHint}`,
     );
 
     // When the API rejects with a context-length error, escalate the compression

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -8138,6 +8138,12 @@ async function handleConversationTurn(
 
   if (!upstreamResponse.ok) {
     const errorBody = await upstreamResponse.text();
+    // Friendly diagnostic suffix for a pass-through 429 misread as a Lore bug.
+    // 🔴 credScheme is the LOAD-BEARING exclusion for Bedrock: Bedrock also
+    // reports effectiveProtocol === "anthropic", so the protocol gate does NOT
+    // exclude it — only its "api-key" scheme (x-api-key) does. Never drop the
+    // credScheme arg or hardcode it, or Bedrock 429s would misfire the
+    // "your Anthropic subscription's rate limit" hint.
     const errorHint = upstreamErrorHint({
       status: upstreamResponse.status,
       body: errorBody,

--- a/packages/gateway/src/upstream-error-hint.ts
+++ b/packages/gateway/src/upstream-error-hint.ts
@@ -1,0 +1,49 @@
+/**
+ * Human-friendly hints appended to upstream-error logs.
+ *
+ * Some upstream errors are routinely misread as Lore bugs. The clearest example:
+ * a `429 rate_limit_error` on an Anthropic OAuth (Claude subscription) session.
+ * Lore forwards the request verbatim exactly once and never retries a 429, so
+ * the limit is the user's subscription rate limit — but the bare log line
+ * (`upstream error: 429 {...}`) gives no signal of that, and users have reported
+ * it as a suspected Lore bug.
+ *
+ * This module produces a short clarifying suffix for such cases. It is purely
+ * diagnostic — it does NOT change pass-through behavior.
+ */
+
+export interface UpstreamErrorContext {
+  /** HTTP status from the upstream response. */
+  status: number;
+  /** Raw (possibly truncated) upstream error body. */
+  body: string;
+  /** Effective upstream protocol for this request (e.g. "anthropic"). */
+  protocol: string;
+  /**
+   * Auth scheme of the credential used for this turn, if known. OAuth/Claude
+   * subscription tokens authenticate as `"bearer"`; API keys as `"api-key"`.
+   */
+  credScheme?: "bearer" | "api-key";
+}
+
+/**
+ * Return a short, human-friendly hint to append to an upstream-error log line,
+ * or `""` when no hint applies.
+ *
+ * Currently covers exactly one case (kept deliberately narrow to avoid noise):
+ * an Anthropic `429 rate_limit_error` on a bearer (OAuth) credential.
+ */
+export function upstreamErrorHint(ctx: UpstreamErrorContext): string {
+  if (
+    ctx.status === 429 &&
+    ctx.protocol === "anthropic" &&
+    ctx.credScheme === "bearer" &&
+    /rate_limit_error/.test(ctx.body)
+  ) {
+    return (
+      " — this is your Anthropic subscription's rate limit, not a Lore issue. " +
+      "Lore forwarded this request once and did not retry."
+    );
+  }
+  return "";
+}

--- a/packages/gateway/src/upstream-error-hint.ts
+++ b/packages/gateway/src/upstream-error-hint.ts
@@ -32,6 +32,12 @@ export interface UpstreamErrorContext {
  *
  * Currently covers exactly one case (kept deliberately narrow to avoid noise):
  * an Anthropic `429 rate_limit_error` on a bearer (OAuth) credential.
+ *
+ * NOTE: Bedrock also reports `protocol === "anthropic"` but authenticates with
+ * an `x-api-key` (`api-key` scheme), so it is excluded by the `bearer` check —
+ * NOT by protocol. Known narrow limitation: routing an AWS Bedrock *bearer* API
+ * key (a newer, non-default mantle path) through a 429 could misfire this hint.
+ * That path is undocumented for mantle (which uses `x-api-key`) and low-risk.
  */
 export function upstreamErrorHint(ctx: UpstreamErrorContext): string {
   if (

--- a/packages/gateway/test/upstream-error-hint.test.ts
+++ b/packages/gateway/test/upstream-error-hint.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from "vitest";
+import { upstreamErrorHint } from "../src/upstream-error-hint";
+
+const RATE_LIMIT_BODY = JSON.stringify({
+  type: "error",
+  error: { type: "rate_limit_error", message: "Error" },
+  request_id: "req_011Cd4Lvq487jGTkCUBGJsia",
+});
+
+describe("upstreamErrorHint", () => {
+  test("anthropic 429 rate_limit_error on a bearer (OAuth) credential → friendly hint", () => {
+    const hint = upstreamErrorHint({
+      status: 429,
+      body: RATE_LIMIT_BODY,
+      protocol: "anthropic",
+      credScheme: "bearer",
+    });
+    expect(hint).toContain("Anthropic subscription's rate limit");
+    expect(hint).toContain("not a Lore issue");
+    expect(hint).toContain("forwarded this request once and did not retry");
+    // Must be a suffix (leading separator), never a standalone line.
+    expect(hint.startsWith(" — ")).toBe(true);
+  });
+
+  test("api-key credential → no hint (only OAuth/subscription tokens rate-limit this way)", () => {
+    expect(
+      upstreamErrorHint({
+        status: 429,
+        body: RATE_LIMIT_BODY,
+        protocol: "anthropic",
+        credScheme: "api-key",
+      }),
+    ).toBe("");
+  });
+
+  test("unknown credential scheme → no hint", () => {
+    expect(
+      upstreamErrorHint({
+        status: 429,
+        body: RATE_LIMIT_BODY,
+        protocol: "anthropic",
+        credScheme: undefined,
+      }),
+    ).toBe("");
+  });
+
+  test("non-anthropic protocol → no hint", () => {
+    expect(
+      upstreamErrorHint({
+        status: 429,
+        body: RATE_LIMIT_BODY,
+        protocol: "openai",
+        credScheme: "bearer",
+      }),
+    ).toBe("");
+  });
+
+  test("429 without rate_limit_error in body → no hint", () => {
+    expect(
+      upstreamErrorHint({
+        status: 429,
+        body: JSON.stringify({ error: { type: "overloaded_error" } }),
+        protocol: "anthropic",
+        credScheme: "bearer",
+      }),
+    ).toBe("");
+  });
+
+  test("non-429 status with rate_limit_error body → no hint", () => {
+    // A 400/500 that happens to mention rate_limit_error must not trigger it.
+    expect(
+      upstreamErrorHint({
+        status: 400,
+        body: RATE_LIMIT_BODY,
+        protocol: "anthropic",
+        credScheme: "bearer",
+      }),
+    ).toBe("");
+  });
+
+  test("all four conditions are required (matrix)", () => {
+    const base = {
+      status: 429,
+      body: RATE_LIMIT_BODY,
+      protocol: "anthropic",
+      credScheme: "bearer" as const,
+    };
+    // Baseline matches.
+    expect(upstreamErrorHint(base)).not.toBe("");
+    // Flip each condition individually — each flip must suppress the hint.
+    expect(upstreamErrorHint({ ...base, status: 500 })).toBe("");
+    expect(upstreamErrorHint({ ...base, protocol: "bedrock" })).toBe("");
+    expect(upstreamErrorHint({ ...base, credScheme: "api-key" })).toBe("");
+    expect(upstreamErrorHint({ ...base, body: "{}" })).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #1358.

## Problem

A `429 rate_limit_error` on an Anthropic **OAuth** (Claude subscription) session is routinely misread as a Lore bug. A real user (Pi extension) hit three back-to-back 429s across separate turns, read the bare log line, and reported it as a suspected bug:

```
[ERROR] upstream error: 429 {"type":"error","error":{"type":"rate_limit_error","message":"Error"},"request_id":"..."}
```

Lore forwards the request verbatim **once** and never retries a 429 (`pipeline.ts` returns the error straight to the client) — so the limit is the user's subscription rate limit, not a Lore issue. The bare log gives no signal of that.

## Change

Append a short clarifying suffix to the upstream-error log **only** in that specific case:

```
upstream error: 429 {...} — this is your Anthropic subscription's rate limit, not a Lore issue. Lore forwarded this request once and did not retry.
```

- New pure helper `upstream-error-hint.ts` (`upstreamErrorHint`), gated on **all** of: `status === 429`, `protocol === "anthropic"`, `credScheme === "bearer"` (OAuth), and body matches `/rate_limit_error/`. Returns `""` otherwise — kept deliberately narrow to avoid log noise.
- Wired into `pipeline.ts` at the single upstream-error log site; credential scheme read via `resolveAuth(sessionID)?.scheme`.
- **Log-only / diagnostic.** Does not change pass-through behavior (no retry, error still returned verbatim to the client). A client-visible variant can come later.

## Tests
`upstream-error-hint.test.ts` — the happy path plus each gating condition. All four AND conditions are **mutation-verified load-bearing** (dropping any one kills ≥2 tests).

## Verification
- `pnpm run typecheck` / `lint` / `format` — clean
- `pnpm exec vitest run` — **6047 passed**, 0 failures

## Notes
Follow-up to the investigation behind PR #1366 (deferred auto-import). Scope is exactly the friendly-429 hint; the `no auth credentials` cold-start warnings were addressed separately in #1366.