### PR TITLE
fix(supabase): GitHub-provision role upgrade-on-resync + role validation (#1314 parts 2-4)

### DIFF
--- a/packages/gateway/test/sync-github-provision.integration.test.ts
+++ b/packages/gateway/test/sync-github-provision.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for migration 0035 — GitHub Teams provisioning (E-5-a, #827) against a real
+ * Integration tests for migration 0035 + 0048 — GitHub Teams provisioning (E-5-a, #827) against a real
  * Postgres. Proves the SERVICE-ROLE-ONLY provisioning RPC that mirrors a user's GitHub org/team
  * memberships into Lore orgs/scopes:
  *  - creates the org + scope keyed by GitHub numeric id, with the mapped roles;
@@ -106,174 +106,326 @@ const scopeRole = (scope: string, uid: string) =>
     )
     .then((r) => r.rows[0]?.role as string | undefined);
 
-describe.skipIf(gate())("0035 GitHub provisioning (E-5-a, #827)", () => {
-  it("provisions an org + scope keyed by GitHub id, with the mapped roles", async () => {
-    const a = await h.createUser();
-    await provision(
-      a,
-      [{ github_org_id: 100, login: "acme", role: "manager" }],
-      [
-        {
-          github_team_id: 200,
-          github_org_id: 100,
-          slug: "eng",
-          name: "Engineering",
-          role: "admin",
-        },
-      ],
-    );
-    const org = await orgRow(100);
-    expect(org.kind).toBe("team");
-    expect(org.owner_user_id).toBe(a);
-    expect(org.name).toBe("acme");
-    const scope = await scopeRow(200);
-    expect(scope.org_id).toBe(org.id);
-    expect(scope.name).toBe("Engineering");
-    expect(await orgRole(org.id, a)).toBe("manager");
-    expect(await scopeRole(scope.id, a)).toBe("admin");
-  });
+describe.skipIf(gate())(
+  "GitHub provisioning (E-5-a, #827; 0035 + 0048 upgrade/validation)",
+  () => {
+    it("provisions an org + scope keyed by GitHub id, with the mapped roles", async () => {
+      const a = await h.createUser();
+      await provision(
+        a,
+        [{ github_org_id: 100, login: "acme", role: "manager" }],
+        [
+          {
+            github_team_id: 200,
+            github_org_id: 100,
+            slug: "eng",
+            name: "Engineering",
+            role: "admin",
+          },
+        ],
+      );
+      const org = await orgRow(100);
+      expect(org.kind).toBe("team");
+      expect(org.owner_user_id).toBe(a);
+      expect(org.name).toBe("acme");
+      const scope = await scopeRow(200);
+      expect(scope.org_id).toBe(org.id);
+      expect(scope.name).toBe("Engineering");
+      expect(await orgRole(org.id, a)).toBe("manager");
+      expect(await scopeRole(scope.id, a)).toBe("admin");
+    });
 
-  it("is idempotent — re-running produces no duplicate orgs/scopes/memberships", async () => {
-    const a = await h.createUser();
-    const orgs: OrgIn[] = [
-      { github_org_id: 101, login: "beta", role: "member" },
-    ];
-    const teams: TeamIn[] = [
-      {
-        github_team_id: 201,
-        github_org_id: 101,
-        slug: "ops",
-        name: "Ops",
-        role: "editor",
-      },
-    ];
-    await provision(a, orgs, teams);
-    await provision(a, orgs, teams);
-    const orgs2 = await h.client.query(
-      "select id from public.orgs where github_org_id=101",
-    );
-    const scopes2 = await h.client.query(
-      "select id from public.scopes where github_team_id=201",
-    );
-    expect(orgs2.rowCount).toBe(1);
-    expect(scopes2.rowCount).toBe(1);
-    const scope = await scopeRow(201);
-    const members = await h.client.query(
-      "select count(*)::int n from public.scope_members where scope_id=$1 and user_id=$2",
-      [scope.id, a],
-    );
-    expect(members.rows[0].n).toBe(1);
-  });
-
-  it("converges by GitHub id — two users map to ONE shared scope", async () => {
-    const a = await h.createUser();
-    const b = await h.createUser();
-    await provision(
-      a,
-      [{ github_org_id: 102, login: "gamma", role: "manager" }],
-      [
+    it("is idempotent — re-running produces no duplicate orgs/scopes/memberships", async () => {
+      const a = await h.createUser();
+      const orgs: OrgIn[] = [
+        { github_org_id: 101, login: "beta", role: "member" },
+      ];
+      const teams: TeamIn[] = [
         {
-          github_team_id: 202,
-          github_org_id: 102,
-          slug: "core",
-          name: "Core",
-          role: "admin",
-        },
-      ],
-    );
-    await provision(
-      b,
-      [{ github_org_id: 102, login: "gamma", role: "member" }],
-      [
-        {
-          github_team_id: 202,
-          github_org_id: 102,
-          slug: "core",
-          name: "Core",
+          github_team_id: 201,
+          github_org_id: 101,
+          slug: "ops",
+          name: "Ops",
           role: "editor",
         },
-      ],
-    );
-    const orgs = await h.client.query(
-      "select id from public.orgs where github_org_id=102",
-    );
-    const scopes = await h.client.query(
-      "select id from public.scopes where github_team_id=202",
-    );
-    expect(orgs.rowCount).toBe(1); // one org
-    expect(scopes.rowCount).toBe(1); // one scope, shared
-    const scope = await scopeRow(202);
-    expect(await scopeRole(scope.id, a)).toBe("admin");
-    expect(await scopeRole(scope.id, b)).toBe("editor");
-  });
+      ];
+      await provision(a, orgs, teams);
+      await provision(a, orgs, teams);
+      const orgs2 = await h.client.query(
+        "select id from public.orgs where github_org_id=101",
+      );
+      const scopes2 = await h.client.query(
+        "select id from public.scopes where github_team_id=201",
+      );
+      expect(orgs2.rowCount).toBe(1);
+      expect(scopes2.rowCount).toBe(1);
+      const scope = await scopeRow(201);
+      const members = await h.client.query(
+        "select count(*)::int n from public.scope_members where scope_id=$1 and user_id=$2",
+        [scope.id, a],
+      );
+      expect(members.rows[0].n).toBe(1);
+    });
 
-  it("is additive + never-demote — a re-sync as a lower role leaves an admin untouched", async () => {
-    const a = await h.createUser();
-    await provision(
-      a,
-      [{ github_org_id: 103, login: "delta", role: "manager" }],
-      [
-        {
-          github_team_id: 203,
-          github_org_id: 103,
-          slug: "sec",
-          name: "Sec",
-          role: "admin",
-        },
-      ],
-    );
-    // A subsequent sync reports the user as only a plain member/editor — must NOT demote.
-    await provision(
-      a,
-      [{ github_org_id: 103, login: "delta", role: "member" }],
-      [
-        {
-          github_team_id: 203,
-          github_org_id: 103,
-          slug: "sec",
-          name: "Sec",
-          role: "editor",
-        },
-      ],
-    );
-    const org = await orgRow(103);
-    const scope = await scopeRow(203);
-    expect(await orgRole(org.id, a)).toBe("manager"); // unchanged
-    expect(await scopeRole(scope.id, a)).toBe("admin"); // unchanged
-  });
+    it("converges by GitHub id — two users map to ONE shared scope", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      await provision(
+        a,
+        [{ github_org_id: 102, login: "gamma", role: "manager" }],
+        [
+          {
+            github_team_id: 202,
+            github_org_id: 102,
+            slug: "core",
+            name: "Core",
+            role: "admin",
+          },
+        ],
+      );
+      await provision(
+        b,
+        [{ github_org_id: 102, login: "gamma", role: "member" }],
+        [
+          {
+            github_team_id: 202,
+            github_org_id: 102,
+            slug: "core",
+            name: "Core",
+            role: "editor",
+          },
+        ],
+      );
+      const orgs = await h.client.query(
+        "select id from public.orgs where github_org_id=102",
+      );
+      const scopes = await h.client.query(
+        "select id from public.scopes where github_team_id=202",
+      );
+      expect(orgs.rowCount).toBe(1); // one org
+      expect(scopes.rowCount).toBe(1); // one scope, shared
+      const scope = await scopeRow(202);
+      expect(await scopeRole(scope.id, a)).toBe("admin");
+      expect(await scopeRole(scope.id, b)).toBe("editor");
+    });
 
-  it("is SERVICE-ROLE-ONLY — an authenticated client cannot call it (no forging)", async () => {
-    const a = await h.createUser();
-    const err = await expectError(() =>
-      h.asUser(a, (c) =>
-        c.query(
-          "select public.provision_github_membership($1, '[]'::jsonb, '[]'::jsonb)",
-          [a],
+    it("is additive + never-demote — a re-sync as a lower role leaves an admin untouched", async () => {
+      const a = await h.createUser();
+      await provision(
+        a,
+        [{ github_org_id: 103, login: "delta", role: "manager" }],
+        [
+          {
+            github_team_id: 203,
+            github_org_id: 103,
+            slug: "sec",
+            name: "Sec",
+            role: "admin",
+          },
+        ],
+      );
+      // A subsequent sync reports the user as only a plain member/editor — must NOT demote.
+      await provision(
+        a,
+        [{ github_org_id: 103, login: "delta", role: "member" }],
+        [
+          {
+            github_team_id: 203,
+            github_org_id: 103,
+            slug: "sec",
+            name: "Sec",
+            role: "editor",
+          },
+        ],
+      );
+      const org = await orgRow(103);
+      const scope = await scopeRow(203);
+      expect(await orgRole(org.id, a)).toBe("manager"); // unchanged
+      expect(await scopeRole(scope.id, a)).toBe("admin"); // unchanged
+    });
+
+    it("is SERVICE-ROLE-ONLY — an authenticated client cannot call it (no forging)", async () => {
+      const a = await h.createUser();
+      const err = await expectError(() =>
+        h.asUser(a, (c) =>
+          c.query(
+            "select public.provision_github_membership($1, '[]'::jsonb, '[]'::jsonb)",
+            [a],
+          ),
         ),
-      ),
-    );
-    // permission denied for function (execute revoked from authenticated)
-    expect(err.code).toBe("42501");
-  });
+      );
+      // permission denied for function (execute revoked from authenticated)
+      expect(err.code).toBe("42501");
+    });
 
-  it("skips a team whose org was not provisioned (defensive)", async () => {
-    const a = await h.createUser();
-    await provision(
-      a,
-      [], // no orgs provided
-      [
+    it("skips a team whose org was not provisioned (defensive)", async () => {
+      const a = await h.createUser();
+      await provision(
+        a,
+        [], // no orgs provided
+        [
+          {
+            github_team_id: 204,
+            github_org_id: 104,
+            slug: "x",
+            name: "X",
+            role: "editor",
+          },
+        ],
+      );
+      const scopes = await h.client.query(
+        "select id from public.scopes where github_team_id=204",
+      );
+      expect(scopes.rowCount).toBe(0); // scope not created without its org
+    });
+
+    // #1314 part 2 — role UPGRADE on re-sync (still never demote).
+    it("UPGRADES on re-sync — member→manager (org) and editor→admin (scope)", async () => {
+      const a = await h.createUser();
+      await provision(
+        a,
+        [{ github_org_id: 110, login: "up", role: "member" }],
+        [
+          {
+            github_team_id: 210,
+            github_org_id: 110,
+            slug: "t",
+            name: "T",
+            role: "editor",
+          },
+        ],
+      );
+      const org = await orgRow(110);
+      const scope = await scopeRow(210);
+      expect(await orgRole(org.id, a)).toBe("member");
+      expect(await scopeRole(scope.id, a)).toBe("editor");
+      // The user is later promoted on GitHub → a re-sync must ratchet the role UP.
+      await provision(
+        a,
+        [{ github_org_id: 110, login: "up", role: "manager" }],
+        [
+          {
+            github_team_id: 210,
+            github_org_id: 110,
+            slug: "t",
+            name: "T",
+            role: "admin",
+          },
+        ],
+      );
+      expect(await orgRole(org.id, a)).toBe("manager"); // upgraded
+      expect(await scopeRole(scope.id, a)).toBe("admin"); // upgraded
+    });
+
+    // #1314 part 2 — the upgrade WHERE clause must never touch a manual-only org role.
+    it("never upgrades over a manual owner/billing org role on re-sync", async () => {
+      const a = await h.createUser();
+      await provision(
+        a,
+        [{ github_org_id: 111, login: "bill", role: "member" }],
+        [],
+      );
+      const org = await orgRow(111);
+      // A human manually grants `billing` (a non-GitHub, off-ladder role).
+      await h.client.query(
+        "update public.org_members set role='billing' where org_id=$1 and user_id=$2",
+        [org.id, a],
+      );
+      // A GitHub re-sync maps the user to `manager` — must NOT clobber the manual billing role.
+      await provision(
+        a,
+        [{ github_org_id: 111, login: "bill", role: "manager" }],
+        [],
+      );
+      expect(await orgRole(org.id, a)).toBe("billing"); // off-ladder → untouched
+    });
+
+    // #1314 part 3 — explicit per-record role validation (clear error, not an opaque CHECK rollback).
+    it("rejects an invalid mapped role with a clear error (part 3)", async () => {
+      const a = await h.createUser();
+      const orgErr = await expectError(() =>
+        h.asService((c) =>
+          c.query(
+            "select public.provision_github_membership($1, $2::jsonb, '[]'::jsonb)",
+            [
+              a,
+              JSON.stringify([
+                { github_org_id: 112, login: "z", role: "owner" },
+              ]),
+            ],
+          ),
+        ),
+      );
+      expect(orgErr.code).toBe("22023");
+      expect(orgErr.message).toMatch(/invalid github org role/i);
+      const teamErr = await expectError(() =>
+        h.asService((c) =>
+          c.query(
+            "select public.provision_github_membership($1, $2::jsonb, $3::jsonb)",
+            [
+              a,
+              JSON.stringify([
+                { github_org_id: 112, login: "z", role: "manager" },
+              ]),
+              JSON.stringify([
+                {
+                  github_team_id: 212,
+                  github_org_id: 112,
+                  slug: "t",
+                  name: "T",
+                  role: "viewer",
+                },
+              ]),
+            ],
+          ),
+        ),
+      );
+      expect(teamErr.code).toBe("22023");
+      expect(teamErr.message).toMatch(/invalid github team role/i);
+    });
+
+    // #1314 part 4 — concurrent provisioning of the SAME GitHub org/team by two users must converge to
+    // ONE org/scope (exercises the lost-race re-read branches, 0048:59-66 / 93-101). Two overlapping
+    // service transactions race the first-insert; the loser re-reads the winner's row.
+    it("two concurrent provisions of the same GitHub org/team converge to one org/scope (race)", async () => {
+      const a = await h.createUser();
+      const b = await h.createUser();
+      const orgs = [
+        { github_org_id: 113, login: "race", role: "member" as const },
+      ];
+      const teams = [
         {
-          github_team_id: 204,
-          github_org_id: 104,
-          slug: "x",
-          name: "X",
-          role: "editor",
+          github_team_id: 213,
+          github_org_id: 113,
+          slug: "r",
+          name: "R",
+          role: "editor" as const,
         },
-      ],
-    );
-    const scopes = await h.client.query(
-      "select id from public.scopes where github_team_id=204",
-    );
-    expect(scopes.rowCount).toBe(0); // scope not created without its org
-  });
-});
+      ];
+      // Fire both concurrently (separate service connections → real interleave against Postgres).
+      await Promise.all([provision(a, orgs, teams), provision(b, orgs, teams)]);
+      // Exactly one org and one scope exist for the shared GitHub ids — no duplicate from the race.
+      expect(
+        (
+          await h.client.query(
+            "select id from public.orgs where github_org_id=113",
+          )
+        ).rowCount,
+      ).toBe(1);
+      expect(
+        (
+          await h.client.query(
+            "select id from public.scopes where github_team_id=213",
+          )
+        ).rowCount,
+      ).toBe(1);
+      // Both users are members of the single shared org + scope.
+      const org = await orgRow(113);
+      const scope = await scopeRow(213);
+      expect(await orgRole(org.id, a)).toBe("member");
+      expect(await orgRole(org.id, b)).toBe("member");
+      expect(await scopeRole(scope.id, a)).toBe("editor");
+      expect(await scopeRole(scope.id, b)).toBe("editor");
+    });
+  },
+);

--- a/supabase/migrations/0048_github_provision_upgrade.sql
+++ b/supabase/migrations/0048_github_provision_upgrade.sql
@@ -1,0 +1,123 @@
+-- Migration 0048 — GitHub provisioning follow-ups (#1314 parts 2-4, E-5-a).
+--
+-- Reworks provision_github_membership (0035) with two behavioral fixes; the concurrent-race
+-- re-read branches are unchanged (now covered by a regression test):
+--
+--   Part 2 — role UPGRADE-on-resync (still NEVER demote). 0035 used ON CONFLICT DO NOTHING, so a
+--     member later promoted on GitHub (plain member → org owner/admin, or team editor → maintainer)
+--     stayed at their first-seen role forever — a team could remain permanently admin-less. Now a
+--     re-sync RATCHETS the role UP the GitHub-mappable ladder, and never down:
+--       org:   member(1) < manager(2)      scope: viewer(1) < editor(2) < admin(3)
+--     The manual-only, non-GitHub org roles `owner` and `billing` are treated as un-demotable and
+--     are NEVER touched by a resync (a GitHub sync only ever maps to member/manager) — the UPDATE is
+--     gated on the EXISTING role being on the GitHub ladder AND the incoming role strictly out-
+--     ranking it. This upholds the union-not-demote invariant: manual grants / higher roles win.
+--
+--   Part 3 — explicit per-record role validation. 0035 passed rec->>'role' straight through, so a
+--     bad value only failed via the CHECK constraint, rolling back the WHOLE provision with an
+--     opaque error. Now each record's role is validated up front with a clear, actionable message.
+
+-- Role-rank helpers (IMMUTABLE, pure). Rank 0 = unknown/off-ladder → never wins an upgrade compare.
+-- Org: only the GitHub-mappable ladder is ranked (member<manager); owner/billing return 0 so they
+-- are never the target of an upgrade and the resync WHERE clause (existing rank between 1 and 2)
+-- excludes them entirely. Defined BEFORE provision_github_membership (it references them).
+create or replace function public.org_role_rank(p_role text)
+returns int language sql immutable set search_path = pg_catalog, public as $$
+  select case p_role when 'member' then 1 when 'manager' then 2 else 0 end
+$$;
+
+create or replace function public.scope_role_rank(p_role text)
+returns int language sql immutable set search_path = pg_catalog, public as $$
+  select case p_role when 'viewer' then 1 when 'editor' then 2 when 'admin' then 3 else 0 end
+$$;
+
+create or replace function public.provision_github_membership(
+  p_user uuid, p_orgs jsonb, p_teams jsonb)
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+declare
+  rec       jsonb;
+  v_org     uuid;
+  v_scope   uuid;
+  v_gid     bigint;
+  v_role    text;
+begin
+  if p_user is null then
+    raise exception 'p_user required' using errcode = '22004';
+  end if;
+
+  -- Orgs first: a team's org must exist before the team's scope can reference it.
+  for rec in select value from jsonb_array_elements(coalesce(p_orgs, '[]'::jsonb)) as t(value) loop
+    v_gid  := (rec->>'github_org_id')::bigint;
+    -- Part 3: validate the mapped org role up front (GitHub sync only ever maps to member/manager).
+    v_role := coalesce(rec->>'role', 'member');
+    if v_role not in ('member', 'manager') then
+      raise exception 'invalid github org role %; expected member or manager', v_role
+        using errcode = '22023';
+    end if;
+    select id into v_org from public.orgs where github_org_id = v_gid;
+    if v_org is null then
+      insert into public.orgs (kind, owner_user_id, name, github_org_id, github_login)
+        values ('team', p_user, rec->>'login', v_gid, rec->>'login')
+        on conflict (github_org_id) where github_org_id is not null do nothing
+        returning id into v_org;
+      if v_org is null then  -- lost a concurrent race; re-read the winner's row
+        select id into v_org from public.orgs where github_org_id = v_gid;
+      end if;
+    end if;
+    -- Part 2: additive insert; on conflict, UPGRADE-only along the org ladder. The WHERE clause
+    -- leaves `owner`/`billing` (manual-only, off-ladder) untouched, and never lowers a rank.
+    insert into public.org_members (org_id, user_id, role)
+      values (v_org, p_user, v_role)
+      on conflict (org_id, user_id) do update
+        set role = excluded.role
+        where public.org_role_rank(public.org_members.role) between 1 and 2
+          and public.org_role_rank(excluded.role) > public.org_role_rank(public.org_members.role);
+  end loop;
+
+  -- Teams: create the scope keyed by GitHub team id, add org + scope membership.
+  for rec in select value from jsonb_array_elements(coalesce(p_teams, '[]'::jsonb)) as t(value) loop
+    v_gid  := (rec->>'github_org_id')::bigint;
+    -- Part 3: validate the mapped scope role up front (GitHub sync maps to editor/admin).
+    v_role := coalesce(rec->>'role', 'editor');
+    if v_role not in ('editor', 'admin') then
+      raise exception 'invalid github team role %; expected editor or admin', v_role
+        using errcode = '22023';
+    end if;
+    select id into v_org from public.orgs where github_org_id = v_gid;
+    if v_org is null then
+      continue;  -- team's org was not provisioned (not in p_orgs) — skip defensively
+    end if;
+    select id into v_scope from public.scopes
+      where github_team_id = (rec->>'github_team_id')::bigint;
+    if v_scope is null then
+      insert into public.scopes (org_id, kind, name, github_team_id, github_team_slug)
+        values (v_org, 'team', rec->>'name', (rec->>'github_team_id')::bigint, rec->>'slug')
+        on conflict (github_team_id) where github_team_id is not null do nothing
+        returning id into v_scope;
+      if v_scope is null then  -- lost a concurrent race
+        select id into v_scope from public.scopes
+          where github_team_id = (rec->>'github_team_id')::bigint;
+      end if;
+    end if;
+    -- Org membership (so a scope member can see the org) — additive only, never demote a manual role.
+    insert into public.org_members (org_id, user_id, role) values (v_org, p_user, 'member')
+      on conflict (org_id, user_id) do nothing;
+    -- Part 2: scope role — additive insert; on conflict, UPGRADE-only along the scope ladder.
+    insert into public.scope_members (scope_id, user_id, role)
+      values (v_scope, p_user, v_role)
+      on conflict (scope_id, user_id) do update
+        set role = excluded.role
+        where public.scope_role_rank(excluded.role) > public.scope_role_rank(public.scope_members.role);
+  end loop;
+end $$;
+
+-- Re-assert the service-role-only boundary (create-or-replace does not change grants, but be explicit
+-- so a fresh apply of this file alone is self-contained).
+revoke all on function public.provision_github_membership(uuid, jsonb, jsonb)
+  from public, anon, authenticated;
+grant execute on function public.provision_github_membership(uuid, jsonb, jsonb) to service_role;
+-- The rank helpers are only called from within the SECURITY DEFINER function (as its owner), so no
+-- external grant is needed. Revoke the default PUBLIC EXECUTE to keep the surface minimal.
+revoke all on function public.org_role_rank(text)   from public, anon, authenticated;
+revoke all on function public.scope_role_rank(text) from public, anon, authenticated;


### PR DESCRIPTION
Closes #1314 (parts 2-4; part 1 landed in #1374). Follow-ups to `provision_github_membership` (0035) from the E-5-a review. Migration 0048.

## Part 2 — role UPGRADE on re-sync (still never demote)
0035 used `ON CONFLICT DO NOTHING`, so a member promoted on GitHub (member→owner/admin, or team editor→maintainer) kept their **first-seen role forever** — a team could stay permanently admin-less/unshareable. Now a re-sync **ratchets the role UP** the GitHub-mappable ladder and never down:
- org `member(1) < manager(2)`, scope `viewer(1) < editor(2) < admin(3)`.

The manual-only, off-ladder org roles `owner`/`billing` are **never touched** (per the resolved design question): the UPGRADE is gated on the *existing* role being on the GitHub ladder AND the incoming role strictly out-ranking it. A manual `billing`/`owner` grant is preserved — the union-not-demote invariant holds. Two `IMMUTABLE` rank helpers (`org_role_rank`/`scope_role_rank`); EXECUTE revoked from all external roles (only the definer function calls them).

## Part 3 — explicit per-record role validation
0035 passed `rec->>'role'` straight through; a bad value only failed via the CHECK constraint, rolling back the **whole** provision with an opaque error. Now each record's role is validated up front (`errcode 22023`, clear message: org expects member/manager, team expects editor/admin).

## Part 4 — concurrent-race regression test
A new test provisions the **same** GitHub org/team from two users concurrently (`Promise.all`, separate service connections) and asserts convergence to exactly **one** org + **one** scope — exercising the lost-race re-read branches (0035:65-67 / 88-91) that the sequential tests never hit.

## Tests (Tier-1, real Postgres)
upgrade member→manager / editor→admin; never upgrade over a manual `billing`; invalid-role rejection (22023); concurrent-race convergence. Existing never-demote + idempotency + service-role-only tests still green (10/10 in the file). Lint/typecheck/format clean.