### PR TITLE
style(ci): format invariant-check report.mjs (oxfmt)

### DIFF
--- a/.github/actions/invariant-check/report.mjs
+++ b/.github/actions/invariant-check/report.mjs
@@ -20,7 +20,9 @@ let result;
 try {
   result = JSON.parse(readFileSync(path, "utf8"));
 } catch (e) {
-  console.log(`::notice title=Lore invariant-check::unreadable result (${String(e)})`);
+  console.log(
+    `::notice title=Lore invariant-check::unreadable result (${String(e)})`,
+  );
   process.exit(0);
 }
 


### PR DESCRIPTION
PR #1363 landed `.github/actions/invariant-check/report.mjs` with a line exceeding the oxfmt width. The **Format check** step is currently red on main (run for #1363 failed) and blocks every open PR.

One-line fix: wrap the over-long `console.log` call so `oxfmt --check` passes. No behavior change.