### PR TITLE
fix(core): FTS fallback for passive context-sources (#961 Gap 2b)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2505,11 +2505,17 @@ export async function forSession(
   // fairly and inherit the identical stickyIds hysteresis + deterministic
   // packing below — the system[2] cache stays stable. Synthetic entries carry
   // the RECALLED_CONTEXT_CATEGORY tag and recall-id form ids.
-  if (options?.includeContextSources?.length && contextVec) {
+  //
+  // Runs whenever there is a session context to score against — NOT gated on
+  // contextVec. The FTS fallback inside surfaces facts even when embeddings are
+  // unavailable (worker init window, pre-embed race, non-embedding runtime); the
+  // vector pass adds semantic matches when a vector is present. (#961 Gap 2b)
+  if (options?.includeContextSources?.length && sessionContext.trim()) {
     const contextScored = await timer.await(
       loadContextSourceCandidates(
         pid,
         contextVec,
+        sessionContext,
         options.includeContextSources,
         options.contextSourceLimit ?? CONTEXT_SOURCE_LIMIT,
         sessionID,
@@ -2687,7 +2693,18 @@ const RECALLED_TEMPORAL_MAX_CHARS = 2000;
 
 /**
  * Build synthetic, relevance-scored context entries from non-knowledge sources
- * (distillation, temporal) using the SAME cosine context vector as knowledge.
+ * (distillation, temporal).
+ *
+ * Hybrid scoring, mirroring the knowledge path: when a context vector is
+ * available each source is ranked by cosine similarity; independently, a BM25
+ * keyword pass over the source's FTS index (`distillation_fts` / `temporal_fts`)
+ * folds in matches the vector missed OR that exist when the vector index is
+ * empty/unavailable (embeddings down, worker still initializing, or the row not
+ * yet embedded). This is the durable fix for #961 Gap 2b: without an FTS
+ * fallback, distillation facts never surfaced into system[2] whenever embeddings
+ * were unavailable — the knowledge path degraded to FTS, context-sources did
+ * not. `contextVec` is therefore OPTIONAL; with it absent the FTS pass alone
+ * still surfaces relevant facts.
  *
  * Returned entries are shaped as KnowledgeEntry so they flow through the caller's
  * stickyIds hysteresis + deterministic packing (cache-stable). Ids use recall-id
@@ -2698,7 +2715,8 @@ const RECALLED_TEMPORAL_MAX_CHARS = 2000;
  */
 async function loadContextSourceCandidates(
   pid: string,
-  contextVec: Float32Array,
+  contextVec: Float32Array | undefined,
+  sessionContext: string,
   sources: ContextSource[],
   limit: number,
   _sessionID?: string,
@@ -2743,20 +2761,80 @@ async function loadContextSourceCandidates(
     last_reinforced_at: null,
   });
 
+  // Extract keyword terms once for the FTS fallback passes below. Empty when
+  // the session context is too thin — the FTS passes then no-op and the vector
+  // path (if any) still runs.
+  const ftsTerms = extractTopTerms(sessionContext);
+  const ftsMatch = ftsTerms.length
+    ? ftsTerms.map((t) => `${t}*`).join(" OR ")
+    : null;
+
   if (sources.includes("distillation")) {
     try {
-      // vectorSearchDistillations is NOT project-scoped (distillation_vec
-      // partitions by project but the helper takes no pid), so over-fetch and
-      // filter by project_id in hydration — otherwise another project's
-      // distillation could be injected here (cross-project leak). Temporal is
-      // already project-scoped via vectorSearchTemporal(pid). Follow-up: add a
-      // project-scoped distillation vector search to avoid the over-fetch.
-      const hits = await embedding.vectorSearchDistillations(
-        contextVec,
-        limit * 4,
-      );
-      if (hits.length) {
-        const ids = hits.map((h) => h.id);
+      // Candidate id → best normalized score (0–1), merged across the vector and
+      // FTS passes. A doc that both cosine-matches and keyword-matches keeps the
+      // stronger signal (max), mirroring the knowledge path (Seer #1318). FTS
+      // keyword hits qualify regardless of any vector signal, so facts still
+      // surface when the vector index is empty/unavailable.
+      const scoreById = new Map<string, number>();
+
+      // Vector pass (only when a context vector is available).
+      if (contextVec) {
+        // vectorSearchDistillations takes no pid: the vec0 backend partitions
+        // distillation_vec by project (so results are already project-scoped),
+        // but the legacy blob backend is not — so over-fetch and re-filter by
+        // project_id in hydration below to keep another project's distillation
+        // from leaking in regardless of backend. Temporal is already
+        // project-scoped via vectorSearchTemporal(pid).
+        const hits = await embedding.vectorSearchDistillations(
+          contextVec,
+          limit * 4,
+        );
+        for (const h of hits) {
+          // Match the knowledge path's floor semantics: a context source must
+          // be a POSITIVE cosine at or above the floor. The `<= 0` clause keeps
+          // an exactly-orthogonal (or negative) hit out even when minRelevance
+          // is 0, so context sources and knowledge behave identically.
+          if (h.similarity <= 0 || h.similarity < minRelevance) continue;
+          const prev = scoreById.get(h.id) ?? 0;
+          if (h.similarity > prev) scoreById.set(h.id, h.similarity);
+        }
+      }
+
+      // FTS pass: BM25 keyword fallback over distillation_fts (project-scoped
+      // via the join to distillations). Surfaces facts whenever the vector index
+      // is empty/unavailable, or a keyword-relevant row the vector missed.
+      if (ftsMatch) {
+        const ftsRows = (await offloadAll(
+          `SELECT d.id AS id, bm25(distillation_fts) AS rank
+             FROM distillation_fts f
+             CROSS JOIN distillations d ON d.rowid = f.rowid
+            WHERE distillation_fts MATCH ?
+              AND d.archived = 0 AND d.project_id = ?
+            ORDER BY rank
+            LIMIT ?`,
+          [ftsMatch, pid, limit * 4],
+        )) as Array<{ id: string; rank: number }>;
+        // BM25 rank is negative (more negative = better). Min-max normalize to
+        // 0–1 so FTS and cosine live on the same scale before the max-merge. An
+        // FTS keyword hit is inherently relevant → not subject to minRelevance.
+        if (ftsRows.length) {
+          const ranks = ftsRows.map((r) => r.rank);
+          const minRank = Math.min(...ranks);
+          const maxRank = Math.max(...ranks);
+          for (const r of ftsRows) {
+            const norm =
+              minRank === maxRank
+                ? 1
+                : (maxRank - r.rank) / (maxRank - minRank);
+            const prev = scoreById.get(r.id) ?? 0;
+            if (norm > prev) scoreById.set(r.id, norm);
+          }
+        }
+      }
+
+      if (scoreById.size) {
+        const ids = [...scoreById.keys()];
         const rows = db()
           .query(
             `SELECT id, observations, created_at FROM distillations
@@ -2769,15 +2847,12 @@ async function loadContextSourceCandidates(
           created_at: number;
         }>;
         const byId = new Map(rows.map((r) => [r.id, r]));
+        // Highest score first so the per-source `limit` keeps the best matches.
+        const ranked = [...scoreById.entries()].sort((a, b) => b[1] - a[1]);
         let added = 0;
-        for (const h of hits) {
+        for (const [id, score] of ranked) {
           if (added >= limit) break;
-          // Match the knowledge path's floor semantics: a context source must
-          // be a POSITIVE cosine at or above the floor. The `<= 0` clause keeps
-          // an exactly-orthogonal (or negative) hit out even when minRelevance
-          // is 0, so context sources and knowledge behave identically.
-          if (h.similarity <= 0 || h.similarity < minRelevance) continue;
-          const r = byId.get(h.id);
+          const r = byId.get(id);
           if (!r?.observations) continue;
           out.push({
             entry: mkEntry(
@@ -2786,7 +2861,7 @@ async function loadContextSourceCandidates(
               r.observations,
               r.created_at,
             ),
-            score: h.similarity,
+            score,
           });
           added++;
         }
@@ -2801,31 +2876,78 @@ async function loadContextSourceCandidates(
 
   if (sources.includes("temporal")) {
     try {
-      // Project-wide (sessionId omitted) so facts from EARLIER sessions surface.
-      const hits = await embedding.vectorSearchTemporal(contextVec, pid, limit);
-      if (hits.length) {
-        // temporal_vec is chunk-keyed (`<id>#<n>`); map back to message id.
-        const msgIds = [...new Set(hits.map((h) => h.id.split("#")[0]))];
+      // messageId → best normalized score, merged across vector + FTS passes.
+      const scoreByMsg = new Map<string, number>();
+
+      // Vector pass (only when a context vector is available).
+      if (contextVec) {
+        // Project-wide (sessionId omitted) so facts from EARLIER sessions surface.
+        const hits = await embedding.vectorSearchTemporal(
+          contextVec,
+          pid,
+          limit,
+        );
+        for (const h of hits) {
+          if (h.similarity <= 0 || h.similarity < minRelevance) continue;
+          // temporal_vec is chunk-keyed (`<id>#<n>`); map back to message id.
+          const mid = h.id.split("#")[0];
+          const prev = scoreByMsg.get(mid) ?? 0;
+          if (h.similarity > prev) scoreByMsg.set(mid, h.similarity);
+        }
+      }
+
+      // FTS pass: BM25 keyword fallback over temporal_fts (project-scoped via the
+      // join to temporal_messages). Surfaces cross-session facts whenever the
+      // vector index is empty/unavailable.
+      if (ftsMatch) {
+        const ftsRows = (await offloadAll(
+          `SELECT m.id AS id, bm25(temporal_fts) AS rank
+             FROM temporal_fts f
+             CROSS JOIN temporal_messages m ON m.rowid = f.rowid
+            WHERE temporal_fts MATCH ?
+              AND m.project_id = ?
+            ORDER BY rank
+            LIMIT ?`,
+          [ftsMatch, pid, limit * 4],
+        )) as Array<{ id: string; rank: number }>;
+        if (ftsRows.length) {
+          const ranks = ftsRows.map((r) => r.rank);
+          const minRank = Math.min(...ranks);
+          const maxRank = Math.max(...ranks);
+          for (const r of ftsRows) {
+            const norm =
+              minRank === maxRank
+                ? 1
+                : (maxRank - r.rank) / (maxRank - minRank);
+            const prev = scoreByMsg.get(r.id) ?? 0;
+            if (norm > prev) scoreByMsg.set(r.id, norm);
+          }
+        }
+      }
+
+      if (scoreByMsg.size) {
+        const msgIds = [...scoreByMsg.keys()];
         const rows = db()
           .query(
+            // Defense-in-depth: re-filter by project_id at hydration (mirrors the
+            // distillation hydration above). Both passes that populate scoreByMsg
+            // are already project-scoped, but this makes temporal robust to a
+            // future unscoped signal source rather than relying on upstream only.
             `SELECT id, role, content, created_at FROM temporal_messages
-             WHERE id IN (${msgIds.map(() => "?").join(",")})`,
+             WHERE project_id = ?
+               AND id IN (${msgIds.map(() => "?").join(",")})`,
           )
-          .all(...msgIds) as Array<{
+          .all(pid, ...msgIds) as Array<{
           id: string;
           role: string;
           content: string | null;
           created_at: number;
         }>;
         const byId = new Map(rows.map((r) => [r.id, r]));
-        const seen = new Set<string>();
-        for (const h of hits) {
-          // Match the knowledge path's floor semantics (positive cosine at or
-          // above the floor); see the distillation source above.
-          if (h.similarity <= 0 || h.similarity < minRelevance) continue;
-          const mid = h.id.split("#")[0];
-          if (seen.has(mid)) continue;
-          seen.add(mid);
+        const ranked = [...scoreByMsg.entries()].sort((a, b) => b[1] - a[1]);
+        let added = 0;
+        for (const [mid, score] of ranked) {
+          if (added >= limit) break;
           const r = byId.get(mid);
           if (!r?.content) continue;
           const content =
@@ -2839,8 +2961,9 @@ async function loadContextSourceCandidates(
               content,
               r.created_at,
             ),
-            score: h.similarity,
+            score,
           });
+          added++;
         }
       }
     } catch (err) {

--- a/packages/core/test/ltm-context-sources.test.ts
+++ b/packages/core/test/ltm-context-sources.test.ts
@@ -292,6 +292,11 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
     // zero test coverage — a regression there would pass CI. Drive both hits
     // BELOW the default floor (0.35) and assert neither synthetic surfaces,
     // while knowledge (above floor) still does.
+    //
+    // Use a keyword-DISJOINT hint so the FTS fallback pass (which is inherently
+    // relevant and bypasses the cosine floor) does NOT independently match these
+    // facts — otherwise the FTS pass would legitimately surface them and this
+    // test could no longer isolate the vector floor. (#961 Gap 2b)
     vi.spyOn(embedding, "vectorSearchDistillations").mockResolvedValue([
       { id: distId, similarity: 0.1 },
     ]);
@@ -300,7 +305,7 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
     ]);
     const result = await ltm.forSession(PROJ, undefined, 4000, {
       excludeCategories: ["preference"],
-      contextHint: HINT,
+      contextHint: "gateway proxy memory injection architecture overview",
       includeContextSources: ["distillation", "temporal"],
     });
     const byId = new Set(result.map((e) => e.id));
@@ -315,6 +320,7 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
     // when the floor is disabled, a cosine-0 (orthogonal) or negative hit must
     // still be excluded from the context-source fold — `h.similarity < 0` alone
     // would admit it. Guards the `<= 0` clause on both source guards.
+    // Keyword-disjoint hint so the FTS fallback doesn't independently match.
     const orig = config().knowledge.minRelevance;
     config().knowledge.minRelevance = 0;
     try {
@@ -326,7 +332,7 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
       ]);
       const result = await ltm.forSession(PROJ, undefined, 4000, {
         excludeCategories: ["preference"],
-        contextHint: HINT,
+        contextHint: "gateway proxy memory injection architecture overview",
         includeContextSources: ["distillation", "temporal"],
       });
       const byId = new Set(result.map((e) => e.id));
@@ -335,5 +341,122 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
     } finally {
       config().knowledge.minRelevance = orig;
     }
+  });
+
+  test("FTS fallback: facts surface when embeddings are UNAVAILABLE (no vector) via keyword match (#961 Gap 2b)", async () => {
+    // The core Gap 2b fix: with embeddings down, contextVec is never built and
+    // the vector pass is skipped entirely. The FTS keyword pass over
+    // distillation_fts / temporal_fts must still surface the keyword-relevant
+    // facts into system[2]. HINT shares "hex color" (dist) and "tests" (temporal).
+    for (const s of spies) s.mockRestore();
+    spies = [];
+    // Embeddings unavailable → forSession skips embed()/vectorSearch* entirely.
+    spies.push(vi.spyOn(embedding, "isAvailable").mockReturnValue(false));
+    const distSpy = vi.spyOn(embedding, "vectorSearchDistillations");
+    const tempSpy = vi.spyOn(embedding, "vectorSearchTemporal");
+
+    const result = await ltm.forSession(PROJ, undefined, 4000, {
+      excludeCategories: ["preference"],
+      contextHint: HINT,
+      includeContextSources: ["distillation", "temporal"],
+    });
+    const byId = new Set(result.map((e) => e.id));
+    // The vector helpers must NOT have been called (no contextVec).
+    expect(distSpy).not.toHaveBeenCalled();
+    expect(tempSpy).not.toHaveBeenCalled();
+    // Yet both facts surface via the FTS fallback.
+    expect(byId.has(`d:${distId}`)).toBe(true);
+    expect(byId.has(`t:${tempId}`)).toBe(true);
+    distSpy.mockRestore();
+    tempSpy.mockRestore();
+  });
+
+  test("VACUITY: FTS fallback does NOT surface facts whose keywords are absent from the context", async () => {
+    // Guards against the FTS pass folding in EVERY distillation regardless of
+    // relevance. With embeddings unavailable and a keyword-disjoint hint, the
+    // BM25 MATCH finds nothing → no synthetic context sources.
+    for (const s of spies) s.mockRestore();
+    spies = [];
+    spies.push(vi.spyOn(embedding, "isAvailable").mockReturnValue(false));
+
+    const result = await ltm.forSession(PROJ, undefined, 4000, {
+      excludeCategories: ["preference"],
+      contextHint: "completely unrelated zephyr quokka umbrella syzygy",
+      includeContextSources: ["distillation", "temporal"],
+    });
+    const byId = new Set(result.map((e) => e.id));
+    expect(byId.has(`d:${distId}`)).toBe(false);
+    expect(byId.has(`t:${tempId}`)).toBe(false);
+  });
+
+  test("SECURITY: FTS fallback never surfaces distillation/temporal facts from ANOTHER project", async () => {
+    // The FTS pass must be project-scoped (both the MATCH query WHERE clause and
+    // hydration). Plant a foreign-project distillation + temporal message that
+    // share keywords with HINT ("hex color" / "tests"), run forSession on PROJ
+    // with embeddings DOWN (so only the FTS path runs), and assert neither
+    // foreign fact leaks into PROJ's system[2]. Mutation-verified: dropping the
+    // project_id filter from either FTS query surfaces the foreign rows.
+    const otherProj = "/test/ltm/context-sources-OTHER";
+    const otherPid = ensureProject(otherProj);
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(otherPid);
+    db()
+      .query("DELETE FROM temporal_messages WHERE project_id = ?")
+      .run(otherPid);
+
+    const foreignDist = uuidv7();
+    db()
+      .query(
+        `INSERT INTO distillations (id, project_id, session_id, narrative, facts, observations, source_ids, generation, token_count, archived, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        foreignDist,
+        otherPid,
+        "sess-foreign",
+        "",
+        "",
+        "the OTHER project also used hex color #deadbe in its theme",
+        "[]",
+        0,
+        20,
+        0,
+        Date.now() - 100_000,
+      );
+
+    const foreignTemp = uuidv7();
+    db()
+      .query(
+        `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+         VALUES (?, ?, ?, 'assistant', ?, 12, 0, ?, '{}')`,
+      )
+      .run(
+        foreignTemp,
+        otherPid,
+        "sess-foreign",
+        "42 SHA-256 tests pass in the OTHER project",
+        Date.now() - 90_000,
+      );
+
+    for (const s of spies) s.mockRestore();
+    spies = [];
+    spies.push(vi.spyOn(embedding, "isAvailable").mockReturnValue(false));
+
+    const result = await ltm.forSession(PROJ, undefined, 4000, {
+      excludeCategories: ["preference"],
+      contextHint: HINT, // shares "hex color" / "tests" with the foreign rows
+      includeContextSources: ["distillation", "temporal"],
+    });
+    const byId = new Set(result.map((e) => e.id));
+    // PROJ's own facts DO surface (same keywords) — proves the FTS pass ran.
+    expect(byId.has(`d:${distId}`)).toBe(true);
+    expect(byId.has(`t:${tempId}`)).toBe(true);
+    // The foreign project's facts must NOT leak in.
+    expect(byId.has(`d:${foreignDist}`)).toBe(false);
+    expect(byId.has(`t:${foreignTemp}`)).toBe(false);
+
+    db().query("DELETE FROM distillations WHERE project_id = ?").run(otherPid);
+    db()
+      .query("DELETE FROM temporal_messages WHERE project_id = ?")
+      .run(otherPid);
   });
 });


### PR DESCRIPTION
## Problem

The passive context-source path (`loadContextSourceCandidates`, from #1228/#1293) that folds relevant **distillation/temporal facts into system[2]** was **vector-only** and fully gated behind a context embedding vector. Whenever embeddings are unavailable:

- the worker-init retry window,
- the pre-embed race (a distillation created before its async embed completes),
- or a non-embedding runtime,

`embedDistillation()` silently no-ops (`embedding.ts`: `if (!isAvailable()) return`) → `distillation_vec` stays empty → `vectorSearchDistillations` returns nothing every turn → **distillation facts never surface into system[2].**

The **knowledge path already degrades gracefully to FTS** in exactly this situation; context-sources did not. This is the root cause of #961 Gap 2b (facts stored but never surfaced in long/cross sessions when the embedding worker was down).

## Fix

Make `loadContextSourceCandidates` **hybrid**, mirroring the knowledge path. Alongside the vector pass it now runs a **BM25 keyword pass over the existing `distillation_fts` / `temporal_fts` indexes** (project-scoped), merging candidates by id and keeping the stronger normalized signal (max, per Seer #1318). FTS keyword hits are inherently relevant, so they bypass the cosine floor (identical to knowledge). `contextVec` is now **optional** and the call-site guard is relaxed from `&& contextVec` to `&& sessionContext.trim()`, so the block runs (FTS-only) when embeddings are down.

**No schema change** — `distillation_fts` already exists (db v7) and its sync triggers already populate it.

## Tests

- New **FTS-fallback test**: embeddings unavailable → vector helpers are never called, yet both distillation + temporal facts surface via keyword match. **Mutation-verified**: neutering the FTS match fails it (`expected false to be true`).
- New **vacuity test**: a keyword-disjoint context surfaces nothing (the FTS pass doesn't fold in every row).
- Retargeted the two vector-floor tests to a keyword-disjoint hint so they still isolate the cosine floor (they previously shared keywords with the fixtures and would now legitimately match via FTS).
- 3014 core tests green; tsc / lint / oxfmt clean.

## Live validation

A Sonnet session with embeddings disabled generated **22 distillations**; `distillation_fts` indexed all 22 (`distillation_vec` empty), and a BM25 query surfaced the **code-invisible probe fact** (`orders ride the WHOLESALE channel, EMEA region, warehouse WH-07`) as the top hit — nothing surfaced under the old vector-only path.

## Scope note

The embedding-worker init failure that exposed this in the eval is **eval-only infra** (the isolated eval gateway runs under Bun; `onnxruntime-node` throws "protobuf parsing failed" under a Bun worker). Production embeddings are healthy (`/health` reports `available:true, state:ok`). This PR is the durable product fix that makes context-sources resilient to **any** embedding outage regardless of runtime.