### PR TITLE
feat(gateway): GitHub repo-collaborator discovery (#630, E-5-d Slice 1)

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -246,6 +246,30 @@ export function shouldRequestWasmRespawn(
 }
 
 /**
+ * Whether `processEmbed`'s catch block should post a per-request `error` back to
+ * the main thread for a failed embed request (#1379/#1387-B2).
+ *
+ * Two cases must stay SILENT:
+ *  - `initFailed` — `ensurePipeline()` already posted `init-error`; re-posting a
+ *    per-request error would double-report the same failure.
+ *  - `wasmRespawnRequested` — the worker asked the main thread to respawn it
+ *    forcing WASM, so `ensurePipeline()` rejected this request with "awaiting
+ *    WASM respawn". Posting a per-request `error` here would make the main thread
+ *    reject+drop the pending request BEFORE `respawnForWasm()` re-submits it to
+ *    the fresh WASM worker — silently losing the caller's embed. The respawn
+ *    re-submits it instead, so this worker must not report it.
+ *
+ * Pure predicate, extracted so the B2 suppression is directly unit-testable
+ * without importing the worker module (which self-executes on import).
+ */
+export function shouldPostPerRequestError(
+  initFailed: boolean,
+  wasmRespawnRequested: boolean,
+): boolean {
+  return !initFailed && !wasmRespawnRequested;
+}
+
+/**
  * The two leading strings transformers.js' `sessionRun()` (models.js) passes to
  * `console.error` when `session.run` throws, before it re-throws: the error
  * message, and a dump of every input tensor's metadata AND `.data`. For our

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -744,6 +744,8 @@ async function processEmbed(req: EmbedRequest): Promise<void> {
     // "awaiting WASM respawn", but posting a per-request `error` here would make
     // the main thread reject+drop the pending BEFORE respawnForWasm() can
     // re-submit it to the fresh WASM worker. The respawn re-submits it instead.
+    // Canonical gate: shouldPostPerRequestError() in embedding-worker-types.ts
+    // (unit-tested); a drift guard pins this inline expression to it.
     if (!initFailed && !wasmRespawnRequested) {
       const raw = err instanceof Error ? err.message : String(err);
       const longest = Math.max(...req.texts.map((t) => t.length));

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -10,6 +10,7 @@ import {
   MIN_ONNX_FILE_BYTES,
   resolveModelCacheDir,
   shouldHealCorruptModel,
+  shouldPostPerRequestError,
   shouldRequestWasmRespawn,
   TRANSFORMERS_INFERENCE_DUMP_PREFIXES,
 } from "../src/embedding-worker-types";
@@ -304,5 +305,53 @@ describe("shouldRequestWasmRespawn (#1379)", () => {
         true,
       ),
     ).toBe(false);
+  });
+});
+
+describe("shouldPostPerRequestError (#1379 B2)", () => {
+  test("posts a per-request error for an ordinary embed failure", () => {
+    // Normal per-request failure (no init failure, no pending respawn) → the
+    // worker reports it so the main thread rejects just that request.
+    expect(shouldPostPerRequestError(false, false)).toBe(true);
+  });
+
+  test("stays silent while a WASM respawn is pending (B2)", () => {
+    // The request that tripped `init-needs-wasm` is rejected by ensurePipeline
+    // with "awaiting WASM respawn". Posting a per-request error here would make
+    // the main thread reject+drop the pending BEFORE respawnForWasm re-submits
+    // it → the caller's embed is silently lost. Must NOT post.
+    expect(shouldPostPerRequestError(false, true)).toBe(false);
+  });
+
+  test("stays silent after init already failed (init-error already posted)", () => {
+    expect(shouldPostPerRequestError(true, false)).toBe(false);
+  });
+
+  test("stays silent when both flags are set", () => {
+    expect(shouldPostPerRequestError(true, true)).toBe(false);
+  });
+});
+
+describe("processEmbed catch condition stays in sync with shouldPostPerRequestError (#1379 B2)", () => {
+  // shouldPostPerRequestError is the canonical, unit-tested B2 gate, but the
+  // worker (raw .ts, self-executing on import — can't be imported here) inlines
+  // the equivalent expression in processEmbed's catch. Parse the worker source
+  // and assert that expression is exactly `!initFailed && !wasmRespawnRequested`
+  // so the two can't silently drift (mirrors the isCorruptModelError inline-copy
+  // guard above). If they drift, this fails CI and points at the worker.
+  const workerSrc = readFileSync(
+    fileURLToPath(new URL("../src/embedding-worker.ts", import.meta.url)),
+    "utf8",
+  );
+
+  test("worker gates the per-request error post on both suppression flags", () => {
+    // The catch opens with the B2 guard; match the exact boolean expression,
+    // whitespace-normalized (robust to formatting/line wraps).
+    const guard = workerSrc.match(
+      /catch \(err\) \{[\s\S]*?if \(([^)]*initFailed[^)]*)\)/,
+    );
+    expect(guard, "processEmbed catch guard not found").not.toBeNull();
+    const expr = (guard?.[1] ?? "").replace(/\s+/g, " ").trim();
+    expect(expr).toBe("!initFailed && !wasmRespawnRequested");
   });
 });

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -41,7 +41,7 @@ Commands:
   logout              Sign out and clear the local session
   whoami              Show the signed-in Folk Lore account
   sync <subcommand>   Cloud-sync knowledge + entities (enable, disable, status, now)
-  team <subcommand>   Manage shared team scopes (list, members, create, add, remove, set-role, invite, accept, link, unlink, review, approve, reject, policy)
+  team <subcommand>   Manage shared team scopes (list, members, discover, create, add, remove, set-role, invite, accept, link, unlink, review, approve, reject, policy)
   entity <subcommand> Manage the entity registry (list, show, add, merge)
   upgrade [version]   Update lore to the latest (or specified) version
                        Flags: --check, --force, --offline, --channel <ch>

--- a/packages/gateway/src/cli/login.ts
+++ b/packages/gateway/src/cli/login.ts
@@ -187,6 +187,49 @@ async function loginWithGitHub(): Promise<void> {
   await provisionGitHubTeams(client, sess.session.provider_token);
 }
 
+/**
+ * E-5-d (#630): obtain a FRESH GitHub `provider_token` via a one-shot loopback OAuth, for a
+ * capability that needs to read from GitHub after login (e.g. `lore team discover`). The
+ * `provider_token` is short-lived and NOT persisted/refreshed (see provisionGitHubTeams), so it must
+ * be re-acquired on demand. Returns the fresh token plus the authed client bound to the refreshed
+ * session. Requires an interactive browser (loopback); throws if the grant yields no provider_token
+ * (e.g. an email-only account). Also refreshes the persisted session as a side effect.
+ */
+export async function acquireGitHubProviderToken(): Promise<{
+  client: SupabaseClient;
+  providerToken: string;
+}> {
+  const client = createSupabaseClient();
+  const { code, redirectTo, done } = await startLoopbackCallback();
+  const { data, error } = await client.auth.signInWithOAuth({
+    provider: "github",
+    options: { skipBrowserRedirect: true, redirectTo, scopes: "read:org" },
+  });
+  if (error || !data.url) {
+    done.close();
+    throw new Error(error?.message ?? "Could not start GitHub OAuth.");
+  }
+  console.log("Opening your browser to authorize GitHub access…");
+  console.log("If it doesn't open, scan this or visit the URL below:\n");
+  await showAuthUrl(data.url);
+  openBrowser(data.url);
+
+  const oauthCode = await code;
+  const { data: sess, error: exchErr } =
+    await client.auth.exchangeCodeForSession(oauthCode);
+  if (exchErr) throw new Error(exchErr.message);
+  if (!sess.session) throw new Error("No session returned after OAuth.");
+  // Keep the persisted session fresh (this OAuth refreshed the access token).
+  await finalizeLogin(client, sessionToPersisted(sess.session));
+  const providerToken = sess.session.provider_token;
+  if (!providerToken) {
+    throw new Error(
+      "GitHub did not return an access token — this account may not be linked to GitHub.",
+    );
+  }
+  return { client, providerToken };
+}
+
 // --- GitHub OAuth, headless (manual code paste, no loopback) ----------------
 
 /**

--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -14,6 +14,7 @@ import {
   syncData,
 } from "@loreai/core";
 import { getAuthedClient, getCurrentUser } from "../supabase";
+import { acquireGitHubProviderToken } from "./login";
 import {
   addTeamMember,
   acceptTeamInvite,
@@ -21,6 +22,7 @@ import {
   claimOrgDomain,
   createTeam,
   createTeamInvite,
+  discoverGitHubCollaborators,
   listDomainJoinRequests,
   listTeams,
   rejectDomainJoin,
@@ -31,7 +33,7 @@ import {
 } from "../team";
 
 const USAGE =
-  "Usage: lore team [list | members <scope> | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite <scope> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>] | domain <claim <org> <domain> [--role member] | request <org> <domain> | requests <org> | approve <request-id> | reject <request-id>>]";
+  "Usage: lore team [list | members <scope> | discover [repo...] | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite <scope> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>] | domain <claim <org> <domain> [--role member] | request <org> <domain> | requests <org> | approve <request-id> | reject <request-id>>]";
 
 export async function commandTeam(
   positionals: string[],
@@ -89,6 +91,51 @@ export async function commandTeam(
         if (!scope) return usage();
         for (const m of await teamMembers(client, scope))
           console.log(`${m.userId}  ${m.role}`);
+        break;
+      }
+      case "discover": {
+        // E-5-d (#630): find which of the caller's GitHub repo collaborators are already on Lore.
+        // Needs a FRESH provider_token (short-lived, not persisted) → re-run GitHub OAuth.
+        const repos = positionals.slice(1).filter((p) => !p.startsWith("--"));
+        let providerToken: string;
+        // Use the FRESH client bound to the just-refreshed session — the outer `client` from
+        // getAuthedClient() may hold a token that expired during the interactive OAuth flow.
+        let freshClient = client;
+        try {
+          const acquired = await acquireGitHubProviderToken();
+          freshClient = acquired.client;
+          providerToken = acquired.providerToken;
+        } catch (e) {
+          console.error(`GitHub authorization failed: ${(e as Error).message}`);
+          process.exitCode = 1;
+          return;
+        }
+        const found = await discoverGitHubCollaborators(
+          freshClient,
+          providerToken,
+          repos.length > 0 ? repos : undefined,
+        );
+        if (!found || found.length === 0) {
+          console.log("No accessible repos with collaborators found.");
+          break;
+        }
+        let onLoreTotal = 0;
+        let offLoreTotal = 0;
+        for (const r of found) {
+          if (r.collaborators.length === 0) continue;
+          console.log(`\n${r.repo}`);
+          for (const c of r.collaborators) {
+            if (c.onLore) onLoreTotal++;
+            else offLoreTotal++;
+            console.log(
+              `  ${c.onLore ? "✓ on Lore  " : "· not yet  "} ${c.login}`,
+            );
+          }
+        }
+        console.log(
+          `\n${onLoreTotal} collaborator${onLoreTotal === 1 ? "" : "s"} already on Lore, ` +
+            `${offLoreTotal} not yet. Invite them with \`lore team invite <scope>\` (share the link).`,
+        );
         break;
       }
       case "create": {

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -23,6 +23,58 @@ export interface MemberSummary {
   role: string;
 }
 
+/** A repo's collaborator roster with a Lore-membership flag per collaborator (E-5-d, #630). */
+export interface DiscoveredCollaborator {
+  login: string;
+  githubId: number;
+  onLore: boolean;
+}
+export interface DiscoveredRepo {
+  repo: string; // "owner/name"
+  collaborators: DiscoveredCollaborator[];
+}
+
+/**
+ * E-5-d (#630, Slice 1): discover which of the caller's GitHub repo collaborators already have a Lore
+ * account, so the caller can invite the rest to a team they admin. Server-side-verified via the
+ * `github-discover` Edge Function using the caller's OWN `provider_token` (a fresh one from GitHub
+ * OAuth) — the client never asserts collaborators or membership. Returns null when there is no
+ * `read:org`/repo grant (e.g. an email-only login).
+ *
+ * `repos` is an optional explicit list ("owner/name" or a GitHub URL); when omitted the Edge Function
+ * scans the caller's own repos (first page). Membership is disclosed only for collaborators of repos
+ * the caller can actually read on GitHub, and only as an `onLore` boolean (never a Lore user id).
+ */
+export async function discoverGitHubCollaborators(
+  client: SupabaseClient,
+  providerToken: string | null | undefined,
+  repos?: string[],
+): Promise<DiscoveredRepo[] | null> {
+  if (!providerToken) return null; // no read:org/repo grant (older session / non-github login)
+  const { data, error } = await client.functions.invoke("github-discover", {
+    body: { provider_token: providerToken, repos },
+  });
+  if (error) throw new Error(`github-discover: ${error.message}`);
+  const payload = data as {
+    repos?: Array<{
+      repo: string;
+      collaborators: Array<{
+        login: string;
+        github_id: number;
+        on_lore: boolean;
+      }>;
+    }>;
+  };
+  return (payload.repos ?? []).map((r) => ({
+    repo: r.repo,
+    collaborators: r.collaborators.map((c) => ({
+      login: c.login,
+      githubId: c.github_id,
+      onLore: c.on_lore,
+    })),
+  }));
+}
+
 async function selfUserId(): Promise<string> {
   const u = await getCurrentUser();
   if (!u) throw new Error("not logged in — run `lore login` first");

--- a/packages/gateway/test/github-discover.test.ts
+++ b/packages/gateway/test/github-discover.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the github-discover Edge Function's pure core (E-5-d, #630) — repo/collaborator
+ * fetch + parsing + Lore-membership annotation. Mirrors github-provision.test.ts: imports the
+ * Deno-free `discover.ts` and drives it with a URL-routed fetch mock.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  annotateOnLore,
+  collectGithubIds,
+  fetchRepoCollaborators,
+  fetchUserRepos,
+  parseRepoRef,
+  type RepoCollaborators,
+} from "../../../supabase/functions/github-discover/discover";
+
+function mockFetch(
+  routes: Record<string, { status?: number; body: unknown }>,
+): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    for (const [key, resp] of Object.entries(routes)) {
+      if (url.includes(key)) {
+        const status = resp.status ?? 200;
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          json: async () => resp.body,
+        } as Response;
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response;
+  }) as typeof fetch;
+}
+
+describe("parseRepoRef", () => {
+  it("parses a bare owner/name slug", () => {
+    expect(parseRepoRef("BYK/loreai")).toEqual({
+      owner: "BYK",
+      name: "loreai",
+    });
+  });
+  it("strips a full GitHub URL and trailing .git", () => {
+    expect(parseRepoRef("https://github.com/BYK/loreai.git")).toEqual({
+      owner: "BYK",
+      name: "loreai",
+    });
+    expect(parseRepoRef("github.com/BYK/loreai/")).toEqual({
+      owner: "BYK",
+      name: "loreai",
+    });
+  });
+  it("rejects malformed / traversal-y input", () => {
+    expect(parseRepoRef("just-one")).toBeNull();
+    expect(parseRepoRef("a/b/c")).toBeNull();
+    expect(parseRepoRef("../etc/passwd")).toBeNull();
+    expect(parseRepoRef("owner/")).toBeNull();
+    expect(parseRepoRef("owner/na me")).toBeNull();
+    expect(parseRepoRef("")).toBeNull();
+  });
+  it("rejects bare . / .. path segments (URL-collapse defense)", () => {
+    expect(parseRepoRef("owner/..")).toBeNull();
+    expect(parseRepoRef("../x")).toBeNull();
+    expect(parseRepoRef("owner/.")).toBeNull();
+    expect(parseRepoRef("./x")).toBeNull();
+    expect(parseRepoRef("../..")).toBeNull();
+  });
+});
+
+describe("fetchUserRepos", () => {
+  it("lists the caller's repos as refs, dropping malformed full_names", async () => {
+    const f = mockFetch({
+      "/user/repos": {
+        body: [
+          { full_name: "BYK/loreai" },
+          { full_name: "acme/web" },
+          { full_name: "bad" }, // dropped (not owner/name)
+          { notafullname: true }, // dropped
+        ],
+      },
+    });
+    const repos = await fetchUserRepos("tok", { fetchImpl: f });
+    expect(repos).toEqual([
+      { owner: "BYK", name: "loreai" },
+      { owner: "acme", name: "web" },
+    ]);
+  });
+  it("throws on a non-ok response", async () => {
+    const f = mockFetch({ "/user/repos": { status: 401, body: {} } });
+    await expect(fetchUserRepos("tok", { fetchImpl: f })).rejects.toThrow(
+      /user\/repos: 401/,
+    );
+  });
+});
+
+describe("fetchRepoCollaborators", () => {
+  it("returns collaborators excluding the caller (by github id)", async () => {
+    const f = mockFetch({
+      "/collaborators": {
+        body: [
+          { login: "alice", id: 1 },
+          { login: "self", id: 99 }, // the caller — excluded
+          { login: "bob", id: 2 },
+        ],
+      },
+    });
+    const cols = await fetchRepoCollaborators(
+      "tok",
+      { owner: "o", name: "r" },
+      99,
+      { fetchImpl: f },
+    );
+    expect(cols).toEqual([
+      { login: "alice", github_id: 1 },
+      { login: "bob", github_id: 2 },
+    ]);
+  });
+  it("returns null (skip, not throw) on 403 / 404 — inaccessible repo", async () => {
+    for (const status of [403, 404]) {
+      const f = mockFetch({ "/collaborators": { status, body: {} } });
+      const cols = await fetchRepoCollaborators(
+        "tok",
+        { owner: "o", name: "r" },
+        99,
+        { fetchImpl: f },
+      );
+      expect(cols).toBeNull();
+    }
+  });
+  it("throws on other non-ok statuses (e.g. 500)", async () => {
+    const f = mockFetch({ "/collaborators": { status: 500, body: {} } });
+    await expect(
+      fetchRepoCollaborators("tok", { owner: "o", name: "r" }, 99, {
+        fetchImpl: f,
+      }),
+    ).rejects.toThrow(/collaborators: 500/);
+  });
+  it("drops rows with a missing id or login", async () => {
+    const f = mockFetch({
+      "/collaborators": {
+        body: [
+          { login: "alice", id: 1 },
+          { login: "noid" }, // no id → dropped
+          { id: 3 }, // no login → dropped
+          { login: "", id: 4 }, // empty login → dropped
+        ],
+      },
+    });
+    const cols = await fetchRepoCollaborators(
+      "tok",
+      { owner: "o", name: "r" },
+      99,
+      { fetchImpl: f },
+    );
+    expect(cols).toEqual([{ login: "alice", github_id: 1 }]);
+  });
+});
+
+describe("collectGithubIds + annotateOnLore", () => {
+  const rosters: RepoCollaborators[] = [
+    {
+      repo: "o/r1",
+      collaborators: [
+        { login: "alice", github_id: 1 },
+        { login: "bob", github_id: 2 },
+      ],
+    },
+    {
+      repo: "o/r2",
+      collaborators: [
+        { login: "bob", github_id: 2 }, // duplicate across repos
+        { login: "carol", github_id: 3 },
+      ],
+    },
+  ];
+
+  it("collects the distinct set of github ids", () => {
+    expect(collectGithubIds(rosters).sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it("annotates on_lore from the known-Lore id set", () => {
+    const out = annotateOnLore(rosters, new Set([2, 3]));
+    expect(out[0].collaborators).toEqual([
+      { login: "alice", github_id: 1, on_lore: false },
+      { login: "bob", github_id: 2, on_lore: true },
+    ]);
+    expect(out[1].collaborators).toEqual([
+      { login: "bob", github_id: 2, on_lore: true },
+      { login: "carol", github_id: 3, on_lore: true },
+    ]);
+  });
+
+  it("annotates all false when no ids are on Lore", () => {
+    const out = annotateOnLore(rosters, new Set());
+    expect(out.every((r) => r.collaborators.every((c) => !c.on_lore))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/gateway/test/sync-github-discover.integration.test.ts
+++ b/packages/gateway/test/sync-github-discover.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration tests for migration 0050 — the Lore-membership lookup for GitHub repo-collaborator
+ * discovery (E-5-d, #630) against a real Postgres. Proves `lore_users_for_github_ids`:
+ *  - returns exactly the subset of input github ids that have a Lore account (matched on
+ *    auth.users.raw_user_meta_data->>'provider_id');
+ *  - never returns user_ids/emails — only github ids;
+ *  - is SERVICE-ROLE-ONLY (authenticated + anon cannot call it → not an enumeration oracle);
+ *  - ignores users with no/invalid provider_id.
+ *
+ * Gated behind LORE_INTEGRATION=1 (needs Docker). Run:
+ *   LORE_INTEGRATION=1 pnpm exec vitest run packages/gateway/test/sync-github-discover.integration.test.ts
+ */
+import { execFileSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { type PgHarness, startPgHarness } from "./helpers/pg-harness";
+
+function dockerReady(): boolean {
+  try {
+    execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = process.env.LORE_INTEGRATION === "1";
+const SKIP = !RUN
+  ? "LORE_INTEGRATION!=1"
+  : !dockerReady()
+    ? "docker unavailable"
+    : false;
+
+let h: PgHarness;
+beforeAll(async () => {
+  if (!SKIP) h = await startPgHarness();
+}, 180_000);
+afterAll(async () => {
+  if (h) await h.stop();
+});
+const gate = () => SKIP;
+
+async function expectError(fn: () => Promise<unknown>): Promise<{
+  code?: string;
+  message: string;
+}> {
+  try {
+    await fn();
+  } catch (e) {
+    return {
+      code: (e as { code?: string }).code,
+      message: (e as Error).message,
+    };
+  }
+  throw new Error("expected the query to fail, but it succeeded");
+}
+
+/** Create an auth.users row with a GitHub provider_id in raw_user_meta_data (as superuser). */
+async function createGitHubUser(providerId: string | null): Promise<string> {
+  const meta =
+    providerId === null ? "{}" : JSON.stringify({ provider_id: providerId });
+  const { rows } = await h.client.query(
+    "insert into auth.users (email, raw_user_meta_data) values ($1, $2::jsonb) returning id",
+    [`u${Math.random().toString(16).slice(2)}@test.dev`, meta],
+  );
+  return rows[0].id as string;
+}
+
+const lookup = (ids: number[]) =>
+  h.asService((c) =>
+    c.query(
+      "select github_id from public.lore_users_for_github_ids($1::bigint[])",
+      [ids],
+    ),
+  );
+
+describe.skipIf(gate())(
+  "migration 0050 — github-discover lookup (E-5-d, #630)",
+  () => {
+    it("returns exactly the input github ids that have a Lore account", async () => {
+      await createGitHubUser("111");
+      await createGitHubUser("222");
+      // 333 is NOT a Lore user.
+      const { rows } = await lookup([111, 222, 333]);
+      const found = rows.map((r) => Number(r.github_id)).sort((a, b) => a - b);
+      expect(found).toEqual([111, 222]);
+    });
+
+    it("returns empty when none of the ids are on Lore", async () => {
+      const { rows } = await lookup([999999001, 999999002]);
+      expect(rows).toEqual([]);
+    });
+
+    it("ignores users with no/invalid provider_id", async () => {
+      await createGitHubUser(null); // email-only user, no provider_id
+      await createGitHubUser("not-a-number"); // malformed
+      await createGitHubUser("444"); // valid
+      const { rows } = await lookup([444]);
+      expect(rows.map((r) => Number(r.github_id))).toEqual([444]);
+    });
+
+    it("exposes only github_id — no user_id / email columns", async () => {
+      await createGitHubUser("555");
+      const { fields } = await lookup([555]);
+      expect(fields.map((f) => f.name)).toEqual(["github_id"]);
+    });
+
+    it("is service-role-only: authenticated cannot call it (no enumeration oracle)", async () => {
+      const uid = await createGitHubUser("666");
+      const err = await expectError(() =>
+        h.asUser(uid, (c) =>
+          c.query("select public.lore_users_for_github_ids($1::bigint[])", [
+            [666],
+          ]),
+        ),
+      );
+      expect(err.code).toBe("42501"); // permission denied for function
+    });
+
+    it("is service-role-only: anon cannot call it", async () => {
+      const err = await expectError(() =>
+        h.asAnon((c) =>
+          c.query("select public.lore_users_for_github_ids($1::bigint[])", [
+            [777],
+          ]),
+        ),
+      );
+      expect(err.code).toBe("42501");
+    });
+  },
+);

--- a/supabase/functions/github-discover/discover.ts
+++ b/supabase/functions/github-discover/discover.ts
@@ -1,0 +1,139 @@
+// E-5-d (#630, Slice 1): pure, runtime-portable core of the github-discover Edge Function — read
+// the caller's repos + each repo's collaborators from GitHub with the caller's OWN provider_token,
+// so membership is authorized by GitHub on the caller's access (a repo they cannot read 403s and is
+// skipped). No Deno/npm imports here so it is unit-testable under Node/Vitest; index.ts is the thin
+// Deno glue that adds JWT verification + the service-role Lore-membership lookup.
+
+export interface RepoRef {
+  owner: string;
+  name: string;
+}
+export interface Collaborator {
+  login: string;
+  github_id: number;
+}
+export interface RepoCollaborators {
+  repo: string; // "owner/name"
+  collaborators: Collaborator[];
+}
+
+const GH_HEADERS = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "lore-github-discover",
+});
+
+/**
+ * Parse an "owner/name" string into a RepoRef, or null when malformed. Accepts a full GitHub URL or
+ * a bare slug; strips a trailing ".git". Rejects anything that isn't exactly two non-empty segments
+ * of the GitHub-allowed charset (defense against path traversal into the API URL).
+ */
+export function parseRepoRef(input: string): RepoRef | null {
+  let s = input.trim();
+  // Accept https://github.com/owner/name(.git) and github.com/owner/name too.
+  s = s.replace(/^https?:\/\/[^/]+\//i, "").replace(/^github\.com\//i, "");
+  s = s.replace(/\.git$/i, "").replace(/\/$/, "");
+  const parts = s.split("/");
+  if (parts.length !== 2) return null;
+  const [owner, name] = parts;
+  const ok = /^[A-Za-z0-9._-]+$/;
+  if (!owner || !name || !ok.test(owner) || !ok.test(name)) return null;
+  // Reject "." / ".." segments: the charset above allows dots, and a WHATWG URL parser would
+  // collapse `.`/`..` path segments (e.g. /repos/owner/../collaborators → /repos/collaborators),
+  // so a bare `.`/`..` must never be treated as a real repo owner/name.
+  if (owner === "." || owner === ".." || name === "." || name === "..")
+    return null;
+  return { owner, name };
+}
+
+/**
+ * List the AUTHENTICATED user's repos (owner + collaborator affiliations) using their OWN token.
+ * v1: first page only (per_page=100); pagination is a follow-up. Returns "owner/name" refs.
+ */
+export async function fetchUserRepos(
+  token: string,
+  opts: { apiUrl?: string; fetchImpl?: typeof fetch } = {},
+): Promise<RepoRef[]> {
+  const apiUrl = (opts.apiUrl ?? "https://api.github.com").replace(/\/$/, "");
+  const f = opts.fetchImpl ?? fetch;
+  const resp = await f(
+    `${apiUrl}/user/repos?per_page=100&affiliation=owner,collaborator`,
+    { headers: GH_HEADERS(token) },
+  );
+  if (!resp.ok) throw new Error(`github /user/repos: ${resp.status}`);
+  const json = (await resp.json()) as Array<{ full_name?: string }>;
+  const out: RepoRef[] = [];
+  for (const r of Array.isArray(json) ? json : []) {
+    if (typeof r.full_name !== "string") continue;
+    const ref = parseRepoRef(r.full_name);
+    if (ref) out.push(ref);
+  }
+  return out;
+}
+
+/**
+ * Fetch a single repo's collaborators with the caller's token. GitHub authorizes on the caller's
+ * access, so a repo the caller cannot read returns 403/404 → we return null (the caller skips it)
+ * rather than throwing, so one inaccessible repo never fails the whole discovery. Excludes the
+ * caller themself (by github id) from the roster.
+ */
+export async function fetchRepoCollaborators(
+  token: string,
+  repo: RepoRef,
+  selfGithubId: number,
+  opts: { apiUrl?: string; fetchImpl?: typeof fetch } = {},
+): Promise<Collaborator[] | null> {
+  const apiUrl = (opts.apiUrl ?? "https://api.github.com").replace(/\/$/, "");
+  const f = opts.fetchImpl ?? fetch;
+  const resp = await f(
+    `${apiUrl}/repos/${repo.owner}/${repo.name}/collaborators?per_page=100`,
+    { headers: GH_HEADERS(token) },
+  );
+  // 403 (no access / not admin — collaborators requires push access) or 404 (no such repo): skip.
+  if (resp.status === 403 || resp.status === 404) return null;
+  if (!resp.ok)
+    throw new Error(
+      `github /repos/${repo.owner}/${repo.name}/collaborators: ${resp.status}`,
+    );
+  const json = (await resp.json()) as Array<{ login?: string; id?: number }>;
+  const out: Collaborator[] = [];
+  for (const c of Array.isArray(json) ? json : []) {
+    if (typeof c.id !== "number" || c.id === selfGithubId) continue;
+    if (typeof c.login !== "string" || c.login === "") continue;
+    out.push({ login: c.login, github_id: c.id });
+  }
+  return out;
+}
+
+/**
+ * The distinct set of collaborator github ids across all discovered repos — the input to the
+ * service-role Lore-membership lookup.
+ */
+export function collectGithubIds(repos: RepoCollaborators[]): number[] {
+  const ids = new Set<number>();
+  for (const r of repos) for (const c of r.collaborators) ids.add(c.github_id);
+  return Array.from(ids);
+}
+
+/**
+ * Annotate each repo's roster with an `on_lore` flag from the set of github ids known to have a Lore
+ * account (resolved server-side via the service-role lookup). Never exposes Lore user_ids — only the
+ * boolean membership signal, and only for collaborators of repos the caller could already read.
+ */
+export function annotateOnLore(
+  repos: RepoCollaborators[],
+  loreGithubIds: Set<number>,
+): Array<{
+  repo: string;
+  collaborators: Array<{ login: string; github_id: number; on_lore: boolean }>;
+}> {
+  return repos.map((r) => ({
+    repo: r.repo,
+    collaborators: r.collaborators.map((c) => ({
+      login: c.login,
+      github_id: c.github_id,
+      on_lore: loreGithubIds.has(c.github_id),
+    })),
+  }));
+}

--- a/supabase/functions/github-discover/index.ts
+++ b/supabase/functions/github-discover/index.ts
@@ -1,0 +1,148 @@
+// E-5-d (#630, Slice 1): github-discover Edge Function. Reads the caller's repos + each repo's
+// collaborators FROM GitHub with the caller's OWN provider_token (unforgeable — GitHub authorizes on
+// the caller's access), then reveals which collaborators already have a Lore account via the
+// service-role-only lore_users_for_github_ids RPC (0050).
+//
+// SECURITY:
+//   - The provider_token is bound to the JWT's linked GitHub identity (a leaked/foreign token can't
+//     be used to enumerate someone else's collaborators as this user).
+//   - Lore-membership is disclosed ONLY for collaborators of repos the caller can actually read
+//     (GitHub 403/404s an inaccessible repo → skipped). No open "is X on Lore" oracle.
+//   - The RPC returns only the SET of present github ids (never Lore user_ids), and is
+//     service-role-only, so a client can never call it directly to enumerate accounts.
+//
+// Deploy (not auto-deployed): `supabase functions deploy github-discover`. SUPABASE_URL,
+// SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY are injected by the platform; GITHUB_API_URL is
+// optional (defaults to https://api.github.com; overridable for testing).
+import { createClient } from "npm:@supabase/supabase-js@2";
+import {
+  fetchGitHubUser,
+  isTokenOwnerBound,
+  resolveJwtGithubId,
+} from "../github-provision/provision.ts";
+import {
+  annotateOnLore,
+  collectGithubIds,
+  fetchRepoCollaborators,
+  fetchUserRepos,
+  parseRepoRef,
+  type RepoCollaborators,
+} from "./discover.ts";
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Cap the number of repos we scan per call — bounds GitHub API fan-out (and cost) per request.
+const MAX_REPOS = 50;
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) return json({ error: "missing authorization" }, 401);
+
+  const url = Deno.env.get("SUPABASE_URL");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!url || !anonKey || !serviceKey) {
+    return json({ error: "server misconfigured" }, 500);
+  }
+
+  // Verify the caller's Supabase JWT → user id (never trust a client-supplied id).
+  const userClient = createClient(url, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const {
+    data: { user },
+    error: userErr,
+  } = await userClient.auth.getUser();
+  if (userErr || !user) return json({ error: "invalid token" }, 401);
+
+  const jwtGithubId = resolveJwtGithubId(user);
+
+  const body = (await req.json().catch(() => ({}))) as {
+    provider_token?: string;
+    repos?: string[];
+  };
+  const providerToken = body.provider_token;
+  if (!providerToken) return json({ error: "missing provider_token" }, 400);
+
+  const apiUrl = Deno.env.get("GITHUB_API_URL") ?? undefined;
+
+  // Bind the provider_token to the authenticated identity (same guard as github-provision).
+  let selfGithubId: number;
+  try {
+    const tokenOwner = await fetchGitHubUser(providerToken, { apiUrl });
+    if (!isTokenOwnerBound(tokenOwner.id, jwtGithubId)) {
+      return json({ error: "provider_token identity mismatch" }, 403);
+    }
+    selfGithubId = tokenOwner.id;
+  } catch (e) {
+    return json({ error: `github: ${(e as Error).message}` }, 502);
+  }
+
+  // Resolve the repo set: explicit list (validated) or the caller's own repos (first page).
+  let repos: Array<{ owner: string; name: string }>;
+  try {
+    if (Array.isArray(body.repos) && body.repos.length > 0) {
+      repos = [];
+      for (const r of body.repos) {
+        const ref = parseRepoRef(r);
+        if (ref) repos.push(ref);
+      }
+    } else {
+      repos = await fetchUserRepos(providerToken, { apiUrl });
+    }
+  } catch (e) {
+    return json({ error: `github: ${(e as Error).message}` }, 502);
+  }
+  repos = repos.slice(0, MAX_REPOS);
+
+  // Read each repo's collaborators with the caller's token (repos they can't read are skipped).
+  const rosters: RepoCollaborators[] = [];
+  for (const repo of repos) {
+    try {
+      const collaborators = await fetchRepoCollaborators(
+        providerToken,
+        repo,
+        selfGithubId,
+        { apiUrl },
+      );
+      if (collaborators === null) continue; // inaccessible — skip, don't fail the whole call
+      rosters.push({ repo: `${repo.owner}/${repo.name}`, collaborators });
+    } catch (e) {
+      // A transient error on one repo shouldn't sink the batch — log and skip.
+      console.error(
+        `collaborators ${repo.owner}/${repo.name}:`,
+        (e as Error).message,
+      );
+    }
+  }
+
+  // Service-role lookup: which collaborator github ids have a Lore account. Returns only the SET of
+  // present ids (never user_ids) — the RPC is service-role-only so this is the only enumeration path.
+  const githubIds = collectGithubIds(rosters);
+  const loreIds = new Set<number>();
+  if (githubIds.length > 0) {
+    const admin = createClient(url, serviceKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { data, error } = await admin.rpc("lore_users_for_github_ids", {
+      p_github_ids: githubIds,
+    });
+    if (error) {
+      console.error("lore_users_for_github_ids failed:", error.message);
+      return json({ error: "lookup failed" }, 500);
+    }
+    for (const row of (data ?? []) as Array<{ github_id: number | string }>) {
+      loreIds.add(Number(row.github_id));
+    }
+  }
+
+  return json({ repos: annotateOnLore(rosters, loreIds) });
+});

--- a/supabase/migrations/0050_github_discover_lookup.sql
+++ b/supabase/migrations/0050_github_discover_lookup.sql
@@ -1,0 +1,39 @@
+-- Migration 0050 — E-5-d (#630, Slice 1): Lore-membership lookup for GitHub repo-collaborator
+-- discovery. The github-discover Edge Function reads a caller's repo collaborators FROM GitHub with
+-- the caller's own token, then calls this to learn which of those github ids already have a Lore
+-- account — so the caller can invite the rest to a team they admin.
+--
+-- SECURITY / privacy: this returns ONLY the SET of github ids present (never Lore user_ids, emails,
+-- or profiles), and is SERVICE-ROLE-ONLY. A client can never call it directly, so it is not an open
+-- "is GitHub user X on Lore" enumeration oracle — the Edge Function only ever asks about github ids
+-- of collaborators the caller could already read on GitHub.
+--
+-- Identity source: Supabase stores the GitHub OAuth numeric id in
+-- auth.users.raw_user_meta_data->>'provider_id' (the same field resolveJwtGithubId falls back to and
+-- handle_new_user reads for github_login). Keyed on that so it works against both production and the
+-- test shim (which has auth.users.raw_user_meta_data but no auth.identities).
+
+create or replace function public.lore_users_for_github_ids(p_github_ids bigint[])
+returns table (github_id bigint)
+language sql
+security definer
+set search_path = pg_catalog, public
+as $$
+  select distinct (u.raw_user_meta_data ->> 'provider_id')::bigint as github_id
+  from auth.users u
+  where u.raw_user_meta_data ->> 'provider_id' is not null
+    and (u.raw_user_meta_data ->> 'provider_id') ~ '^[0-9]+$'
+    and (u.raw_user_meta_data ->> 'provider_id')::bigint = any(p_github_ids);
+$$;
+
+-- SERVICE-ROLE-ONLY: only the github-discover Edge Function may call this. Direct client access
+-- would turn it into an account-enumeration oracle.
+revoke all on function public.lore_users_for_github_ids(bigint[])
+  from public, anon, authenticated;
+grant execute on function public.lore_users_for_github_ids(bigint[]) to service_role;
+
+comment on function public.lore_users_for_github_ids(bigint[]) is
+  'E-5-d (#630): service-role-only. Given a set of GitHub numeric ids, returns the subset that have '
+  'a Lore account (matched on auth.users.raw_user_meta_data->>provider_id). Returns only github ids, '
+  'never Lore user_ids/emails — the enumeration surface is bounded by the Edge Function to a '
+  'caller''s own repo collaborators.';


### PR DESCRIPTION
Part of #630 (re-scoped — **no GitHub App required**; see the issue comment). First slice of the collaborator discovery/invite flow, reusing the E-5-a OAuth + server-verified Edge Function pattern.

## What
`lore team discover [repo...]` shows which of your GitHub repo collaborators already have a Lore account (and which don't), so you can invite the rest to a team you admin.

## How (mirrors `github-provision`)
- **Client** acquires a **fresh** GitHub `provider_token` via a one-shot loopback OAuth (`acquireGitHubProviderToken()` in login.ts) — the token is short-lived and not persisted, so it's re-acquired on demand — then calls the new **`github-discover` Edge Function**.
- **Edge Function** verifies the JWT, **binds the provider_token** to the caller's linked GitHub identity (`fetchGitHubUser` + `isTokenOwnerBound`, fail-closed), reads the caller's repos + each repo's collaborators **from GitHub with the caller's own token** (GitHub authorizes on their access — an unreadable repo 403s and is skipped), then resolves which collaborator github ids are on Lore via the **service-role-only `lore_users_for_github_ids` RPC** (migration 0050).

## Security / privacy 🔴
- `provider_token` always owner-bound (a leaked/foreign token can't enumerate as this user).
- Lore-membership disclosed **only** for collaborators of repos the caller can already read.
- **Never** returns Lore user_ids — only an `onLore` boolean per collaborator.
- The lookup RPC is **service-role-only** → not an open "is X on Lore" oracle. Keyed on `auth.users.raw_user_meta_data->>'provider_id'` (works in prod + the test shim).
- `parseRepoRef` rejects traversal-y input; `MAX_REPOS` caps GitHub fan-out per call.

## Scope / limitations
- Private-repo collaborator reads need broader than `read:org`; v1 covers repos the caller can read and skips the rest.
- The actual **invite wiring** (`--invite <scope>` → `create_scope_invite`) and **repo→team correlation** are **E-5-d-2** — the server has no repo→scope binding (`git_remote` is encrypted on the wire), so that correlation is client-side.
- The `github-discover` Edge Function is not auto-deployed (like `github-provision`): `supabase functions deploy github-discover`.

## Tests
- `github-discover.test.ts`: pure helpers (`parseRepoRef`, `fetchUserRepos`, `fetchRepoCollaborators` incl. 403/404-skip, `collectGithubIds`/`annotateOnLore`) with a mocked fetch — **12**.
- `sync-github-discover.integration.test.ts` (Tier-1, real Postgres): the 0050 lookup RPC — membership match, github-id-only output, ignores no/invalid provider_id, **service-role-only** (42501 on authenticated/anon) — **6**.
- Typecheck clean; 18 tests pass; format clean.