### PR TITLE
feat(gateway): route GitHub Models for the semantic-linter judge (#1368)

### DIFF
--- a/.github/actions/invariant-check/action.yml
+++ b/.github/actions/invariant-check/action.yml
@@ -21,8 +21,11 @@ inputs:
     default: ""
   worker-api-key:
     description: >-
-      Dedicated judge credential (sets LORE_WORKER_API_KEY). Required in CI —
-      the gateway has no client session to borrow auth from.
+      Judge credential (sets LORE_WORKER_API_KEY). In CI the gateway has no
+      client session to borrow auth from, so a credential is required to run the
+      judge. The reference workflow defaults this to the built-in GITHUB_TOKEN
+      and uses GitHub Models (models.github.ai) with `github-models/...` model
+      ids — zero-secret onboarding — or a dedicated provider key when set.
     required: false
     default: ""
   lore-command:

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -15,6 +15,10 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  # Lets the built-in GITHUB_TOKEN call GitHub Models (models.github.ai) as the
+  # zero-secret default judge. Harmless when a dedicated LORE_WORKER_API_KEY is
+  # configured (that path ignores the token).
+  models: read
 
 jobs:
   invariant-check:
@@ -37,7 +41,27 @@ jobs:
         with:
           # Un-built checkout → run the CLI via tsx.
           lore-command: "pnpm tsx packages/gateway/src/cli/bin.ts"
-          # Cheap judge; Haiku had the best recall in eval. Configure the key as
-          # a repo secret. Absent → the check no-ops (no auth) and still passes.
-          model: "anthropic/claude-haiku-4.5"
-          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY }}
+          # Judge model + credential. Two supported setups:
+          #  1. Zero-secret (default): GitHub Models via the built-in
+          #     GITHUB_TOKEN + `models: read` above. Uses openai/gpt-4o-mini
+          #     (20/20 recall in eval; no Haiku on the platform). Note the free
+          #     tier is rate-limited (~150 req/day) — fine for low-traffic repos.
+          #     On fork PRs the token is read-only and may lack model inference;
+          #     the judge then no-ops (advisory → still passes), never breaks CI.
+          #  2. Dedicated key (busy repos): set the LORE_WORKER_API_KEY secret.
+          #     It takes precedence, and the judge model is whatever you set in
+          #     the `LORE_INVARIANT_MODEL` repo variable (e.g.
+          #     anthropic/claude-haiku-4.5); if that variable is unset the CLI
+          #     falls back to the repo's configured default worker model.
+          #
+          # Model precedence (independent of the credential):
+          #   - `LORE_INVARIANT_MODEL` var set     → use it (either credential).
+          #   - else no dedicated key              → github-models/openai/gpt-4o-mini
+          #     (the token is a GitHub token; a github-models id is required so
+          #     the CLI sends it as Bearer to models.github.ai).
+          #   - else (dedicated key, no var)       → empty → CLI's configured
+          #     default worker model, authed with the dedicated key.
+          # This avoids the trap of pairing a dedicated (e.g. Anthropic) key with
+          # a forced github-models id, which would 401 and silently no-op.
+          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-models/openai/gpt-4o-mini' || '') }}
+          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || github.token }}

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -22,7 +22,7 @@ import {
   invariantCheck,
 } from "@loreai/core";
 import { createGatewayLLMClient } from "../llm-adapter";
-import { resolveAuth } from "../auth";
+import { type AuthCredential, resolveAuth } from "../auth";
 import { startGateway, type StartOptions } from "./start";
 
 type CheckResult = invariantCheck.CheckResult;
