### PR TITLE
fix(sync): migrate an orphaned entity graph back to personal on team knowledge deletion (#1312, E-5-F3)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -654,6 +654,20 @@ export function onKnowledgeTeamPromotionChanged(
   teamPromotionChangedCb = cb;
 }
 
+// E-5-F3 (#1312): notified with the entity ids that LOST their last ref to a knowledge entry when
+// that entry is deleted (remove()). The entity graph's team-scope is derived from the APPROVED
+// knowledge that references each entity (entityTeamScope); once the referencing team-knowledge is
+// tombstoned + its refs dropped, a formerly team-scoped entity may no longer belong to any team and
+// must migrate BACK to personal. remove() deletes the refs (no trigger re-resolves the entity), so
+// the entities/aliases/relations are re-enqueued explicitly for the push to re-resolve their scope.
+// A hook (not a direct import) because sync-data.ts already imports ltm.ts (reverse would be a cycle).
+let knowledgeDeletedCb: ((lostEntityIds: string[]) => void) | null = null;
+export function onKnowledgeDeleted(
+  cb: (lostEntityIds: string[]) => void,
+): void {
+  knowledgeDeletedCb = cb;
+}
+
 /**
  * Approve a knowledge entry for team promotion (manual review). Sets 'approved' + reviewer/time on
  * the current version, in place. Idempotent; returns false if no current row matched the id.
@@ -818,6 +832,11 @@ export function remove(id: string, metadata?: KnowledgeMetadata) {
     .query("DELETE FROM knowledge_entity_refs WHERE knowledge_id = ?")
     .run(logicalId);
   for (const entityId of entitiesLosingRef) recomputeEntityRank(entityId);
+  // E-5-F3 (#1312): if any entity just lost its last ref to this (possibly team-scoped) entry, its
+  // team-scope may have changed — re-enqueue the affected entity graph so the push re-resolves each
+  // row's scope and migrates back to personal what no longer belongs to a team. No-op when sync is
+  // disabled (the hook guards on it) or nothing lost a ref.
+  if (entitiesLosingRef.length > 0) knowledgeDeletedCb?.(entitiesLosingRef);
   db()
     .query("DELETE FROM knowledge_refs WHERE from_id = ? OR to_id = ?")
     .run(logicalId, logicalId);

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -31,6 +31,7 @@ import {
 } from "./db";
 import { putWrappedScopeKey } from "./crypto/keystore";
 import {
+  onKnowledgeDeleted,
   onKnowledgeTeamPromotionChanged,
   rematerializeConfidence,
 } from "./ltm";
@@ -1347,6 +1348,54 @@ export function reenqueueKnowledgeTeamGraph(logicalId: string): void {
   );
 }
 onKnowledgeTeamPromotionChanged(reenqueueKnowledgeTeamGraph);
+
+/**
+ * #1312: re-enqueue an entity graph after the entities LOST their last ref to a deleted knowledge
+ * entry (remove()). Unlike reenqueueKnowledgeTeamGraph, the knowledge's refs are already gone, so we
+ * key off the affected ENTITY ids directly (captured pre-delete in ltm.remove). Re-enqueues each
+ * entity, its aliases, and any relation touching it — so the push re-resolves each row's scope
+ * (teamScopeForContent) and migrates back to personal what no longer belongs to a team. Idempotent:
+ * an unchanged row (same scope AND content_hash) short-circuits in the push.
+ */
+export function reenqueueDeletedKnowledgeGraph(entityIds: string[]): void {
+  if (getTeamConfig(ENABLED_KEY) !== "1") return;
+  if (entityIds.length === 0) return;
+  const now = Date.now();
+  const placeholders = entityIds.map(() => "?").join(", ");
+  const enqueue = (sql: string, ...params: unknown[]) =>
+    db()
+      .query(
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at) ${sql}`,
+      )
+      .run(...params);
+  // The affected entities (their team-scope may have dropped now the referencing knowledge is gone).
+  // NOTE: remove()'s recomputeEntityRank already UPDATEs each entity and trigger-enqueues it, so this
+  // entity clause is redundant; the LOAD-BEARING part is the aliases + relations below (no trigger
+  // fires for them from a ref delete). Kept for self-documenting parity with reenqueueKnowledgeTeamGraph.
+  enqueue(
+    `SELECT 'entities', e.id, 'upsert', ? FROM entities e
+      WHERE e.id IN (${placeholders}) AND ${remoteBackedGate("e.")}`,
+    now,
+    ...entityIds,
+  );
+  // Their aliases (follow the entity).
+  enqueue(
+    `SELECT 'entity_aliases', a.id, 'upsert', ? FROM entity_aliases a
+      WHERE a.entity_id IN (${placeholders}) AND ${entityParentGate("a.entity_id")}`,
+    now,
+    ...entityIds,
+  );
+  // Relations touching an affected entity (both endpoints gated; the push re-resolves each).
+  enqueue(
+    `SELECT 'entity_relations', r.id, 'upsert', ? FROM entity_relations r
+      WHERE (r.entity_a IN (${placeholders}) OR r.entity_b IN (${placeholders}))
+        AND ${entityParentGate("r.entity_a")} AND ${entityParentGate("r.entity_b")}`,
+    now,
+    ...entityIds,
+    ...entityIds,
+  );
+}
+onKnowledgeDeleted(reenqueueDeletedKnowledgeGraph);
 
 // ---------------------------------------------------------------------------
 // Per-row sync state

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -2630,6 +2630,88 @@ describe("pushOnce — team scope promotion + migration (E-5-F3-3)", () => {
     ).toBe(REMOTE_SCOPE);
     expect(tableRows("entities").filter((r) => r.id === "e1")).toHaveLength(1);
   });
+
+  test("deleting a team entry migrates its now-orphaned entity graph back to personal (#1312)", async () => {
+    const pid = ensureProjectCore("/tmp/lore-f3del");
+    db()
+      .query("UPDATE projects SET git_remote='github.com/x/gdel' WHERE id=?")
+      .run(pid);
+    db()
+      .query(
+        "INSERT INTO scopes (id, org_id, kind, name, promotion_policy, created_at, updated_at) VALUES ('TD','o','team','TD','auto',0,0)",
+      )
+      .run();
+    setProjectScope(pid, "TD");
+    const kid = ltm.create({
+      projectPath: "/tmp/lore-f3del",
+      category: "pattern",
+      title: "K",
+      content: "c",
+      scope: "project",
+    });
+    // e1 is linked ONLY to K (will orphan on delete); e2 is linked to K AND to a SECOND approved
+    // entry K2 (must STAY in the team after K is deleted).
+    const kid2 = ltm.create({
+      projectPath: "/tmp/lore-f3del",
+      category: "pattern",
+      title: "K2",
+      content: "c2",
+      scope: "project",
+    });
+    for (const e of ["e1", "e2"])
+      db()
+        .query(
+          "INSERT INTO entities (id, project_id, entity_type, canonical_name, created_at, updated_at) VALUES (?,?,'tool',?,0,0)",
+        )
+        .run(e, pid, e);
+    db()
+      .query(
+        "INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES (?, 'e1'), (?, 'e2')",
+      )
+      .run(kid, kid);
+    db()
+      .query(
+        "INSERT INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES (?, 'e2')",
+      )
+      .run(kid2);
+    db()
+      .query(
+        "INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, created_at) VALUES ('a1','e1','name','X',0)",
+      )
+      .run();
+    // A relation between e1 (orphans on delete) and e2 (stays team) — team while BOTH are team.
+    db()
+      .query(
+        "INSERT INTO entity_relations (id, entity_a, entity_b, relation, created_at, updated_at) VALUES ('r1','e1','e2','rel',0,0)",
+      )
+      .run();
+
+    syncData.enableSync("basic");
+    await pushOnce(makeClient() as never);
+    const scopeOf = (t: string, pred: (r: RemoteRow) => boolean) =>
+      tableRows(t).find(pred)?.scope_id;
+    // Auto policy → K and K2 approved on create → the whole linked graph is team-scoped.
+    expect(scopeOf("knowledge", (r) => r.id === kid)).toBe("TD");
+    expect(scopeOf("entities", (r) => r.id === "e1")).toBe("TD");
+    expect(scopeOf("entities", (r) => r.id === "e2")).toBe("TD");
+    expect(scopeOf("entity_aliases", (r) => r.id === "a1")).toBe("TD");
+    expect(scopeOf("entity_relations", (r) => r.id === "r1")).toBe("TD"); // both endpoints team
+
+    // Delete K → e1 (now referenced by NO team knowledge) + its alias migrate back to personal.
+    // e2 stays team (still linked to K2). K's own death-cert stays team-scoped so team peers learn
+    // of the deletion (a tombstone is not a scope migration). The r1 relation migrates to personal
+    // (only one endpoint remains team, and a relation is team-scoped only when BOTH endpoints are).
+    ltm.remove(kid);
+    await pushOnce(makeClient() as never);
+    expect(scopeOf("entities", (r) => r.id === "e1")).toBe(REMOTE_SCOPE); // orphaned → personal
+    expect(scopeOf("entity_aliases", (r) => r.id === "a1")).toBe(REMOTE_SCOPE);
+    expect(scopeOf("entity_relations", (r) => r.id === "r1")).toBe(
+      REMOTE_SCOPE,
+    ); // one endpoint left team
+    expect(scopeOf("entities", (r) => r.id === "e2")).toBe("TD"); // still team (linked to K2)
+    // No team leftover for the orphaned entity.
+    expect(tableRows("entities").filter((r) => r.id === "e1")).toHaveLength(1);
+  });
 });
 
 describe("knowledge team-scope pull decrypt — E-5-F2 (#827)", () => {


### PR DESCRIPTION
Closes #1312 (follow-up from the #1311 / #1307 review).

## Problem
#1311 made team-promotion scope migration symmetric for the **review** flow: `approveForTeam`/`rejectForTeam` re-enqueue the linked entity graph so the push re-resolves each row's scope. The remaining asymmetry was **`remove()`** (append-only death-cert deletion).

When a team-scoped knowledge entry is deleted, its own death-cert propagates and its `knowledge_entity_refs` are dropped (both ride capture triggers), but the linked **entities/aliases/relations** were **not** re-enqueued — so an entity that was team-scoped *only* because of the now-deleted entry lingered in the team scope on the remote until some unrelated mutation happened to re-enqueue it.

## Fix
`remove()` now fires a new `onKnowledgeDeleted` hook with the entity ids that just lost their last ref (already captured pre-delete for `recomputeEntityRank`). `sync-data` registers `reenqueueDeletedKnowledgeGraph`, which re-enqueues those entities + their aliases + relations so the push re-resolves each row's scope (`teamScopeForContent`) — migrating back to personal what no longer belongs to any team, while an entity still linked to **another** team-approved entry stays team-scoped.

**Cost / the many-call-sites concern:** gated on sync being enabled (no-op otherwise) and on `entitiesLosingRef` being non-empty, so the non-team `remove()` call sites (decay, eviction, curator) pay nothing when sync is off and only a cheap, idempotent re-enqueue when on. The hook (not a direct import) mirrors the existing `onKnowledgeTeamPromotionChanged` pattern (sync-data already imports ltm → reverse would be a cycle).

**Note:** a deleted team entry's **own** death-cert stays team-scoped — a tombstone is not a scope migration; team peers must learn of the deletion. Only the orphaned entity graph migrates.

## Test (full engine)
A team entry K links `e1` (only K) + `e2` (K **and** a second approved K2); after `remove(K)`, `e1` + its alias migrate back to personal while `e2` stays team. Mutation-verified: without the re-enqueue, `e1` stays team and the test fails. Typecheck/lint/format clean; 213 tests across the affected suites green.