### PR TITLE
fix(supabase): detach team-org ownership on account deletion (#1314 part 1)

### DIFF
--- a/packages/gateway/test/sync-team-owner-detach.integration.test.ts
+++ b/packages/gateway/test/sync-team-owner-detach.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration tests for migration 0047 — team-org ownership survives its provisioner's account
+ * deletion (#1314 part 1, E-5-a durability). Against a real Postgres with FKs/triggers enforced.
+ *
+ * Proves:
+ *  - Deleting a TEAM org's owner (the arbitrary provisioner) DETACHES the org (owner_user_id → NULL)
+ *    and leaves the org + its scope + its content INTACT for the remaining members (the fix — under
+ *    the old ON DELETE CASCADE this wiped the whole team).
+ *  - Deleting a PERSONAL org's owner still hard-removes the personal org → scope → content (behavior
+ *    preserved, now via the BEFORE DELETE trigger rather than the FK cascade).
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-team-owner-detach.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+beforeAll(async () => {
+  if (!SKIP) h = await startPgHarness();
+}, 180_000);
+afterAll(async () => {
+  if (h) await h.stop();
+});
+const gate = () => SKIP;
+
+describe.skipIf(gate())(
+  "migration 0047 — team-org owner detach on account deletion (#1314)",
+  () => {
+    it("detaches a team org (owner→NULL) and preserves its scope + content when the owner is deleted", async () => {
+      // Owner provisions a team; a second member joins and content lands in the team scope.
+      const owner = await h.createUser("owner@acme.dev");
+      const member = await h.createUser("member@acme.dev");
+      const scope = await h.asUser(owner, (c) =>
+        c
+          .query("select public.create_team($1) s", ["Rockets"])
+          .then((r) => r.rows[0].s),
+      );
+      await h.asUser(owner, (c) =>
+        c.query("select public.add_scope_member($1,$2,'editor')", [
+          scope,
+          member,
+        ]),
+      );
+      const orgId = (
+        await h.client.query("select org_id from public.scopes where id=$1", [
+          scope,
+        ])
+      ).rows[0].org_id;
+      // Content in the TEAM scope (author = member, so it does not ride the owner's cascade path).
+      await h.asUser(member, (c) =>
+        c.query(
+          "insert into public.knowledge (id, scope_id, category, title, content) values ('k-team',$1,'p','T','C')",
+          [scope],
+        ),
+      );
+
+      // Delete the org's owner/provisioner.
+      await h.client.query("delete from auth.users where id=$1", [owner]);
+
+      // The team org SURVIVES, now detached (owner_user_id → NULL).
+      const org = (
+        await h.client.query(
+          "select owner_user_id, kind from public.orgs where id=$1",
+          [orgId],
+        )
+      ).rows;
+      expect(org).toHaveLength(1);
+      expect(org[0].kind).toBe("team");
+      expect(org[0].owner_user_id).toBeNull();
+      // Its scope and content survive for the remaining member.
+      expect(
+        (
+          await h.client.query("select 1 from public.scopes where id=$1", [
+            scope,
+          ])
+        ).rowCount,
+      ).toBe(1);
+      expect(
+        (
+          await h.client.query(
+            "select 1 from public.knowledge where id='k-team'",
+          )
+        ).rowCount,
+      ).toBe(1);
+      // The remaining member's own membership row is intact.
+      expect(
+        (
+          await h.client.query(
+            "select role from public.scope_members where scope_id=$1 and user_id=$2",
+            [scope, member],
+          )
+        ).rows[0]?.role,
+      ).toBe("editor");
+    });
+
+    it("still hard-removes a personal org → scope → content when its owner is deleted (behavior preserved)", async () => {
+      const uid = await h.createUser("personal@acme.dev");
+      // Personal scope id == user id (E-1). Insert content into it.
+      await h.asUser(uid, (c) =>
+        c.query(
+          "insert into public.knowledge (id, category, title, content) values ('k-personal','p','T','C')",
+        ),
+      );
+      await h.client.query("delete from auth.users where id=$1", [uid]);
+
+      // The personal org, its scope, and its content are all gone (cascade via the BEFORE DELETE
+      // trigger — same outcome as the old FK cascade).
+      expect(
+        (
+          await h.client.query(
+            "select 1 from public.orgs where owner_user_id=$1 and kind='personal'",
+            [uid],
+          )
+        ).rowCount,
+      ).toBe(0);
+      expect(
+        (await h.client.query("select 1 from public.scopes where id=$1", [uid]))
+          .rowCount,
+      ).toBe(0);
+      expect(
+        (
+          await h.client.query(
+            "select 1 from public.knowledge where id='k-personal'",
+          )
+        ).rowCount,
+      ).toBe(0);
+    });
+  },
+);

--- a/supabase/migrations/0047_team_org_owner_detach.sql
+++ b/supabase/migrations/0047_team_org_owner_detach.sql
@@ -1,0 +1,54 @@
+-- Migration 0047 — team-org ownership survives its provisioner's account deletion (#1314 part 1,
+-- E-5-a durability). Pre-GA gate before any content lands in a team scope.
+--
+-- Problem: `orgs.owner_user_id` was `NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE`. For a
+-- PERSONAL org that cascade is correct (deleting a user removes their own org → scope → content).
+-- But for a TEAM org, `owner_user_id` is NOT an authz axis (all gates use is_org_member/org_role/
+-- scope_role) — it is just the arbitrary first provisioner (a plain GitHub member for a mirrored
+-- org, or the create_team caller). If THAT user deletes their account, the whole team org → all its
+-- scopes → all team content cascade-delete FOR EVERY OTHER MEMBER. That is a data-loss footgun.
+--
+-- Fix: detach a team org from its owner on user deletion instead of cascading.
+--   1. `owner_user_id` becomes NULLABLE and the FK becomes `ON DELETE SET NULL` — so deleting a
+--      user leaves their team orgs intact (owner_user_id → NULL; the org, scopes, and content
+--      survive for the remaining members).
+--   2. A `BEFORE DELETE ON auth.users` trigger still HARD-DELETES that user's PERSONAL org first
+--      (its unique 1:1 owner), which cascades to the personal scope + content — preserving the
+--      prior, correct personal-data-removal behavior. The trigger runs before the FK's SET NULL, so
+--      only team orgs reach the SET NULL path.
+--
+-- Invariants preserved: the unique partial index `(owner_user_id) WHERE kind='personal'` still holds
+-- (a detached team org has NULL owner, excluded from that index). RLS/gates never read owner_user_id
+-- for access, so a NULL team owner changes no authz outcome.
+
+-- ---------------------------------------------------------------------------------------------------
+-- 1. Nullable owner + ON DELETE SET NULL
+-- ---------------------------------------------------------------------------------------------------
+alter table public.orgs alter column owner_user_id drop not null;
+
+alter table public.orgs drop constraint if exists orgs_owner_user_id_fkey;
+alter table public.orgs
+  add constraint orgs_owner_user_id_fkey
+  foreign key (owner_user_id) references auth.users (id) on delete set null;
+
+-- ---------------------------------------------------------------------------------------------------
+-- 2. Personal orgs still cascade-delete on user deletion (team orgs are left for SET NULL)
+-- ---------------------------------------------------------------------------------------------------
+-- SECURITY DEFINER: fires as part of an auth.users delete (admin/service path); it only ever deletes
+-- rows the leaving user OWNS as a PERSONAL org, so it cannot touch another tenant's data. search_path
+-- pinned to public (definer-safety: never resolve an object from a caller-controlled schema).
+create or replace function public.delete_personal_org_on_user_delete()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from public.orgs where kind = 'personal' and owner_user_id = old.id;
+  return old;
+end $$;
+
+drop trigger if exists delete_personal_org_on_user_delete on auth.users;
+create trigger delete_personal_org_on_user_delete
+  before delete on auth.users
+  for each row execute function public.delete_personal_org_on_user_delete();


