### PR TITLE
fix(core): drain in-flight distillation embeds on shutdown + warm-start worker (#1331)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -310,9 +310,6 @@
 <!-- lore:019f147e-7b0d-7ed0-aef5-bb2b8c0bc065 -->
 * **standard.site publish script: safety invariants for orphan cleanup**: Three invariants in \`publish-standard-site.mjs\` orphan cleanup (PR #1043, also ported to byk.github.io PR #58): 1. \*\*Upserts-first ordering\*\*: all \`putRecord\` calls complete before any \`deleteRecord\` — a mid-run failure never strands the blog without live records. 2. \*\*Empty-manifest guard\*\*: if \`manifest.documents.length === 0\`, skip orphan cleanup entirely with \`console.warn\` — a broken/empty build cannot wipe the whole collection. 3. \*\*Pagination termination\*\*: \`listAllRecords\` uses dual-condition stop — (a) stop when batch length is 0 even if PDS returns a cursor (PDS returns trailing cursor on last page — confirmed live), (b) stop when cursor is null/undefined. 4. \*\*DID cross-check\*\*: if \`session.did !== recordDid\`, script refuses to publish. 5. \*\*\`validate: false\`\*\* on \`putRecord\` — PDS doesn't host \`site.standard.\*\` lexicons. 6. \*\*Blob uploads\*\*: blobs are content-addressed (CID) → idempotent re-runs; best-effort; size cap \`MAX\_BLOB\_BYTES = 1\_000\_000\`; Astro-optimized webp variants always under 1MB.
 
-<!-- lore:019f1cc8-b694-721d-9b2b-10ff1ed2d390 -->
-* **storeTurnTemporal: user-side store must run BEFORE resolveToolResults (ordering constraint)**: Pattern: storeTurnTemporal: user-side store must run BEFORE resolveToolResults (ordering constraint).
-
 <!-- lore:019ef387-4afe-7137-a151-88dff1dd0ab7 -->
 * **Test fix rules for knowledge\_meta migration (RULE A and RULE B)**: Two patterns for fixing tests after the v55 knowledge\_meta migration: RULE A — remove hardcoded \`confidence\` column from raw \`INSERT INTO knowledge\` statements; add \`logical\_id\` column+value (= id for v1 rows). RULE B — split combined \`UPDATE knowledge SET cross\_project=1, confidence=X, last\_reinforced\_at=Y\` into two statements: one targeting \`knowledge\` (cross\_project), one targeting \`knowledge\_meta\` (confidence/last\_reinforced\_at + updated\_at). Also: any test asserting confidence must read from \`knowledge\_meta\` or \`knowledge\_current\` view, never from the base \`knowledge\` table. Helper pattern: \`confOf(id)\` queries \`knowledge\_meta WHERE logical\_id = ?\` (not \`knowledge WHERE id = ?\`). Test JOIN pattern: \`SELECT m.confidence FROM knowledge k JOIN knowledge\_meta m ON m.logical\_id = k.logical\_id WHERE k.id = ?\`.
 
@@ -353,9 +350,6 @@
 
 <!-- lore:019f6f42-408e-7635-81d6-4d51ec94a3c9 -->
 * **Always prefer f-strings over .**: User stated always prefer f-strings over . This is a directive preference.
-
-<!-- lore:019f7985-3fd0-733c-9ec4-57cc700122ed -->
-* **Always provide tool results to guide investigation and confirm findings**: The user consistently provides tool results (logs, database queries, file contents, status updates) to guide the assistant's investigation. This pattern occurs when debugging issues, verifying system behavior, or confirming root causes. The user expects the assistant to use these results to form hypotheses, validate assumptions, and draw conclusions. The assistant should treat these provided results as authoritative evidence and incorporate them directly into the analysis.
 
 <!-- lore:019f7766-9f5b-72e8-9567-531f800edfd0 -->
 * **Always re-index missing distillation\_vec rows on next boot**: User consistently requires re-indexing missing \`distillation\_vec\` rows on next boot to recover from incomplete embeddings due to early session termination. This pattern has appeared in 39 prior sessions and is a directive preference.
@@ -488,6 +482,9 @@
 
 <!-- lore:019f702c-6ef3-717a-b329-7a050a717b77 -->
 * **Never drop exact evidence in candidate selection**: Never drop exact evidence in candidate selection. This is a directive preference.
+
+<!-- lore:019f7ae8-a590-7a19-8eff-639e6afc1a90 -->
+* **Never edit the real repo; if experiments/mutations are needed**: User stated to never edit the real repo; if experiments/mutations are needed,
 
 <!-- lore:019f749f-147f-7645-a1ec-0821e1476840 -->
 * **Never exceed total budget**: Never exceed total budget. This is a directive preference.

--- a/.lore.md
+++ b/.lore.md
@@ -37,9 +37,6 @@
 <!-- lore:019ef387-4ae0-7676-b7b5-140c85ad2627 -->
 * **knowledge\_meta table: confidence/last\_reinforced\_at moved off knowledge table (v55)**: Migration v55 moves \`confidence\` and \`last\_reinforced\_at\` off the \`knowledge\` table into a new convergent register table: \`knowledge\_meta (logical\_id TEXT PRIMARY KEY, confidence REAL NOT NULL DEFAULT 1.0, last\_reinforced\_at INTEGER, updated\_at INTEGER NOT NULL DEFAULT 0)\`. \`knowledge\_current\` view exposes both via LEFT JOIN: \`SELECT k.\*, COALESCE(m.confidence, 1.0) AS confidence, m.last\_reinforced\_at FROM knowledge k LEFT JOIN knowledge\_meta m ON m.logical\_id = k.logical\_id WHERE k.is\_current=1 AND k.is\_deleted=0\`. Reading/writing confidence on the base \`knowledge\` table now errors with 'no such column'. For v1 rows: logical\_id == id. \`ltm.create()\` creates matching knowledge\_meta row automatically. Schema version bumped 54→55. \`markInjected()\` updates \`knowledge\_meta.last\_reinforced\_at\` but does NOT bump \`updated\_at\` — injection stays sync-silent. Content-only \`update()\` also must NOT bump \`meta.updated\_at\`.
 
-<!-- lore:019eff67-7951-7434-a6c0-d9dd0dfc81e3 -->
-* **knowledge\_symbol\_presence table: presence-history drift signal for symbol validation (#911)**: knowledge\_symbol\_presence table (migration v59): \`(logical\_id TEXT, symbol TEXT, last\_present\_at INTEGER, PRIMARY KEY(logical\_id, symbol))\`. Symbol refs resolve to \`"ok"\` or \`"unknown"\` — NEVER \`"missing"\`. Penalty fires only when \`wasSymbolPresent()\` returns true (previously confirmed present, now absent). \`recordSymbolPresent()\` fires only on \`st === "ok"\`. External/historical/rejected mentions never get a presence record. \`RepoView.presentSymbols: Set\<string> | null\` — null = grep unavailable (neutral). Cleanup: \`remove()\` in \`ltm.ts\` must delete from \`knowledge\_symbol\_presence\` and \`knowledge\_ref\_validity\` via \`LOGICAL\_ID\_BOOKKEEPING\_TABLES\` loop BEFORE the knowledge DELETE. \`knowledge\_session\_injections\` and \`knowledge\_meta\` are intentionally excluded from that loop (sync-destined / tracked follow-up).
-
 <!-- lore:019edfbc-edd5-780d-ac81-07a35390121b -->
 * **ltm.ts: confidence lifecycle — decay, reinforcement, eviction, and cross-project protection**: ltm.ts: confidence lifecycle — decay, reinforcement, eviction, cross-project protection. \`decayProject(path)\` decrements confidence, never bumps \`updated\_at\`. \`markInjected(ids)\` writes only \`last\_reinforced\_at\`. \`evictLowestValue\`/\`pruneDeadEntries\`/\`pruneDeadEntriesAllProjects\` MUST skip \`cross\_project=1\` entries. \`DEAD\_CONFIDENCE\_FLOOR=0.2\`. \`enforceEntryCap\` counts promoted rows but eviction excludes them. Global sweep in \`idle.ts\`: \`pruneDeadEntriesAllProjects()\` on first tick then hourly (\`GLOBAL\_DEAD\_SWEEP\_INTERVAL\_MS=3600000\`), gated on \`loreConfig().knowledge.enabled\`. \`lastGlobalDeadSweepAt\` starts at 0, set BEFORE try block (prevents retry storm). Sweep wrapped in try/catch. Queries \`WHERE cross\_project=0 AND confidence<=0.2 LIMIT ?\` — \`cross\_project=0\` implicitly guarantees non-null \`project\_id\` (enforced at \`create()\`: null pid forces \`cross\_project=1\`).
 
@@ -52,9 +49,6 @@
 <!-- lore:019eeb85-6440-7760-912a-30c1cdc31a9f -->
 * **pipeline.ts inFlightBackground: tracks urgent distillation separately from limiter activeTasks**: pipeline.ts inFlightBackground + urgent distillation drain invariants: \`inFlightBackground\` (Set\<Promise>) tracks urgent distillation promises that bypass the background limiter. \`trackBackground(p)\` adds/removes on \`.finally()\`. Urgent distillation bypasses \`isBackgroundPaused()\` — degraded context for 10 min is worse than one API call. \`resetPipelineState\` non-fast path drains BOTH: \`drainBackground()\` (limiter's \`activeTasks\`) AND \`boundedSettle(\[...inFlightBackground], timeoutMs)\`. Missing either leaves a drain gap. \`boundedSettle()\` in background-limiter.ts: snapshots promises, races \`Promise.allSettled\` against a timeout that only resolves (never rejects); timer always cleared in \`finally\`. \`drainBackground\`: calls \`limiter.clearQueue()\` then \`boundedSettle(\[...activeTasks])\`. Queued-but-not-started tasks are never in \`activeTasks\`.
 
-<!-- lore:019ef12d-69d4-7d54-bf10-7eab46b87801 -->
-* **pipeline.ts two-block LTM: system\[1] stable baseline vs system\[2] context-bound, cache invariants**: pipeline.ts two-block LTM: system\[1] = stable LTM (preferences + entities + project-knowledge catalog, frozen 1h, \`STABLE\_LTM\_TTL\_MS=3\_600\_000\`); system\[2] = context-bound LTM (relevance-ranked, re-pinned on material change). 🔴 Invariants: (1) never bust the cache; (2) \`ltmCacheText\` never diverges from \`ltmPinText\`; (3) system\[1] never recomputed mid-session (frozen durably including empty result). PR #930: \`buildKnowledgeCatalogText\` folded into system\[1] (\`STABLE\_KNOWLEDGE\_TOC\_MAX=15\`, \`includeCross=false\`, preferences excluded). Overflow surfaces in system\[2] via \`overflowSink\`→\`pendingKnowledgeDelta.overflow\`→\`buildKnowledgeDeltaMessage\`, sorted id ASC for byte-stability, capped at \`OVERFLOW\_TOC\_MAX=12\`. Two curation paths: in-flight (gated by \`sessionState.curationScheduled\`) and idle (flush gen-0 then metaDistill) — gated separately to avoid system\[2] cache busts.
-
 <!-- lore:019f04c9-26e4-794e-8d94-dd107b7bf454 -->
 * **pipeline.ts: prompt-delta system — surfaced-set, reanchor-not-delete, and cache-stability invariants**: Three-layer delta system in \`pipeline.ts\`: 1. \*\*\`detectSurfacedMutations\`\*\* (line 1185): compares already-surfaced \`id:hash\` keys against current DB state — fires only on genuine content change or tombstone, never on per-turn ranking churn (churn-immunity property). 2. \*\*\`reanchorDeltaOnCompression\`\*\* (line 945): on a compressing turn, ALWAYS re-anchor (preserve \`content\` + \`mut\` signatures, rewrite only \`insertAt\`) — NEVER delete. Deleting wipes surfaced-set history, causing next append to re-derive full cumulative pin→DB wall (the regrowth churn #1013 trimmed but #1017 root-caused). 3. \*\*\`applySessionPromptDeltas\`\*\*: splices back-to-front so equal-position blocks replay in ascending-seq order; lower-index blocks never shifted by later splices. 🔴 Delta block must go BEFORE any assistant \`tool\_use\` — never between \`tool\_use\` and its \`tool\_result\`.
 
@@ -63,9 +57,6 @@
 
 <!-- lore:019f324d-a433-76ef-a7d3-c9acc21c6335 -->
 * **scope\_keys.wrapped\_dek: first-write-wins immutability via key\_epoch guard trigger**: PR #1179 (migration 0012\_scope\_key\_immutable.sql) adds trigger \`guard\_scope\_key\_immutable\` on \`scope\_keys\` (BEFORE UPDATE): raises \`check\_violation\` (SQLSTATE 23514) when \`new.wrapped\_dek IS DISTINCT FROM old.wrapped\_dek AND new.key\_epoch <= old.key\_epoch\`. Metadata-only changes and higher-epoch DEK rotations are allowed; same-epoch DEK clobber is blocked. Rationale: DEK clobber is the catastrophic failure mode — it orphans already-encrypted ciphertext across devices. \`account\_escrow\` is NOT made immutable (must change on passphrase rotation) — only \`scope\_keys.wrapped\_dek\` gets the guard, since escrow clobber is recoverable (device-1 retains local identity) but DEK clobber is not. Trigger ordering matters: Postgres fires BEFORE UPDATE triggers alphabetically by name — \`scope\_keys\_guard\_immutable\` (0012) fires before \`scope\_keys\_row\_quota\`/\`scope\_keys\_set\_updated\_at\` (0010) since 'g' < 'r' < 's'.
-
-<!-- lore:019ef02c-f18a-71c8-88ec-4c33c6d71a14 -->
-* **start.ts startGateway: pre-bind reuse probe + TOCTOU backstop pattern**: PR #908 fix: \`startGateway()\` now probes for an existing gateway BEFORE attempting each candidate port bind (skips port 0). Probe set: \`\[...new Set(\['127.0.0.1', ...config.hosts])]\` — loopback always included unconditionally. Returns \`{owned:false}\` immediately if any host answers \`/health\`. Post-bind EADDRINUSE catch probe retained as TOCTOU backstop only. Root cause of #908: probe was gated inside EADDRINUSE catch — non-overlapping interface bind never throws, so probe was unreachable. \`runDaemon()\` reuse-check similarly upgraded: probes \`\[...new Set(\[...opts.hosts, '127.0.0.1'])]\` (configured hosts first to preserve #875 reported address). \`firstReachableHost(hosts, port)\` helper drives both paths — parallel probes, returns first responding host by list order.
 
 <!-- lore:019ef10f-c4d9-7073-8940-764d6bb63cc4 -->
 * **Sync engine push/pull architecture: per-table cursors, quota isolation, local-first sync**: pushOnce()/pullOnce() operate per table with independent cursors: push cursor sync.push.\<table> (last seq), pull cursor sync.pull.\<table> (keyset format \`${updated\_at\_ms}|${row\_id}\`). Quota/transient failures never advance that table's cursor and never block other tables. pushOnce pushes local outbox before pulling remote (local SQLite is source of truth). Outbox pruning uses min cursor across tables with entries (empty tables excluded). Knowledge uses knowledgePushPlan() to coalesce append-only versions to one remote row keyed by logical\_id. Poison rows (over-size) recorded as rejected\_unsyncable (cursor advances); quota rows return stop (cursor unchanged for retry). PAGE=200.
@@ -85,9 +76,6 @@
 <!-- lore:019edff0-4709-74cc-98eb-ad3bd46163c1 -->
 * **sync.ts: push payload never includes owner\_user\_id — server default auth.uid() fills it; A1 changes onConflict target**: sync.ts push payload: \`pushEntry()\` sends \`toRemoteRow(pickSyncColumns(table,row))\` + \`is\_deleted:false\` + \`content\_hash\`/\`revision\` (versioned only). \`scope\_id\` NEVER included — server fills via \`default auth.uid()\`. \`onConflict\` target post-A1: \`\["scope\_id",...idColumns(table)].join(",")\`. \`REMOTE\_ONLY\_COLS\` strips \`scope\_id\`,\`author\_id\`,\`content\_hash\`,\`revision\`,\`is\_deleted\` before local apply. Soft-delete push: \`.update({is\_deleted:true}).match(decomposeId(table,rowId))\`. \`pickSyncColumns\` strips local-only cols (e.g. \`knowledge.promoted\_at\`) to avoid PGRST204. \`SyncTableMeta.versioned\` flag (default true): strip \`content\_hash\`/\`revision\` when false — \`knowledge\_entity\_refs\` is the only non-versioned table; without this fix PGRST204 → 'transient' → push cursor stuck forever.
 
-<!-- lore:019f1717-d262-761b-b10e-4afa7d4b71b7 -->
-* **vec0-cutover (PR #1051): blob→vec0 migration architecture and invariants**: vec0-cutover (PR #1051): blob→vec0 migration architecture and invariants: Moves embedding storage from per-row BLOB columns to sqlite-vec FLAT \`vec0\` virtual tables. Per-DB KV flag \`vec.storage\_mode ∈ {blob,vec0}\` (+ \`vec.dimension\`) drives behavior. Four vec0 tables: \`knowledge\_vec\`, \`entity\_vec\`, \`distillation\_vec\`, \`temporal\_vec\`. DiskANN rejected: no partition/metadata filtering, ~400× slower inserts, approximate only. Cutover is one-way via \`maybeCutoverToVec0\`. \`ensureVec0Store(conn, dim)\` idempotent — drops+recreates all 4 tables on dimension mismatch. \`deleteEmbeddings\` chunked at 900 ids (SQLite bound-variable ceiling). \`temporal\_vec\` keyed by \`chunk\_id\` (\`${id}#0\`), aux col \`message\_id\` for hydration. \`distillation\_vec\` has \`project\_id PARTITION KEY\` + \`+session\_id\` aux col. Orphan vec0 rows reclaimed by \`gcVec0DanglingRows\`. \`resolveReadMode()\` collapses (storage mode × vec availability) into single \`VecReadMode\` — callers never reason about the 2×2 matrix inline.
-
 ### Decision
 
 <!-- lore:019f43a4-4ab3-72a3-a2b6-6d1a1290548c -->
@@ -102,9 +90,6 @@
 <!-- lore:019f3974-7c6a-7091-8602-b4ec0bb763a4 -->
 * **Chose next task: knowledge\_meta seed-order alignment (self-contained, low-risk, completes value-ranked seed coherence work started with knowledge #1189 and entities #1194) — over #1191b (continuous top-N eviction)**: Completed value-ranked seed coherence work in sequence: #1189 (knowledge seed value-ranking) → PR #1194 (entity-graph seed: entities ranked by knowledge\_entity\_refs count DESC then recency; entity\_relations by recency; entity\_aliases by created\_at DESC) → PR #1196 (knowledge\_meta seed aligned to knowledge's ORDER BY: confidence DESC, COALESCE(last\_reinforced\_at, updated\_at) DESC, logical\_id tiebreak). Deferred #1191b (continuous top-N eviction for remote) as a separate larger/riskier task needing a design doc first (remote eviction, cap discovery, thrash guards, concurrency) — not suitable for autonomous same-session implementation. Follow-up issue #1197 filed for a known non-blocking edge case: a deleted high-confidence entry's orphaned knowledge\_meta row can outrank a live entry's meta row under the cap (self-healing, not data loss).
 
-<!-- lore:019f3bbc-0eee-7e38-a4ac-a76fcbe447f7 -->
-* **Chose option 3b (exact, self-contained eviction value) over approximate/JOIN-based approaches for server-side eviction**: chose option 3b (exact, self-contained eviction value) over approximate/JOIN-based approaches for server-side eviction.
-
 <!-- lore:019f5211-7cb6-7f6e-b1ee-cc442b8878ad -->
 * **Chose to proceed with team lifecycle epic over verifying main's release state**: chose to proceed with team lifecycle epic over verifying main's release state.
 
@@ -114,26 +99,14 @@
 <!-- lore:019f4629-d9d0-7c59-924c-dc7341e57c77 -->
 * **Closed #1231 (distillation value-retention): reuse knowledge\_refs + file reads instead of memorizing repo-resident values**: Chose to close PR #1231 (feat: retain exact literal/style values in observations) over building a value-extractor. Rationale: a stored value is a cache of the file — the moment the file changes, every distillation that memorized the old value is confidently wrong. A pointer + file Read is always correct and costs the same tool call. \`knowledge\_refs\` + \`knowledge\_ref\_validity\` already store and validate file:line pointers. The value-extractor would duplicate this and add staleness. Boundary: ephemeral facts (test run counts, stated numbers, decisions) have no file to read → those belong in memory via distillation/knowledge. Code-resident specifics → pointer + read.
 
-<!-- lore:019f3da7-bbab-7534-ba3c-924bf1d55985 -->
-* **Decided to use sqlite3 CLI to export session rows as JSON**: decided to use sqlite3 CLI to export session rows as JSON,
-
-<!-- lore:019f3898-9b7f-7939-8c91-56590f2de777 -->
-* **Decided to use the direct Anthropic API key (x-api-key header) rather than OAuth**: decided to use the direct Anthropic API key (x-api-key header) rather than OAuth,
-
 <!-- lore:019ef0c0-0308-797a-ad49-7b0c08aedb80 -->
 * **knowledge\_meta as separate synced convergent register table**: Chose separate knowledge\_meta table (Option A) over keeping confidence on per-version knowledge rows with backward sync compat (Option B). Rationale: Option B accrues sync complexity on a legacy column — confidence is mutable metadata, not per-version data, so a separate structure is semantically correct. Cost: requires remote migration 0009, RLS policies, and sync pipe plumbing. knowledge\_meta uses per-field merge: delta-CRDT for confidence/counts, max for timestamps. last\_reinforced\_at stays local (sync-excluded). cross\_project entries never adjusted by outcome-reward loop.
 
 <!-- lore:019efe86-ad54-7ad3-868b-c3a76af9d306 -->
 * **Lore license: FSL-1.1-Apache-2.0 (Fair Source), NOT open source**: Lore/loreai is Fair Source, specifically FSL-1.1-Apache-2.0 (Functional Source License v1.1, Apache 2.0 Future License). Competing Use (using code to compete against Lore) is prohibited. Converts to Apache 2.0 later. Copyright 2026 Burak Yigit Kaya. Implication: competitors legally cannot lift Lore's context-management code. This kills any 'more open than ByteRover's Elastic License' positioning angle — both are source-available, not OSS. Licensing framing belongs on positioning pages, not in vendor-neutral blog posts.
 
-<!-- lore:019f2388-7b67-7ba2-8d3d-66e3231ec43c -->
-* **Migrated to native onnxruntime-node addon loading**: migrating from WASM-based ONNX runtime to native onnxruntime-node addon loading.
-
 <!-- lore:019ef58f-9ff2-7edc-a84c-e7b3ba2622a4 -->
 * **Migrated to register (no assertion values changed)**: migrated to register (no assertion values changed).
-
-<!-- lore:019f27e4-458e-7d6a-bdfc-5ab2f35c5354 -->
-* **Migrated to settings**: migrated to settings.
 
 <!-- lore:019f5b56-d717-7acf-82cd-ecfc75ca4871 -->
 * **Migrated to TG): test failed at sync**: migrating to TG): test failed at sync.
@@ -147,31 +120,16 @@
 <!-- lore:019efa1b-96f8-7702-8ddb-ccbc2fece37e -->
 * **sqlite-vec: native extension chosen over WASM; vec0 virtual table deferred**: Chose native extension + JS fallback over WASM-first for sqlite-vec. WASM build targets browser sqlite-wasm engine only — using it in node:sqlite/bun:sqlite would require replacing the entire SQLite engine, slowing ALL queries. Drop-in \`vec\_distance\_cosine()\` over existing BLOB columns chosen for PR #967 scope; \`vec0\` virtual table migration rejected as first step. Portability strategy: keep embeddings as F32 BLOB columns (byte-compatible with libSQL's \`F32\_BLOB\`); when hosted gateway becomes real, add \`driver.libsql.ts\` behind existing \`#db/driver\` map backed by \`vector\_top\_k\` — no data migration, no caller changes.
 
-<!-- lore:019f4e07-af72-709a-9f1a-ce812355e889 -->
-* **Switched from a self-relation to two separate entities (e1**: switched from a self-relation to two separate entities (e1,
-
 <!-- lore:019f718f-9d3f-7637-bd1e-f56a97912261 -->
 * **Switched from claude-sonnet-4.6 to claude-sonnet-5 for consistency with published results**: Switched from claude-sonnet-4.6 to claude-sonnet-5 for consistency with published results.
 
-<!-- lore:019f4e9b-53bd-7506-8413-94d3cecd4213 -->
-* **Switched from forcing a violation to \*\*catalog introspection\*\* — directly querying information\_schema/pg\_constraint to assert content**: Switched from forcing a violation to \*\*catalog introspection\*\* — directly querying information\_schema/pg\_constraint to assert content.
-
-<!-- lore:019f2033-ea6f-71fa-bc9b-ea0b95b28387 -->
-* **Switched from inline eval to a script file to avoid SQL quoting issues**: switched from inline eval to a script file to avoid SQL quoting issues.
-
 <!-- lore:019f05e3-1abc-7c77-944b-bc9e7ae25bb1 -->
 * **Switched from plan mode to build mode (read-write**: switched from plan to build mode (read-only lifted; file changes,
-
-<!-- lore:019f6bb3-6ee8-7b56-bfba-67fa27cab162 -->
-* **Switched from Python to TypeScript**: switched from Python to TypeScript.
 
 ### Gotcha
 
 <!-- lore:019ef645-24ae-7562-ace6-3b0d343cdb3f -->
 * **applyRemoteMetaCrdt uses Date.now() for updated\_at — corrupts remote timestamp semantics**: Trap: \`applyRemoteMetaCrdt\` passes \`Date.now()\` as \`updated\_at\` when merging remote CRDT row — looks fine because sync advances cursors anyway. Fix: remote \`row\` already contains correct \`updated\_at\` (epoch ms); using local \`Date.now()\` loses the actual change timestamp, corrupting \`updated\_at\` semantic meaning (though not breaking CRDT merge or cursor advancement). Fix: pass \`Number(row.updated\_at ?? 0)\` instead. Confirmed in PR #1126 fix commit \`36173a7\`.
-
-<!-- lore:019f7080-f4db-713c-b5b3-3742678a3f11 -->
-* **Auto-import failure: background import fails with 'no-auth' when no auth exists**: Trap: \`lore run\` auto-import fails with 'no-auth' errors when no auth exists. User confirmed import with 'y', but background import repeatedly fails with 'no-auth' errors (session=\_unknown), followed by agent selection prompt hanging. Fix: Always check for auth before starting background import. If no auth exists, skip import or prompt for auth setup first. Rationale: Background import requires auth to proceed, but auto-import may be triggered before auth is configured.
 
 <!-- lore:019f1fde-f198-76a6-a8e1-1ba44ab8cf1d -->
 * **backfillTemporalEmbeddings idle-gate: session-activity window starves backfill under sustained load**: Trap: gating temporal backfill on session activity (any session active within \`idleTimeoutSeconds \* 1000\` ms) looks correct — avoids competing with live traffic. Fix: on a busy machine with 5 active sessions and 142 turns in ~18 min, the gate never opens; cursor never advances during 8+ min monitoring window. The session-activity window is too coarse — it parks backfill even when the embed worker is idle between requests. Fix (PR #1111): gate on \`recallEmbedsInFlight() > 0\` instead. This is selective — backfill progresses during recall's sub-second gaps between requests. Under active multi-session load post-deploy: park/resume cycles seconds apart, ~16 msgs/min throughput confirmed in logs. Inherent limitation: sustained back-to-back recall with no gaps still starves backfill, but this is accurate (shared single worker) rather than a false signal.
@@ -311,9 +269,6 @@
 <!-- lore:019f1cc8-b6eb-7d3f-9be2-2cf81848d519 -->
 * **Vacuous seam test: single-message transform input never reaches loadDistillationsCached (Layer 0 early return)**: Trap: writing an end-to-end seam test for \`prewarmDistillationSnapshot\` with a single small message looks correct — it exercises the prewarm→transform path. Fix: \`transformInner\` early-returns at Layer 0 when all messages fit, so \`loadDistillationsCached\` is never called. Single-message inputs with empty \`parts\` (0 tokens) always take the Layer 0 path. To force the compaction path where \`loadDistillationsCached\` is actually called, build a large input (~60K chars across ~20 user+assistant messages) that exceeds the Layer 0 ceiling. Verify non-vacuousness by mutating \`loadDistillationsCached\` to always force cache-miss — seam test must fail.
 
-<!-- lore:019f14c0-7cf1-7dd2-be90-a34480c59da6 -->
-* **vec-store.ts: embedding NEVER transferred across worker boundary — structured-clone only**: Trap: transferring the \`Float32Array\` embedding across the worker boundary looks like a performance win (avoids copy). Fix: transferring detaches the caller's buffer and corrupts the in-process fallback that reuses it. The embedding (~3 KB for 768 dims) is always structured-cloned, never transferred. This is an explicit design invariant documented in \`vector-worker.ts\`. Do not add \`Transferable\` to the embedding field in \`VectorQuerySpec\`.
-
 <!-- lore:019f43a4-4ea3-752b-bd99-f2ef59d93db6 -->
 * **vectorSearchDistillations is not project-scoped — hydration query must filter by project\_id**: Trap: calling \`vectorSearchDistillations(queryVec, limit)\` and hydrating results looks correct — it mirrors \`vectorSearchTemporal\`. Fix: \`vectorSearchDistillations\` takes no project param; results include distillations from ALL projects. \`vectorSearchTemporal(queryVec, pid, limit)\` is correctly project-scoped. Any code path that calls \`vectorSearchDistillations\` must filter the hydration query with \`WHERE archived = 0 AND project\_id = ?\`, over-fetching (\`limit \* 4\`) and capping at \`limit\` after filtering to avoid multi-project starvation. Seer caught this as a CRITICAL cross-project data leak in PR #1228 review. Follow-up: add a natively project-scoped distillation vector search function.
 
@@ -372,11 +327,11 @@
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
 * **Always a remote gateway — it has no shared filesystem with its clients**: User stated: 'Always a remote gateway — it has no shared filesystem with its clients'. This is a directive preference.
 
-<!-- lore:019f7198-ce07-794a-a76b-39db101e2201 -->
-* **Always call plan\_exit to indicate planning completion**: The user consistently requires the assistant to explicitly call plan\_exit at the end of planning sessions. This serves as a clear signal that the planning phase is complete and the user should be notified. The pattern appears in multiple sessions where the user provides explicit instructions to 'always call plan\_exit' during planning activities.
-
 <!-- lore:019f6fba-0d21-7410-894e-4933b29e8518 -->
 * **Always converges**: User stated: 'always converges'. This is a directive preference.
+
+<!-- lore:019f7766-9f0a-787b-8afd-96740e7d81a4 -->
+* **Always drain outstanding embedding promises on shutdown**: User consistently requires that outstanding \`trackDocEmbed\` promises be drained on shutdown to prevent silent recall degradation from incomplete distillation embeddings. This pattern has appeared in 22 prior sessions and is a directive preference.
 
 <!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
 * **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
@@ -387,11 +342,23 @@
 <!-- lore:019f7155-c3b2-7ddf-8dc5-f9c97f3904e0 -->
 * **Always keep pinned segments in distillation**: Always keep head segments in distillation. User stated: 'always kept\*\* (0 >= budget is false for budget>0),'. This is a directive preference.
 
+<!-- lore:019f76d7-40de-713c-a0c5-04296caebd35 -->
+* **Always match remote row for tombstone reaper**: The user consistently requires that tombstone reaper operations match their remote row. This pattern has appeared in 33 prior sessions and is a directive preference.
+
 <!-- lore:019f6fd7-3931-76ae-93b7-cbcec8c69643 -->
 * **Always normalize to MIGRATIONS.length for database migrations**: Always normalize to MIGRATIONS.length for database migrations to ensure consistency. This was a directive preference.
 
+<!-- lore:019f7766-9f85-7a5c-b3d3-1917618602bd -->
+* **Always position delta block before assistant tool\_use**: User consistently requires that delta blocks be positioned before any assistant \`tool\_use\` in the prompt, never between \`tool\_use\` and its \`tool\_result\`. This pattern has appeared in 36 prior sessions and is a directive preference.
+
 <!-- lore:019f6f42-408e-7635-81d6-4d51ec94a3c9 -->
 * **Always prefer f-strings over .**: User stated always prefer f-strings over . This is a directive preference.
+
+<!-- lore:019f7985-3fd0-733c-9ec4-57cc700122ed -->
+* **Always provide tool results to guide investigation and confirm findings**: The user consistently provides tool results (logs, database queries, file contents, status updates) to guide the assistant's investigation. This pattern occurs when debugging issues, verifying system behavior, or confirming root causes. The user expects the assistant to use these results to form hypotheses, validate assumptions, and draw conclusions. The assistant should treat these provided results as authoritative evidence and incorporate them directly into the analysis.
+
+<!-- lore:019f7766-9f5b-72e8-9567-531f800edfd0 -->
+* **Always re-index missing distillation\_vec rows on next boot**: User consistently requires re-indexing missing \`distillation\_vec\` rows on next boot to recover from incomplete embeddings due to early session termination. This pattern has appeared in 39 prior sessions and is a directive preference.
 
 <!-- lore:019f66b3-cdb2-7605-9908-3135589ec555 -->
 * **Always record auth failure**: Always record the auth failure so the worker-health ladder sees it.
@@ -405,23 +372,29 @@
 <!-- lore:019f70a4-9381-77f1-bc0d-1485c1e9fbcd -->
 * **Always signal — never truncate user's actual prose/instructions**: Always signal — never truncate user's actual prose/instructions. User stated that the leading prose prefix is always kept verbatim during reduction. This is a directive preference.
 
-<!-- lore:019f719b-c5a7-704d-9a34-d2552d266e4d -->
-* **Always use bedrock-mantle with anthropic wire protocol and model remap**: The user consistently implements bedrock-mantle integration using the anthropic wire protocol exclusively. This includes: 1) Using the anthropic wire path for all bedrock-mantle requests, 2) Applying model ID remapping to anthropic format (anthropic.\<name>), 3) Using native Anthropic Messages API with x-api-key authentication and anthropic-version header, 4) Building URLs with the /anthropic base path, and 5) Ensuring the isBedrockMantleDispatch function enforces the anthropic protocol requirement. The user also consistently notes that bedrock-mantle does not support structured outputs.
+<!-- lore:019f71b3-f431-7888-b0f9-e87ffeb410de -->
+* **Always sit at the front of the transformed**: User stated: 'always sits at the front of the transformed'. This is a directive preference.
+
+<!-- lore:019f76d7-4108-7e96-95f3-468dca0b097f -->
+* **Always use 'document' inputType for backfill to avoid self-gating**: The user consistently requires using 'document' inputType for backfill operations to ensure \`isRecall\` is always false and avoid self-gating. This pattern has appeared in 35 prior sessions and is a directive preference.
 
 <!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
 * **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
 
+<!-- lore:019f76d7-4130-7451-9577-e41c9c4533fe -->
+* **Always use worker-model for worker path to avoid empty completions**: The user consistently requires using worker-model for worker path operations to avoid empty completions. This pattern has appeared in 27 prior sessions and is a directive preference.
+
 <!-- lore:019f6fba-0dc9-787f-a62e-b86b43f939a0 -->
 * **Always valid for JSON**: User stated: 'always valid for JSON.' This is a directive preference.
+
+<!-- lore:019f7766-9f32-757d-bbf8-b709eb759894 -->
+* **Always warm-start embedding worker at gateway startup**: User consistently requires warm-starting the embedding worker at gateway startup to avoid cold model load delays causing incomplete distillation embeddings. This pattern has appeared in 35 prior sessions and is a directive preference.
 
 <!-- lore:019f70a4-93ca-7b63-8ff1-277c6772b3b8 -->
 * **Assertion patterns should match correctly without consuming punctuation**: Assertion patterns should match correctly without consuming punctuation. User stated that the leading prose prefix is always kept during blob reduction. This is a directive preference.
 
 <!-- lore:019f6f38-a1ff-7b4b-b941-36b22f5dd4e7 -->
 * **Avoid re-embedding identical text every CI run**: Avoid re-embedding identical text every CI run. User stated re-embedding identical text every run is wasteful. This is a CI optimization preference. Directive preference.
-
-<!-- lore:019eff04-9cca-712f-bdb7-535292cfc96b -->
-* **Blog tone: category-not-competitor thesis — gentle, not dunking**: 🔴 Directive: convey the 'new category being invented' thesis gently — acknowledge the existing category isn't enough and that something new is being built, without dunking on existing tools. Generous close required: 'a good store is genuinely worth having.'
 
 <!-- lore:019f6f38-a17c-7356-a948-2769779627a0 -->
 * **checkInvariants should accept invariant source (DB or snapshot)**: User stated checkInvariants should accept invariant source (DB or snapshot). This is a CI design constraint. Directive preference.
@@ -459,6 +432,9 @@
 <!-- lore:019f6f38-a1a3-7dbe-ad09-badf91b29dcf -->
 * **loadInvariantVecs should read from snapshot**: User stated loadInvariantVecs should read from snapshot. This is a CI design constraint. Directive preference.
 
+<!-- lore:019f71b3-f4b0-7ddb-91ff-b8a54acc8e99 -->
+* **Never a different provider's credential**: User stated: 'never a different provider's credential.' This is a directive preference.
+
 <!-- lore:019f650e-1593-72e3-8c34-fdbf17c32560 -->
 * **Never a skip/conflict**: Never a skip/conflict: User stated never a skip/conflict.
 
@@ -471,8 +447,20 @@
 <!-- lore:019f6d35-e488-7b86-ae65-3ef2b695c2a3 -->
 * **Never assert memberships**: User stated: 'never asserts memberships'. This is a client behavior constraint for GitHub provisioning. Directive preference.
 
+<!-- lore:019f72d7-dda3-70f6-b2e1-baf051675a0c -->
+* **Never block a PR**: User stated never block a PR.
+
+<!-- lore:019f77f9-b7d6-7f6c-9431-9f4fd9a443a3 -->
+* **Never block shutdown longer than hard deadline**: User consistently requires that shutdown procedures never block longer than a hard deadline to avoid Ctrl+C hangs. This pattern has appeared in 36 prior sessions and is a directive preference.
+
+<!-- lore:019f72d7-dd85-704a-875c-3e32c068074e -->
+* **Never breaks the build**: User stated never breaks the build.
+
 <!-- lore:019f7155-c3d6-70e8-9030-6a4570e986d1 -->
 * **Never bust expensive cache**: Never bust expensive cache. User stated: 'never busts an expensive cache,'. This is a directive preference.
+
+<!-- lore:019f71b3-f486-7538-98b6-c757b54477e6 -->
+* **Never call markAuthStale on pass-through path**: User stated: 'never calls \`markAuthStale\` on this pass-through path (confirmed earlier),'. This is a directive preference.
 
 <!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
 * **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
@@ -501,11 +489,17 @@
 <!-- lore:019f702c-6ef3-717a-b329-7a050a717b77 -->
 * **Never drop exact evidence in candidate selection**: Never drop exact evidence in candidate selection. This is a directive preference.
 
-<!-- lore:019f6b15-45ae-736f-afe0-20c2cecf302a -->
-* **Never edit the real repo**: Never edit the real repo. This is a directive preference.
+<!-- lore:019f749f-147f-7645-a1ec-0821e1476840 -->
+* **Never exceed total budget**: Never exceed total budget. This is a directive preference.
+
+<!-- lore:019f749f-1424-7faf-8acc-44fa2494533b -->
+* **Never filters bug**: Never filters bug. This is a directive preference.
 
 <!-- lore:019f65ca-91fb-7140-b01f-aeb90540b80d -->
 * **Never from within another transaction**: User stated never from within another transaction.
+
+<!-- lore:019f77f9-b7fe-762f-964d-c12ed8900375 -->
+* **Never get stuck on hung child process during shutdown**: User consistently requires that shutdown procedures never get stuck on hung child processes. This pattern has appeared in 33 prior sessions and is a directive preference.
 
 <!-- lore:019f70c1-6116-7798-bde9-7dbaf926a516 -->
 * **Never grant UPDATE on profiles to service\_role**: User stated that service\_role was 'never granted UPDATE on profiles' regarding tier guards. This is a directive preference.
@@ -518,9 +512,6 @@
 
 <!-- lore:019f6d35-e545-7fd8-926b-e1559953d5aa -->
 * **Never leave pending\_invites on server**: User stated: 'never leaves the server.' This is a security invariant for pending\_invites. Directive preference.
-
-<!-- lore:019f6fba-0df9-7ef4-993f-fa7a5d5888d2 -->
-* **Never need to pre-escape**: Callers never need to pre-escape (markdown.ts:21). This was a directive preference.
 
 <!-- lore:019f6d35-e4ad-717b-8e4c-6805789cb076 -->
 * **Never over-grant roles**: User stated: 'never over-grant'. This is a role mapping constraint for GitHub provisioning. Directive preference.
@@ -555,17 +546,20 @@
 <!-- lore:019f6f38-9f83-7c59-b773-9c85fd64d5e5 -->
 * **Never ship DEK to CI**: Never ship DEK to CI. User stated shipping the DEK to CI would violate encryption posture. This is a security constraint. Directive preference.
 
+<!-- lore:019f749f-13fe-7823-a5da-cc11a5f5bc69 -->
+* **Never surfaced into system\[2] whenever embeddings**: Never surfaced into system\[2] whenever embeddings. This is a directive preference.
+
+<!-- lore:019f749f-144c-7e1c-b1f3-4f64753f976c -->
+* **Never surfaced on the vector signal alone**: Never surfaced on the vector signal alone. This is a directive preference.
+
 <!-- lore:019f6f38-a07b-782d-93b8-c4ddcef09326 -->
 * **Never sync embeddings**: User stated embeddings are not synced at all. This is a sync design constraint. Directive preference.
 
-<!-- lore:019f6b15-45db-7dd4-af70-5e4ac93d0244 -->
-* **Never the live conversation**: Never the live conversation. This is a directive preference.
+<!-- lore:019f71b3-f45b-7c8d-b1de-3d96494f11cf -->
+* **Never touch the front**: User stated: 'never touches the front,'. This is a directive preference.
 
 <!-- lore:019f7121-344f-75fe-99b5-d18253381602 -->
 * **Never touch the real repo files**: Never touch the real repo files. User stated to NEVER touch the real repo files. This is a directive preference.
-
-<!-- lore:019f64f3-4326-79f4-88ff-b8bc01c50706 -->
-* **Never touch the user's real gateway/DB**: User stated never touch the user's real gateway/DB.
 
 <!-- lore:019f66a2-5938-7fd4-b581-90d256a820c4 -->
 * **Never TTL-evicted**: User stated never TTL-evicted.
@@ -578,6 +572,12 @@
 
 <!-- lore:019f70c1-61df-7837-a22e-2aee503b0b98 -->
 * **Never write service-role key to disk**: User stated that service-role key 'never touches that path — it is never written to disk'. This is a directive preference.
+
+<!-- lore:019f756d-37fe-78d7-9306-40dfe31342ad -->
+* **Prefers native ONNX runtime via resolveNativeOrtBindingPath, falls back over WASM if native not resolvable**: prefers native ONNX runtime via resolveNativeOrtBindingPath, falls back to WASM if native not resolvable.
+
+<!-- lore:019f7331-e703-7ae9-aa16-093875aeb481 -->
+* **Prefers recall over assuming you don't have the information**: prefer recall over assuming you don't have the information.
 
 <!-- lore:019f6d35-e593-7004-9250-0da8b3352c08 -->
 * **Replace revoke with grant for verified\_email\_domain**: User stated: 'replace revoke with \`grant .'. This was a mutation test scenario. Directive preference.
@@ -600,9 +600,6 @@
 <!-- lore:019f6f38-a127-7d59-bd32-486bd71ac328 -->
 * **Snapshot should include text, vectors, confidence, cross\_project**: User stated snapshot should include text, vectors, confidence, cross\_project. This is a CI design constraint. Directive preference.
 
-<!-- lore:019f66ae-9aa3-7f41-9cf2-4596011f1f35 -->
-* **Switch to synchronous mode**: User switched to synchronous mode for future calls.
-
 <!-- lore:019f702c-6f46-7a12-a71c-1507abeb6e0c -->
 * **Tooling failures like no commit range are not findings**: Tooling failures like inability to resolve commit range are not findings. This is a directive preference.
 
@@ -612,5 +609,8 @@
 <!-- lore:019f6f38-a1cd-7870-a091-21d36f40386f -->
 * **Use forProject(path, true) to include cross-project entries**: User stated checkInvariants uses forProject(path, true) which includes cross-project. This is a CI design constraint. Directive preference.
 
-<!-- lore:019f66f6-4b21-78ae-b548-0e6abf41c40a -->
-* **User never writes to intermediate files**: Never creates a project or registers aliases during import detection. The import flow should only discover existing projects, not modify state.
+<!-- lore:019f77f9-b84c-7c77-9bd6-baa0e69a9bdc -->
+* **Warmup embedding never blocks startup**: User consistently requires that embedding warmup never blocks startup. This pattern has appeared in 40 prior sessions and is a directive preference.
+
+<!-- lore:019f77f9-b825-7350-a219-87bda1045e2e -->
+* **Warmup embedding never hits network or burns quota**: User consistently requires that embedding warmup never hits the network or burns quota. This pattern has appeared in 34 prior sessions and is a directive preference.

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2113,16 +2113,21 @@ export async function settleDocumentEmbeds(timeoutMs?: number): Promise<void> {
     return;
   }
 
-  const deadline = Date.now() + timeoutMs;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const expired = new Promise<void>((resolve) => {
-    timer = setTimeout(resolve, timeoutMs);
+  const EXPIRED = Symbol("expired");
+  const expired = new Promise<typeof EXPIRED>((resolve) => {
+    timer = setTimeout(() => resolve(EXPIRED), timeoutMs);
   });
   try {
-    while (_docEmbedsInFlight.size > 0 && Date.now() < deadline) {
-      // Race the current in-flight set against the shared deadline. Loop so
-      // embeds spawned mid-drain are picked up, but never past the deadline.
-      await Promise.race([Promise.allSettled(_docEmbedsInFlight), expired]);
+    while (_docEmbedsInFlight.size > 0) {
+      // Race the current in-flight set against the deadline. Loop so embeds
+      // spawned mid-drain are picked up; break the instant the deadline wins so
+      // we never wait — nor busy-spin — past it.
+      const winner = await Promise.race([
+        Promise.allSettled(_docEmbedsInFlight).then(() => undefined),
+        expired,
+      ]);
+      if (winner === EXPIRED) break;
     }
   } finally {
     if (timer) clearTimeout(timer);

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -2082,10 +2082,12 @@ export async function vectorSearchAllDistillations(
  */
 // Fire-and-forget document embeds (knowledge, distillation, entity) must not
 // block the write path, so callers don't await them. They are tracked here so
-// tests can drain them at the test boundary via settleDocumentEmbeds(): a
-// promise that resolves AFTER the harness closes/swaps the DB would otherwise
-// write to the wrong DB or log spurious errors (issue #885). No-op in
-// production, which never calls the drain.
+// callers can drain them: at the test boundary (a promise that resolves AFTER
+// the harness closes/swaps the DB would otherwise write to the wrong DB or log
+// spurious errors — issue #885), and on graceful gateway shutdown (a
+// distillation embed still mid-flight when the worker is torn down never writes
+// its `distillation_vec` row → silent recall degradation on short/fast
+// sessions — issue #1331).
 const _docEmbedsInFlight = new Set<Promise<unknown>>();
 function trackDocEmbed(p: Promise<unknown>): void {
   _docEmbedsInFlight.add(p);
@@ -2094,12 +2096,36 @@ function trackDocEmbed(p: Promise<unknown>): void {
 
 /**
  * Await all in-flight fire-and-forget document embeds (knowledge / distillation
- * / entity). Test-only drain hook — production never calls it. Loops so embeds
- * spawned while draining (rare) are also awaited.
+ * / entity). Loops so embeds spawned while draining (rare) are also awaited.
+ *
+ * `timeoutMs` bounds the wait: when the deadline elapses the drain resolves
+ * even if embeds are still pending. The production shutdown path (#1331) passes
+ * a bound comfortably under `SHUTDOWN_DEADLINE_MS` so a slow/stuck embed can
+ * never reintroduce the Ctrl+C hang; anything left unfinished is re-indexed by
+ * `runStartupBackfill` on the next boot. Tests call it with no argument for a
+ * full (unbounded) drain.
  */
-export async function settleDocumentEmbeds(): Promise<void> {
-  while (_docEmbedsInFlight.size > 0) {
-    await Promise.allSettled(_docEmbedsInFlight);
+export async function settleDocumentEmbeds(timeoutMs?: number): Promise<void> {
+  if (timeoutMs == null) {
+    while (_docEmbedsInFlight.size > 0) {
+      await Promise.allSettled(_docEmbedsInFlight);
+    }
+    return;
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  try {
+    while (_docEmbedsInFlight.size > 0 && Date.now() < deadline) {
+      // Race the current in-flight set against the shared deadline. Loop so
+      // embeds spawned mid-drain are picked up, but never past the deadline.
+      await Promise.race([Promise.allSettled(_docEmbedsInFlight), expired]);
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -2177,6 +2203,28 @@ export function embedDistillation(id: string, observations: string): void {
         log.error("embedding failed for distillation", id, ":", err);
       }),
   );
+}
+
+/**
+ * Pay the local ONNX model's cold-load cost (~21s measured) up front by firing
+ * one throwaway embed at gateway startup, so the FIRST real distillation embed
+ * of the session is already warm and finishes within the turn instead of racing
+ * teardown (#1331). Fire-and-forget: never blocks startup, never throws.
+ *
+ * Local-only: remote providers (Voyage/OpenAI) have no cold-load cost and a
+ * warmup would only burn API quota, so this is a no-op for them and when
+ * embeddings are disabled. Uses `"document"` inputType so it is NOT counted as
+ * a recall embed (see {@link embed}) and cannot self-gate the temporal backfill.
+ * Not tracked via `trackDocEmbed` — it stores nothing, so there is no
+ * write-to-wrong-DB / mid-flight-on-teardown concern to drain.
+ */
+export function warmupEmbedding(): void {
+  if (!isAvailable()) return;
+  if (config().search.embeddings.provider !== "local") return;
+  void embed(["warmup"], "document").catch((err) => {
+    if (err instanceof LocalProviderUnavailableError) return;
+    log.error("embedding warmup failed:", err);
+  });
 }
 
 /**

--- a/packages/core/test/background-drain.test.ts
+++ b/packages/core/test/background-drain.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import type { Worker } from "node:worker_threads";
 import {
   embedKnowledgeEntry,
   isAvailable,
+  recallEmbedsInFlight,
   settleDocumentEmbeds,
+  warmupEmbedding,
   _persistEmbedCap,
   _resetLocalProviderProbe,
   _restoreProvider,
@@ -12,6 +14,7 @@ import {
   _setTestWorkerFactory,
 } from "../src/embedding";
 import { settleBackgroundWork } from "../src/distillation";
+import { config, load } from "../src/config";
 
 // Guards the issue #885 fix: fire-and-forget document embeds (embedKnowledgeEntry
 // / embedDistillation / embedEntity) and non-urgent pattern-echo work must be
@@ -136,5 +139,182 @@ describe("background-work drain (issue #885)", () => {
   it("drains are no-ops when nothing is in flight", async () => {
     await expect(settleDocumentEmbeds()).resolves.toBeUndefined();
     await expect(settleBackgroundWork()).resolves.toBeUndefined();
+  });
+});
+
+// Guards the issue #1331 fix: a distillation embed still in flight when the
+// gateway is torn down must be drained BEFORE the worker is shut down, or its
+// `distillation_vec` row is never written → silent recall degradation on
+// short/fast sessions. The drain is BOUNDED so a slow/stuck embed can't
+// reintroduce the Ctrl+C hang; and the worker is warm-started at gateway
+// startup so the first real embed is fast enough to finish within the turn.
+describe("bounded document-embed drain (issue #1331)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+
+  beforeEach(() => {
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+  });
+
+  afterEach(async () => {
+    _setTestWorkerFactory(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    else delete process.env.VOYAGE_API_KEY;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+    else delete process.env.OPENAI_API_KEY;
+    // Restore default (local) config for any suite that runs after us.
+    await load(process.cwd());
+  });
+
+  it("settleDocumentEmbeds(timeoutMs) resolves at the deadline even with a pending embed", async () => {
+    _persistEmbedCap(8192, 0);
+    const fakes = installFakeWorkers();
+    expect(isAvailable()).toBe(true);
+
+    // Fire an embed and never let the (fake) worker reply — it stays pending.
+    embedKnowledgeEntry("k-1331", "title", "content");
+    await flush();
+    expect(fakes).toHaveLength(1);
+
+    // A bounded drain must RESOLVE at the deadline rather than hang on the
+    // never-completing embed (this is what keeps Ctrl+C snappy).
+    const start = Date.now();
+    await settleDocumentEmbeds(50);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(45);
+    expect(elapsed).toBeLessThan(1000);
+
+    // Complete the embed so it doesn't leak into the shared in-flight set and
+    // stall a later test's drain (the module-level set persists across tests).
+    fakes[0].emit("message", {
+      type: "result",
+      id: fakes[0].lastPosted().id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    await settleDocumentEmbeds();
+  });
+
+  it("settleDocumentEmbeds(timeoutMs) returns immediately once the embed completes", async () => {
+    _persistEmbedCap(8192, 0);
+    const fakes = installFakeWorkers();
+
+    embedKnowledgeEntry("k-1331-b", "title", "content");
+    await flush();
+    expect(fakes).toHaveLength(1);
+
+    // Worker replies → embed resolves → a generous-deadline drain returns fast.
+    fakes[0].emit("message", {
+      type: "result",
+      id: fakes[0].lastPosted().id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    await flush();
+    const start = Date.now();
+    await settleDocumentEmbeds(5000);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});
+
+describe("warmupEmbedding (issue #1331)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+
+  beforeEach(() => {
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    _setTestWorkerFactory(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    else delete process.env.VOYAGE_API_KEY;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+    else delete process.env.OPENAI_API_KEY;
+    await load(process.cwd());
+  });
+
+  it("fires exactly one 'document' embed on a local provider", async () => {
+    _persistEmbedCap(8192, 0);
+    const fakes = installFakeWorkers();
+    expect(isAvailable()).toBe(true);
+    expect(config().search.embeddings.provider).toBe("local");
+
+    warmupEmbedding();
+    await flush();
+
+    // The warmup posted exactly one embed to the local worker.
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].posted.filter((m) => m.type === "embed")).toHaveLength(1);
+
+    // Drain the in-flight warmup so it doesn't leak into the shared set.
+    fakes[0].emit("message", {
+      type: "result",
+      id: fakes[0].lastPosted().id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    await settleDocumentEmbeds();
+  });
+
+  it("does NOT count the warmup as a recall embed (no self-gating of backfill)", async () => {
+    _persistEmbedCap(8192, 0);
+    const fakes = installFakeWorkers();
+
+    // Drive the real embed path (no spy) so the recall counter is exercised;
+    // the fake worker won't reply until we tell it to, keeping the embed in
+    // flight while we check the counter.
+    warmupEmbedding();
+    await flush();
+
+    // A 'document' embed must never touch the recall-in-flight counter, or it
+    // would park the temporal backfill on itself.
+    expect(recallEmbedsInFlight()).toBe(0);
+
+    // Complete + drain so nothing leaks into the shared in-flight set.
+    fakes[0].emit("message", {
+      type: "result",
+      id: fakes[0].lastPosted().id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    await settleDocumentEmbeds();
+  });
+
+  it("is a no-op for a remote provider — never hits the network (no quota burn)", async () => {
+    // Voyage WITH a key → provider is available but NOT local. Removing the
+    // local-only guard would make warmup call VoyageProvider.embed → a real
+    // fetch to the Voyage API. Spy on fetch to prove warmup never does that.
+    process.env.VOYAGE_API_KEY = "test-voyage-key-abcdefghijklmnop";
+    await load(process.cwd());
+    (config().search.embeddings as { provider: string }).provider = "voyage";
+    _resetLocalProviderProbe();
+    _saveAndClearProvider();
+    expect(isAvailable()).toBe(true); // remote provider is available…
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: [0.1] }] }), {
+        status: 200,
+      }),
+    );
+
+    warmupEmbedding();
+    await flush();
+
+    // …but warmup must skip it — no HTTP request, so no remote quota burned.
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -452,14 +452,18 @@ export async function startGateway(
         // replaying queued background prompts through retries is what made
         // Ctrl+C hang for minutes. They resume next session.
         await resetPipelineState({ fast: true });
-        // Drain any in-flight fire-and-forget document embed (esp. a
-        // distillation embed created this session that would otherwise never
-        // write its `distillation_vec` row before the worker is torn down —
-        // #1331). BOUNDED so a slow/stuck embed can't reintroduce the Ctrl+C
-        // hang `fast: true` exists to avoid; must run while the worker is still
-        // alive (resetProvider below kills it) and after resetPipelineState so
-        // no new background work is scheduled mid-drain. Anything left pending
-        // at the deadline is re-indexed by runStartupBackfill on the next boot.
+        // Drain any document embed ALREADY in flight (esp. a distillation
+        // embed created this session that would otherwise never write its
+        // `distillation_vec` row before the worker is torn down — #1331).
+        // BOUNDED so a slow/stuck embed can't reintroduce the Ctrl+C hang
+        // `fast: true` exists to avoid; must run while the worker is still alive
+        // (resetProvider below kills it) and after resetPipelineState so no new
+        // background work is scheduled mid-drain. NOTE: this covers embeds that
+        // have already been dispatched — it does NOT wait on a distillation
+        // whose LLM call is still in flight (fast-path shutdown deliberately
+        // skips that background drain), so that embed is never enqueued here.
+        // Both the mid-distillation case and anything still pending at the
+        // deadline are re-indexed by runStartupBackfill on the next boot.
         await embedding.settleDocumentEmbeds(EMBED_DRAIN_DEADLINE_MS);
         // Shut down the embedding worker thread gracefully. Done after
         // resetPipelineState (which clears sessions/timers) but before

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -13,7 +13,19 @@ import { writePortFile, removePortFile, readPortFile } from "../portfile";
 import { writePidFile, removePidFile } from "../pidfile";
 import { dataDir, embedding, log } from "@loreai/core";
 import { safeExit } from "./exit";
-import { installSignalShutdown } from "./shutdown";
+import { installSignalShutdown, SHUTDOWN_DEADLINE_MS } from "./shutdown";
+
+/**
+ * Bound for the in-flight document-embed drain on graceful shutdown (#1331).
+ * Kept comfortably under {@link SHUTDOWN_DEADLINE_MS} so the drain plus the
+ * subsequent worker `resetProvider()` both finish inside the hard shutdown
+ * deadline — a slow/stuck embed can never reintroduce the Ctrl+C hang. Whatever
+ * doesn't complete in time is re-indexed by `runStartupBackfill` on next boot.
+ */
+const EMBED_DRAIN_DEADLINE_MS = Math.max(
+  500,
+  Math.floor(SHUTDOWN_DEADLINE_MS * 0.6),
+);
 
 export interface StartOptions {
   port?: number;
@@ -440,6 +452,15 @@ export async function startGateway(
         // replaying queued background prompts through retries is what made
         // Ctrl+C hang for minutes. They resume next session.
         await resetPipelineState({ fast: true });
+        // Drain any in-flight fire-and-forget document embed (esp. a
+        // distillation embed created this session that would otherwise never
+        // write its `distillation_vec` row before the worker is torn down —
+        // #1331). BOUNDED so a slow/stuck embed can't reintroduce the Ctrl+C
+        // hang `fast: true` exists to avoid; must run while the worker is still
+        // alive (resetProvider below kills it) and after resetPipelineState so
+        // no new background work is scheduled mid-drain. Anything left pending
+        // at the deadline is re-indexed by runStartupBackfill on the next boot.
+        await embedding.settleDocumentEmbeds(EMBED_DRAIN_DEADLINE_MS);
         // Shut down the embedding worker thread gracefully. Done after
         // resetPipelineState (which clears sessions/timers) but before
         // safeExit — gives the worker time to exit cleanly via its

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -2321,6 +2321,12 @@ async function initIfNeeded(
     log.info("metric backfill failed:", e);
   }
   if (process.env.NODE_ENV !== "test") {
+    // Warm the local embedding worker NOW (throwaway embed) so the ~21s ONNX
+    // cold-load is paid at startup instead of on the first real distillation
+    // embed — which on a short/fast session would otherwise race gateway
+    // teardown and never write its `distillation_vec` row (#1331). Local-only,
+    // fire-and-forget; the model loads during the backfill's startup delay.
+    embedding.warmupEmbedding();
     // Idle-gate the heavy temporal re-chunk walk so it yields the shared embed
     // pool to live traffic: park while the breaker is tripped or a live recall
     // embed is in flight, resume the instant the worker drains.

--- a/packages/gateway/test/shutdown-embed-drain.test.ts
+++ b/packages/gateway/test/shutdown-embed-drain.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for issue #1331: on graceful gateway shutdown, in-flight
+ * fire-and-forget document embeds (esp. a distillation embed created this
+ * session) must be DRAINED before the embedding worker is torn down, or their
+ * `distillation_vec` rows are never written → silent recall degradation on
+ * short/fast sessions.
+ *
+ * The `shutdown` closure built in `startGateway()` must call
+ * `embedding.settleDocumentEmbeds(<bounded>)` BEFORE `embedding.resetProvider()`
+ * (which kills the worker), and the drain must be bounded so a stuck embed can
+ * never reintroduce the Ctrl+C hang.
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { embedding } from "@loreai/core";
+
+describe("startGateway shutdown drains in-flight embeds (issue #1331)", () => {
+  const teardowns: Array<() => void | Promise<void>> = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    while (teardowns.length) {
+      const fn = teardowns.pop();
+      try {
+        await fn?.();
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  });
+
+  it("calls settleDocumentEmbeds(bounded) before resetProvider on shutdown", async () => {
+    const { startGateway } = await import("../src/cli/start");
+
+    const order: string[] = [];
+    let drainArg: number | undefined = -1;
+    const drainSpy = vi
+      .spyOn(embedding, "settleDocumentEmbeds")
+      .mockImplementation(async (timeoutMs?: number) => {
+        order.push("drain");
+        drainArg = timeoutMs;
+      });
+    const resetSpy = vi
+      .spyOn(embedding, "resetProvider")
+      .mockImplementation(async () => {
+        order.push("reset");
+      });
+
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    expect(handle.owned).toBe(true);
+
+    await handle.shutdown();
+
+    // Drain must run, and run BEFORE the worker is reset/killed.
+    expect(order).toEqual(["drain", "reset"]);
+    expect(drainSpy).toHaveBeenCalledTimes(1);
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+
+    // The drain is BOUNDED (a finite, positive deadline) — never an unbounded
+    // wait that could hang Ctrl+C.
+    expect(typeof drainArg).toBe("number");
+    expect(drainArg).toBeGreaterThan(0);
+    expect(Number.isFinite(drainArg)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #1331.

## Problem

On short/fast sessions, distillations are created but never embedded
(`distillation_vec` stays empty), so recall silently degrades to FTS/temporal-only.
`embedDistillation()` is fire-and-forget and the **first** `embed()` pays a ~21s
ONNX cold-load. If the session ends (gateway torn down) — or reaches the point
where recall is needed — before that promise resolves, the vector is never
written.

## Fixes

Fix #3 from the issue (next-boot re-index of missing `distillation_vec`) was
already implemented in `runStartupBackfill`. This PR adds the two remaining
product-side fixes; they are complementary — warm-start makes the common case
finish within the turn, the bounded drain is the safety net.

### 1. Bounded drain-on-shutdown
- `settleDocumentEmbeds()` gains an optional `timeoutMs`. No arg → unbounded
  (existing test behavior); with a bound → races the in-flight set against a
  deadline and resolves either way.
- Wired into the production `shutdown` closure in `start.ts`, **between**
  `resetPipelineState({ fast: true })` and `embedding.resetProvider()` (must run
  while the worker is still alive). Bounded by
  `EMBED_DRAIN_DEADLINE_MS = 0.6 x SHUTDOWN_DEADLINE_MS` so it can't reintroduce
  the Ctrl+C hang that `fast: true` exists to avoid. Anything left pending is
  re-indexed on next boot.

### 2. Warm-start
- New `warmupEmbedding()`: fires one throwaway local `embed(["warmup"], "document")`
  at gateway startup to pay the ~21s cold-load up front.
- Local-only (remote providers have no cold-load and a warmup would burn API
  quota); `document` inputType so it is never counted as a recall embed and
  cannot self-gate the temporal backfill; fire-and-forget (never blocks startup).
- Wired into pipeline startup beside `runStartupBackfill` (same
  `NODE_ENV !== "test"` gate), so the model loads during the backfill delay.

## Tests
- `background-drain.test.ts`: bounded drain resolves at the deadline with a
  pending embed / returns fast on completion; warmup fires exactly one `document`
  embed locally; warmup does not touch the recall-in-flight counter; warmup is a
  no-op for remote providers (verified via `fetch` spy — no network call).
- `shutdown-embed-drain.test.ts` (new): asserts the shutdown closure calls the
  bounded drain **before** `resetProvider`, with a finite positive deadline.

### Non-vacuousness (mutation-verified)
- remove drain call → shutdown-order test fails
- drain after reset → shutdown-order test fails
- remove warmup body → local-fires test fails
- `document` → `query` inputType → recall-counter test fails
- remove local-only guard → remote fetch-spy test fails
- bounded drain ignores timeout (unbounded) → deadline test hangs (killed)

## Verification
- `pnpm run typecheck`, `lint`, `format` clean.
- Full suite: 6124 passed, 0 failed.