### PR TITLE
feat(gateway): email team invites via SMTP2GO (E-5-e, #630/#827)

### DIFF
--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -23,11 +23,13 @@ import {
   createTeam,
   createTeamInvite,
   discoverGitHubCollaborators,
+  isEmailAddress,
   listDomainJoinRequests,
   listTeams,
   rejectDomainJoin,
   removeTeamMember,
   requestDomainJoin,
+  sendInviteEmail,
   setTeamRole,
   teamMembers,
 } from "../team";
@@ -194,11 +196,22 @@ export async function commandTeam(
         const token = await createTeamInvite(client, scope, role, hint, {
           offline,
         });
+        // E-5-e: if --email is a real address, email the join link. A send failure NEVER loses the
+        // invite — the token/link is always still printed.
+        const willEmail = !!hint && isEmailAddress(hint);
+        const emailed = willEmail
+          ? await sendInviteEmail(client, token, hint)
+          : false;
         console.log(
           `Invite created (${role}${hint ? `, for ${hint}` : ""}${offline ? ", offline" : ""}). It expires in 14 days.\n` +
             (offline
               ? "This token carries a one-time decryption key — treat it like a password and prefer a private channel.\n"
               : "") +
+            (willEmail && emailed
+              ? `Emailed the join link to ${hint}.\n`
+              : willEmail
+                ? "Could not send the email — share the link manually below.\n"
+                : "") +
             `Share this with the invitee — they run:\n\n  lore team accept ${token}\n`,
         );
         break;

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -297,6 +297,31 @@ export async function createTeamInvite(
   return `${data as string}${ephSecretSeg}`;
 }
 
+/** Conservative "looks like an email" check — decides whether `--email` is a real address to send to. */
+export function isEmailAddress(s: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.trim());
+}
+
+/**
+ * E-5-e (#630/#827): email a team invitee their join link via the `send-invite-email` Edge Function
+ * (SMTP2GO). Best-effort — returns false (never throws) on any failure so the caller can fall back to
+ * printing the token link; the invite itself already exists server-side.
+ */
+export async function sendInviteEmail(
+  client: SupabaseClient,
+  token: string,
+  email: string,
+): Promise<boolean> {
+  try {
+    const { error } = await client.functions.invoke("send-invite-email", {
+      body: { token, email },
+    });
+    return !error;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Redeem an invite token (E-5-c): self-add to the scope, publish this device's identity key so the
  * admin can wrap the DEK, and pull so the joined team shows in `lore team list`. Returns the scope

--- a/packages/gateway/test/send-invite-email.test.ts
+++ b/packages/gateway/test/send-invite-email.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the send-invite-email Edge Function's pure core (E-5-e, #630/#827) — invite email
+ * body construction + SMTP2GO HTTP send. Mirrors github-discover.test.ts: imports the Deno-free
+ * `send.ts` and drives sendViaSmtp2go with a fetch mock.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildInviteEmail,
+  capabilityOf,
+  sendViaSmtp2go,
+} from "../../../supabase/functions/send-invite-email/send";
+
+describe("capabilityOf", () => {
+  it("returns a capability-only token unchanged", () => {
+    expect(capabilityOf("abc123")).toBe("abc123");
+  });
+  it("strips the ephemeral secret suffix (offline invite) — DB stores only the capability", () => {
+    expect(capabilityOf("cap.SECRETb64url")).toBe("cap");
+    // only the FIRST dot delimits — the secret itself may contain no dots but be defensive.
+    expect(capabilityOf("cap.a.b")).toBe("cap");
+  });
+});
+
+describe("buildInviteEmail", () => {
+  it("includes the accept command, team name, role, and expiry", () => {
+    const m = buildInviteEmail({
+      token: "tok123",
+      teamName: "Acme",
+      role: "editor",
+    });
+    expect(m.subject).toContain("Acme");
+    expect(m.text).toContain("lore team accept tok123");
+    expect(m.text).toContain("as editor");
+    expect(m.text).toContain("14 days");
+    expect(m.html).toContain("lore team accept tok123");
+  });
+
+  it("defaults role to editor and team name when absent", () => {
+    const m = buildInviteEmail({ token: "t" });
+    expect(m.text).toContain("as editor");
+    expect(m.subject).toContain("a Lore team");
+  });
+
+  it("maps an unknown role to editor (never leaks a bogus role)", () => {
+    const m = buildInviteEmail({ token: "t", role: "admin" });
+    expect(m.text).toContain("as editor");
+  });
+
+  it("adds the one-time-key warning ONLY for offline invites", () => {
+    const online = buildInviteEmail({ token: "t", offline: false });
+    const offline = buildInviteEmail({ token: "t", offline: true });
+    expect(online.text).not.toContain("one-time key");
+    expect(offline.text).toContain("one-time key");
+    expect(offline.html).toContain("one-time key");
+  });
+
+  it("escapes HTML in the team name (no injection into the html body)", () => {
+    const m = buildInviteEmail({ token: "t", teamName: "<script>x</script>" });
+    expect(m.html).not.toContain("<script>x</script>");
+    expect(m.html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("sendViaSmtp2go", () => {
+  const email = { subject: "s", text: "t", html: "<p>h</p>" };
+  const opts = (fetchImpl: typeof fetch) => ({
+    apiKey: "KEY",
+    sender: "keeper@withlore.ai",
+    fetchImpl,
+  });
+
+  it("POSTs to the SMTP2GO API with the key header and recipient, and resolves on success", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const f = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init: init ?? {} });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { succeeded: 1, failed: 0 } }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    await sendViaSmtp2go("a@b.com", email, opts(f));
+    expect(calls[0].url).toContain("api.smtp2go.com");
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers["X-Smtp2go-Api-Key"]).toBe("KEY");
+    const sent = JSON.parse(calls[0].init.body as string);
+    expect(sent.to).toEqual(["a@b.com"]);
+    expect(sent.sender).toBe("keeper@withlore.ai");
+    expect(sent.subject).toBe("s");
+  });
+
+  it("throws on a non-ok HTTP status", async () => {
+    const f = (async () =>
+      ({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      }) as Response) as unknown as typeof fetch;
+    await expect(sendViaSmtp2go("a@b.com", email, opts(f))).rejects.toThrow(
+      /smtp2go: 500/,
+    );
+  });
+
+  it("throws when SMTP2GO reports an API-level error on a 200", async () => {
+    const f = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { error: "bad api key" } }),
+      }) as Response) as unknown as typeof fetch;
+    await expect(sendViaSmtp2go("a@b.com", email, opts(f))).rejects.toThrow(
+      /bad api key/,
+    );
+  });
+
+  it("throws when no recipient was accepted (succeeded < 1)", async () => {
+    const f = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { succeeded: 0, failed: 1 } }),
+      }) as Response) as unknown as typeof fetch;
+    await expect(sendViaSmtp2go("a@b.com", email, opts(f))).rejects.toThrow(
+      /no recipients accepted/,
+    );
+  });
+});

