### PR TITLE
fix(ci): run semantic-linter via built CLI bundle, not tsx

### DIFF
--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -36,11 +36,17 @@ jobs:
         with:
           node-version: "24"
       - run: pnpm install --frozen-lockfile
+      # Build the CLI bundle. The CLI cannot run from source via tsx — its entry
+      # (instrument.ts, lib/upgrade.ts, etc.) uses esbuild/Bun CJS `require()`
+      # that throws under tsx's ESM. `bundle` esbuild-inlines @loreai/core + the
+      # gateway into a single CJS binary (dist/bin.cjs) that runs under plain
+      # Node with instrumentation intact — no separate core build needed.
+      - run: pnpm --filter @loreai/gateway run bundle
       - name: Run Lore semantic linter
         uses: ./.github/actions/invariant-check
         with:
-          # Un-built checkout → run the CLI via tsx.
-          lore-command: "pnpm tsx packages/gateway/src/cli/bin.ts"
+          # Run the built CJS binary under Node (see the build step above).
+          lore-command: "node packages/gateway/dist/bin.cjs"
           # Judge model + credential. Two supported setups:
           #  1. Zero-secret (default): GitHub Models via the built-in
           #     GITHUB_TOKEN + `models: read` above. Uses openai/gpt-4o-mini


### PR DESCRIPTION
## The problem
The advisory semantic-linter action (added in #1363, judge wired in #1373) has **silently no-op'd on every PR since it landed**. Its `lore-command` was `pnpm tsx packages/gateway/src/cli/bin.ts`, which crashes at startup:

1. First, `@loreai/core` resolved through its package `exports` to an **unbuilt** `dist/node/index.js` → `ERR_MODULE_NOT_FOUND`.
2. After fixing that, the CLI's module graph (`instrument.ts`, `lib/upgrade.ts`, …) uses esbuild/Bun CJS `require()` which throws `ReferenceError: require is not defined` under tsx's ESM.

The CLI exits 1; the action classifies any non-`2` exit as a *tooling* error and skips (advisory → job still green), so the failure was invisible. Confirmed in the run logs (`::notice skipped (tooling: exit 1)` + `ERR_MODULE_NOT_FOUND`).

## The fix
Build the esbuild **CJS bundle** (`pnpm --filter @loreai/gateway run bundle` → `dist/bin.cjs`, which inlines `@loreai/core`) and run it under plain Node. The bundle runs with instrumentation intact and no ESM/`require` issues — it's the same artifact the shipped binary uses.

## Verification (local, end-to-end)
Reproduced the exact CI flow. The **built binary runs the full funnel** where tsx crashed:
```
$ node packages/gateway/dist/bin.cjs invariant-check --json --head HEAD --base HEAD~1
exit 0 · gate.exitCode: 0 · hunks: 9 · invariants: 71 · candidates: 20 · judged: 20
```
(No key locally → each judge call hits `no-auth` and is skipped gracefully, still exit 0. With the GitHub Models token in CI, those 20 judge calls actually execute.)

Bundle builds cleanly from a fresh checkout with no prebuilt core. YAML + actionlint clean.