### PR TITLE
fix(gateway): provider-aware worker key scheme — Bearer for GitHub Models (Seer #1373)

### DIFF
--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -23,6 +23,21 @@ export type AuthCredential =
   | { scheme: "api-key"; value: string }
   | { scheme: "bearer"; value: string };
 
+/**
+ * The auth scheme a DEDICATED worker key (`LORE_WORKER_API_KEY`) must use for a
+ * given worker-model provider. Defaults to `api-key` (→ `x-api-key`), the shape
+ * the Anthropic/OpenAI/MiniMax dedicated-key paths have always used. GitHub
+ * Models (`github-models`, models.github.ai) authenticates with a GitHub token
+ * as `Authorization: Bearer`, so it is the one provider that needs `bearer`.
+ *
+ * Single source of truth shared by every dedicated-key call site (the worker
+ * pipeline and the `lore invariant-check` CLI) so a new bearer provider is added
+ * in exactly one place and the two paths can never drift.
+ */
+export function workerKeyScheme(providerID?: string): AuthCredential["scheme"] {
+  return providerID === "github-models" ? "bearer" : "api-key";
+}
+
 // ---------------------------------------------------------------------------
 // Header extraction / formatting
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -22,7 +22,7 @@ import {
   invariantCheck,
 } from "@loreai/core";
 import { createGatewayLLMClient } from "../llm-adapter";
-import { type AuthCredential, resolveAuth } from "../auth";
+import { type AuthCredential, resolveAuth, workerKeyScheme } from "../auth";
 import { startGateway, type StartOptions } from "./start";
 
 type CheckResult = invariantCheck.CheckResult;
@@ -111,17 +111,19 @@ export async function commandInvariantCheck(
   // Judge auth. In CI there is no client session, so bare resolveAuth() returns
   // null and every judge call is skipped as "no-auth". Honor LORE_WORKER_API_KEY
   // (the GHA sets it to the judge credential) the same way the pipeline's
-  // getWorkerAuth does. Scheme is provider-aware: GitHub Models authenticates
-  // with a GitHub token as `Authorization: Bearer` (scheme "bearer"), whereas
-  // the default OpenAI/Anthropic worker key path uses "api-key" (x-api-key).
+  // getWorkerAuth does. Scheme is provider-aware via the shared workerKeyScheme:
+  // GitHub Models needs the key as `Authorization: Bearer`; every other provider
+  // uses api-key (x-api-key). Resolve per call on the worker model's provider,
+  // falling back to the judge's default provider.
   const workerKey = config.workerApiKey;
-  const judgeScheme: AuthCredential["scheme"] =
-    defaultModel.providerID === "github-models" ? "bearer" : "api-key";
   const judgeAuth: (
     sessionID?: string,
     providerID?: string,
   ) => AuthCredential | null = workerKey
-    ? () => ({ scheme: judgeScheme, value: workerKey })
+    ? (_sessionID, providerID) => ({
+        scheme: workerKeyScheme(providerID ?? defaultModel.providerID),
+        value: workerKey,
+      })
     : resolveAuth;
 
   const llm = createGatewayLLMClient(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -219,6 +219,7 @@ import {
   setSessionAuth,
   resolveAuth,
   isAuthStale,
+  workerKeyScheme,
   type AuthCredential,
 } from "./auth";
 import type { UpstreamInterceptor } from "./recorder";
@@ -2422,7 +2423,15 @@ function getLLMClient(config: GatewayConfig): LLMClient {
       sessionID?: string,
       providerID?: string,
     ) => AuthCredential | null = workerApiKey
-      ? () => ({ scheme: "api-key", value: workerApiKey })
+      ? (_sessionID, providerID) => ({
+          // Scheme is provider-aware: a GitHub-Models worker needs the key as a
+          // Bearer token; every other provider uses api-key (x-api-key), the
+          // long-standing dedicated-key shape. getAuth is invoked with the
+          // worker MODEL's providerID (see llm-adapter), so this resolves per
+          // worker call, not once at setup.
+          scheme: workerKeyScheme(providerID),
+          value: workerApiKey,
+        })
       : resolveAuth;
 
     // Worker-specific upstream: when LORE_WORKER_UPSTREAM is set, all worker

--- a/packages/gateway/test/auth.test.ts
+++ b/packages/gateway/test/auth.test.ts
@@ -13,6 +13,7 @@ import {
   markGlobalAuthStale,
   isGlobalAuthStale,
   _resetAuthForTest,
+  workerKeyScheme,
   type AuthCredential,
 } from "../src/auth";
 
@@ -557,5 +558,24 @@ describe("global auth staleness", () => {
 
     _resetAuthForTest();
     expect(isGlobalAuthStale()).toBe(false);
+  });
+});
+
+describe("workerKeyScheme (dedicated-key provider→scheme)", () => {
+  test("github-models needs a Bearer token", () => {
+    expect(workerKeyScheme("github-models")).toBe("bearer");
+  });
+
+  test("every other provider uses api-key (x-api-key)", () => {
+    for (const p of [
+      "anthropic",
+      "openai",
+      "minimax",
+      "deepseek",
+      "openrouter",
+      undefined,
+    ]) {
+      expect(workerKeyScheme(p)).toBe("api-key");
+    }
   });
 });

--- a/packages/gateway/test/worker-github-models.test.ts
+++ b/packages/gateway/test/worker-github-models.test.ts
@@ -20,6 +20,7 @@ import { upstreamFetch } from "../src/fetch";
 import { clearAllCosts } from "../src/cost-tracker";
 import { resetBackgroundLimiter } from "../src/background-limiter";
 import { GITHUB_MODELS_API_VERSION } from "../src/translate/openai";
+import { workerKeyScheme } from "../src/auth";
 
 const mockFetch = vi.mocked(upstreamFetch);
 
@@ -125,5 +126,37 @@ describe("worker GitHub Models routing (#1368)", () => {
     const headers = callHeaders(0);
     expect(headers.Accept).toBeUndefined();
     expect(headers["X-GitHub-Api-Version"]).toBeUndefined();
+  });
+
+  test("a dedicated worker key routed to github-models is sent as Bearer, not x-api-key", async () => {
+    // Reproduces the pipeline/CLI getWorkerAuth wiring: a single dedicated key
+    // whose SCHEME is chosen per worker-model provider via workerKeyScheme.
+    // Regression guard for Seer #1373 CRITICAL — the pipeline previously
+    // hardcoded scheme "api-key", so a github-models worker sent x-api-key and
+    // got 401.
+    const WORKER_KEY = "ghp_dedicated";
+    const getWorkerAuth = (_sid?: string, providerID?: string) => ({
+      scheme: workerKeyScheme(providerID),
+      value: WORKER_KEY,
+    });
+
+    const client = createGatewayLLMClient(UPSTREAMS, getWorkerAuth, {
+      providerID: "github-models",
+      modelID: "openai/gpt-4o-mini",
+    });
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-ghm-dedicated",
+      workerID: "lore-distill",
+      model: { providerID: "github-models", modelID: "openai/gpt-4o-mini" },
+    });
+
+    const headers = callHeaders(0);
+    // Bearer, NOT x-api-key.
+    expect(headers.Authorization).toBe(`Bearer ${WORKER_KEY}`);
+    expect(headers["x-api-key"]).toBeUndefined();
+    // And still carries the required GitHub Models headers.
+    expect(headers.Accept).toBe("application/vnd.github+json");
+    expect(headers["X-GitHub-Api-Version"]).toBe(GITHUB_MODELS_API_VERSION);
   });
 });