--- a/packages/gateway/test/sync-team-invite.integration.test.ts
+++ b/packages/gateway/test/sync-team-invite.integration.test.ts
@@ -297,6 +297,36 @@ describe.skipIf(SKIP)("lore team — direct email invite (E-5-c)", () => {
     expect(res.scopeId).toBe(scope);
   });
 
+  it("send-invite-email authorization signals: only the admin who CREATED the token can email it (E-5-e)", async () => {
+    // The send-invite-email Edge Function authorizes on the invite TOKEN, not client input: it
+    // requires (a) scope_role(scope)='admin' for the caller AND (b) invited_by = caller. This proves
+    // both DB-level signals it reads, so it can never be used as an open email-spam relay. (The Deno
+    // function itself isn't run here — the harness has no Deno runtime — but its exact authz reads are.)
+    const scope = await freshAdminTeam("Email-Authz");
+    await createTeamInvite(clientFor(admin), scope, "editor");
+    // The invite row, read as the service does (superuser stands in for the service-role read).
+    const row = await h.client
+      .query(
+        "select scope_id, invited_by from public.pending_invites where scope_id=$1",
+        [scope],
+      )
+      .then((r) => r.rows[0] as { scope_id: string; invited_by: string });
+    expect(row.invited_by).toBe(admin); // creator is the admin
+
+    // Signal (a): scope_role resolves 'admin' for the creator, and NOT for a non-member.
+    const adminRole = await clientFor(admin)
+      .rpc("scope_role", { p_scope: scope })
+      .then((r) => r.data);
+    expect(adminRole).toBe("admin");
+    const outsiderRole = await clientFor(invitee)
+      .rpc("scope_role", { p_scope: scope })
+      .then((r) => r.data);
+    expect(outsiderRole == null || outsiderRole !== "admin").toBe(true);
+
+    // Signal (b): invited_by binds the token to its creator — a different user fails the creator gate.
+    expect(row.invited_by === invitee).toBe(false);
+  });
+
   it("admin's sync auto-wraps the DEK to an invited member — zero follow-up (reconcileScopeWraps)", async () => {
     // B publishes its identity key to the remote directory (its own device), then local is wiped.
     await publishAsInvitee();

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -24,6 +24,10 @@ vi.mock("../src/team", () => ({
   listDomainJoinRequests: vi.fn(),
   approveDomainJoin: vi.fn(),
   rejectDomainJoin: vi.fn(),
+  discoverGitHubCollaborators: vi.fn(),
+  sendInviteEmail: vi.fn(),
+  // Pure predicate — use the real implementation so --email routing behaves in tests.
+  isEmailAddress: (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.trim()),
 }));
 
 import {

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -1,0 +1,113 @@
+// E-5-e (#630/#827): send-invite-email Edge Function. Emails a team invitee their join link via
+// SMTP2GO. Authorization is anchored on the invite TOKEN, not client-supplied scope/role: the caller
+// must be an admin of the invite's scope AND the pending invite must exist (looked up service-role),
+// so this can never be used as an open email-spam relay — you can only email an invite that exists
+// for a team you administer, to one recipient per call.
+//
+// Deploy (not auto-deployed): `supabase functions deploy send-invite-email`. Requires the
+// SMTP2GO_API_KEY Function secret; SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY are
+// injected by the platform. INVITE_SENDER defaults to keeper@withlore.ai; SMTP2GO_API_URL optional.
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { buildInviteEmail, capabilityOf, sendViaSmtp2go } from "./send.ts";
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Conservative RFC-ish email shape check — the recipient is admin-supplied, but we still guard.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) return json({ error: "missing authorization" }, 401);
+
+  const url = Deno.env.get("SUPABASE_URL");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const apiKey = Deno.env.get("SMTP2GO_API_KEY");
+  if (!url || !anonKey || !serviceKey || !apiKey) {
+    return json({ error: "server misconfigured" }, 500);
+  }
+  const sender = Deno.env.get("INVITE_SENDER") ?? "keeper@withlore.ai";
+  const apiUrl = Deno.env.get("SMTP2GO_API_URL") ?? undefined;
+
+  // Verify the caller's JWT → user id (never trust a client-supplied identity).
+  const userClient = createClient(url, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const {
+    data: { user },
+    error: userErr,
+  } = await userClient.auth.getUser();
+  if (userErr || !user) return json({ error: "invalid token" }, 401);
+
+  const body = (await req.json().catch(() => ({}))) as {
+    token?: string;
+    email?: string;
+  };
+  const token = typeof body.token === "string" ? body.token : "";
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  if (!token) return json({ error: "missing token" }, 400);
+  if (!email || !EMAIL_RE.test(email))
+    return json({ error: "invalid email" }, 400);
+
+  // An offline invite token is `<capability>.<base64url(secret)>`; only the capability part is stored
+  // in pending_invites.token (mirrors acceptTeamInvite). Look up by the capability, but email the
+  // FULL token — the invitee needs the secret suffix to unwrap the DEK.
+  const capability = capabilityOf(token);
+
+  // Authorize on the TOKEN: resolve the invite service-role, then confirm the caller is an admin of
+  // its scope. Scope/role/team_name come from the row, never from client input — no spam relay.
+  const admin = createClient(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: inv, error: invErr } = await admin
+    .from("pending_invites")
+    .select("scope_id, role, invited_by, eph_pub, expires_at")
+    .eq("token", capability)
+    .maybeSingle();
+  if (invErr) {
+    console.error("pending_invites read failed:", invErr.message);
+    return json({ error: "lookup failed" }, 500);
+  }
+  // Generic 404 whether the token is absent or expired — never disclose which.
+  if (!inv || new Date(inv.expires_at as string).getTime() <= Date.now())
+    return json({ error: "invite not found" }, 404);
+
+  // The caller must be an ADMIN of the invite's scope. Check via scope_role() with the caller JWT
+  // (RLS-safe; resolves auth.uid()). Belt-and-suspenders: also require they created the invite.
+  const { data: roleRow } = await userClient.rpc("scope_role", {
+    p_scope: inv.scope_id,
+  });
+  const isAdmin = roleRow === "admin";
+  const isCreator = inv.invited_by === user.id;
+  if (!isAdmin || !isCreator) return json({ error: "forbidden" }, 403);
+
+  // Look up the team name for the email copy (service-role read; best-effort).
+  const { data: scopeRow } = await admin
+    .from("scopes")
+    .select("name")
+    .eq("id", inv.scope_id)
+    .maybeSingle();
+
+  const message = buildInviteEmail({
+    token,
+    teamName: (scopeRow?.name as string | null) ?? null,
+    role: inv.role as string | null,
+    offline: !!inv.eph_pub,
+  });
+
+  try {
+    await sendViaSmtp2go(email, message, { apiKey, sender, apiUrl });
+  } catch (e) {
+    console.error("smtp2go send failed:", (e as Error).message);
+    return json({ error: "send failed" }, 502);
+  }
+  return json({ ok: true });
+});

--- a/supabase/functions/send-invite-email/send.ts
+++ b/supabase/functions/send-invite-email/send.ts
@@ -1,0 +1,114 @@
+// E-5-e (#630/#827): pure, runtime-portable core of the send-invite-email Edge Function — build the
+// invite email body and POST it to SMTP2GO's HTTP API. No Deno/npm imports here so it is
+// unit-testable under Node/Vitest; index.ts is the thin Deno glue that adds JWT + service-role
+// token-owner authorization.
+
+export interface InviteEmailInput {
+  token: string;
+  teamName?: string | null;
+  role?: string | null;
+  /** Whether the token itself carries a one-time decryption key (offline/eph: invite). */
+  offline?: boolean;
+}
+export interface InviteEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Build the invite email. An ONLINE invite carries no decryption-capable material (the admin wraps
+ * the DEK to the new member on their next sync); an OFFLINE (eph:) invite's token is
+ * decryption-capable by design, so the copy warns to treat it like a password and use a private
+ * channel — same posture as the CLI printout today, just delivered by email.
+ */
+export function buildInviteEmail(input: InviteEmailInput): InviteEmail {
+  const team = input.teamName?.trim() || "a Lore team";
+  const role = input.role === "viewer" ? "viewer" : "editor";
+  const accept = `lore team accept ${input.token}`;
+  const subject = `You've been invited to ${team} on Lore`;
+  const sensitiveLine = input.offline
+    ? "\nThis invite carries a one-time key — treat it like a password and don't forward it.\n"
+    : "";
+  const text =
+    `You've been invited to join ${team} on Lore as ${role}.\n\n` +
+    `If you don't have Lore yet, install it from https://withlore.ai, sign in, then run:\n\n` +
+    `  ${accept}\n${sensitiveLine}\n` +
+    `This invite expires in 14 days.\n`;
+  const sensitiveHtml = input.offline
+    ? `<p style="color:#b45309">This invite carries a one-time key — treat it like a password and don't forward it.</p>`
+    : "";
+  const html =
+    `<p>You've been invited to join <strong>${escapeHtml(team)}</strong> on Lore as ${role}.</p>` +
+    `<p>If you don't have Lore yet, install it from <a href="https://withlore.ai">withlore.ai</a>, sign in, then run:</p>` +
+    `<pre><code>${escapeHtml(accept)}</code></pre>` +
+    sensitiveHtml +
+    `<p>This invite expires in 14 days.</p>`;
+  return { subject, text, html };
+}
+
+/**
+ * Return the capability (DB-stored) portion of an invite token. An offline invite token is
+ * `<capability>.<base64url(secret)>`; only the capability is stored in pending_invites.token, so a DB
+ * lookup MUST use this (mirrors acceptTeamInvite). A capability-only token has no `.` and is returned
+ * unchanged. The full token (with any secret suffix) is what the invitee needs and what we email.
+ */
+export function capabilityOf(token: string): string {
+  const dot = token.indexOf(".");
+  return dot >= 0 ? token.slice(0, dot) : token;
+}
+
+export interface Smtp2goOptions {
+  apiKey: string;
+  sender: string; // e.g. "keeper@withlore.ai"
+  apiUrl?: string; // default https://api.smtp2go.com/v3/email/send
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Send one email via SMTP2GO's HTTP API. Throws on a non-ok response or an API-level error field so
+ * the caller can surface a generic failure (and still fall back to printing the invite link). The
+ * API key is passed in the X-Smtp2go-Api-Key header and NEVER logged.
+ */
+export async function sendViaSmtp2go(
+  to: string,
+  email: InviteEmail,
+  opts: Smtp2goOptions,
+): Promise<void> {
+  const apiUrl = (
+    opts.apiUrl ?? "https://api.smtp2go.com/v3/email/send"
+  ).replace(/\/$/, "");
+  const f = opts.fetchImpl ?? fetch;
+  const resp = await f(apiUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "X-Smtp2go-Api-Key": opts.apiKey,
+    },
+    body: JSON.stringify({
+      sender: opts.sender,
+      to: [to],
+      subject: email.subject,
+      text_body: email.text,
+      html_body: email.html,
+    }),
+  });
+  if (!resp.ok) throw new Error(`smtp2go: ${resp.status}`);
+  // SMTP2GO returns 200 with a data.error / data.failures payload on partial failure.
+  const body = (await resp.json().catch(() => ({}))) as {
+    data?: { succeeded?: number; failed?: number; error?: string };
+  };
+  const d = body.data ?? {};
+  if (d.error) throw new Error(`smtp2go: ${d.error}`);
+  if (typeof d.succeeded === "number" && d.succeeded < 1)
+    throw new Error("smtp2go: no recipients accepted");
+}


