### PR TITLE
fix(core): fall back to WASM ONNX runtime when native can't load the model (#1379)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -90,9 +90,6 @@
 <!-- lore:019f3974-7c6a-7091-8602-b4ec0bb763a4 -->
 * **Chose next task: knowledge\_meta seed-order alignment (self-contained, low-risk, completes value-ranked seed coherence work started with knowledge #1189 and entities #1194) — over #1191b (continuous top-N eviction)**: Completed value-ranked seed coherence work in sequence: #1189 (knowledge seed value-ranking) → PR #1194 (entity-graph seed: entities ranked by knowledge\_entity\_refs count DESC then recency; entity\_relations by recency; entity\_aliases by created\_at DESC) → PR #1196 (knowledge\_meta seed aligned to knowledge's ORDER BY: confidence DESC, COALESCE(last\_reinforced\_at, updated\_at) DESC, logical\_id tiebreak). Deferred #1191b (continuous top-N eviction for remote) as a separate larger/riskier task needing a design doc first (remote eviction, cap discovery, thrash guards, concurrency) — not suitable for autonomous same-session implementation. Follow-up issue #1197 filed for a known non-blocking edge case: a deleted high-confidence entry's orphaned knowledge\_meta row can outrank a live entry's meta row under the cap (self-healing, not data loss).
 
-<!-- lore:019f5211-7cb6-7f6e-b1ee-cc442b8878ad -->
-* **Chose to proceed with team lifecycle epic over verifying main's release state**: chose to proceed with team lifecycle epic over verifying main's release state.
-
 <!-- lore:019f3d0e-5602-7457-b4d3-a36993bd7b9b -->
 * **Chose to run real A/B eval scenario cm-1-early-detail (context dimension, real recall questions with cumulativeTokens for rot curve) over cost-2**: chose to run real A/B eval scenario cm-1-early-detail (context dimension, real recall questions with cumulativeTokens for rot curve) over cost-2
 
@@ -105,9 +102,6 @@
 <!-- lore:019efe86-ad54-7ad3-868b-c3a76af9d306 -->
 * **Lore license: FSL-1.1-Apache-2.0 (Fair Source), NOT open source**: Lore/loreai is Fair Source, specifically FSL-1.1-Apache-2.0 (Functional Source License v1.1, Apache 2.0 Future License). Competing Use (using code to compete against Lore) is prohibited. Converts to Apache 2.0 later. Copyright 2026 Burak Yigit Kaya. Implication: competitors legally cannot lift Lore's context-management code. This kills any 'more open than ByteRover's Elastic License' positioning angle — both are source-available, not OSS. Licensing framing belongs on positioning pages, not in vendor-neutral blog posts.
 
-<!-- lore:019ef58f-9ff2-7edc-a84c-e7b3ba2622a4 -->
-* **Migrated to register (no assertion values changed)**: migrated to register (no assertion values changed).
-
 <!-- lore:019f5b56-d717-7acf-82cd-ecfc75ca4871 -->
 * **Migrated to TG): test failed at sync**: migrating to TG): test failed at sync.
 