### PR DESCRIPTION
Follow-up to #1373, addressing a **CRITICAL** Seer finding: [#1373 (comment)](https://github.com/BYK/loreai/pull/1373#discussion_r3607242527).

## The bug
#1373 taught the `lore invariant-check` CLI to send a dedicated `LORE_WORKER_API_KEY` as `Authorization: Bearer` for `github-models`. But the **general worker pipeline** (`pipeline.ts` `getWorkerAuth`) still hardcoded `scheme: "api-key"`. So a *background* worker (distillation, curator, pattern-echo, etc.) routed to `github-models` via a dedicated key would send `x-api-key` → **401**.

## The fix
- **`auth.ts`** — new `workerKeyScheme(providerID)`: single source of truth returning `bearer` for `github-models`, `api-key` for everything else.
- **`pipeline.ts`** `getWorkerAuth` — resolves the scheme per worker call via the helper (`getAuth` is already invoked with the worker model's `providerID`).
- **`cli/invariant-check.ts`** — replaces its locally-duplicated ternary with the same helper (no drift).

No regression: existing Anthropic/OpenAI/MiniMax dedicated-key users still get `api-key`.

## Tests
- `auth.test.ts`: `workerKeyScheme` table (github-models → bearer; anthropic/openai/minimax/deepseek/openrouter/undefined → api-key).
- `worker-github-models.test.ts`: end-to-end via the pipeline-style callback — a dedicated key routed to `github-models` is sent as `Bearer` (not `x-api-key`) and still carries the required GitHub Models headers.
- **Mutation-verified**: forcing `workerKeyScheme` to always return `api-key` kills both new tests.

## Verification
typecheck (gateway) clean · oxfmt --check clean · type-aware oxlint (changed files) clean · targeted suites 52 passed.