### PR TITLE
feat(invariant-check): prose-tolerant judge parsing + unparseable visibility

### DIFF
--- a/.github/actions/invariant-check/report.mjs
+++ b/.github/actions/invariant-check/report.mjs
@@ -15,7 +15,7 @@ if (!path) {
   process.exit(0);
 }
 
-/** @type {{findings: Array<{invariantId:string,invariantTitle:string,invariantContent:string,file:string,reason:string|null,severity:string,refHit:boolean,similarity:number,hunk:string}>, hunks:number, invariants:number, candidates:number, judgeCalls:number, model?:string, gate?:object}} */
+/** @type {{findings: Array<{invariantId:string,invariantTitle:string,invariantContent:string,file:string,reason:string|null,severity:string,refHit:boolean,similarity:number,hunk:string}>, hunks:number, invariants:number, candidates:number, judgeCalls:number, unparseable?:number, model?:string, gate?:object}} */
 let result;
 try {
   result = JSON.parse(readFileSync(path, "utf8"));
@@ -29,10 +29,29 @@ try {
 const findings = result.findings ?? [];
 const summaryFile = process.env.GITHUB_STEP_SUMMARY;
 
+// Keep in sync with UNPARSEABLE_WARN_RATIO in packages/core/src/invariant-check.ts.
+const UNPARSEABLE_WARN_RATIO = 0.5;
+
 const funnel =
   `${result.hunks} hunks × ${result.invariants} invariants → ` +
   `${result.candidates} candidates → ${result.judgeCalls} judge calls` +
   (result.model ? ` · ${result.model}` : "");
+
+// A high unparseable rate means the judge failed the JSON output contract — the
+// result (clean OR with findings) is untrustworthy. Emit unconditionally, before
+// the findings branch, so the mixed case (some findings + flaky judge) is not
+// silent. Advisory: a `::warning::` never fails the build.
+{
+  const judgeCalls = result.judgeCalls ?? 0;
+  const unparseable = result.unparseable ?? 0;
+  if (judgeCalls > 0 && unparseable / judgeCalls > UNPARSEABLE_WARN_RATIO) {
+    console.log(
+      `::warning title=Lore invariant-check::${unparseable}/${judgeCalls} judge responses were unparseable — ` +
+        `results may be unreliable (the judge model is likely returning prose, not JSON). ` +
+        `Consider a more capable model via the action's \`model\` input.`,
+    );
+  }
+}
 
 function esc(s) {
   // Escape workflow-command MESSAGE data (the part after `::`). Only %, CR, LF

--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -71,6 +71,13 @@ export const MIN_CONFIDENCE = 0.2;
  *  knowledge base can't blow up the O(hunks×invariants) prefilter. */
 const MAX_INVARIANTS_SCAN = 300;
 
+// If more than this fraction of judge calls come back unparseable, warn: the
+// judge model is likely failing the JSON output contract, so a "clean" result is
+// untrustworthy. High on purpose — a single stray malformed response on an
+// otherwise-healthy run must not cry wolf. Exported so the CLI report and the
+// GHA reporter share one threshold (the reporter mirrors it as a literal).
+export const UNPARSEABLE_WARN_RATIO = 0.5;
+
 /** Never send more than this many pairs to the judge in one run. Surviving
  *  pairs are judged most-similar-first; the cap is the cost ceiling per PR. */
 export const MAX_JUDGE_CALLS = 20;
@@ -460,6 +467,41 @@ export interface InvariantVerdict {
   reason: string | null;
 }
 
+/**
+ * Extract the first balanced top-level `{...}` object from a string, or null.
+ *
+ * Cheap/instruction-light models sometimes wrap the required JSON in prose
+ * ("Sure! Here's my analysis: {\"violates\": false}") — see the GLM 5.2 finding
+ * in Warden's benchmark where clean chunks returned prose instead of the
+ * required JSON and were mis-counted as parser failures. Rather than drop those
+ * (which is indistinguishable from a genuine no-finding), we pull the embedded
+ * object out. String-aware brace matching so braces inside string literals do
+ * not throw off the balance.
+ */
+export function extractFirstJsonObject(text: string): string | null {
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return null; // unbalanced — no complete object
+}
+
 export function parseInvariantVerdict(
   text: string | null,
 ): InvariantVerdict | null {
@@ -468,19 +510,27 @@ export function parseInvariantVerdict(
     .trim()
     .replace(/^```json?\s*/i, "")
     .replace(/\s*```$/i, "");
-  try {
-    const parsed = JSON.parse(cleaned);
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      typeof parsed.violates === "boolean"
-    ) {
-      const reason =
-        typeof parsed.reason === "string" ? parsed.reason.slice(0, 400) : null;
-      return { violates: parsed.violates, reason };
+  // Try the whole (fenced-stripped) payload first — the common clean-JSON path.
+  // Fall back to the first embedded {...} object for chatty models that wrap the
+  // verdict in prose. Both feed the same shape validation.
+  for (const candidate of [cleaned, extractFirstJsonObject(cleaned)]) {
+    if (!candidate) continue;
+    try {
+      const parsed = JSON.parse(candidate);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof parsed.violates === "boolean"
+      ) {
+        const reason =
+          typeof parsed.reason === "string"
+            ? parsed.reason.slice(0, 400)
+            : null;
+        return { violates: parsed.violates, reason };
+      }
+    } catch {
+      // not valid JSON — try the next candidate
     }
-  } catch {
-    // not valid JSON
   }
   return null;
 }
@@ -636,6 +686,12 @@ export interface CheckResult {
   findings: Finding[];
   /** Judge calls actually made (== cost units). */
   judgeCalls: number;
+  /** Judge calls whose response could not be parsed into a verdict (prose
+   *  instead of JSON, etc.). These degrade safely to "no finding", but a HIGH
+   *  rate means the judge model is systemically failing the output contract and
+   *  the clean result is not trustworthy — surfaced so it is not silent
+   *  recall-rot (cf. the GLM 5.2 prose-not-JSON failure in Warden's benchmark). */
+  unparseable: number;
 }
 
 export interface Finding {
@@ -843,6 +899,7 @@ export async function checkInvariants(input: {
     judged: 0,
     findings: [],
     judgeCalls: 0,
+    unparseable: 0,
   };
   if (hunks.length === 0) return empty;
 
@@ -901,6 +958,7 @@ export async function checkInvariants(input: {
   const seenFindings = new Set<string>();
   let judged = 0;
   let judgeCalls = 0;
+  let unparseable = 0;
   const toJudge = selected;
   for (const c of toJudge) {
     const inv = invariants[c.invariantIdx];
@@ -935,7 +993,15 @@ export async function checkInvariants(input: {
     }
     judgeCalls++;
     const verdict = parseInvariantVerdict(responseText);
-    if (!verdict || !verdict.violates) continue;
+    if (!verdict) {
+      // Response was not parseable into a verdict (prose instead of JSON, a
+      // truncated object, etc.). Degrade safely to "no finding" — but COUNT it,
+      // so a systemically-broken judge is visible rather than silently
+      // indistinguishable from a genuine clean run.
+      unparseable++;
+      continue;
+    }
+    if (!verdict.violates) continue;
     // Fan out the verdict to every hunk in the representative's cluster: a
     // repeated change (e.g. one rename across N files) is flagged in all N.
     // Dedup per (invariant, file): the same invariant flagged against several
@@ -962,6 +1028,20 @@ export async function checkInvariants(input: {
     }
   }
 
+  // Visibility for the GLM-style failure mode: if a large share of judge calls
+  // came back unparseable, the "clean" result is not trustworthy — the model is
+  // failing the output contract, not finding nothing. Warn loudly (still never
+  // fails the build; the caller decides). Threshold is deliberately high so a
+  // stray malformed response on an otherwise-healthy run stays quiet.
+  if (judgeCalls > 0 && unparseable / judgeCalls > UNPARSEABLE_WARN_RATIO) {
+    log.warn(
+      `invariant-check: ${unparseable}/${judgeCalls} judge responses were unparseable ` +
+        `(model=${input.model?.providerID ?? "?"}/${input.model?.modelID ?? "?"}). ` +
+        `The "no violation" result may be unreliable — the judge model is likely ` +
+        `returning prose instead of the required JSON verdict.`,
+    );
+  }
+
   return {
     range: input.range,
     hunks: hunks.length,
@@ -970,6 +1050,7 @@ export async function checkInvariants(input: {
     judged,
     findings,
     judgeCalls,
+    unparseable,
   };
 }
 

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -8,6 +8,7 @@ import {
   checkInvariants,
   clusterHunks,
   enforcementLevel,
+  extractFirstJsonObject,
   gateDecision,
   isEnforceableInvariant,
   isEnumerationInvariant,
@@ -637,6 +638,57 @@ describe("parseInvariantVerdict", () => {
     expect(parseInvariantVerdict("not json")).toBeNull();
     expect(parseInvariantVerdict('{"reason": "no verdict field"}')).toBeNull();
   });
+  it("extracts a verdict embedded in prose (GLM prose-not-JSON failure mode)", () => {
+    expect(
+      parseInvariantVerdict(
+        'Sure! Here is my analysis: {"violates": false, "reason": "unrelated"}',
+      ),
+    ).toEqual({ violates: false, reason: "unrelated" });
+  });
+  it("extracts a verdict with trailing prose after the object", () => {
+    expect(
+      parseInvariantVerdict(
+        '{"violates": true, "reason": "y"}\n\nHope this helps!',
+      ),
+    ).toEqual({ violates: true, reason: "y" });
+  });
+  it("is not fooled by braces inside string values", () => {
+    expect(
+      parseInvariantVerdict(
+        'The verdict: {"violates": true, "reason": "found a { in the code"}',
+      ),
+    ).toEqual({ violates: true, reason: "found a { in the code" });
+  });
+  it("still returns null when prose contains no JSON object at all", () => {
+    expect(
+      parseInvariantVerdict("I think this looks fine, no violation here."),
+    ).toBeNull();
+  });
+});
+
+describe("extractFirstJsonObject", () => {
+  it("returns the first balanced object", () => {
+    expect(extractFirstJsonObject('x {"a":1} y {"b":2}')).toBe('{"a":1}');
+  });
+  it("handles nested objects", () => {
+    expect(extractFirstJsonObject('pre {"a":{"b":2}} post')).toBe(
+      '{"a":{"b":2}}',
+    );
+  });
+  it("ignores braces inside strings", () => {
+    expect(extractFirstJsonObject('{"s":"a } b"}')).toBe('{"s":"a } b"}');
+  });
+  it("ignores an escaped quote inside a string", () => {
+    expect(extractFirstJsonObject('{"s":"a \\" } b"}')).toBe(
+      '{"s":"a \\" } b"}',
+    );
+  });
+  it("returns null when there is no object", () => {
+    expect(extractFirstJsonObject("no braces here")).toBeNull();
+  });
+  it("returns null for an unbalanced/truncated object", () => {
+    expect(extractFirstJsonObject('{"violates": true')).toBeNull();
+  });
 });
 
 describe("checkInvariants (funnel, stubbed LLM)", () => {
@@ -701,6 +753,57 @@ describe("checkInvariants (funnel, stubbed LLM)", () => {
     });
     expect(prompt).toHaveBeenCalledTimes(1);
     expect(result.findings).toHaveLength(0);
+  });
+
+  it("counts unparseable (prose) judge responses and degrades to no-finding", async () => {
+    const project = "/tmp/ic-test-proj-unparseable";
+    await seed(
+      project,
+      "sqlite boundary",
+      "node:sqlite must never be imported outside driver.node.ts",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    // Judge returns prose with no JSON object at all → unparseable.
+    const { llm, prompt } = stubLLM(
+      () => "I don't think this violates anything, looks fine to me.",
+    );
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [{ file: "src/other.ts", text: '@@\n+import "node:sqlite"' }],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-unparseable",
+    });
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(result.judgeCalls).toBe(1);
+    expect(result.unparseable).toBe(1);
+    expect(result.findings).toHaveLength(0); // safe degrade, no crash
+  });
+
+  it("prose-wrapped JSON verdict still flags (prose-tolerant parse)", async () => {
+    const project = "/tmp/ic-test-proj-prosejson";
+    await seed(
+      project,
+      "sqlite boundary",
+      "node:sqlite must never be imported outside driver.node.ts",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    const { llm } = stubLLM(
+      () =>
+        'Sure, here is the verdict: {"violates": true, "reason": "adds node:sqlite import"}',
+    );
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [{ file: "src/other.ts", text: '@@\n+import "node:sqlite"' }],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-prosejson",
+    });
+    expect(result.unparseable).toBe(0);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].reason).toContain("node:sqlite");
   });
 
   it("makes ZERO judge calls when nothing clears the funnel (cost floor)", async () => {

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -213,6 +213,21 @@ function printReport(
   );
   console.log("─".repeat(64));
 
+  // Judge-health warning: a high unparseable rate means the model is failing the
+  // JSON contract, so results (clean OR with findings) are unreliable. Printed
+  // regardless of the findings branch so the mixed case isn't silent.
+  if (
+    result.judgeCalls > 0 &&
+    result.unparseable / result.judgeCalls >
+      invariantCheck.UNPARSEABLE_WARN_RATIO
+  ) {
+    console.log(
+      `\n⚠ ${result.unparseable}/${result.judgeCalls} judge responses were unparseable — ` +
+        `results may be unreliable. The judge model is likely returning prose ` +
+        `instead of the required JSON verdict; try a more capable --model.`,
+    );
+  }
+
   if (findings.length === 0) {
     console.log("\n✓ No suspected invariant violations.\n");
     console.log(


### PR DESCRIPTION
Hardens the `lore invariant-check` judge against the **GLM 5.2 failure mode** documented in [Warden's benchmark](https://warden.sentry.dev/benchmarking): cheap/instruction-light judge models sometimes return **prose instead of the required JSON** verdict. Previously an unparseable response was silently indistinguishable from a genuine "no violation" — silent recall-rot, and the exact trap Warden hit ("clean chunks returned prose ... mis-counted").

Relevant because our zero-secret CI default is `github-models/openai/gpt-4o-mini` — a cheap model is precisely where this bites.

## Changes
1. **Prose-tolerant parser** — new `extractFirstJsonObject(text)` does string-aware balanced-brace matching (handles escaped quotes, braces-inside-strings, nesting, truncation→null). `parseInvariantVerdict` tries the whole fenced-stripped payload first, then the extracted object. A chatty-but-correct model (`Sure! {"violates": false}`) now parses instead of being dropped.
2. **`CheckResult.unparseable`** — counts non-throwing judge calls that failed to parse. Still degrades safely to no-finding (never a false `violates:true`, never throws) — but is now **counted**, not silent.
3. **Visibility (unconditional of findings)** — when `unparseable/judgeCalls > UNPARSEABLE_WARN_RATIO` (0.5, exported as the single source of truth): core `log.warn`, CLI prints a ⚠ line, GHA reporter emits a `::warning::`. Fires even when there ARE findings, so the mixed flaky-judge case isn't silent.

## Safety
Advisory invariant preserved: nothing here touches `gate.exitCode` or fails the build. `gateDecision` reads only `findings`; the warning is purely observational.

## Tests
Parser cases (prose-wrapped, trailing prose, brace-in-string, escaped-quote, truncated, multi-object) + `extractFirstJsonObject` unit table + stubbed-LLM e2e (unparseable-counter degrade, prose-tolerant flag). **Mutation-verified**: breaking the extractor kills 8 tests; removing the counter kills 1. Core suite: 145 files pass.

## Review
Adversarial correctness review: **SHIP-WITH-FOLLOWUPS**, no BLOCKERs, advisory-safety confirmed, non-vacuous tests. The one SHOULD-FIX (surface the warning in the with-findings case, not just no-findings) is **folded into this PR**.

Part of a broader "learn from Warden" thread: bounded contradiction-detection against self-maintaining invariants, made robust on cheap models.