### PR TITLE
fix(gateway): surface reasoning-only worker completions from the OpenAI SSE path (#1334)

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1385,6 +1385,19 @@ export function gatewayResponseToWorkerResult(resp: GatewayResponse): {
     )
     .map((b) => b.text)
     .join("");
+  // Reasoning models (e.g. MiniMax-M3 via OpenRouter) can emit their entire answer
+  // as reasoning/thinking with an empty text block. Never treat a present thinking
+  // body as no-response — fall back to it when there is no visible text, mirroring
+  // parseOpenAIResponse (content→reasoning) and parseAnthropicResponse (text→thinking). (#1334)
+  const workerText =
+    text ||
+    resp.content
+      .filter(
+        (b): b is Extract<GatewayContentBlock, { type: "thinking" }> =>
+          b.type === "thinking",
+      )
+      .map((b) => b.thinking)
+      .join("");
   const usage: AnthropicUsage | null = resp.usage
     ? {
         input_tokens: resp.usage.inputTokens,
@@ -1393,7 +1406,7 @@ export function gatewayResponseToWorkerResult(resp: GatewayResponse): {
         cache_creation_input_tokens: resp.usage.cacheCreationInputTokens,
       }
     : null;
-  return { text: text || null, usage, model: resp.model || null };
+  return { text: workerText || null, usage, model: resp.model || null };
 }
 
 /**

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -369,6 +369,11 @@ export async function accumulateOpenAISSEStream(
   let model = "";
   let stopReason = "end_turn";
   let textContent = "";
+  // Some reasoning models (e.g. MiniMax-M3 via OpenRouter) stream their entire
+  // answer as reasoning deltas and leave `content` empty. Capture it so a
+  // reasoning-only response is not mistaken for an empty completion (#1334) —
+  // mirrors the non-streaming parseOpenAIResponse content→reasoning fallback.
+  let reasoningContent = "";
   const toolCalls = new Map<
     number,
     { id: string; name: string; args: string }
@@ -405,6 +410,17 @@ export async function accumulateOpenAISSEStream(
       if (delta) {
         if (typeof delta.content === "string") {
           textContent += delta.content;
+        }
+        // Reasoning deltas: `reasoning` (OpenRouter/others) or `reasoning_content`
+        // (DeepSeek/Qwen). Accumulated separately and surfaced as a thinking block
+        // only when there is no visible text (#1334). No provider emits BOTH fields
+        // in one delta, so the else-if precedence here (reasoning first) is
+        // per-provider identical to parseOpenAIResponse (which prefers
+        // reasoning_content) — the order only diverges in the impossible both-set case.
+        if (typeof delta.reasoning === "string") {
+          reasoningContent += delta.reasoning;
+        } else if (typeof delta.reasoning_content === "string") {
+          reasoningContent += delta.reasoning_content;
         }
         const tcs = delta.tool_calls as
           | Array<Record<string, unknown>>
@@ -452,6 +468,12 @@ export async function accumulateOpenAISSEStream(
   }
 
   const content: GatewayContentBlock[] = [];
+  // Thinking precedes text (Anthropic ordering). Previously reasoning deltas were
+  // dropped entirely on this path; surfacing them lets a reasoning-only response
+  // (empty content) still yield usable text downstream (#1334).
+  if (reasoningContent) {
+    content.push({ type: "thinking", thinking: reasoningContent });
+  }
   if (textContent) {
     content.push({ type: "text", text: textContent });
   }

--- a/packages/gateway/test/stream-openai.test.ts
+++ b/packages/gateway/test/stream-openai.test.ts
@@ -68,4 +68,59 @@ describe("accumulateOpenAISSEStream", () => {
     );
     expect(resp.content).toEqual([{ type: "text", text: "ok" }]);
   });
+
+  test("accumulates `reasoning` deltas into a thinking block when content is empty (#1334)", async () => {
+    // MiniMax-M3 via OpenRouter streams its whole answer as `reasoning` deltas and
+    // leaves `content` empty — previously dropped entirely → empty completion.
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"id":"c1","model":"minimax/minimax-m3","choices":[{"delta":{"reasoning":"the "}}]}',
+        'data: {"choices":[{"delta":{"reasoning":"answer"}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.content).toEqual([
+      { type: "thinking", thinking: "the answer" },
+    ]);
+  });
+
+  test("accumulates `reasoning_content` deltas (DeepSeek/Qwen shape)", async () => {
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"delta":{"reasoning_content":"deep "}}]}',
+        'data: {"choices":[{"delta":{"reasoning_content":"seek"}}]}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.content).toEqual([{ type: "thinking", thinking: "deep seek" }]);
+  });
+
+  test("emits thinking BEFORE text when a model streams both", async () => {
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"delta":{"reasoning":"pondering"}}]}',
+        'data: {"choices":[{"delta":{"content":"final answer"}}]}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.content).toEqual([
+      { type: "thinking", thinking: "pondering" },
+      { type: "text", text: "final answer" },
+    ]);
+  });
+
+  test("no reasoning field → no thinking block (normal path unchanged)", async () => {
+    const resp = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"delta":{"content":"plain"}}]}',
+        "data: [DONE]",
+        "",
+      ]),
+    );
+    expect(resp.content).toEqual([{ type: "text", text: "plain" }]);
+  });
 });

--- a/packages/gateway/test/worker-reasoning-parse.test.ts
+++ b/packages/gateway/test/worker-reasoning-parse.test.ts
@@ -8,11 +8,21 @@
  * `no-response`, blocking background distillation/curation. These tests lock in
  * the reasoning-field fallback AND assert the normal path is unchanged.
  */
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
 import {
+  createGatewayLLMClient,
+  gatewayResponseToWorkerResult,
   parseOpenAIResponse,
   parseAnthropicResponse,
 } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+
+const mockFetch = vi.mocked(upstreamFetch);
 
 describe("parseOpenAIResponse — reasoning-model fallback", () => {
   test("positive: normal content body still parses unchanged", () => {
@@ -138,5 +148,124 @@ describe("parseAnthropicResponse — thinking-block fallback", () => {
   test("negative: missing content returns null", () => {
     const r = parseAnthropicResponse({});
     expect(r.text).toBeNull();
+  });
+});
+
+describe("gatewayResponseToWorkerResult — streaming thinking-block fallback (#1334)", () => {
+  const base = { id: "x", model: "m", stopReason: "end_turn" } as const;
+
+  test("positive: a text block is returned unchanged", () => {
+    const r = gatewayResponseToWorkerResult({
+      ...base,
+      content: [{ type: "text", text: "the real answer" }],
+    });
+    expect(r.text).toBe("the real answer");
+  });
+
+  test("falls back to a thinking block when there is no text (reasoning-only stream)", () => {
+    // MiniMax-M3 via OpenRouter streams reasoning deltas and leaves content empty →
+    // the accumulator emits only a thinking block. It must still yield usable text.
+    const r = gatewayResponseToWorkerResult({
+      ...base,
+      content: [{ type: "thinking", thinking: "answer in reasoning" }],
+    });
+    expect(r.text).toBe("answer in reasoning");
+  });
+
+  test("prefers text over thinking when both present", () => {
+    const r = gatewayResponseToWorkerResult({
+      ...base,
+      content: [
+        { type: "thinking", thinking: "secondary" },
+        { type: "text", text: "primary" },
+      ],
+    });
+    expect(r.text).toBe("primary");
+  });
+
+  test("joins multiple thinking blocks when no text block exists", () => {
+    const r = gatewayResponseToWorkerResult({
+      ...base,
+      content: [
+        { type: "thinking", thinking: "part1 " },
+        { type: "thinking", thinking: "part2" },
+      ],
+    });
+    expect(r.text).toBe("part1 part2");
+  });
+
+  test("negative: a tool_use-only response is still empty (workers consume text)", () => {
+    const r = gatewayResponseToWorkerResult({
+      ...base,
+      content: [{ type: "tool_use", id: "t1", name: "f", input: {} }],
+    });
+    expect(r.text).toBeNull();
+  });
+
+  test("negative: an empty content array returns null", () => {
+    const r = gatewayResponseToWorkerResult({
+      ...base,
+      content: [],
+    });
+    expect(r.text).toBeNull();
+  });
+});
+
+describe("worker end-to-end: reasoning-only SSE body → usable text (#1334 seam)", () => {
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  // The exact wire that regressed in #1334: a worker sends stream:false, but the
+  // provider (OpenRouter/MiniMax-M3) returns an SSE body whose deltas carry only
+  // `reasoning` (empty `content`). This drives the real seam
+  // isSSE → accumulateWorkerSSE(openai) → gatewayResponseToWorkerResult, which the
+  // two unit suites above only cover in halves.
+  test("a reasoning-only OpenAI SSE worker response yields the reasoning as text", async () => {
+    const sseBody = [
+      'data: {"id":"c1","model":"minimax/minimax-m3","choices":[{"delta":{"reasoning":"extracted "}}]}',
+      'data: {"choices":[{"delta":{"reasoning":"knowledge"}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}',
+      "data: [DONE]",
+      "",
+    ].join("\n\n");
+    // Note: content-type is application/json (a mislabeled stream) — the worker
+    // sniffs the body for SSE regardless, exercising the looksLikeSSE path too.
+    mockFetch.mockResolvedValue(
+      new Response(sseBody, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "openrouter"
+          ? { scheme: "bearer", value: "or_worker" }
+          : null,
+      { providerID: "openrouter", modelID: "minimax/minimax-m3" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      sessionID: "sess-m3",
+      workerID: "lore-distill",
+      model: { providerID: "openrouter", modelID: "minimax/minimax-m3" },
+      upstreamUrl: "https://openrouter.ai/api/v1",
+      upstreamProviderID: "openrouter",
+    });
+
+    // Pre-fix this returned null (reasoning dropped) → distillation parse-error.
+    expect(text).toBe("extracted knowledge");
   });
 });


### PR DESCRIPTION
Closes #1334.

## Symptom
MiniMax-M3 via OpenRouter (`openrouter/minimax/minimax-m3`, openai protocol) as the Lore **worker model** produced **0 knowledge entries** — background distillation/curation logged `parse-error` ("empty completion") and cross-session recall returned nothing. DeepSeek V4 Flash (also openai/OpenRouter) worked fine.

## Root cause
An asymmetry between the **non-streaming** and **streaming** worker parse paths. Workers send `stream:false`, but OpenRouter (and DeepSeek etc.) return an SSE body anyway, so the worker read routes through `accumulateOpenAISSEStream` → `gatewayResponseToWorkerResult`. That streaming path **only accumulated `delta.content`** and **only projected `type:"text"` blocks** — it dropped reasoning deltas entirely. M3 streams its whole answer as reasoning deltas and leaves `content` empty → the worker saw an empty completion.

The non-streaming `parseOpenAIResponse` already fell back to `reasoning_content`/`reasoning`; the streaming path did not. DeepSeek worked because it emits real `content`.

## Fix (mirrors the non-streaming fallback)
1. **`stream/openai.ts`** — accumulate `delta.reasoning` (OpenRouter) / `delta.reasoning_content` (DeepSeek/Qwen) into a `thinking` block (emitted before text, Anthropic ordering). Reasoning was previously dropped on this path entirely, so this is purely additive.
2. **`gatewayResponseToWorkerResult`** — fall back to `thinking` blocks when there is no visible text, mirroring `parseOpenAIResponse` (content→reasoning) and `parseAnthropicResponse` (text→thinking). A `tool_use`-only response stays empty (workers consume text, not tool calls).

This also makes a reasoning-only response correctly non-empty on the **conversation** path (the pipeline already handles `thinking` blocks), aligning the OpenAI stream path with the Anthropic path.

## Tests
- `stream-openai.test.ts`: `reasoning`/`reasoning_content` deltas → thinking block; thinking-before-text ordering; no-reasoning path unchanged.
- `worker-reasoning-parse.test.ts`: `gatewayResponseToWorkerResult` thinking fallback, prefer-text, multi-block join, `tool_use`-only stays null.
- Mutation-verified: neutering either half fails the tests. 201 tests across streaming/worker/pipeline suites green; typecheck/lint/format clean.