### PR TITLE
fix(sync): propagate remote registry-mirror deletions via authoritative snapshot (#1294)

### DIFF
--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -140,6 +140,17 @@ export interface SyncTableMeta {
    * hits the existing row (unique_violation 23505) is treated as already-synced. Defaults to false.
    */
   insertOnly?: boolean;
+  /**
+   * #1294: this pull-only mirror is refreshed by an AUTHORITATIVE FULL-SET SNAPSHOT each sync
+   * (`refreshRegistryMirror` in sync.ts → `replaceRegistryTable` here), NOT the keyset delta pull
+   * (which is skipped for it). The remote RLS result IS the member's complete current set for these
+   * tiny org/scope registry tables, so a row ABSENT from the snapshot means the membership was
+   * removed remotely (`remove_scope_member` hard-DELETEs, leaving no tombstone) → the local row is
+   * deleted. This is NOT the forbidden "reconcile-by-absence" of an evicted content table (where
+   * absence is ambiguous with local-cache eviction); here the small table is never evicted and the
+   * server returns the authoritative complete set. Implies pullOnly. Defaults to false.
+   */
+  mirrorSnapshot?: boolean;
 }
 
 /** ASCII Unit Separator — joins composite row ids (mirrors the SQL `char(31)`). */
@@ -432,6 +443,7 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       ftsTables: [],
       versioned: false,
       pullOnly: true,
+      mirrorSnapshot: true,
       syncColumns: [
         "id",
         "kind",
@@ -448,6 +460,7 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       ftsTables: [],
       versioned: false,
       pullOnly: true,
+      mirrorSnapshot: true,
       syncColumns: ["org_id", "user_id", "role", "created_at", "updated_at"],
     },
     {
@@ -456,6 +469,7 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       ftsTables: [],
       versioned: false,
       pullOnly: true,
+      mirrorSnapshot: true,
       syncColumns: [
         "id",
         "org_id",
@@ -472,6 +486,7 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
       ftsTables: [],
       versioned: false,
       pullOnly: true,
+      mirrorSnapshot: true,
       syncColumns: ["scope_id", "user_id", "role", "created_at", "updated_at"],
     },
   ],
@@ -1541,6 +1556,61 @@ export function applyRemoteUpsert(
     db()
       .query(sql)
       .run(...cols.map((c) => row[c] as never));
+  });
+}
+
+/**
+ * #1294: replace a pull-only registry mirror (orgs/org_members/scopes/scope_members) with the
+ * AUTHORITATIVE full set the server returned for this member. Upserts every remote row, then DELETEs
+ * any local row whose PK is not in the remote set — that is how a remote membership removal
+ * (`remove_scope_member` hard-DELETE, no tombstone) propagates to the local mirror WITHOUT client
+ * reconcile-by-absence of an evicted table (these are `mirrorSnapshot` tables: never evicted, and the
+ * RLS result IS the complete current set). Capture-suppressed so nothing is enqueued (pull-only).
+ * The local mirror tables carry NO cross-table FKs (db.ts), so per-table replacement is FK-safe.
+ */
+export function replaceRegistryTable(
+  table: string,
+  remoteRows: Record<string, unknown>[],
+): void {
+  const m = meta(table);
+  if (!m.mirrorSnapshot)
+    throw new Error(
+      `replaceRegistryTable: ${table} is not a mirrorSnapshot table`,
+    );
+  const idCols = m.idColumns;
+  withApplying(() => {
+    const conn = db();
+    // 1. Upsert every authoritative row.
+    for (const row of remoteRows) {
+      const cols = columns(table).filter(
+        (c) => !PAYLOAD_EXCLUDE.has(c) && c in row,
+      );
+      if (cols.length === 0) continue;
+      const placeholders = cols.map(() => "?").join(", ");
+      const nonPk = cols.filter((c) => !idCols.includes(c));
+      const onConflict =
+        nonPk.length > 0
+          ? `DO UPDATE SET ${nonPk.map((c) => `${c}=excluded.${c}`).join(", ")}`
+          : "DO NOTHING";
+      conn
+        .query(
+          `INSERT INTO ${table} (${cols.join(", ")}) VALUES (${placeholders}) ON CONFLICT(${idCols.join(", ")}) ${onConflict}`,
+        )
+        .run(...cols.map((c) => row[c] as never));
+    }
+    // 2. Delete local rows absent from the authoritative set. Build the keep-set of composite ids
+    //    (rowIdOf — the canonical ROW_SEP-joined PK builder) and scan the local table.
+    const keep = new Set(remoteRows.map((r) => rowIdOf(table, r)));
+    const localRows = conn
+      .query(`SELECT ${idCols.join(", ")} FROM ${table}`)
+      .all();
+    const del = conn.query(
+      `DELETE FROM ${table} WHERE ${idCols.map((c) => `${c} = ?`).join(" AND ")}`,
+    );
+    for (const lr of localRows) {
+      if (!keep.has(rowIdOf(table, lr)))
+        del.run(...idCols.map((c) => lr[c] as never));
+    }
   });
 }
 