### PR DESCRIPTION
Addresses #1314 part 1 (E-5-a durability — a hard **pre-GA gate**).

## Problem
`orgs.owner_user_id` was `NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE`. For a **personal** org that cascade is correct. But for a **team** org, `owner_user_id` is **not an authz axis** (all gates use `is_org_member`/`org_role`/`scope_role`) — it's just the arbitrary first provisioner (a plain GitHub member for a mirrored org, or the `create_team` caller). If that user deleted their account, the whole team org → all scopes → **all team content cascade-deleted for every other member**. Harmless today (no content in team scopes pre-GA), but a data-loss footgun to close before team-sync GA.

## Fix — migration 0047
- `owner_user_id` becomes **nullable**; the FK becomes **`ON DELETE SET NULL`** → deleting a user leaves their team orgs intact (owner → NULL; org/scopes/content survive for the remaining members).
- A **`BEFORE DELETE ON auth.users`** trigger (`delete_personal_org_on_user_delete`, SECURITY DEFINER, `search_path=public`) still **hard-deletes the user's personal org** first, which cascades to the personal scope + content — preserving the prior, correct personal-data-removal behavior. It runs before the FK's SET NULL, so only team orgs reach the detach path.

## Invariants preserved
- The unique partial index `(owner_user_id) WHERE kind='personal'` still holds (a detached team org has NULL owner → excluded).
- RLS/gates never read `owner_user_id` for access, so a NULL team owner changes no authz outcome.

## Tests (Tier-1, real Postgres)
- Deleting a team org's owner **detaches** it (owner→NULL) and preserves scope + content + the remaining member's row.
- Deleting a personal org's owner still **hard-removes** org→scope→content.
- The existing `sync-orgs` *"auth.users delete still cascades to content"* behavior-preserving test still passes with the trigger in place (13/13).

Parts 2–4 of #1314 (provision role-upgrade-on-resync, explicit role validation, concurrent-race test coverage) follow separately. Lint/typecheck/format clean.