### PR DESCRIPTION
Builds on the invite infra so `lore team invite --email <addr>` **actually emails** the invitee a join link, instead of only printing a token for the admin to hand-deliver. This is the shared email foundation the collaborator-discovery invite path (E-5-d-2) will reuse.

## What
- New **`send-invite-email` Edge Function** (SMTP2GO HTTP API, sender `keeper@withlore.ai`): pure `send.ts` core (`buildInviteEmail` + `sendViaSmtp2go`, injectable fetch) + thin Deno `index.ts` glue (mirrors `github-discover`).
- `sendInviteEmail` + `isEmailAddress` in team.ts; the CLI `invite` case emails when `--email` is a real address and **always still prints the token link** (a send failure never loses the invite).

## Security / abuse 🔴
- The Edge Function authorizes on the invite **token**, not client input: resolves `pending_invites` service-role, then requires the caller be an **admin** of the invite's scope (`scope_role`) **and** its **creator** (`invited_by = auth.uid()`). → not an open email-spam relay: you can only email an invite you created for a team you admin, one recipient per call. Expired/absent → generic 404 (no oracle).
- Online (auto-wrap) invite emails carry **no** decryption-capable material; offline (`eph:`) tokens are decryption-capable by design (same posture as today, just emailed — copy warns to treat like a password).
- `SMTP2GO_API_KEY` is a server-only Function secret, never shipped to clients / never logged.

## Scope / notes
- **No migration** (reads existing `pending_invites`/`scopes` only).
- GitHub's `/collaborators` API returns no email → GitHub-discovered collaborators (E-5-d-2) can't be auto-emailed; that path prints links and emails only where the admin supplies an address.
- Not auto-deployed: `supabase functions deploy send-invite-email` + set `SMTP2GO_API_KEY`.

## Tests
- `send-invite-email.test.ts`: `buildInviteEmail` (accept cmd/role/expiry, unknown-role→editor, offline-only warning, HTML escaping) + `sendViaSmtp2go` (key header + recipient, non-ok throw, API-error throw, no-recipient throw) — **9**, mocked fetch.
- `sync-team-invite.integration.test.ts`: Tier-1 test asserting the two authorization signals the Edge Function reads (admin role + `invited_by` creator binding).
- Typecheck clean; format clean. (Pre-existing `reconcileScopeWraps` integration test fails in my local Docker env but is green in CI on main @38b44a31 — unrelated.)