--- a/packages/core/test/sync-data.test.ts
+++ b/packages/core/test/sync-data.test.ts
@@ -34,6 +34,7 @@ import {
   readOutbox,
   rebuildFts,
   reconcile,
+  replaceRegistryTable,
   rowIdOf,
   seedOutbox,
   setSyncState,
@@ -1464,5 +1465,96 @@ describe("tier-aware table selection (D-2, #826)", () => {
   test("metaFor resolves any registered table regardless of tier; throws for unknown", () => {
     expect(metaFor("knowledge").table).toBe("knowledge");
     expect(() => metaFor("not_a_table")).toThrow(/not a synced table/);
+  });
+});
+
+describe("replaceRegistryTable — authoritative snapshot replace (#1294)", () => {
+  const seedMember = (scope: string, user: string, role = "editor") =>
+    db()
+      .query(
+        "INSERT OR REPLACE INTO scope_members (scope_id, user_id, role, created_at, updated_at) VALUES (?,?,?,?,?)",
+      )
+      .run(scope, user, role, now(), now());
+  const localMembers = () =>
+    (
+      db()
+        .query(
+          "SELECT scope_id, user_id, role FROM scope_members ORDER BY user_id",
+        )
+        .all() as { scope_id: string; user_id: string; role: string }[]
+    ).map((r) => `${r.scope_id}/${r.user_id}/${r.role}`);
+
+  beforeEach(() => {
+    db().exec("DELETE FROM scope_members");
+    db().exec("DELETE FROM sync_outbox");
+  });
+
+  test("deletes local rows absent from the remote set, upserts the rest", () => {
+    seedMember("s1", "u-keep");
+    seedMember("s1", "u-removed"); // will be absent from the authoritative set → deleted
+    replaceRegistryTable("scope_members", [
+      {
+        scope_id: "s1",
+        user_id: "u-keep",
+        role: "admin", // role change is applied (upsert)
+        created_at: now(),
+        updated_at: now(),
+      },
+      {
+        scope_id: "s1",
+        user_id: "u-new", // a newly-added co-member → inserted
+        role: "viewer",
+        created_at: now(),
+        updated_at: now(),
+      },
+    ]);
+    expect(localMembers()).toEqual(["s1/u-keep/admin", "s1/u-new/viewer"]);
+  });
+
+  test("an empty authoritative set clears the whole local mirror", () => {
+    seedMember("s1", "u-a");
+    seedMember("s2", "u-b");
+    replaceRegistryTable("scope_members", []);
+    expect(localMembers()).toEqual([]);
+  });
+
+  test("is capture-suppressed — never enqueues an outbox row", () => {
+    // These registry tables have no production capture trigger (they're pull-only), so a naive
+    // "no outbox after replace" assertion would pass even if withApplying were removed (vacuous).
+    // Install a REAL-shaped capture trigger (gated on an empty _sync_applying, exactly like
+    // installSyncCapture's triggers) so this test is DISCRIMINATING: with withApplying present the
+    // trigger is suppressed (no outbox); drop the wrapper and it fires → the test fails.
+    db().exec(
+      "CREATE TEMP TABLE IF NOT EXISTS _sync_applying (marker INTEGER)",
+    );
+    db().exec(
+      `CREATE TEMP TRIGGER scope_members_test_outbox AFTER INSERT ON scope_members
+       WHEN (NOT EXISTS (SELECT 1 FROM temp._sync_applying))
+       BEGIN
+         INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
+         VALUES ('scope_members', new.scope_id || char(31) || new.user_id, 'upsert', 0);
+       END;`,
+    );
+    try {
+      db().exec("DELETE FROM sync_outbox");
+      replaceRegistryTable("scope_members", [
+        {
+          scope_id: "s1",
+          user_id: "u-new",
+          role: "editor",
+          created_at: now(),
+          updated_at: now(),
+        },
+      ]);
+      expect(readOutbox(0)).toHaveLength(0);
+    } finally {
+      db().exec("DROP TRIGGER IF EXISTS scope_members_test_outbox");
+    }
+  });
+
+  test("refuses a non-mirrorSnapshot table", () => {
+    expect(() => replaceRegistryTable("knowledge", [])).toThrow(
+      /not a mirrorSnapshot table/,
+    );
   });
 });

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -145,6 +145,15 @@ describe("SYNCED_TABLES registry contract", () => {
         expect(captured).toBe(expectsOwnTrigger);
       });
 
+      if (m.mirrorSnapshot) {
+        test("mirrorSnapshot implies pullOnly (#1294)", () => {
+          // refreshRegistryMirror DELETEs local rows absent from the remote authoritative set — only
+          // safe for a server-authoritative pull-only table. A pushable mirrorSnapshot table would
+          // have its own local writes wiped on the next pull.
+          expect(m.pullOnly).toBe(true);
+        });
+      }
+
       if (m.deleteInvisible) {
         test("a deleteInvisible table has NO DELETE capture trigger", () => {
           // deleteInvisible suppresses reconcile's delete-tombstone pass, but a DELETE

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -755,6 +755,11 @@ export async function pullOnce(
     const touchedFts = new Set<string>();
     let cursor = parseCursor(getKV(pullKey(meta.table)));
 
+    // #1294: registry mirrors (orgs/scopes/members) are NOT keyset-pulled here — they are
+    // authoritatively snapshot-replaced by refreshRegistryMirror after this loop (so a remote
+    // membership removal, which leaves no tombstone, propagates as a local delete). Skip them.
+    if (meta.mirrorSnapshot) continue;
+
     // C-4 (#825): resolve the encryption snapshot for an encrypted table. "locked"
     // (escrow present, not unlocked) → skip the table entirely, leaving its cursor
     // frozen so it re-pulls after unlock (never storing ciphertext as content). The
@@ -1234,6 +1239,51 @@ async function reportDeviceProgress(client: SupabaseClient): Promise<void> {
   }
 }
 
+/**
+ * #1294: refresh the pull-only registry mirrors (orgs/org_members/scopes/scope_members) by
+ * AUTHORITATIVE SNAPSHOT. For each `mirrorSnapshot` table, fetch the member's complete RLS-scoped
+ * set from the remote and replace the local mirror (upsert-all + delete-absent, capture-suppressed).
+ * This is how a remote membership removal (`remove_scope_member` hard-DELETEs → no tombstone → the
+ * keyset delta pull can never see it) propagates to the local mirror, without the forbidden
+ * reconcile-by-absence of an evicted content table (these tiny tables are never evicted, and the RLS
+ * result IS the complete current set). Runs BEFORE reconcileScopeWraps so an admin never re-wraps a
+ * DEK to a member who was just removed. Best-effort: a failure logs and leaves the stale mirror in
+ * place (cosmetic — RLS + DEK rotation remain the real access gate) to retry next tick.
+ */
+export async function refreshRegistryMirror(
+  client: SupabaseClient,
+): Promise<void> {
+  const PAGE = 1000; // registry tables are tiny; a page cap is pure defense-in-depth.
+  for (const meta of syncData.syncedTablesFor(syncData.currentSyncTier())) {
+    if (!meta.mirrorSnapshot) continue;
+    try {
+      const rows: Array<Record<string, unknown>> = [];
+      for (let from = 0; ; from += PAGE) {
+        const { data, error } = await client
+          .from(meta.table)
+          .select("*")
+          .range(from, from + PAGE - 1);
+        if (error) throw new Error(error.message);
+        const page = (data ?? []) as Array<Record<string, unknown>>;
+        // stripSyncCols drops the remote-only tenant columns AND converts the ISO timestamptz
+        // strings to the epoch-ms integers the local schema stores (symmetry with the keyset pull's
+        // applyRemote path). scope_members.scope_id is half the PK → keep it (SCOPE_MEMBER_KEEP).
+        const keep =
+          meta.table === "scope_members" ? SCOPE_MEMBER_KEEP : undefined;
+        for (const r of page) rows.push(stripSyncCols(r, keep));
+        if (page.length < PAGE) break;
+      }
+      syncData.replaceRegistryTable(meta.table, rows);
+    } catch (e) {
+      // A partial/failed fetch must NOT delete the local mirror (we'd lose valid rows). Skip this
+      // table this cycle; the next successful refresh reconciles it.
+      log.info(
+        `sync: registry mirror ${meta.table} refresh skipped: ${(e as Error).message}`,
+      );
+    }
+  }
+}
+
 const IDENTITY_PUB_KV = "sync.identityPub"; // base64 of the last-published public key
 
 /**
@@ -1392,6 +1442,18 @@ export async function syncOnce(
   } catch (e) {
     log.notice(
       `sync: project convergence deferred — ${(e as Error).message ?? e}`,
+    );
+  }
+  // #1294: refresh the org/scope registry mirrors by authoritative snapshot so a remote membership
+  // removal propagates locally. BEFORE reconcileScopeWraps (which reads the local scope_members
+  // mirror to decide who to re-wrap the DEK to) so a just-removed member is never re-wrapped.
+  // Best-effort: the per-table failures are caught inside; this outer guard covers a throw from the
+  // loop header (tier resolution) so it can never abort the rest of the cycle — retried next tick.
+  try {
+    await refreshRegistryMirror(client);
+  } catch (e) {
+    log.notice(
+      `sync: registry mirror refresh deferred — ${(e as Error).message ?? e}`,
     );
   }
   const tierAfter = syncData.currentSyncTier();

--- a/packages/gateway/test/sync-engine.integration.test.ts
+++ b/packages/gateway/test/sync-engine.integration.test.ts
@@ -33,7 +33,12 @@ import {
   it,
   vi,
 } from "vitest";
-import { publishIdentityPub, pullOnce, pushOnce } from "../src/sync";
+import {
+  publishIdentityPub,
+  pullOnce,
+  pushOnce,
+  refreshRegistryMirror,
+} from "../src/sync";
 import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
 
 // The engine drives real supabase-js clients we pass in explicitly, but the encryption
@@ -436,20 +441,16 @@ describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
     expect((await pushOnce(clientFor(uid))).pushed).toBe(0);
   });
 
-  it("mirrors the member's org/scope registry on pull (E-5 foundation, #827)", async () => {
+  it("mirrors the member's org/scope registry on refresh (E-5 foundation, #827)", async () => {
     // A team scope + the caller's admin membership, created server-side by the lifecycle RPC.
     const scopeId = await h.asUser(uid, (c) =>
       c
         .query("select public.create_team($1) as s", ["Rockets"])
         .then((r) => r.rows[0].s),
     );
-    // Opt in to pulling the (pull-only, otherwise parked) registry mirrors.
-    for (const t of ["orgs", "org_members", "scopes", "scope_members"]) {
-      setKV(`sync.pull.${t}`, "0|");
-    }
     syncData.enableSync("basic");
-    const r = await pullOnce(clientFor(uid));
-    expect(r.conflicts).toBe(0);
+    // #1294: the registry mirrors are refreshed by authoritative snapshot, not the keyset pull.
+    await refreshRegistryMirror(clientFor(uid));
 
     // The new team scope + the caller's admin membership are mirrored locally.
     expect(
@@ -468,8 +469,8 @@ describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
           .get(scopeId, uid) as { role?: string } | undefined
       )?.role,
     ).toBe("admin");
-    // The WHOLE registry pulls, not just the team: the personal scope (id == user id) too,
-    // plus the org it belongs to — proving the pull is not team-only.
+    // The WHOLE registry mirrors, not just the team: the personal scope (id == user id) too,
+    // plus the org it belongs to — proving the refresh is not team-only.
     expect(
       (
         db().query("SELECT kind FROM scopes WHERE id=?").get(uid) as
@@ -491,9 +492,71 @@ describe.skipIf(SKIP)("sync engine ↔ real Postgres/PostgREST", () => {
       )?.promotion_policy,
     ).toBe("manual");
 
-    // Idempotent + pull-only: a second pull mirrors nothing new, a push is a no-op.
-    expect((await pullOnce(clientFor(uid))).pulled).toBe(0);
+    // The ISO timestamptz strings from PostgREST are normalized to epoch-ms INTEGERs locally
+    // (via stripSyncCols, matching the keyset pull) — not stored as raw ISO text (#1294/#1372 review).
+    const ts = db()
+      .query("SELECT created_at, updated_at FROM scopes WHERE id=?")
+      .get(scopeId) as { created_at?: unknown; updated_at?: unknown };
+    expect(typeof ts.created_at).toBe("number");
+    expect(typeof ts.updated_at).toBe("number");
+    expect(ts.updated_at as number).toBeGreaterThan(1_000_000_000_000); // plausible epoch-ms
+
+    // Idempotent + pull-only: a second refresh keeps the same rows, a push is a no-op.
+    await refreshRegistryMirror(clientFor(uid));
+    expect(
+      (
+        db()
+          .query(
+            "SELECT role FROM scope_members WHERE scope_id=? AND user_id=?",
+          )
+          .get(scopeId, uid) as { role?: string } | undefined
+      )?.role,
+    ).toBe("admin");
     expect((await pushOnce(clientFor(uid))).pushed).toBe(0);
+  });
+
+  it("propagates a remote membership removal to the local mirror on refresh (#1294)", async () => {
+    // Admin (uid) creates a team and adds a second member (other); both mirror locally.
+    const other = await h.createUser("removed-member@test.dev");
+    const scopeId = await h.asUser(uid, (c) =>
+      c
+        .query("select public.create_team($1) as s", ["Comets"])
+        .then((r) => r.rows[0].s),
+    );
+    await h.asUser(uid, (c) =>
+      c.query("select public.add_scope_member($1,$2,'editor')", [
+        scopeId,
+        other,
+      ]),
+    );
+    syncData.enableSync("basic");
+    await refreshRegistryMirror(clientFor(uid));
+    const memberCount = () =>
+      (
+        db()
+          .query("SELECT COUNT(*) n FROM scope_members WHERE scope_id=?")
+          .get(scopeId) as { n: number }
+      ).n;
+    expect(memberCount()).toBe(2); // admin + other
+
+    // Admin removes `other` remotely (hard DELETE, no tombstone — the keyset pull could never see it).
+    await h.asUser(uid, (c) =>
+      c.query("select public.remove_scope_member($1,$2)", [scopeId, other]),
+    );
+    // The next authoritative refresh deletes the now-absent local row.
+    await refreshRegistryMirror(clientFor(uid));
+    expect(memberCount()).toBe(1); // only the admin remains
+    expect(
+      db()
+        .query("SELECT 1 FROM scope_members WHERE scope_id=? AND user_id=?")
+        .get(scopeId, other),
+    ).toBeNull();
+    // The admin's own membership survives (not wrongly reaped by the delete-absent pass).
+    expect(
+      db()
+        .query("SELECT 1 FROM scope_members WHERE scope_id=? AND user_id=?")
+        .get(scopeId, uid),
+    ).toBeDefined();
   });
 
   it("pulls ALL rows when many share one updated_at (>page is internal; correctness here)", async () => {


### PR DESCRIPTION
Closes #1294 (E-5-F1 registry-mirror follow-up).

## Gap
The pull-only registry mirrors (`orgs`/`org_members`/`scopes`/`scope_members`, #1290) had **no remote-delete propagation**. `remove_scope_member` (0029) hard-DELETEs remotely with no tombstone, and the keyset delta pull can never observe an absence — so a removed member's local mirror row **persisted forever**. Cosmetic today (RLS + group-DEK rotation are the real access gate), but now that **F2 onboarding (#1310) reads the mirror**, a stale row would surface a scope the user was removed from.

## Fix — authoritative full-set snapshot replace (issue's Option 2)
These four tables are tiny and fully RLS-scoped to the member, so the server's RLS result **is** the member's complete current set. New `mirrorSnapshot` flag on their `SyncTableMeta`:
- `pullOnce` **skips** them from the keyset delta loop;
- `refreshRegistryMirror(client)` fetches each table's full RLS set and calls `replaceRegistryTable` — **upsert-all + delete-absent, capture-suppressed**;
- runs in `syncOnce` after `pullOnce` and **before `reconcileScopeWraps`** (so an admin never re-wraps a DEK to a just-removed member).

This is **not** the forbidden reconcile-by-absence of an *evicted* content table (where absence is ambiguous with local-cache eviction): mirrorSnapshot tables are never evicted and the RLS result is authoritative. A partial/failed fetch **skips** the table (never deletes) and retries next tick. Local mirror tables carry no cross-table FKs → per-table replacement is FK-safe.

## Tests
- **Tier-2** (sync-engine integration): remove member remotely → next refresh → local row gone, **admin's own row survives** (the acceptance criterion). Existing registry-mirror test rewired `pullOnce`→`refreshRegistryMirror`.
- **Unit** (sync-data): `replaceRegistryTable` deletes-absent/upserts-rest, empty set clears the mirror, capture-suppressed (no outbox), refuses a non-mirrorSnapshot table.
- **registry-contract**: `mirrorSnapshot` implies `pullOnly`.

No schema change. Full suite green (5957); typecheck/lint/format clean. Part of epic #827.