### PR TITLE
fix(supabase): revoke outstanding invite tokens on scope member removal (#1345, E-5-c F-2)

### DIFF
--- a/packages/gateway/test/sync-team-invite.integration.test.ts
+++ b/packages/gateway/test/sync-team-invite.integration.test.ts
@@ -373,6 +373,44 @@ describe.skipIf(SKIP)("lore team — direct email invite (E-5-c)", () => {
     });
     expect(selfIns.error).toBeNull();
   });
+
+  it("revokes the scope's outstanding invite tokens on member removal (F-2, #1345)", async () => {
+    // A removed member (or anyone holding a live/leaked token) must not be able to re-join via a
+    // still-valid invite. remove_scope_member now wipes ALL of the scope's pending_invites.
+    const scope = await freshAdminTeam("Revoke-On-Remove");
+    await addTeamMember(clientFor(admin), scope, invitee, "editor");
+    // An admin mints an outstanding invite (for some future member) that is still live.
+    const token = await createTeamInvite(clientFor(admin), scope, "editor");
+    expect(
+      await h.client
+        .query(
+          "select count(*)::int n from public.pending_invites where scope_id=$1",
+          [scope],
+        )
+        .then((r) => r.rows[0].n),
+    ).toBe(1);
+    // Admin removes the member → the removal revokes ALL of the scope's outstanding tokens.
+    const { error: rmErr } = await clientFor(admin).rpc("remove_scope_member", {
+      p_scope: scope,
+      p_user: invitee,
+    });
+    expect(rmErr).toBeNull();
+    expect(
+      await h.client
+        .query(
+          "select count(*)::int n from public.pending_invites where scope_id=$1",
+          [scope],
+        )
+        .then((r) => r.rows[0].n),
+    ).toBe(0);
+    // The revoked token can no longer be redeemed (fails identically to an unknown/expired one).
+    mockUid = invitee;
+    await expect(acceptTeamInvite(clientFor(invitee), token)).rejects.toThrow(
+      /invalid or expired invite/,
+    );
+    // And the invitee is NOT a member of the scope (the removal + revoke held).
+    expect(await remoteRole(scope, invitee)).toBeUndefined();
+  });
 });
 
 describe.skipIf(SKIP)("lore team — offline invite (E-5-c-2)", () => {

--- a/supabase/migrations/0049_revoke_invites_on_removal.sql
+++ b/supabase/migrations/0049_revoke_invites_on_removal.sql
@@ -1,0 +1,46 @@
+-- Migration 0049 — revoke outstanding invite tokens on scope member removal (#1345, E-5-c F-2).
+--
+-- Problem (from the E-5-c-1 adversarial review, F-2): `accept_scope_invite` tokens are single-use
+-- and expire in 14 days, but `remove_scope_member` did NOT revoke a scope's outstanding *unredeemed*
+-- invite tokens. A removed member holding a live token (or a leaked token) could re-join the scope as
+-- editor/viewer within the 14-day window. Tokens are NOT bound to a specific invitee (any holder can
+-- redeem one), so there is no per-user token to revoke — the only sound fix is to revoke ALL of the
+-- scope's outstanding tokens on any member removal. An admin can simply re-issue a fresh invite.
+--
+-- Severity is low (membership grants FETCH only; DECRYPT needs a DEK wrap, and F-1 / migration 0043
+-- already blocks re-wrapping the rotated DEK to a non-member), but this closes the roster re-join
+-- nuisance cleanly. `pending_invites` already ON DELETE CASCADEs on scope_id, so scope DELETION
+-- clears tokens; only member *removal* was uncovered — this is the missing piece.
+--
+-- Reproduced from 0029 verbatim except the single new DELETE at the end (marked #1345).
+
+create or replace function public.remove_scope_member(p_scope uuid, p_user uuid)
+returns void language plpgsql security definer set search_path = pg_catalog, public
+as $$
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_scope::text, 0));
+  if public.scope_role(p_scope) is distinct from 'admin' then
+    raise exception 'only a scope admin may remove members' using errcode = '42501';
+  end if;
+  if (select role from public.scope_members where scope_id = p_scope and user_id = p_user) = 'admin'
+     and (select count(*) from public.scope_members where scope_id = p_scope and role = 'admin') <= 1
+  then
+    raise exception 'cannot remove the last admin of a scope' using errcode = '23514';
+  end if;
+  delete from public.scope_members where scope_id = p_scope and user_id = p_user;
+  delete from public.scope_keys where scope_id = p_scope and member_user_id = p_user::text;
+  -- Also drop the org membership IF the user no longer belongs to ANY scope of that org (and
+  -- isn't the org owner) — otherwise a removed member lingers as an org member with roster
+  -- visibility. A member of OTHER scopes in the same org keeps their org membership.
+  delete from public.org_members om
+   where om.user_id = p_user
+     and om.role <> 'owner'
+     and om.org_id = (select org_id from public.scopes where id = p_scope)
+     and not exists (
+       select 1 from public.scope_members sm
+         join public.scopes s on s.id = sm.scope_id
+        where sm.user_id = p_user and s.org_id = om.org_id);
+  -- #1345: revoke ALL of the scope's outstanding invite tokens. They are not invitee-bound, so the
+  -- removed member could hold any live token; wiping the scope's tokens closes the re-join window.
+  delete from public.pending_invites where scope_id = p_scope;
+end $$;


### PR DESCRIPTION
Closes #1345 (E-5-c F-2, follow-up from the E-5-c-1 adversarial review).

## Problem
`accept_scope_invite` tokens are single-use and expire in 14 days, but `remove_scope_member` did **not** revoke a scope's outstanding *unredeemed* invite tokens. A removed member holding a live (or leaked) token could **re-join** the scope as editor/viewer within the 14-day window.

## Fix — migration 0049
Invite tokens are **not invitee-bound** (any holder can redeem one), so there is no per-user token to revoke — the only sound fix is to revoke **all** of the scope's outstanding tokens on any member removal (an admin can re-issue). `remove_scope_member` (reproduced verbatim from 0029) gains one line:
```sql
delete from public.pending_invites where scope_id = p_scope;
```

## Severity
Low — membership grants **FETCH only**; DECRYPT needs a DEK wrap, and F-1 / migration 0043 (`scope_keys_target_member`) already blocks re-wrapping the rotated DEK to a non-member, so a rejoined-via-stale-token user cannot read post-rotation content. This closes the roster **re-join nuisance**. (`pending_invites` already `ON DELETE CASCADE`s on `scope_id`, so scope *deletion* cleared tokens; only member *removal* was uncovered.)

## Test (Tier-2, real Postgres)
Admin mints a live invite, removes a member → all the scope's tokens are revoked, the token can no longer be redeemed (`invalid or expired invite`), and the removed member is not a scope member.

Typecheck/lint/format clean. (Note: a pre-existing, environment-sensitive failure in the *"auto-wraps the DEK"* test in this file reproduces on unmodified main locally and is unrelated to this change; CI's fresh harness is the arbiter.)