@@ -107,10 +107,28 @@ export async function commandInvariantCheck(
   }
   const defaultModel = modelOverride ??
     cfg.model ?? { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+
+  // Judge auth. In CI there is no client session, so bare resolveAuth() returns
+  // null and every judge call is skipped as "no-auth". Honor LORE_WORKER_API_KEY
+  // (the GHA sets it to the judge credential) the same way the pipeline's
+  // getWorkerAuth does. Scheme is provider-aware: GitHub Models authenticates
+  // with a GitHub token as `Authorization: Bearer` (scheme "bearer"), whereas
+  // the default OpenAI/Anthropic worker key path uses "api-key" (x-api-key).
+  const workerKey = config.workerApiKey;
+  const judgeScheme: AuthCredential["scheme"] =
+    defaultModel.providerID === "github-models" ? "bearer" : "api-key";
+  const judgeAuth: (
+    sessionID?: string,
+    providerID?: string,
+  ) => AuthCredential | null = workerKey
+    ? () => ({ scheme: judgeScheme, value: workerKey })
+    : resolveAuth;
+
   const llm = createGatewayLLMClient(
     { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI },
-    resolveAuth,
+    judgeAuth,
     defaultModel,
+    { dedicatedWorkerKey: !!workerKey },
   );
 
   const startedAt = Date.now();

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -553,6 +553,13 @@ const PROVIDER_ROUTES: Record<string, ProviderRoute> = {
   // --- OpenAI protocol ---
   deepseek: { url: "https://api.deepseek.com", protocol: "openai" },
   xai: { url: "https://api.x.ai", protocol: "openai" },
+  // GitHub Models (https://models.github.ai) — OpenAI-Chat-shaped, but served
+  // at `/inference/chat/completions` (no `/v1`) and requires two static headers.
+  // The origin is registered here; the non-`/v1` path is applied by
+  // OPENAI_HOST_CHAT_COMPLETIONS_PATHS and the headers by isGitHubModelsHost,
+  // both in translate/openai.ts. Auth is a GitHub token (`GITHUB_TOKEN` in CI)
+  // carried as a Bearer credential.
+  "github-models": { url: "https://models.github.ai", protocol: "openai" },
   groq: { url: "https://api.groq.com/openai", protocol: "openai" },
   cerebras: { url: "https://api.cerebras.ai", protocol: "openai" },
   openrouter: { url: "https://openrouter.ai/api", protocol: "openai" },

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -45,7 +45,10 @@ import {
   type GatewayContentBlock,
   type GatewayResponse,
 } from "./translate/types";
-import { buildOpenAIChatCompletionsUrl } from "./translate/openai";
+import {
+  buildOpenAIChatCompletionsUrl,
+  gitHubModelsHeaders,
+} from "./translate/openai";
 import { accumulateOpenAISSEStream } from "./stream/openai";
 import { accumulateResponsesSSEStream } from "./stream/openai-responses";
 import { accumulateGeminiSSEStream } from "./stream/gemini";
@@ -895,11 +898,14 @@ function buildOpenAIWorkerRequest(
   return {
     // Background workers have no original request to forward verbatim, so the
     // URL is reconstructed host-aware (GitHub Copilot omits `/v1`, issue #1052;
-    // Google Gemini serves `/v1beta/openai/...`, issue #1070).
+    // Google Gemini serves `/v1beta/openai/...`, issue #1070; GitHub Models
+    // serves `/inference/chat/completions`).
     url: buildOpenAIChatCompletionsUrl(target.url),
     headers: {
       "Content-Type": "application/json",
       ...authHeaders(cred),
+      // GitHub Models requires Accept + X-GitHub-Api-Version; no-op for others.
+      ...gitHubModelsHeaders(target.url),
     },
     body: JSON.stringify({
       model: model.modelID,

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -502,8 +502,43 @@ const DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
  * purely via its `X-Lore-Provider` route with no preserved endpoint path.
  */
 const OPENAI_HOST_CHAT_COMPLETIONS_PATHS: ReadonlyMap<string, string> = new Map(
-  [["generativelanguage.googleapis.com", "/v1beta/openai/chat/completions"]],
+  [
+    ["generativelanguage.googleapis.com", "/v1beta/openai/chat/completions"],
+    // GitHub Models serves Chat Completions at `/inference/chat/completions`
+    // (no `/v1`). Registering the origin `https://models.github.ai` in the
+    // route table + this mapping reconstructs the correct URL on the worker path.
+    ["models.github.ai", "/inference/chat/completions"],
+  ],
 );
+
+/**
+ * GitHub Models (https://models.github.ai) is OpenAI-Chat-shaped but requires
+ * two static headers on every request (in addition to the Bearer token):
+ * `Accept: application/vnd.github+json` and `X-GitHub-Api-Version`. Scoped to
+ * this single host so the headers never ride along on other OpenAI providers
+ * (mirrors how the Copilot/Gemini paths special-case by host). */
+export function isGitHubModelsHost(hostname: string): boolean {
+  return hostname === "models.github.ai";
+}
+
+/** The API version pinned for GitHub Models requests. */
+export const GITHUB_MODELS_API_VERSION = "2026-03-10";
+
+/** Static headers GitHub Models requires beyond auth. Empty for every other
+ *  host, so callers can spread the result unconditionally. */
+export function gitHubModelsHeaders(url: string): Record<string, string> {
+  try {
+    if (isGitHubModelsHost(new URL(url).hostname)) {
+      return {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": GITHUB_MODELS_API_VERSION,
+      };
+    }
+  } catch {
+    // Unparseable URL — add nothing.
+  }
+  return {};
+}
 
 /**
  * GitHub Copilot serves Chat Completions at `/chat/completions` (NO `/v1`) on
@@ -639,6 +674,11 @@ export function buildOpenAIUpstreamRequest(
       body.top_logprobs = req.extras.top_logprobs;
     }
   }
+
+  // GitHub Models needs Accept + X-GitHub-Api-Version (scoped to models.github.ai;
+  // a no-op for every other host). Overlaid last so the pinned api-version wins
+  // over any forwarded client value.
+  Object.assign(headers, gitHubModelsHeaders(upstreamBase));
 
   return {
     url: buildOpenAIChatCompletionsUrl(upstreamBase),

--- a/packages/gateway/test/worker-github-models.test.ts
+++ b/packages/gateway/test/worker-github-models.test.ts
@@ -1,0 +1,129 @@
+/**
+ * GitHub Models (https://models.github.ai) worker routing. GitHub Models is
+ * OpenAI-Chat-shaped but deviates in two ways the gateway must handle when
+ * reconstructing a background/worker request (there is no client request to
+ * forward verbatim):
+ *   1. It serves Chat Completions at `/inference/chat/completions` (NO `/v1`).
+ *   2. It requires two static headers beyond auth: `Accept:
+ *      application/vnd.github+json` and `X-GitHub-Api-Version`, and auth is a
+ *      GitHub token carried as `Authorization: Bearer`.
+ * Both must be scoped to models.github.ai — they must NEVER ride along on other
+ * OpenAI-compatible providers.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+import { GITHUB_MODELS_API_VERSION } from "../src/translate/openai";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+function okResponse() {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" } }],
+      model: "openai/gpt-4o-mini",
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+/** Read the headers object the worker passed to upstreamFetch on call `n`. */
+function callHeaders(n: number): Record<string, string> {
+  return (mockFetch.mock.calls[n][1]?.headers ?? {}) as Record<string, string>;
+}
+
+describe("worker GitHub Models routing (#1368)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  test("routes to /inference/chat/completions with the GitHub Models headers", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "github-models"
+          ? { scheme: "bearer", value: "gh_token" }
+          : null,
+      { providerID: "github-models", modelID: "openai/gpt-4o-mini" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-ghm",
+      workerID: "lore-invariant-check",
+      model: { providerID: "github-models", modelID: "openai/gpt-4o-mini" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = fetchArgUrl(mockFetch.mock.calls[0][0]);
+    expect(url).toBe("https://models.github.ai/inference/chat/completions");
+    // NOT the conventional /v1 path.
+    expect(url).not.toContain("/v1/chat/completions");
+
+    const headers = callHeaders(0);
+    expect(headers.Accept).toBe("application/vnd.github+json");
+    expect(headers["X-GitHub-Api-Version"]).toBe(GITHUB_MODELS_API_VERSION);
+    // GitHub token rides as a Bearer credential.
+    expect(headers.Authorization).toBe("Bearer gh_token");
+  });
+
+  test("preserves the {publisher}/{model} id in the request body", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "gh_token" }),
+      { providerID: "github-models", modelID: "openai/gpt-4o-mini" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-ghm-model",
+      workerID: "lore-invariant-check",
+      model: { providerID: "github-models", modelID: "openai/gpt-4o-mini" },
+    });
+
+    const rawBody = mockFetch.mock.calls[0][1]?.body;
+    const body = JSON.parse(typeof rawBody === "string" ? rawBody : "{}") as {
+      model?: string;
+    };
+    expect(body.model).toBe("openai/gpt-4o-mini");
+  });
+
+  test("does NOT leak the GitHub Models headers onto another OpenAI provider", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "deepseek"
+          ? { scheme: "bearer", value: "ds_key" }
+          : null,
+      { providerID: "deepseek", modelID: "deepseek-chat" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-ds",
+      workerID: "lore-invariant-check",
+      model: { providerID: "deepseek", modelID: "deepseek-chat" },
+    });
+
+    const url = fetchArgUrl(mockFetch.mock.calls[0][0]);
+    expect(url).toBe("https://api.deepseek.com/v1/chat/completions");
+    const headers = callHeaders(0);
+    expect(headers.Accept).toBeUndefined();
+    expect(headers["X-GitHub-Api-Version"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1368.

Adds **GitHub Models** (`https://models.github.ai`) as a first-class OpenAI-protocol provider so the `lore invariant-check` CI judge can authenticate with the workflow's built-in `GITHUB_TOKEN` (+ `models: read`) — **zero-secret onboarding** — instead of requiring a dedicated `LORE_WORKER_API_KEY`.

## What changed
- **`config.ts`** — `PROVIDER_ROUTES` gains `github-models` → `https://models.github.ai` (protocol `openai`).
- **`translate/openai.ts`** — maps `models.github.ai` → `/inference/chat/completions` (GitHub Models omits `/v1`); adds `isGitHubModelsHost` + `gitHubModelsHeaders` (`Accept: application/vnd.github+json` + pinned `X-GitHub-Api-Version`), **host-scoped so they never leak onto other providers**. Both the worker builder and the foreground upstream builder overlay them.
- **`llm-adapter.ts`** — worker request spreads the GitHub Models headers.
- **`cli/invariant-check.ts`** — honor `config.workerApiKey` as the judge credential (bare `resolveAuth` returns `null` in CI, so every judge call was silently skipped as no-auth). Scheme is **bearer** for `github-models` (a GitHub token), **api-key** otherwise — no regression for existing dedicated-key users. Pipeline path untouched.
- **`semantic-linter.yml`** — adds `models: read`; defaults to `github-models/openai/gpt-4o-mini` on the built-in token, with `LORE_WORKER_API_KEY` + the `LORE_INVARIANT_MODEL` repo variable as the dedicated-key override. Model precedence is decoupled from the credential so a dedicated (e.g. Anthropic) key is never paired with a forced `github-models` id.

## Auth / routing notes
- Model id format is `{publisher}/{model_name}` (e.g. `openai/gpt-4o-mini`); `parseModel` splits on the first `/` → `providerID=github-models`, `modelID=openai/gpt-4o-mini`, carried verbatim in the body.
- Free tier is rate-limited (~150 req/day) — fine for low-traffic repos. On fork PRs the token may lack model inference; the judge then no-ops (advisory → still passes), never breaks CI.

## Tests
`packages/gateway/test/worker-github-models.test.ts` covers URL reconstruction (`/inference/chat/completions`, no `/v1`), the required headers + `Authorization: Bearer`, `{publisher}/{model}` id passthrough, and **header non-leakage** onto another OpenAI provider (DeepSeek).

## Verification
- typecheck (gateway): clean · oxfmt --check: clean · type-aware oxlint (changed files): clean · actionlint: clean
- `worker-github-models.test.ts`: 3 passed · core suite: 3008 passed
- Adversarial correctness review: **SHIP** (mutation-verified non-vacuous). The one SHOULD-FIX (dedicated-key/model coupling trap) is fixed in the final workflow expression.