### PR TITLE
test(core): direct coverage for WASM-respawn per-request error suppression (#1379 B2)

### DIFF
--- a/packages/core/src/embedding-worker-types.ts
+++ b/packages/core/src/embedding-worker-types.ts
@@ -246,6 +246,30 @@ export function shouldRequestWasmRespawn(
 }
 
 /**
+ * Whether `processEmbed`'s catch block should post a per-request `error` back to
+ * the main thread for a failed embed request (#1379/#1387-B2).
+ *
+ * Two cases must stay SILENT:
+ *  - `initFailed` — `ensurePipeline()` already posted `init-error`; re-posting a
+ *    per-request error would double-report the same failure.
+ *  - `wasmRespawnRequested` — the worker asked the main thread to respawn it
+ *    forcing WASM, so `ensurePipeline()` rejected this request with "awaiting
+ *    WASM respawn". Posting a per-request `error` here would make the main thread
+ *    reject+drop the pending request BEFORE `respawnForWasm()` re-submits it to
+ *    the fresh WASM worker — silently losing the caller's embed. The respawn
+ *    re-submits it instead, so this worker must not report it.
+ *
+ * Pure predicate, extracted so the B2 suppression is directly unit-testable
+ * without importing the worker module (which self-executes on import).
+ */
+export function shouldPostPerRequestError(
+  initFailed: boolean,
+  wasmRespawnRequested: boolean,
+): boolean {
+  return !initFailed && !wasmRespawnRequested;
+}
+
+/**
  * The two leading strings transformers.js' `sessionRun()` (models.js) passes to
  * `console.error` when `session.run` throws, before it re-throws: the error
  * message, and a dump of every input tensor's metadata AND `.data`. For our

--- a/packages/core/src/embedding-worker.ts
+++ b/packages/core/src/embedding-worker.ts
@@ -744,6 +744,8 @@ async function processEmbed(req: EmbedRequest): Promise<void> {
     // "awaiting WASM respawn", but posting a per-request `error` here would make
     // the main thread reject+drop the pending BEFORE respawnForWasm() can
     // re-submit it to the fresh WASM worker. The respawn re-submits it instead.
+    // Canonical gate: shouldPostPerRequestError() in embedding-worker-types.ts
+    // (unit-tested); a drift guard pins this inline expression to it.
     if (!initFailed && !wasmRespawnRequested) {
       const raw = err instanceof Error ? err.message : String(err);
       const longest = Math.max(...req.texts.map((t) => t.length));

--- a/packages/core/test/embedding-worker-types.test.ts
+++ b/packages/core/test/embedding-worker-types.test.ts
@@ -10,6 +10,7 @@ import {
   MIN_ONNX_FILE_BYTES,
   resolveModelCacheDir,
   shouldHealCorruptModel,
+  shouldPostPerRequestError,
   shouldRequestWasmRespawn,
   TRANSFORMERS_INFERENCE_DUMP_PREFIXES,
 } from "../src/embedding-worker-types";
@@ -304,5 +305,53 @@ describe("shouldRequestWasmRespawn (#1379)", () => {
         true,
       ),
     ).toBe(false);
+  });
+});
+
+describe("shouldPostPerRequestError (#1379 B2)", () => {
+  test("posts a per-request error for an ordinary embed failure", () => {
+    // Normal per-request failure (no init failure, no pending respawn) → the
+    // worker reports it so the main thread rejects just that request.
+    expect(shouldPostPerRequestError(false, false)).toBe(true);
+  });
+
+  test("stays silent while a WASM respawn is pending (B2)", () => {
+    // The request that tripped `init-needs-wasm` is rejected by ensurePipeline
+    // with "awaiting WASM respawn". Posting a per-request error here would make
+    // the main thread reject+drop the pending BEFORE respawnForWasm re-submits
+    // it → the caller's embed is silently lost. Must NOT post.
+    expect(shouldPostPerRequestError(false, true)).toBe(false);
+  });
+
+  test("stays silent after init already failed (init-error already posted)", () => {
+    expect(shouldPostPerRequestError(true, false)).toBe(false);
+  });
+
+  test("stays silent when both flags are set", () => {
+    expect(shouldPostPerRequestError(true, true)).toBe(false);
+  });
+});
+
+describe("processEmbed catch condition stays in sync with shouldPostPerRequestError (#1379 B2)", () => {
+  // shouldPostPerRequestError is the canonical, unit-tested B2 gate, but the
+  // worker (raw .ts, self-executing on import — can't be imported here) inlines
+  // the equivalent expression in processEmbed's catch. Parse the worker source
+  // and assert that expression is exactly `!initFailed && !wasmRespawnRequested`
+  // so the two can't silently drift (mirrors the isCorruptModelError inline-copy
+  // guard above). If they drift, this fails CI and points at the worker.
+  const workerSrc = readFileSync(
+    fileURLToPath(new URL("../src/embedding-worker.ts", import.meta.url)),
+    "utf8",
+  );
+
+  test("worker gates the per-request error post on both suppression flags", () => {
+    // The catch opens with the B2 guard; match the exact boolean expression,
+    // whitespace-normalized (robust to formatting/line wraps).
+    const guard = workerSrc.match(
+      /catch \(err\) \{[\s\S]*?if \(([^)]*initFailed[^)]*)\)/,
+    );
+    expect(guard, "processEmbed catch guard not found").not.toBeNull();
+    const expr = (guard?.[1] ?? "").replace(/\s+/g, " ").trim();
+    expect(expr).toBe("!initFailed && !wasmRespawnRequested");
   });
 });


### PR DESCRIPTION
Follow-up to #1387 (adversarial review #2 SHOULD-FIX): the B2 fix — the worker staying silent (not posting a per-request `error`) while a WASM respawn is pending — had no independent test. The `embedding-wasm-fallback` suite uses a fake worker and never runs the real `embedding-worker.ts`, and the main-thread per-worker guard (B1) already drops the trailing error in that harness, so reverting the worker-side `!wasmRespawnRequested` guard passed the whole suite.

## Change
- Extract the B2 gate into a pure, exported predicate `shouldPostPerRequestError(initFailed, wasmRespawnRequested)` in `embedding-worker-types.ts` (the worker can't be imported in tests — it self-executes and throws without `parentPort`).
- Unit-test the predicate directly (all four boolean combinations, incl. the B2 "stay silent while respawn pending" case).
- Add a source-parse **drift guard** asserting `processEmbed`'s catch condition in the worker is exactly `!initFailed && !wasmRespawnRequested`, mirroring the existing `isCorruptModelError` inline-copy guard, so the tested predicate and the worker's inline expression can't silently diverge.

Behavior-neutral (no production logic change; the worker keeps the same inline expression, now pinned + documented).

## Verification
- Mutation A (predicate ignores `wasmRespawnRequested`) → kills the B2 predicate test.
- Mutation B (worker catch drops the `!wasmRespawnRequested` clause) → kills the drift guard.
- `embedding-worker-types` / `embedding-wasm-fallback` / `embedding-oom-recovery`: 76 passed. typecheck + format clean.