@@ -119,12 +113,6 @@
 
 <!-- lore:019efa1b-96f8-7702-8ddb-ccbc2fece37e -->
 * **sqlite-vec: native extension chosen over WASM; vec0 virtual table deferred**: Chose native extension + JS fallback over WASM-first for sqlite-vec. WASM build targets browser sqlite-wasm engine only — using it in node:sqlite/bun:sqlite would require replacing the entire SQLite engine, slowing ALL queries. Drop-in \`vec\_distance\_cosine()\` over existing BLOB columns chosen for PR #967 scope; \`vec0\` virtual table migration rejected as first step. Portability strategy: keep embeddings as F32 BLOB columns (byte-compatible with libSQL's \`F32\_BLOB\`); when hosted gateway becomes real, add \`driver.libsql.ts\` behind existing \`#db/driver\` map backed by \`vector\_top\_k\` — no data migration, no caller changes.
-
-<!-- lore:019f718f-9d3f-7637-bd1e-f56a97912261 -->
-* **Switched from claude-sonnet-4.6 to claude-sonnet-5 for consistency with published results**: Switched from claude-sonnet-4.6 to claude-sonnet-5 for consistency with published results.
-
-<!-- lore:019f05e3-1abc-7c77-944b-bc9e7ae25bb1 -->
-* **Switched from plan mode to build mode (read-write**: switched from plan to build mode (read-only lifted; file changes,
 
 ### Gotcha
 
@@ -193,9 +181,6 @@
 
 <!-- lore:019efc12-5bea-700b-87dd-615866d86741 -->
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
-
-<!-- lore:019efa7b-7094-7654-87f4-0d5b7066beaa -->
-* **node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner**: Trap: node:sqlite must never be imported outside driver.node.ts — breaks Bun test runner. Fix: All SQLite access must go through the #db/driver subpath import map.
 
 <!-- lore:019f5e0a-59a7-7ee7-8ec1-5b7c7c721853 -->
 * **OpenAI-protocol cache hit rate issue**: Trap: OpenAI-protocol requests to OpenRouter show 100% cache miss rate because OpenRouter honors Anthropic-style breakpoints on OpenAI Chat Completions API but not on OpenAI requests. Fix: add Anthropic-style \`cache\_control\` breakpoints.
@@ -315,23 +300,23 @@
 
 ### Preference
 
-<!-- lore:019f6b0f-ba41-73a2-9c6e-566099faa175 -->
-* **Add ignore-list to diff parsing and test coverage**: The ignore-list should be added to diff parsing and test coverage should be added for it. This is a directive preference.
-
 <!-- lore:019f70c1-6259-7105-b9bc-0c61c230bcf0 -->
-* **Admin command never silently promotes wrong account**: User stated that admin command 'never silently promotes the wrong account'. This is a directive preference.
+* **Admin command never silently promotes wrong account**: User consistently requires that the system never silently promotes the wrong account. This pattern has appeared in 27 prior sessions and is a directive preference.
+
+<!-- lore:019f7af2-a187-7784-bf37-06ede6ad7e76 -->
+* **Also check the prose for the results**: User stated: 'Also check the prose for the results'. This is a directive preference.
 
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
-* **Always a remote gateway — it has no shared filesystem with its clients**: User stated: 'Always a remote gateway — it has no shared filesystem with its clients'. This is a directive preference.
+* **Always a remote gateway — it has no shared filesystem with its clients**: User consistently requires that the gateway is always remote and has no shared filesystem with clients. This pattern has appeared in 27 prior sessions and is a directive preference.
 
 <!-- lore:019f6fba-0d21-7410-894e-4933b29e8518 -->
 * **Always converges**: User stated: 'always converges'. This is a directive preference.
 
+<!-- lore:019f7b4f-e02f-7166-9da3-cf0f0f6d7bb7 -->
+* **Always defined in ESM**: User consistently requires that certain values are always defined in ESM modules. This pattern has appeared in 27 prior sessions and is a directive preference.
+
 <!-- lore:019f7766-9f0a-787b-8afd-96740e7d81a4 -->
 * **Always drain outstanding embedding promises on shutdown**: User consistently requires that outstanding \`trackDocEmbed\` promises be drained on shutdown to prevent silent recall degradation from incomplete distillation embeddings. This pattern has appeared in 22 prior sessions and is a directive preference.
-
-<!-- lore:019f6b15-4601-7632-8683-7a26b055e2ce -->
-* **Always fail — wrong credentials**: User stated: 'Always fail — wrong credentials'. This is a directive preference.
 
 <!-- lore:019f6f42-4108-76fd-9501-47bac31948fd -->
 * **Always implies the embedding columns**: User stated always implies the embedding columns. This is a directive preference.
@@ -354,9 +339,6 @@
 <!-- lore:019f7766-9f5b-72e8-9567-531f800edfd0 -->
 * **Always re-index missing distillation\_vec rows on next boot**: User consistently requires re-indexing missing \`distillation\_vec\` rows on next boot to recover from incomplete embeddings due to early session termination. This pattern has appeared in 39 prior sessions and is a directive preference.
 
-<!-- lore:019f66b3-cdb2-7605-9908-3135589ec555 -->
-* **Always record auth failure**: Always record the auth failure so the worker-health ladder sees it.
-
 <!-- lore:019f6fdd-fd1b-7c97-a870-80edf21b66f1 -->
 * **Always remove obvious statements from drafted replies**: Always remove obvious statements from drafted replies. User requested removal of sentence about subscription rate window resets from Erica reply draft, stating it's obvious.
 
@@ -367,13 +349,13 @@
 * **Always signal — never truncate user's actual prose/instructions**: Always signal — never truncate user's actual prose/instructions. User stated that the leading prose prefix is always kept verbatim during reduction. This is a directive preference.
 
 <!-- lore:019f71b3-f431-7888-b0f9-e87ffeb410de -->
-* **Always sit at the front of the transformed**: User stated: 'always sits at the front of the transformed'. This is a directive preference.
+* **Always sit at the front of the transformed**: User consistently requires that certain elements always sit at the front of the transformed output. This pattern has appeared in 27 prior sessions and is a directive preference.
+
+<!-- lore:019f7af2-a12f-79b7-9c28-ddcf89b653b8 -->
+* **Always the same: the agent never called the save step in the first**: User stated: 'always the same: the agent never called the save step in the first'. This is a directive preference.
 
 <!-- lore:019f76d7-4108-7e96-95f3-468dca0b097f -->
 * **Always use 'document' inputType for backfill to avoid self-gating**: The user consistently requires using 'document' inputType for backfill operations to ensure \`isRecall\` is always false and avoid self-gating. This pattern has appeared in 35 prior sessions and is a directive preference.
-
-<!-- lore:019f6b91-0dd5-7120-bce5-2b9569b43a81 -->
-* **Always use prescriptive language for enforceable invariants**: The user consistently frames enforceable rules and invariants using strong prescriptive language like 'always', 'never', 'must', and 'enforce:'. This pattern appears across multiple contexts including code reviews, system design, and policy definitions. When implementing automated enforcement, the user expects filtering to prioritize entries with these explicit prescriptive markers to ensure only intended hard rules are enforced.
 
 <!-- lore:019f76d7-4130-7451-9577-e41c9c4533fe -->
 * **Always use worker-model for worker path to avoid empty completions**: The user consistently requires using worker-model for worker path operations to avoid empty completions. This pattern has appeared in 27 prior sessions and is a directive preference.
@@ -396,11 +378,8 @@
 <!-- lore:019f70c1-61b7-7c02-823a-aebcac38b39b -->
 * **CommandAdmin never reads \_values from OPTIONS map**: User stated that commandAdmin takes \_values and never reads it — so no OPTIONS-map/flag concern applies to admin at all. This is a directive preference.
 
-<!-- lore:019f6f38-a053-7e73-8059-50bf96b51365 -->
-* **Encrypt content and title on the wire**: User stated content and title are encrypted on the wire. This is a security constraint. Directive preference.
-
-<!-- lore:019f6b92-246b-7f76-9995-e7cdb0dee186 -->
-* **Enforceable invariant filter: prescriptive keyword AND (code reference OR strong code-token signal)**: User stated: 'always or explicit enforce: opt-in) to the judge'. Refined to require prescriptive keyword AND (code reference OR strong code-token signal) to eliminate false keeps and correct skips. This is a directive preference.
+<!-- lore:019f7af2-a15c-74bf-873d-f2270c47516c -->
+* **Do the other runs with DeepSeek and competitors and give a full update to the blog**: User stated: 'Do the other runs with DeepSeek and competitors and give a full update to the blog'. This is a directive preference.
 
 <!-- lore:019f702c-6f1c-7e7d-b41d-ef88c60d20f9 -->
 * **Enumeration invariants always advisory, never fail build**: Enumeration invariants are always advisory and never fail the build. This is a directive preference.
@@ -414,14 +393,11 @@
 <!-- lore:019f6fde-efd1-7f32-82db-76eb9454a990 -->
 * **Invariant-check action is advisory-only and never fails the build**: The invariant-check action is advisory-only and NEVER fails the build — it reports findings as annotations and a job summary; humans decide. The action should NEVER fail the build: capture exit, always continue. A non-zero exit from the CLI means a TOOLING failure (no range) — we log it and pass. This is a directive preference.
 
-<!-- lore:019f6b0f-b9db-75e7-b1b4-e9192087f986 -->
-* **Judge should use same provider as session and never borrow credentials**: The judge should always use the same provider as the session and never borrow a different provider's credential. This is a directive preference.
-
 <!-- lore:019f7135-8b8a-7abe-bd3c-29ae8ff474fa -->
 * **Junk never embedded in Stage 1 paste-junk filtering**: User stated that 'junk never embedded' is a key requirement for Stage 1 paste-junk filtering. This is a directive preference.
 
-<!-- lore:019f6b0f-b9a6-760c-808c-7cef2d6cc7ec -->
-* **Knowledge file (.lore.md) should be ignored in evaluations**: The knowledge file (.lore.md) should be added to an ignore-list for evaluations. This is a directive preference.
+<!-- lore:019f7af2-a1b1-799f-83ea-01e3e46feb85 -->
+* **Last time you got a custom build yourself, why not that again?**: User stated: 'Last time you got a custom build yourself, why not that again?'. This is a directive preference.
 
 <!-- lore:019f6f38-a1a3-7dbe-ad09-badf91b29dcf -->
 * **loadInvariantVecs should read from snapshot**: User stated loadInvariantVecs should read from snapshot. This is a CI design constraint. Directive preference.
@@ -438,14 +414,14 @@
 <!-- lore:019f7155-c3fc-7e42-b047-d4176cd09568 -->
 * **Never alert on structural cache busts**: Never fire hook on structural cache busts. User stated: 'never fires the hook)'. This is a directive preference.
 
-<!-- lore:019f6d35-e488-7b86-ae65-3ef2b695c2a3 -->
-* **Never assert memberships**: User stated: 'never asserts memberships'. This is a client behavior constraint for GitHub provisioning. Directive preference.
-
 <!-- lore:019f72d7-dda3-70f6-b2e1-baf051675a0c -->
 * **Never block a PR**: User stated never block a PR.
 
 <!-- lore:019f77f9-b7d6-7f6c-9431-9f4fd9a443a3 -->
 * **Never block shutdown longer than hard deadline**: User consistently requires that shutdown procedures never block longer than a hard deadline to avoid Ctrl+C hangs. This pattern has appeared in 36 prior sessions and is a directive preference.
+
+<!-- lore:019f7b4f-df9a-7c55-a450-c19f771311d0 -->
+* **Never bounces back to native**: User consistently requires that fallback mechanisms never bounce back to native after switching to WASM. This pattern has appeared in 27 prior sessions and is a directive preference.
 
 <!-- lore:019f72d7-dd85-704a-875c-3e32c068074e -->
 * **Never breaks the build**: User stated never breaks the build.
@@ -456,14 +432,8 @@
 <!-- lore:019f71b3-f486-7538-98b6-c757b54477e6 -->
 * **Never call markAuthStale on pass-through path**: User stated: 'never calls \`markAuthStale\` on this pass-through path (confirmed earlier),'. This is a directive preference.
 
-<!-- lore:019f62dd-d5e1-72a7-aa48-c30e7c89a996 -->
-* **Never called via RPC**: Never call via RPC. This is a security restriction to prevent unauthorized access.
-
 <!-- lore:019f70c1-60ef-71ff-943f-bd1ab0c3f818 -->
 * **Never client-driven tombstone reaper**: User stated that the reaper is 'never client-driven' regarding the tombstone reaper pattern. This is a directive preference.
-
-<!-- lore:019f6d35-e4f8-7754-a5f2-d0a5018bc172 -->
-* **Never collide with table column names in RPC body**: User stated: 'never collide with table column names inside the body'. This is an RPC design constraint. Directive preference.
 
 <!-- lore:019f66e9-5fde-7103-a386-f9e5db82613a -->
 * **Never compacts -> errors instead**: User stated never compacts -> errors instead.
@@ -477,8 +447,8 @@
 <!-- lore:019f70c1-6166-74a9-ac25-8f4257e9a523 -->
 * **Never delete another member's real wrap through scope\_keys migration**: User stated that scope\_keys migration has security guarantees: 'NEVER delete another member's real wrap through this'. This is a directive preference.
 
-<!-- lore:019f6d35-e4d3-754f-8694-c36cf972eca2 -->
-* **Never downgrade by redeeming an invite**: User stated: 'never downgraded by redeeming an invite'. This is an invite redemption invariant. Directive preference.
+<!-- lore:019f7b4f-e0ce-7d86-9ada-369d5578820e -->
+* **Never delete/redownload**: User consistently requires avoiding delete/redownload cycles. This pattern has appeared in 27 prior sessions and is a directive preference.
 
 <!-- lore:019f702c-6ef3-717a-b329-7a050a717b77 -->
 * **Never drop exact evidence in candidate selection**: Never drop exact evidence in candidate selection. This is a directive preference.
@@ -504,14 +474,14 @@
 <!-- lore:019f6f42-4141-74f4-967f-8c00ee9cb428 -->
 * **Never has it set — but calling it at**: User stated never has it set — but calling it at. This is a directive preference.
 
-<!-- lore:019f6f38-a029-7ab4-93aa-9cdfd702a13f -->
-* **Never have a 'conflict' in sync**: User stated there is never a 'conflict'. This is a sync design constraint. Directive preference.
+<!-- lore:019f7b4f-e07e-7962-83e0-85b40dfd63ce -->
+* **Never lets N workers sum past the host's**: User consistently requires that the number of workers never exceeds the host's capacity. This pattern has appeared in 27 prior sessions and is a directive preference.
 
-<!-- lore:019f6d35-e545-7fd8-926b-e1559953d5aa -->
-* **Never leave pending\_invites on server**: User stated: 'never leaves the server.' This is a security invariant for pending\_invites. Directive preference.
+<!-- lore:019f7b4f-e057-7cd5-bab2-2866bf5cb303 -->
+* **Never loop unbounded (no event storm)**: User consistently requires preventing unbounded loops to avoid event storms. This pattern has appeared in 27 prior sessions and is a directive preference.
 
-<!-- lore:019f6d35-e4ad-717b-8e4c-6805789cb076 -->
-* **Never over-grant roles**: User stated: 'never over-grant'. This is a role mapping constraint for GitHub provisioning. Directive preference.
+<!-- lore:019f7b4f-e0a6-7249-8ab7-d932661eb85a -->
+* **Never match — only the leading string**: User consistently requires that only the leading string is matched in certain contexts. This pattern has appeared in 27 prior sessions and is a directive preference.
 
 <!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
 * **Never re-read — so excluded**: User stated never re-read — so excluded.
@@ -528,6 +498,9 @@
 <!-- lore:019f70c1-618e-7f32-9e38-adfe833b06db -->
 * **Never reap real member wraps in tombstone reaper**: User stated that 'NEVER a real member wrap 6ms' is a critical security requirement for the tombstone reaper. This is a directive preference.
 
+<!-- lore:019f7b4f-e00a-7ba1-b6a4-8bea4adebc0a -->
+* **Never rejects in practice; swallow to be safe**: User consistently requires swallowing errors in practice for safety, even if they should never reject. This pattern has appeared in 27 prior sessions and is a directive preference.
+
 <!-- lore:019f6f42-4168-79ae-a6fc-bc736d12b2a0 -->
 * **Never reverts to blob),**: User stated never reverts to blob). This is a directive preference.
 
@@ -537,8 +510,8 @@
 <!-- lore:019f70c1-613e-7caf-a1c9-cd7a330cd0c2 -->
 * **Never self-upgrade team via client**: User stated that a client can 'never self-upgrade a team' regarding org tier guards. This is a directive preference.
 
-<!-- lore:019f6f38-9fad-7135-95e7-d64c4294bc30 -->
-* **Never send embeddings over the wire**: User stated embeddings are never sent over the wire: BLOB \`embedding\`. This is a security constraint. Directive preference.
+<!-- lore:019f7b4f-dfe5-7592-a5bf-987ca14d2a0d -->
+* **Never sets this in production**: User consistently requires that certain flags or values are never set in production. This pattern has appeared in 27 prior sessions and is a directive preference.
 
 <!-- lore:019f6f38-9f83-7c59-b773-9c85fd64d5e5 -->
 * **Never ship DEK to CI**: Never ship DEK to CI. User stated shipping the DEK to CI would violate encryption posture. This is a security constraint. Directive preference.
@@ -549,20 +522,17 @@
 <!-- lore:019f749f-144c-7e1c-b1f3-4f64753f976c -->
 * **Never surfaced on the vector signal alone**: Never surfaced on the vector signal alone. This is a directive preference.
 
-<!-- lore:019f6f38-a07b-782d-93b8-c4ddcef09326 -->
-* **Never sync embeddings**: User stated embeddings are not synced at all. This is a sync design constraint. Directive preference.
-
 <!-- lore:019f71b3-f45b-7c8d-b1de-3d96494f11cf -->
 * **Never touch the front**: User stated: 'never touches the front,'. This is a directive preference.
 
 <!-- lore:019f7121-344f-75fe-99b5-d18253381602 -->
 * **Never touch the real repo files**: Never touch the real repo files. User stated to NEVER touch the real repo files. This is a directive preference.
 
+<!-- lore:019f7b4f-df75-7bf3-9725-8b4f00c384bb -->
+* **Never trust the fix without seeing it fail**: User consistently requires seeing a fix fail before trusting it. This pattern has appeared in 33 prior sessions and is a directive preference.
+
 <!-- lore:019f66a2-5938-7fd4-b581-90d256a820c4 -->
 * **Never TTL-evicted**: User stated never TTL-evicted.
-
-<!-- lore:019f6d35-e51f-7dc3-9466-e1d05c1db0aa -->
-* **Never unwrap ephemeral invite after retirement**: User stated: 'never unwrap it again: delete the remote row'. This is a security invariant for ephemeral invite retirement. Directive preference.
 
 <!-- lore:019f6f42-4193-7f4e-b2e5-0328bc5ebdde -->
 * **Never vec0->blob) ===**: User stated never vec0->blob) ===. This is a directive preference.
@@ -570,23 +540,17 @@
 <!-- lore:019f70c1-61df-7837-a22e-2aee503b0b98 -->
 * **Never write service-role key to disk**: User stated that service-role key 'never touches that path — it is never written to disk'. This is a directive preference.
 
+<!-- lore:019f7af2-a0ff-7363-bbb3-3802fab59406 -->
+* **Never written to any intermediate file**: User stated: 'never written to any intermediate file,'. This is a directive preference.
+
 <!-- lore:019f756d-37fe-78d7-9306-40dfe31342ad -->
 * **Prefers native ONNX runtime via resolveNativeOrtBindingPath, falls back over WASM if native not resolvable**: prefers native ONNX runtime via resolveNativeOrtBindingPath, falls back to WASM if native not resolvable.
 
 <!-- lore:019f7331-e703-7ae9-aa16-093875aeb481 -->
 * **Prefers recall over assuming you don't have the information**: prefer recall over assuming you don't have the information.
 
-<!-- lore:019f6d35-e593-7004-9250-0da8b3352c08 -->
-* **Replace revoke with grant for verified\_email\_domain**: User stated: 'replace revoke with \`grant .'. This was a mutation test scenario. Directive preference.
-
 <!-- lore:019f6f38-a151-7f51-8e1c-6cf644642f8f -->
 * **Restore snapshot with actions/cache in CI**: User stated CI should restore snapshot with actions/cache. This is a CI optimization preference. Directive preference.
-
-<!-- lore:019f6b0f-ba69-7367-be31-3455b5c4d3c7 -->
-* **Run eval against batch of merged PRs to count TP/FP**: To get a real false-positive rate, run the eval against a batch of merged PRs across cheap models and count TP/FP. This is a directive preference.
-
-<!-- lore:019f6f38-9fd6-7043-a9dc-175e18465ae1 -->
-* **Server never sees plaintext**: User stated the server never sees plaintext. This is a security constraint. Directive preference.
 
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
@@ -597,14 +561,50 @@
 <!-- lore:019f6f38-a127-7d59-bd32-486bd71ac328 -->
 * **Snapshot should include text, vectors, confidence, cross\_project**: User stated snapshot should include text, vectors, confidence, cross\_project. This is a CI design constraint. Directive preference.
 
+<!-- lore:019f7b4f-dfc0-7519-8f40-46eb29afc29a -->
+* **Switch to WASM when native fails**: User consistently requires switching to WASM when native runtime fails. This pattern has appeared in 27 prior sessions and is a directive preference.
+
 <!-- lore:019f702c-6f46-7a12-a71c-1507abeb6e0c -->
 * **Tooling failures like no commit range are not findings**: Tooling failures like inability to resolve commit range are not findings. This is a directive preference.
 
-<!-- lore:019f6f38-a000-790d-ac83-8d2d74153607 -->
-* **Use explicit per-table semantic allowlist for sync**: User stated to switch to an explicit per-table semantic allowlist. This is a sync design constraint. Directive preference.
-
 <!-- lore:019f6f38-a1cd-7870-a091-21d36f40386f -->
 * **Use forProject(path, true) to include cross-project entries**: User stated checkInvariants uses forProject(path, true) which includes cross-project. This is a CI design constraint. Directive preference.
+
+<!-- lore:019f7b66-8ff8-7d82-9ee8-fcd3a9521686 -->
+* **Warden analysis: acknowledge genuine utility before extracting ideas**: User consistently requires acknowledging Warden's genuine utility before extracting ideas. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-90ea-7e8c-b238-ce1b2f1e4e7a -->
+* **Warden analysis: caution against over-rotating on automation**: User consistently requires caution against over-rotating on automation when analyzing Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-8fca-7d46-a8a6-c5918d6f1cb3 -->
+* **Warden analysis: extract working ideas, not just criticism**: User consistently requires extracting working ideas from Warden analysis, not just criticism. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-909e-72e9-a518-2cbad5e16348 -->
+* **Warden analysis: frame as complementary, not direct competitor**: User consistently requires framing Lore as complementary to Warden rather than direct competitor. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-9077-7692-bdbf-eab4dff4676e -->
+* **Warden analysis: identify structural advantages for Lore**: User consistently requires identifying structural advantages for Lore when analyzing Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-9021-75fd-8e66-8bb2bfaa179d -->
+* **Warden analysis: note model capability requirements**: User consistently requires noting model capability requirements when analyzing Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-9187-7420-b714-270c2b547199 -->
+* **Warden analysis: note reputation opportunity**: User consistently requires noting reputation opportunity when analyzing Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-9113-732d-bac6-96a43f09ba8c -->
+* **Warden analysis: offer actionable next steps**: User consistently requires offering actionable next steps after Warden analysis. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-913a-754c-98e8-22cd7332e06a -->
+* **Warden analysis: prioritize highest-leverage moves**: User consistently requires prioritizing highest-leverage moves after Warden analysis. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-90c3-79a4-8a85-0197fd5b1d20 -->
+* **Warden analysis: propose concrete ideas from analysis**: User consistently requires proposing concrete ideas from Warden analysis. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-904c-7c39-83c2-37f352644161 -->
+* **Warden analysis: pull benchmark data for concrete analysis**: User consistently requires pulling benchmark data for concrete analysis of Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
+
+<!-- lore:019f7b66-9162-772a-bdc5-591ba0ddbf86 -->
+* **Warden analysis: use benchmark data to show value**: User consistently requires using benchmark data to show value when analyzing Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
 
 <!-- lore:019f77f9-b84c-7c77-9bd6-baa0e69a9bdc -->
 * **Warmup embedding never blocks startup**: User consistently requires that embedding warmup never blocks startup. This pattern has appeared in 40 prior sessions and is a directive preference.

--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -70,7 +70,35 @@ export interface InitError {
   error: string;
 }
 
-export type WorkerOutbound = EmbedResult | EmbedError | InitError;
+/**
+ * The worker's native ONNX Runtime backend could not load the model (an
+ * `isCorruptModelError` parse/deserialize failure) even though the on-disk model
+ * files look structurally intact — the hallmark of a native-runtime
+ * incompatibility rather than a corrupt download. The canonical case is running
+ * the npm bundle under **Bun**: `onnxruntime-node`'s NAPI addon resolves and
+ * loads, but `InferenceSession.create()` fails with "protobuf parsing failed"
+ * (Bun ↔ onnxruntime-node worker-thread native-addon incompatibility, #1379).
+ *
+ * The backend choice (native vs WASM) is committed at the FIRST
+ * `require("onnxruntime-node")` (the bundle's runtime shim reads
+ * `globalThis.__LORE_ORT_BINDING_PATH__` once and caches the module), so an
+ * in-process retry can't switch to WASM. The main thread respawns a FRESH worker
+ * with `WorkerInitData.forceWasm=true` — a new module graph that skips native and
+ * uses the bundled, Bun-hardened WASM runtime. Distinct from `init-error` so the
+ * main thread takes the respawn-once path instead of the purge / cooldown-retry
+ * path (the model is NOT corrupt, so purging it would be destructive).
+ */
+export interface InitNeedsWasm {
+  type: "init-needs-wasm";
+  /** The underlying native model-load error, for diagnostics. */
+  error: string;
+}
+
+export type WorkerOutbound =
+  | EmbedResult
+  | EmbedError
+  | InitError
+  | InitNeedsWasm;
 
 // ---------------------------------------------------------------------------
 // Worker exit codes
@@ -183,6 +211,38 @@ export function isMissingLocalStackError(msg: string): boolean {
     );
   if (!moduleNotFound) return false;
   return /@huggingface\/transformers|onnxruntime|\bsharp\b/i.test(msg);
+}
+
+/**
+ * Decide whether a failed pipeline init should ask the main thread to respawn
+ * the worker forcing the WASM ONNX Runtime (#1379) rather than purge/retry.
+ *
+ * True only when ALL hold:
+ *  - the NATIVE backend was in use (`usedNative`) — WASM can't fall back to
+ *    itself, so a WASM parse failure is a genuine problem, not a backend issue;
+ *  - the model is NOT vendored (`isVendored`) — the SEA binary ships its own
+ *    native runtime and has no WASM sibling to fall back to;
+ *  - the error is an `isCorruptModelError` parse/deserialize failure; AND
+ *  - the on-disk model looks structurally intact (`fileLooksIntact`) — an
+ *    actually-truncated download is real corruption (purge + re-download), not a
+ *    backend incompatibility.
+ *
+ * The canonical trigger is the npm bundle under Bun: native `onnxruntime-node`
+ * loads but `InferenceSession.create()` fails with "protobuf parsing failed"
+ * despite an intact ~137 MB model. Pure predicate, extracted for testability.
+ */
+export function shouldRequestWasmRespawn(
+  usedNative: boolean,
+  isVendored: boolean,
+  errorMessage: string,
+  fileLooksIntact: boolean,
+): boolean {
+  return (
+    usedNative &&
+    !isVendored &&
+    fileLooksIntact &&
+    isCorruptModelError(errorMessage)
+  );
 }
 
 /**
@@ -373,4 +433,12 @@ export interface WorkerInitData {
    *  The worker gates its `console.warn` diagnostics on this flag inline (it runs
    *  as raw .ts and can't value-import siblings — see embedding-worker.ts). */
   stderrSilenced?: boolean;
+  /** Force the bundled WASM ONNX Runtime, skipping native-addon resolution
+   *  entirely. Set by the main thread ONLY when respawning after the previous
+   *  (native) worker posted `init-needs-wasm` — i.e. native loaded the addon but
+   *  couldn't parse the model despite intact on-disk files (the Bun ↔
+   *  onnxruntime-node incompatibility, #1379). A no-op in vendored/SEA mode (that
+   *  path is native via `__LORE_ORT_BINDING_PATH__` and never sets this) and in
+   *  dev/test (raw .ts, no sibling WASM). Default/undefined = prefer native. */
+  forceWasm?: boolean;
 }

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -42,6 +42,10 @@ const port = parentPort;
 
 const init = workerData as WorkerInitData;
 const { modelId, dimensions, vendorModel } = init;
+// Force the bundled WASM ONNX Runtime, skipping native-addon resolution (see
+// WorkerInitData.forceWasm). Set by the main thread only when respawning after a
+// native worker posted `init-needs-wasm` (#1379). Default false = prefer native.
+const forceWasm = init.forceWasm ?? false;
 // Snapshot of the host's stderr-silence state (see WorkerInitData). When true,
 // every diagnostic below stays off stderr so it can't corrupt the host's TUI.
 const stderrSilenced = init.stderrSilenced ?? false;
@@ -163,6 +167,14 @@ type FeatureExtractionPipeline = {
 };
 
 let pipe: FeatureExtractionPipeline | null = null;
+/** True once `loadPipeline` commits the NATIVE ONNX Runtime backend (false only
+ *  on the npm-bundle WASM fallback). Read by `ensurePipeline` to decide whether
+ *  a model-parse failure warrants an `init-needs-wasm` respawn (#1379). */
+let usedNativeBinding = false;
+/** Set once this (native) worker has asked the main thread to respawn it forcing
+ *  WASM (#1379). Suppresses the "pipe is null" hard error on the awaiting init
+ *  caller — the worker is about to be terminated and replaced. */
+let wasmRespawnRequested = false;
 let tokenizer: {
   encode(text: string, options?: Record<string, unknown>): number[];
   decode(ids: number[] | bigint[], options?: Record<string, unknown>): string;
@@ -226,6 +238,26 @@ async function ensurePipeline(): Promise<void> {
           // because the worker runs as raw .ts and can't value-import siblings.
           const intact = await cachedModelLooksIntact();
           if (intact) {
+            // Native backend loaded the addon but couldn't parse a
+            // structurally-intact model — the signature of a native-runtime
+            // incompatibility (Bun ↔ onnxruntime-node, #1379), NOT a corrupt
+            // download. An in-process retry can't help: the backend is already
+            // committed for this worker's module graph. Ask the main thread to
+            // respawn a FRESH worker forcing WASM (a new graph). WASM-path
+            // parse-failures of an intact file fall through to the retry below
+            // (respawn wouldn't change the already-WASM backend). Do NOT post
+            // init-error — that's the main thread's break signal.
+            if (usedNativeBinding) {
+              if (!stderrSilenced) {
+                console.warn(
+                  `[embedding-worker] native ONNX could not parse an intact model (${msg}); ` +
+                    `requesting WASM respawn`,
+                );
+              }
+              post({ type: "init-needs-wasm", error: msg });
+              wasmRespawnRequested = true;
+              return;
+            }
             if (!stderrSilenced) {
               console.warn(
                 `[embedding-worker] model parse failed but on-disk files look intact (${msg}); retrying load without purging`,
@@ -264,7 +296,15 @@ async function ensurePipeline(): Promise<void> {
   }
 
   await initPromise;
-  if (!pipe) throw new Error("pipeline init completed but pipe is null");
+  if (!pipe) {
+    // We asked the main thread to respawn us with WASM (#1379); it will
+    // terminate this worker imminently. Reject this init caller with a plain
+    // error (NOT init-error, already handled by the message above) so the
+    // triggering embed settles instead of hanging on a pipe that will never load.
+    if (wasmRespawnRequested)
+      throw new Error("embedding worker awaiting WASM respawn");
+    throw new Error("pipeline init completed but pipe is null");
+  }
 }
 
 /**
@@ -307,8 +347,16 @@ async function loadPipeline(): Promise<void> {
       !globals.__LORE_ORT_BINDING_PATH__ &&
       !globals.__LORE_NPM_WASM_PATHS__
     ) {
-      const { resolveNativeOrtBindingPath } = await import("./ort-native");
-      const nativePath = resolveNativeOrtBindingPath(__filename);
+      // forceWasm (#1379): a prior native worker loaded the addon but couldn't
+      // parse the model (Bun ↔ onnxruntime-node). Skip native outright and use
+      // the shipped WASM so the retry actually changes backend — resolving
+      // native again would just repeat the failure. `nativePath` is only
+      // consulted when not forcing WASM.
+      const nativePath = forceWasm
+        ? null
+        : (await import("./ort-native")).resolveNativeOrtBindingPath(
+            __filename,
+          );
       if (nativePath) {
         globals.__LORE_ORT_BINDING_PATH__ = nativePath;
       } else {
@@ -319,6 +367,14 @@ async function loadPipeline(): Promise<void> {
       }
     }
   }
+
+  // The ONLY code path that runs on the WASM backend is the npm-bundle fallback
+  // that set `__LORE_NPM_WASM_PATHS__` above (dist-only / unsupported platform /
+  // forceWasm). Every other path — dev/test (real onnxruntime-node), the SEA
+  // vendored binary, and the npm bundle's native branch — runs native. So a
+  // model-parse failure is "native couldn't parse it" iff WASM was NOT selected.
+  // This drives the init-needs-wasm respawn decision in ensurePipeline (#1379).
+  usedNativeBinding = !globals.__LORE_NPM_WASM_PATHS__;
 
   const transformers = await import("@huggingface/transformers");
   const { pipeline, env, layer_norm } = transformers;
@@ -683,7 +739,12 @@ async function processEmbed(req: EmbedRequest): Promise<void> {
     post({ type: "result", id: req.id, vectors });
   } catch (err) {
     // Don't re-post init-error — it was already sent in ensurePipeline().
-    if (!initFailed) {
+    // Also stay silent when we've asked the main thread to respawn us forcing
+    // WASM (#1379/#1387-B2): ensurePipeline() rejected this request with
+    // "awaiting WASM respawn", but posting a per-request `error` here would make
+    // the main thread reject+drop the pending BEFORE respawnForWasm() can
+    // re-submit it to the fresh WASM worker. The respawn re-submits it instead.
+    if (!initFailed && !wasmRespawnRequested) {
       const raw = err instanceof Error ? err.message : String(err);
       const longest = Math.max(...req.texts.map((t) => t.length));
       const effectiveMax = req.maxTokens ?? maxTokens;

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -688,6 +688,15 @@ class LocalProvider implements EmbeddingProvider {
    *  full `EMBED_MEM_FRACTION` share and sum past the host's RAM (BUG: native
    *  OOM is an uncatchable SIGKILL, so this must be prevented, not recovered). */
   private readonly memDivisor: number;
+  /** Force the worker onto the bundled WASM ONNX Runtime, set after a native
+   *  worker reported it couldn't parse an intact model (`init-needs-wasm`, the
+   *  Bun ↔ onnxruntime-node incompatibility, #1379). Threaded into every
+   *  subsequent `workerData` so respawns (incl. OOM backoff) stay on WASM. */
+  private forceWasm = false;
+  /** One-shot latch: we respawn once onto WASM after `init-needs-wasm`. A second
+   *  `init-needs-wasm` (WASM also failing, which shouldn't happen) is treated as
+   *  a genuine init failure instead of looping respawns. */
+  private wasmFallbackTried = false;
 
   constructor(modelId: string, dimensions: number, memDivisor = 1) {
     this.modelId = modelId;
@@ -765,6 +774,9 @@ class LocalProvider implements EmbeddingProvider {
         // Snapshot the host's silence state — the worker's own `globalThis`
         // can't see the main thread's flag (re-read on every OOM respawn).
         stderrSilenced: log.isStderrSilenced(),
+        // Force WASM once a native worker proved it couldn't parse the model
+        // (#1379). Sticky across respawns so we don't bounce back to native.
+        forceWasm: this.forceWasm,
       };
 
       if (testWorkerFactory) {
@@ -821,8 +833,16 @@ class LocalProvider implements EmbeddingProvider {
       // Don't let the worker prevent process exit.
       this.worker.unref();
 
+      // Capture the worker THIS init spawned. Every event handler below is bound
+      // to `spawned` and early-returns if `this.worker !== spawned` — a stale
+      // worker's late events (e.g. the `exit(1)` that `terminate()` emits during
+      // a WASM fallback respawn, #1379/#1387-B1) must never clobber the fresh
+      // worker's state, reject its resubmitted requests, or latch the provider.
+      const spawned = this.worker;
+
       // Wire up response handler.
       this.worker.on("message", (msg: WorkerOutbound) => {
+        if (this.worker !== spawned) return; // superseded worker — ignore
         switch (msg.type) {
           case "result": {
             const pending = this.pendingRequests.get(msg.id);
@@ -866,64 +886,34 @@ class LocalProvider implements EmbeddingProvider {
             }
             break;
           }
+          case "init-needs-wasm": {
+            // The native ONNX backend loaded but couldn't parse an intact model
+            // (#1379 — Bun ↔ onnxruntime-node). Respawn a FRESH worker forcing
+            // WASM; the backend is committed per module-graph, so only a new
+            // worker can switch. One-shot: if WASM ALSO reports this (shouldn't
+            // happen — it means genuine corruption on both backends), fall
+            // through to the init-error path so we don't loop respawns.
+            if (!this.wasmFallbackTried) {
+              this.wasmFallbackTried = true;
+              this.forceWasm = true;
+              this.workerReady = false;
+              // Clear any transient init debt so the deliberate respawn isn't
+              // fast-failed, mirroring the OOM backoff path.
+              this.workerInitError = null;
+              log.info(
+                "native ONNX runtime could not load the embedding model " +
+                  `(${msg.error}); retrying with the bundled WASM runtime`,
+              );
+              void this.respawnForWasm();
+              break;
+            }
+            // Already tried WASM and it also failed — treat as a real init
+            // failure (genuine corruption on both backends, or a non-Bun cause).
+            this.handleInitError(msg.error);
+            break;
+          }
           case "init-error": {
-            // Model init failed inside the worker — surface as
-            // LocalProviderUnavailableError on all pending + future requests.
-            this.workerInitError = msg.error;
-            this.workerReady = false;
-            if (isMissingLocalStackError(msg.error)) {
-              // Optional local-embedding stack not installed (#1026 — an
-              // expected, actionable degraded state that will NOT self-heal on
-              // its own). Latch permanently; recall degrades to FTS-only. Flag
-              // it so the self-heal re-probe skips it (a reinstall, not a retry,
-              // is what recovers this).
-              localProviderKnownBroken = true;
-              localStackMissing = true;
-              if (!localProviderErrorLogged) {
-                localProviderErrorLogged = true;
-                log.warn(
-                  "local embedding dependencies not installed " +
-                    "(optional '@huggingface/transformers' / 'onnxruntime-node' absent) — " +
-                    "recall will use FTS-only search. Reinstall without --omit=optional to " +
-                    "enable local embeddings, or set search.embeddings.provider in .lore.json " +
-                    "to a remote provider (voyage/openai) with the matching API key.",
-                );
-              }
-            } else {
-              // A potentially transient failure (e.g. a model read that raced a
-              // concurrent writer during a multi-instance restart, momentary
-              // memory pressure). Retry a FRESH worker after a cooldown rather
-              // than disabling local embeddings for the whole process lifetime;
-              // only give up (latch) once the retry budget is exhausted.
-              localInitFailures++;
-              if (localInitFailures >= LOCAL_INIT_MAX_ATTEMPTS) {
-                localProviderKnownBroken = true;
-                localInitRetryAt = 0;
-                if (!localProviderErrorLogged) {
-                  localProviderErrorLogged = true;
-                  log.error(
-                    `local embedding provider failed to init after ${localInitFailures} attempts: ${msg.error}. ` +
-                      `Set search.embeddings.provider in .lore.json to use a remote provider.`,
-                    new Error(`embedding worker init failed: ${msg.error}`),
-                  );
-                }
-              } else {
-                const retryDelayMs = computeInitRetryDelayMs(
-                  localInitFailures,
-                  localInitCooldownMs,
-                );
-                localInitRetryAt = Date.now() + retryDelayMs;
-                log.warn(
-                  `local embedding init failed (attempt ${localInitFailures}/${LOCAL_INIT_MAX_ATTEMPTS}): ${msg.error}. ` +
-                    `Retrying with a fresh worker in ~${Math.round(retryDelayMs / 1000)}s; recall is FTS-only until then.`,
-                );
-              }
-            }
-            for (const [, p] of this.pendingRequests) {
-              p.reject(new LocalProviderUnavailableError(msg.error));
-            }
-            this.pendingRequests.clear();
-            this.updateWorkerRef();
+            this.handleInitError(msg.error);
             break;
           }
         }
@@ -933,6 +923,7 @@ class LocalProvider implements EmbeddingProvider {
       // Null out `this.worker` in both handlers so the `?.` optional chaining
       // in embed() prevents postMessage on a terminated Worker (LOREAI-GATEWAY-1T).
       this.worker.on("error", (err: Error) => {
+        if (this.worker !== spawned) return; // superseded worker — ignore
         this.workerInitError = err.message;
         this.workerReady = false;
         this.worker = null;
@@ -945,6 +936,7 @@ class LocalProvider implements EmbeddingProvider {
       });
 
       this.worker.on("exit", (code) => {
+        if (this.worker !== spawned) return; // superseded worker — ignore
         this.workerReady = false;
         this.worker = null;
         this.initPromise = null;
@@ -1158,6 +1150,131 @@ class LocalProvider implements EmbeddingProvider {
       } catch {
         // Worker died again between ensureWorker() and here — its exit handler
         // drives the next backoff/latch. Leave pending in place.
+      }
+    }
+    this.updateWorkerRef();
+  }
+
+  /**
+   * Shared handler for a fatal worker init failure. Surfaces
+   * `LocalProviderUnavailableError` on all pending + future requests, either
+   * latching FTS-only (missing stack / retry budget exhausted) or scheduling a
+   * cooldown retry with a fresh worker. Called from the `init-error` message and
+   * from `init-needs-wasm` once the one-shot WASM fallback has already been used
+   * (a WASM init that also fails is a genuine failure, #1379).
+   */
+  private handleInitError(errorMsg: string): void {
+    this.workerInitError = errorMsg;
+    this.workerReady = false;
+    if (isMissingLocalStackError(errorMsg)) {
+      // Optional local-embedding stack not installed (#1026 — an expected,
+      // actionable degraded state that will NOT self-heal on its own). Latch
+      // permanently; recall degrades to FTS-only. Flag it so the self-heal
+      // re-probe skips it (a reinstall, not a retry, is what recovers this).
+      localProviderKnownBroken = true;
+      localStackMissing = true;
+      if (!localProviderErrorLogged) {
+        localProviderErrorLogged = true;
+        log.warn(
+          "local embedding dependencies not installed " +
+            "(optional '@huggingface/transformers' / 'onnxruntime-node' absent) — " +
+            "recall will use FTS-only search. Reinstall without --omit=optional to " +
+            "enable local embeddings, or set search.embeddings.provider in .lore.json " +
+            "to a remote provider (voyage/openai) with the matching API key.",
+        );
+      }
+    } else {
+      // A potentially transient failure (e.g. a model read that raced a
+      // concurrent writer during a multi-instance restart, momentary memory
+      // pressure). Retry a FRESH worker after a cooldown rather than disabling
+      // local embeddings for the whole process lifetime; only give up (latch)
+      // once the retry budget is exhausted.
+      localInitFailures++;
+      if (localInitFailures >= LOCAL_INIT_MAX_ATTEMPTS) {
+        localProviderKnownBroken = true;
+        localInitRetryAt = 0;
+        if (!localProviderErrorLogged) {
+          localProviderErrorLogged = true;
+          log.error(
+            `local embedding provider failed to init after ${localInitFailures} attempts: ${errorMsg}. ` +
+              `Set search.embeddings.provider in .lore.json to use a remote provider.`,
+            new Error(`embedding worker init failed: ${errorMsg}`),
+          );
+        }
+      } else {
+        const retryDelayMs = computeInitRetryDelayMs(
+          localInitFailures,
+          localInitCooldownMs,
+        );
+        localInitRetryAt = Date.now() + retryDelayMs;
+        log.warn(
+          `local embedding init failed (attempt ${localInitFailures}/${LOCAL_INIT_MAX_ATTEMPTS}): ${errorMsg}. ` +
+            `Retrying with a fresh worker in ~${Math.round(retryDelayMs / 1000)}s; recall is FTS-only until then.`,
+        );
+      }
+    }
+    for (const [, p] of this.pendingRequests) {
+      p.reject(new LocalProviderUnavailableError(errorMsg));
+    }
+    this.pendingRequests.clear();
+    this.updateWorkerRef();
+  }
+
+  /**
+   * Respawn a FRESH worker forcing the bundled WASM ONNX Runtime after a native
+   * worker reported `init-needs-wasm` (#1379). The native worker is still alive
+   * (it returned from init without exiting), so terminate it first, then let
+   * `ensureWorker()` build a new one — `this.forceWasm` (set by the caller) makes
+   * its `workerData` skip native. Any request that triggered the failed init is
+   * re-posted to the WASM worker so the fallback is transparent to callers.
+   */
+  private async respawnForWasm(): Promise<void> {
+    const dead = this.worker;
+    this.worker = null;
+    this.initPromise = null;
+    // Belt-and-suspenders: ensureWorker() early-returns when `workerReady` is
+    // true, so it MUST be false here or the WASM worker would never spawn and
+    // pending requests would be lost. The `init-needs-wasm` caller already
+    // clears it, but re-clear locally so this invariant holds for any caller and
+    // survives refactors (defense against the workerReady race Seer flagged).
+    this.workerReady = false;
+    if (dead) {
+      // Fire-and-forget: we don't await termination (the fresh worker is
+      // independent). terminate() never rejects in practice; swallow to be safe.
+      // NOTE: terminate() DOES emit an async `exit(1)` on the dead worker. That
+      // event is harmless here only because each handler is bound to its own
+      // `spawned` worker and early-returns when `this.worker` has moved on (see
+      // ensureWorker) — otherwise the stale exit would latch the provider broken
+      // and clobber the fresh WASM worker (#1387-B1).
+      void dead.terminate().catch(() => {});
+    }
+    try {
+      await this.ensureWorker();
+    } catch {
+      // Synchronous respawn failure — nothing else will settle these requests
+      // (the local embed path has no timeout). Reject them here.
+      for (const [, p] of this.pendingRequests) {
+        p.reject(
+          new LocalProviderUnavailableError(
+            "embedding worker respawn failed after WASM fallback",
+          ),
+        );
+      }
+      this.pendingRequests.clear();
+      return;
+    }
+    // Re-read through a cast: TS still has `this.worker` narrowed to null from
+    // the `this.worker = null` above (it can't see that ensureWorker() reassigns
+    // it across the await), so a direct read would be typed `never`.
+    const worker = this.worker as import("node:worker_threads").Worker | null;
+    if (worker == null) return; // raced with an exit — that handler owns pending
+    for (const [, p] of this.pendingRequests) {
+      p.payload.maxTokens = this.effectiveMaxTokens();
+      try {
+        worker.postMessage(p.payload satisfies WorkerInbound);
+      } catch {
+        // Worker died between ensureWorker() and here — its exit handler drives
+        // the next step. Leave pending in place.
       }
     }
     this.updateWorkerRef();

--- a/packages/core/test/embedding-wasm-fallback.test.ts
+++ b/packages/core/test/embedding-wasm-fallback.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import {
+  embed,
+  isAvailable,
+  LocalProviderUnavailableError,
+  _persistEmbedCap,
+  _resetLocalProviderProbe,
+  _restoreProvider,
+  _saveAndClearProvider,
+  _setConstrainedMemoryForTest,
+  _setContainerFreeForTest,
+  _setTestWorkerFactory,
+} from "../src/embedding";
+import { EMBED_OOM_EXIT_CODE } from "../src/embedding-worker-types";
+import type { WorkerInitData } from "../src/embedding-worker-types";
+
+// Exercises the native→WASM fallback lifecycle in LocalProvider (#1379): when a
+// native worker reports `init-needs-wasm` (it loaded the ONNX addon but couldn't
+// parse an intact model — the Bun ↔ onnxruntime-node incompatibility), the main
+// thread must respawn a FRESH worker forcing WASM and re-submit in-flight work.
+// A fake worker (the _setTestWorkerFactory seam) drives the message/exit events
+// deterministically without a real ONNX runtime.
+
+type EmbedMsg = { type: string; id: number; maxTokens: number };
+
+class FakeWorker extends EventEmitter {
+  readonly posted: EmbedMsg[] = [];
+  terminated = false;
+  postMessage(msg: unknown): void {
+    this.posted.push({ ...(msg as EmbedMsg) });
+  }
+  ref(): void {}
+  unref(): void {}
+  terminate(): Promise<number> {
+    this.terminated = true;
+    // Faithful to node:worker_threads: terminate() asynchronously emits an
+    // `exit` event (non-zero code). The main thread's per-worker handler guard
+    // (#1387-B1) must ignore this stale exit so it can't latch the provider or
+    // clobber the freshly-spawned WASM worker. Emitting it here is what makes
+    // this suite able to catch that regression.
+    queueMicrotask(() => this.emit("exit", 1));
+    return Promise.resolve(0);
+  }
+  lastPosted(): EmbedMsg {
+    const m = this.posted.at(-1);
+    if (!m) throw new Error("fake worker received no message");
+    return m;
+  }
+}
+
+/** Install the factory and collect (fake, initData) pairs it hands out. */
+function installFakeWorkers(): Array<{
+  fake: FakeWorker;
+  init: WorkerInitData;
+}> {
+  const spawns: Array<{ fake: FakeWorker; init: WorkerInitData }> = [];
+  _setTestWorkerFactory((init) => {
+    const fake = new FakeWorker();
+    spawns.push({ fake, init });
+    return fake as unknown as Worker;
+  });
+  return spawns;
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function settle<T>(
+  p: Promise<T>,
+): Promise<{ ok: true; value: T } | { ok: false; err: unknown }> {
+  return p.then(
+    (value) => ({ ok: true as const, value }),
+    (err) => ({ ok: false as const, err }),
+  );
+}
+
+describe("embedding native→WASM fallback (#1379)", () => {
+  let savedProvider: unknown;
+  let savedVoyage: string | undefined;
+  let savedOpenAI: string | undefined;
+
+  beforeEach(() => {
+    savedVoyage = process.env.VOYAGE_API_KEY;
+    savedOpenAI = process.env.OPENAI_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    _setConstrainedMemoryForTest(0);
+    _setContainerFreeForTest(16 * 1024 * 1024 * 1024);
+    _resetLocalProviderProbe();
+    savedProvider = _saveAndClearProvider();
+  });
+
+  afterEach(() => {
+    _setTestWorkerFactory(null);
+    _setContainerFreeForTest(null);
+    _setConstrainedMemoryForTest(null);
+    _resetLocalProviderProbe();
+    _restoreProvider(savedProvider);
+    if (savedVoyage !== undefined) process.env.VOYAGE_API_KEY = savedVoyage;
+    if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
+  });
+
+  it("respawns forcing WASM and re-submits the in-flight request on init-needs-wasm", async () => {
+    _persistEmbedCap(8192, 0);
+    const spawns = installFakeWorkers();
+
+    const promise = embed(["hello world"], "query");
+    await flush();
+
+    expect(spawns).toHaveLength(1);
+    // First worker spawned WITHOUT forceWasm (prefers native).
+    expect(spawns[0].init.forceWasm ?? false).toBe(false);
+    const first = spawns[0].fake.lastPosted();
+    expect(first.type).toBe("embed");
+
+    // Native loaded the addon but couldn't parse the (intact) model.
+    spawns[0].fake.emit("message", {
+      type: "init-needs-wasm",
+      error: "Failed to load model because protobuf parsing failed",
+    });
+    await flush();
+
+    // A fresh worker was spawned WITH forceWasm, and the native one terminated.
+    expect(spawns).toHaveLength(2);
+    expect(spawns[1].init.forceWasm).toBe(true);
+    expect(spawns[0].fake.terminated).toBe(true);
+
+    // The original request was re-submitted to the WASM worker (same id).
+    const resubmitted = spawns[1].fake.lastPosted();
+    expect(resubmitted.type).toBe("embed");
+    expect(resubmitted.id).toBe(first.id);
+
+    // WASM worker succeeds → the caller's promise resolves.
+    spawns[1].fake.emit("message", {
+      type: "result",
+      id: resubmitted.id,
+      vectors: [new Float32Array([0.1, 0.2, 0.3])],
+    });
+    const vectors = await promise;
+    expect(vectors).toHaveLength(1);
+    expect(isAvailable()).toBe(true);
+  });
+
+  it("keeps forceWasm sticky across a later OOM respawn", async () => {
+    _persistEmbedCap(8192, 0);
+    const spawns = installFakeWorkers();
+
+    const result = settle(embed(["hello world"], "query"));
+    await flush();
+
+    // Native → WASM fallback.
+    spawns[0].fake.emit("message", {
+      type: "init-needs-wasm",
+      error: "protobuf parsing failed",
+    });
+    await flush();
+    expect(spawns).toHaveLength(2);
+    expect(spawns[1].init.forceWasm).toBe(true);
+
+    // The WASM worker then OOMs → respawn must STILL force WASM (never bounce
+    // back to the native runtime that already failed).
+    spawns[1].fake.emit("exit", EMBED_OOM_EXIT_CODE);
+    await flush();
+    expect(spawns).toHaveLength(3);
+    expect(spawns[2].init.forceWasm).toBe(true);
+
+    spawns[2].fake.emit("message", {
+      type: "result",
+      id: spawns[2].fake.lastPosted().id,
+      vectors: [new Float32Array([0.1])],
+    });
+    const r = await result;
+    expect(r.ok).toBe(true);
+  });
+
+  it("treats a second init-needs-wasm (WASM also fails) as a genuine init failure — no respawn loop", async () => {
+    _persistEmbedCap(8192, 0);
+    const spawns = installFakeWorkers();
+
+    const result = settle(embed(["hello world"], "query"));
+    await flush();
+
+    // Native fails → respawn onto WASM (spawn #2).
+    spawns[0].fake.emit("message", {
+      type: "init-needs-wasm",
+      error: "protobuf parsing failed",
+    });
+    await flush();
+    expect(spawns).toHaveLength(2);
+
+    // WASM ALSO reports it can't load — one-shot latch: do NOT respawn again.
+    spawns[1].fake.emit("message", {
+      type: "init-needs-wasm",
+      error: "protobuf parsing failed",
+    });
+    await flush();
+
+    expect(spawns).toHaveLength(2); // did NOT loop into a 3rd spawn
+    const r = await result;
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.err).toBeInstanceOf(LocalProviderUnavailableError);
+  });
+
+  it("stays available and re-submits when the native worker emits the full real protocol (init-needs-wasm + trailing per-request error + terminate exit)", async () => {
+    // #1387-B1+B2 regression: the REAL native worker, on a WASM-fallback init,
+    // (1) posts `init-needs-wasm`, (2) rejects the triggering request so
+    // processEmbed posts a trailing `{type:"error", id}`, and (3) is terminated
+    // by the main thread, which asynchronously emits `exit(1)`. Naively, (2)
+    // drops the pending before resubmit and (3) latches the provider broken —
+    // both reproduce the #1379 symptom (isAvailable()===false, embed dropped).
+    // The fix (worker suppresses the trailing error under wasmRespawnRequested;
+    // main thread guards handlers per-worker) must keep the caller alive.
+    _persistEmbedCap(8192, 0);
+    const spawns = installFakeWorkers();
+
+    const promise = embed(["hello world"], "query");
+    await flush();
+    expect(spawns).toHaveLength(1);
+    const first = spawns[0].fake.lastPosted();
+
+    // Native can't parse the intact model → request WASM respawn. The worker
+    // does NOT post a per-request error for this request (it's being resubmitted).
+    spawns[0].fake.emit("message", {
+      type: "init-needs-wasm",
+      error: "Failed to load model because protobuf parsing failed",
+    });
+    // The REAL worker's processEmbed catch would fire right after — with the B2
+    // fix it stays silent, but a regressed worker (or the main thread not
+    // guarding it) would post this trailing error for the SAME request id.
+    // Emitting it here asserts the main thread does NOT let it drop the pending
+    // before the resubmit. (Post-fix the worker won't send it; this models the
+    // adversarial worst case where it still arrives.)
+    spawns[0].fake.emit("message", {
+      type: "error",
+      id: first.id,
+      error: "embedding worker awaiting WASM respawn",
+    });
+    await flush();
+
+    // Fresh WASM worker spawned; the stale native worker was terminated and its
+    // async exit(1) must have been ignored (per-worker handler guard).
+    expect(spawns).toHaveLength(2);
+    expect(spawns[1].init.forceWasm).toBe(true);
+    expect(spawns[0].fake.terminated).toBe(true);
+
+    // The request was re-submitted to the WASM worker (not dropped by a trailing
+    // error and not lost to the terminated worker's exit).
+    const resubmitted = spawns[1].fake.lastPosted();
+    expect(resubmitted.type).toBe("embed");
+    expect(resubmitted.id).toBe(first.id);
+
+    // WASM worker succeeds → caller resolves; provider stays available.
+    spawns[1].fake.emit("message", {
+      type: "result",
+      id: resubmitted.id,
+      vectors: [new Float32Array([0.1])],
+    });
+    const vectors = await promise;
+    expect(vectors).toHaveLength(1);
+    expect(isAvailable()).toBe(true);
+  });
+});

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -10,6 +10,7 @@ import {
   MIN_ONNX_FILE_BYTES,
   resolveModelCacheDir,
   shouldHealCorruptModel,
+  shouldRequestWasmRespawn,
   TRANSFORMERS_INFERENCE_DUMP_PREFIXES,
 } from "../src/embedding-worker-types";
 
@@ -192,6 +193,33 @@ describe("TRANSFORMERS_INFERENCE_DUMP_PREFIXES inline copy stays in sync", () =>
     expect(workerBody.length).toBeGreaterThan(0);
     expect(workerBody).toBe(bodyOf(typesSrc));
   });
+
+  test("worker inline isCorruptModelError body matches the canonical function", () => {
+    // embedding-worker.ts inlines isCorruptModelError (same raw-.ts constraint).
+    // It is the load-bearing component of the native→WASM respawn decision
+    // (#1379): the worker's inline check `!vendorModel && isCorruptModelError &&
+    // intact && usedNativeBinding` mirrors shouldRequestWasmRespawn(). If the
+    // corruption classifier drifts, that decision silently drifts too — so guard
+    // the inline copy against the canonical. Strip line comments first so this
+    // asserts LOGIC parity only (the two copies carry different explanatory
+    // comments by design).
+    const bodyOf = (src: string): string => {
+      const m = src.match(
+        /function isCorruptModelError\(msg: string\): boolean \{([\s\S]*?)\n\}/,
+      );
+      expect(
+        m,
+        "isCorruptModelError not found (worker or canonical)",
+      ).not.toBeNull();
+      return (m?.[1] ?? "")
+        .replace(/^\s*\/\/.*$/gm, "") // drop full-line // comments
+        .replace(/\s+/g, " ")
+        .trim();
+    };
+    const workerBody = bodyOf(workerSrc);
+    expect(workerBody.length).toBeGreaterThan(0);
+    expect(workerBody).toBe(bodyOf(typesSrc));
+  });
 });
 
 describe("looksLikeIntactOnnxFile", () => {
@@ -234,6 +262,47 @@ describe("shouldHealCorruptModel", () => {
     expect(shouldHealCorruptModel(false, "out of memory")).toBe(false);
     expect(
       shouldHealCorruptModel(false, "401 Unauthorized: failed to load model"),
+    ).toBe(false);
+  });
+});
+
+describe("shouldRequestWasmRespawn (#1379)", () => {
+  const PARSE = "Failed to load model because protobuf parsing failed";
+
+  test("requests WASM respawn: native backend, intact file, parse error", () => {
+    // The canonical Bun ↔ onnxruntime-node case — native loaded but couldn't
+    // parse an intact model.
+    expect(shouldRequestWasmRespawn(true, false, PARSE, true)).toBe(true);
+  });
+
+  test("does NOT request respawn when already on WASM", () => {
+    // WASM can't fall back to itself; an intact-file parse failure there is the
+    // existing retry-without-purge case, not a backend switch.
+    expect(shouldRequestWasmRespawn(false, false, PARSE, true)).toBe(false);
+  });
+
+  test("does NOT request respawn for a vendored (SEA) binary", () => {
+    // SEA ships its own native runtime and has no WASM sibling to fall back to.
+    expect(shouldRequestWasmRespawn(true, true, PARSE, true)).toBe(false);
+  });
+
+  test("does NOT request respawn when the on-disk file is truncated", () => {
+    // A genuinely corrupt/partial download is real corruption → purge path,
+    // not a backend incompatibility.
+    expect(shouldRequestWasmRespawn(true, false, PARSE, false)).toBe(false);
+  });
+
+  test("does NOT request respawn on a non-corruption error", () => {
+    expect(shouldRequestWasmRespawn(true, false, "out of memory", true)).toBe(
+      false,
+    );
+    expect(
+      shouldRequestWasmRespawn(
+        true,
+        false,
+        "401 Unauthorized: failed to load model",
+        true,
+      ),
     ).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #1379.

## Problem

The eval iso-gateway runs the npm bundle under **Bun** (`dist/index.bun.js`). The embedding worker's `loadPipeline()` prefers native ONNX: `resolveNativeOrtBindingPath()` uses `createRequire().resolve()`, which **works under Bun** and finds the installed `@loreai/onnxruntime-<target>` addon → native path is selected. But the native `onnxruntime-node` NAPI addon then **fails to load the model under Bun** with `Failed to load model because protobuf parsing failed` (a Bun ↔ onnxruntime-node worker-thread native-addon incompatibility).

Because native *resolution* succeeds, the already-Bun-hardened WASM fallback is never reached. Worse, the failure matches `isCorruptModelError`, so the worker's corrupt-model self-heal would (wrongly) treat an intact model as corrupt. Result: `isAvailable()` is false for the whole run, `embedDistillation()` no-ops, `distillation_vec`/`knowledge_vec` stay empty, and vector recall is dark. **Production (Node) is unaffected.**

## Fix — probe native, fall back to WASM keyed on the actual error

The backend choice is committed at the first `require("onnxruntime-node")` (the bundle's runtime shim reads `globalThis.__LORE_ORT_BINDING_PATH__` once and caches the module), so an in-process retry cannot switch to WASM. The fix mirrors the existing OOM→respawn pattern:

1. **Worker** — when pipeline init fails with an `isCorruptModelError` parse failure **while native was in use** and the on-disk model **looks structurally intact** (`looksLikeIntactOnnxFile`), it posts a new `init-needs-wasm` message instead of purging (the model isn't corrupt) or retrying in-process (same backend).
2. **Main thread** (`LocalProvider`) — on `init-needs-wasm`, terminates the native worker and respawns a **fresh** worker with `WorkerInitData.forceWasm=true` (a new module graph that skips native → uses the bundled, Bun-hardened WASM runtime), re-submitting any in-flight request. `forceWasm` is **sticky** across later respawns (incl. OOM backoff) so it never bounces back to native.
3. **One-shot latch** — a second `init-needs-wasm` (WASM also failing, i.e. genuine corruption on both backends) falls through to the normal `init-error` path; no respawn loop.

This is runtime-agnostic (keyed on the real signal, not a Bun sniff), so it also self-heals any future native-incompat while keeping Node/production and the SEA binary on fast native.

## Tests (all non-vacuous, mutation-verified)

- `embedding-wasm-fallback.test.ts` — respawn-forcing-WASM + resubmit; `forceWasm` sticky across a later OOM respawn; second `init-needs-wasm` latches (no loop).
- `embedding-worker-types.test.ts` — new pure predicate `shouldRequestWasmRespawn` (native/WASM, vendored, intact/truncated, error-kind).

Mutations killed: don't-set-forceWasm (2 tests), remove-one-shot-latch (1 test), drop-usedNative-clause in predicate (1 test).

Full suite: 6143 passed / 0 failed. typecheck + lint + format clean.