### PR TITLE
feat(invariant-check): --effort knob + invariantCheck.effort config

### DIFF
--- a/.github/actions/invariant-check/action.yml
+++ b/.github/actions/invariant-check/action.yml
@@ -19,6 +19,13 @@ inputs:
     description: "Judge model (provider/id). Defaults to the configured worker model."
     required: false
     default: ""
+  effort:
+    description: >-
+      Reasoning effort for the judge (off|low|medium|high|xhigh). A cost/depth
+      dial on reasoning-capable models; ignored by non-reasoning models like
+      gpt-4o-mini. Defaults to the `invariantCheck.effort` config value (off).
+    required: false
+    default: ""
   worker-api-key:
     description: >-
       Judge credential (sets LORE_WORKER_API_KEY). In CI the gateway has no
@@ -92,6 +99,7 @@ runs:
         LORE_IC_BASE: ${{ inputs.base }}
         LORE_IC_HEAD: ${{ inputs.head }}
         LORE_IC_MODEL: ${{ inputs.model }}
+        LORE_IC_EFFORT: ${{ inputs.effort }}
         LORE_WORKER_API_KEY: ${{ inputs.worker-api-key }}
         LORE_CMD: ${{ inputs.lore-command }}
         # Point the whole lore stack (db(), forProject, loadInvariantVecs) at the
@@ -120,6 +128,7 @@ runs:
         [ -n "$base" ] && args+=(--base "$base")
         [ -n "$head" ] && args+=(--head "$head")
         [ -n "${LORE_IC_MODEL}" ] && args+=(--model "${LORE_IC_MODEL}")
+        [ -n "${LORE_IC_EFFORT}" ] && args+=(--effort "${LORE_IC_EFFORT}")
         # On a cache MISS, seed the DB from .lore.md (imports + embeds, once).
         # On a HIT the DB already exists; --import-lore-md fast-paths (mtime/hash
         # match) and is a cheap no-op, so it is always safe to pass.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -931,6 +931,21 @@ export const LoreConfig = z.object({
     .describe(
       "User identity for the self-entity. Falls back to git config user.name / user.email if omitted.",
     ),
+  invariantCheck: z
+    .object({
+      /** Reasoning effort for the `lore invariant-check` judge. A cost/depth
+       *  dial on reasoning-capable models: `off` (default) sends no reasoning
+       *  param; higher values trade cost for depth. Overridable per-run via
+       *  `--effort`. Ignored by non-reasoning models (e.g. gpt-4o-mini). */
+      effort: z
+        .enum(["off", "low", "medium", "high", "xhigh"])
+        .default("off")
+        .describe(
+          "Reasoning effort for the invariant-check judge (off|low|medium|high|xhigh). Trades cost for depth on reasoning-capable models. Default: off. Override per-run with --effort.",
+        ),
+    })
+    .default({ effort: "off" })
+    .describe("`lore invariant-check` (semantic linter) tuning."),
 });
 
 export type LoreConfig = z.infer<typeof LoreConfig>;

--- a/packages/core/src/effort.ts
+++ b/packages/core/src/effort.ts
@@ -1,0 +1,90 @@
+/**
+ * Reasoning-effort vocabulary and per-protocol mappings for worker LLM calls.
+ *
+ * Effort is a single knob a caller can turn to trade cost for depth on a
+ * reasoning-capable model. It is surfaced by `lore invariant-check` (as
+ * `--effort` / the `invariantCheck.effort` config key) and threaded through
+ * `LLMClient.prompt(..., { reasoningEffort })` into the gateway worker request
+ * builders.
+ *
+ * The vocabulary matches Warden's (`off | low | medium | high | xhigh`) so the
+ * two tools speak the same language. Each protocol maps it to its own native
+ * dial:
+ *   - OpenAI Chat Completions → `reasoning_effort` (ignored by non-reasoning
+ *     models like gpt-4o-mini; honored by o-series / gpt-5). `xhigh` is not a
+ *     standard OpenAI value, so it is clamped to `high` to avoid a 400.
+ *   - Anthropic Messages / Vertex → extended-thinking `budget_tokens`.
+ *
+ * `off` is the default and means "send no reasoning dial at all" — identical to
+ * the pre-effort behavior (OpenAI: omit `reasoning_effort`; Anthropic: the
+ * worker's existing `thinking:{type:"disabled"}` suppression still applies).
+ */
+export type ReasoningEffort = "off" | "low" | "medium" | "high" | "xhigh";
+
+export const REASONING_EFFORTS: readonly ReasoningEffort[] = [
+  "off",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+] as const;
+
+/** Narrow an arbitrary string to a ReasoningEffort, or null if unrecognized. */
+export function parseReasoningEffort(
+  s: string | undefined | null,
+): ReasoningEffort | null {
+  if (!s) return null;
+  const v = s.trim().toLowerCase();
+  return (REASONING_EFFORTS as readonly string[]).includes(v)
+    ? (v as ReasoningEffort)
+    : null;
+}
+
+/**
+ * Map effort to OpenAI Chat Completions `reasoning_effort`.
+ *
+ * Returns null when no param should be sent (`off`). `xhigh` clamps to `high`
+ * because OpenAI does not accept `xhigh` and would reject the request.
+ */
+export function openAIReasoningEffort(
+  effort: ReasoningEffort | undefined,
+): "low" | "medium" | "high" | null {
+  switch (effort) {
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "xhigh":
+      return "high"; // not a standard OpenAI value — clamp down, don't 400
+    default:
+      return null; // "off" / undefined → omit the param
+  }
+}
+
+/**
+ * Map effort to an Anthropic extended-thinking `budget_tokens`, or null when
+ * thinking should not be explicitly enabled (`off`/undefined → caller keeps its
+ * existing disable-thinking behavior).
+ *
+ * Budgets are deliberately modest — the judge does bounded single-shot
+ * classification, not open-ended agentic reasoning. Anthropic requires
+ * `budget_tokens >= 1024`.
+ */
+export function anthropicThinkingBudget(
+  effort: ReasoningEffort | undefined,
+): number | null {
+  switch (effort) {
+    case "low":
+      return 2048;
+    case "medium":
+      return 8192;
+    case "high":
+      return 16384;
+    case "xhigh":
+      return 32768;
+    default:
+      return null; // "off" / undefined → do not enable thinking
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,13 @@ export * as data from "./data";
 export * as distillation from "./distillation";
 export * as contradiction from "./contradiction";
 export * as invariantCheck from "./invariant-check";
+export {
+  anthropicThinkingBudget,
+  openAIReasoningEffort,
+  parseReasoningEffort,
+  REASONING_EFFORTS,
+  type ReasoningEffort,
+} from "./effort";
 export * as curator from "./curator";
 export type { ChangedEntry } from "./curator";
 export * as embedding from "./embedding";

--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -32,6 +32,7 @@
 import { execFileSync } from "node:child_process";
 import { db } from "./db";
 import { embeddingByIdSource, readStorageMode } from "./db/vec-store";
+import { anthropicThinkingBudget, type ReasoningEffort } from "./effort";
 import * as embedding from "./embedding";
 import * as ltm from "./ltm";
 import type { KnowledgeEntry } from "./ltm";
@@ -70,6 +71,20 @@ export const MIN_CONFIDENCE = 0.2;
 /** Cap the invariant set scanned (forProject is confidence DESC) so a huge
  *  knowledge base can't blow up the O(hunks×invariants) prefilter. */
 const MAX_INVARIANTS_SCAN = 300;
+
+// Output budget for the judge's verdict JSON. Tiny without reasoning; with effort
+// ON, reasoning tokens are billed against the output budget. For OpenAI reasoning
+// models this max_completion_tokens IS the effective ceiling (the gateway does not
+// bump it), so it must cover reasoning + the verdict. For Anthropic the gateway
+// independently raises max_tokens above the thinking budget; we still send a
+// generous value here so the two paths agree. Headroom matches the gateway's
+// THINKING_OUTPUT_HEADROOM (8192) so the numbers don't diverge confusingly.
+const JUDGE_VERDICT_TOKENS = 256;
+const JUDGE_VERDICT_HEADROOM = 8192;
+function judgeMaxTokens(effort: ReasoningEffort | undefined): number {
+  const budget = anthropicThinkingBudget(effort) ?? 0;
+  return budget > 0 ? budget + JUDGE_VERDICT_HEADROOM : JUDGE_VERDICT_TOKENS;
+}
 
 // If more than this fraction of judge calls come back unparseable, warn: the
 // judge model is likely failing the JSON output contract, so a "clean" result is
@@ -884,6 +899,10 @@ export async function checkInvariants(input: {
   range: ResolvedRange;
   llm: LLMClient;
   model?: { providerID: string; modelID: string };
+  /** Reasoning effort for the judge call. `off`/undefined leaves reasoning off
+   *  (the default). Higher effort trades cost for depth on reasoning-capable
+   *  models — a knob for tuning recall vs. spend. */
+  effort?: ReasoningEffort;
   sessionID: string;
   /** onProgress for CLI heartbeat. */
   onJudge?: (n: number, total: number) => void;
@@ -978,10 +997,14 @@ export async function checkInvariants(input: {
           model: input.model,
           workerID: "lore-invariant-check",
           thinking: false,
+          reasoningEffort: input.effort,
           // Interactive CLI: must return this turn, not defer to the batch queue.
           urgent: true,
           sessionID: input.sessionID,
-          maxTokens: 256,
+          // The verdict JSON is tiny (256 is ample without reasoning). With
+          // effort ON, reasoning tokens count against the output budget, so the
+          // model would exhaust 256 before emitting the verdict — give it room.
+          maxTokens: judgeMaxTokens(input.effort),
           temperature: 0,
         },
       );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,6 +11,8 @@
  * the host's UI or for features Lore doesn't touch are omitted.
  */
 
+import type { ReasoningEffort } from "./effort";
+
 // ---------------------------------------------------------------------------
 // Messages
 // ---------------------------------------------------------------------------
@@ -299,6 +301,20 @@ export interface LLMClient {
        *   the field is silently ignored
        */
       temperature?: number;
+      /**
+       * Reasoning effort for this call — a cost/depth dial on reasoning-capable
+       * models. `off` (or absent) sends no reasoning param (pre-effort
+       * behavior). The gateway adapter maps it per protocol: OpenAI Chat
+       * Completions → `reasoning_effort` (ignored by non-reasoning models like
+       * gpt-4o-mini); Anthropic Messages / Vertex → extended-thinking
+       * `budget_tokens` (which also overrides the default worker
+       * disable-thinking suppression when set).
+       *
+       * Adapter behavior:
+       * - Gateway: honored (per-protocol mapping above)
+       * - Pi / OpenCode: ignored (no equivalent on their prompt surface)
+       */
+      reasoningEffort?: ReasoningEffort;
       /**
        * Override the upstream URL for this call. When set, the adapter
        * routes the request to this URL instead of the default provider

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -283,3 +283,21 @@ describe("load — reads config from .lore.json", () => {
     expect(cfg.agentsFile.path).toBe("auto");
   });
 });
+
+describe("LoreConfig — invariantCheck schema", () => {
+  test("defaults: effort=off when omitted", () => {
+    const cfg = LoreConfig.parse({});
+    expect(cfg.invariantCheck.effort).toBe("off");
+  });
+
+  test("effort can be set to a reasoning level", () => {
+    const cfg = LoreConfig.parse({ invariantCheck: { effort: "high" } });
+    expect(cfg.invariantCheck.effort).toBe("high");
+  });
+
+  test("rejects an unknown effort value", () => {
+    expect(() =>
+      LoreConfig.parse({ invariantCheck: { effort: "ultra" } }),
+    ).toThrow();
+  });
+});

--- a/packages/core/test/effort.test.ts
+++ b/packages/core/test/effort.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  anthropicThinkingBudget,
+  openAIReasoningEffort,
+  parseReasoningEffort,
+  REASONING_EFFORTS,
+  type ReasoningEffort,
+} from "../src/effort";
+
+describe("parseReasoningEffort", () => {
+  it("accepts every canonical value", () => {
+    for (const e of REASONING_EFFORTS) {
+      expect(parseReasoningEffort(e)).toBe(e);
+    }
+  });
+  it("is case- and whitespace-insensitive", () => {
+    expect(parseReasoningEffort("  HIGH ")).toBe("high");
+    expect(parseReasoningEffort("Medium")).toBe("medium");
+  });
+  it("returns null for unknown / empty / nullish", () => {
+    expect(parseReasoningEffort("ultra")).toBeNull();
+    expect(parseReasoningEffort("")).toBeNull();
+    expect(parseReasoningEffort(undefined)).toBeNull();
+    expect(parseReasoningEffort(null)).toBeNull();
+  });
+});
+
+describe("openAIReasoningEffort", () => {
+  it("passes low/medium/high through", () => {
+    expect(openAIReasoningEffort("low")).toBe("low");
+    expect(openAIReasoningEffort("medium")).toBe("medium");
+    expect(openAIReasoningEffort("high")).toBe("high");
+  });
+  it("clamps xhigh to high (not a standard OpenAI value)", () => {
+    expect(openAIReasoningEffort("xhigh")).toBe("high");
+  });
+  it("returns null for off / undefined (omit the param)", () => {
+    expect(openAIReasoningEffort("off")).toBeNull();
+    expect(openAIReasoningEffort(undefined)).toBeNull();
+  });
+});
+
+describe("anthropicThinkingBudget", () => {
+  it("returns an ascending budget for low→xhigh", () => {
+    const low = anthropicThinkingBudget("low")!;
+    const medium = anthropicThinkingBudget("medium")!;
+    const high = anthropicThinkingBudget("high")!;
+    const xhigh = anthropicThinkingBudget("xhigh")!;
+    expect(low).toBeGreaterThanOrEqual(1024); // Anthropic minimum
+    expect(medium).toBeGreaterThan(low);
+    expect(high).toBeGreaterThan(medium);
+    expect(xhigh).toBeGreaterThan(high);
+  });
+  it("returns null for off / undefined (do not enable thinking)", () => {
+    expect(anthropicThinkingBudget("off")).toBeNull();
+    expect(anthropicThinkingBudget(undefined)).toBeNull();
+  });
+  it("every enabled budget is at least Anthropic's 1024 floor", () => {
+    for (const e of ["low", "medium", "high", "xhigh"] as ReasoningEffort[]) {
+      expect(anthropicThinkingBudget(e)!).toBeGreaterThanOrEqual(1024);
+    }
+  });
+});

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -20,6 +20,8 @@ import {
   embedding,
   importLoreFile,
   invariantCheck,
+  parseReasoningEffort,
+  type ReasoningEffort,
 } from "@loreai/core";
 import { createGatewayLLMClient } from "../llm-adapter";
 import { type AuthCredential, resolveAuth, workerKeyScheme } from "../auth";
@@ -48,6 +50,17 @@ export async function commandInvariantCheck(
   const projectPath = resolve((values.project as string) ?? process.cwd());
   const asJson = !!values.json;
   const modelOverride = parseModel(values.model as string | undefined);
+  // Reasoning effort: --effort overrides the `invariantCheck.effort` config,
+  // which defaults to "off". An unrecognized --effort value is a hard error
+  // (fail fast on a typo rather than silently running with the wrong dial).
+  const effortRaw = values.effort as string | undefined;
+  const effortOverride = parseReasoningEffort(effortRaw);
+  if (effortRaw != null && effortOverride == null) {
+    console.error(
+      `[lore] Invalid --effort "${effortRaw}". Use one of: off, low, medium, high, xhigh.`,
+    );
+    process.exit(1);
+  }
   // CI flow: no local lore.db exists, so seed the active DB (LORE_DB_PATH,
   // typically an actions/cache path) from the repo's `.lore.md`. Deriving
   // embeddings is fire-and-forget, so we drain them below before the funnel —
@@ -107,6 +120,8 @@ export async function commandInvariantCheck(
   }
   const defaultModel = modelOverride ??
     cfg.model ?? { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+  const effectiveEffort: ReasoningEffort =
+    effortOverride ?? cfg.invariantCheck.effort;
 
   // Judge auth. In CI there is no client session, so bare resolveAuth() returns
   // null and every judge call is skipped as "no-auth". Honor LORE_WORKER_API_KEY
@@ -143,6 +158,7 @@ export async function commandInvariantCheck(
       range,
       llm,
       model: defaultModel,
+      effort: effectiveEffort,
       sessionID: `invariant-check-${Date.now()}`,
       onJudge: (n, total) => {
         process.stderr.write(`\r[lore]   judging ${n}/${total}...`);
@@ -174,6 +190,7 @@ export async function commandInvariantCheck(
       JSON.stringify(
         {
           model: `${defaultModel.providerID}/${defaultModel.modelID}`,
+          effort: effectiveEffort,
           elapsedMs,
           gate,
           ...result,
@@ -191,7 +208,7 @@ export async function commandInvariantCheck(
     return;
   }
 
-  printReport(result, defaultModel, elapsedMs, gate);
+  printReport(result, defaultModel, elapsedMs, gate, effectiveEffort);
   process.exitCode = gate.exitCode;
 }
 
@@ -200,6 +217,7 @@ function printReport(
   model: { providerID: string; modelID: string },
   elapsedMs: number,
   gate: invariantCheck.GateResult,
+  effort: ReasoningEffort,
 ): void {
   const { findings } = result;
   console.log("");
@@ -209,7 +227,7 @@ function printReport(
       `${result.candidates} candidates → ${result.judgeCalls} judge calls`,
   );
   console.log(
-    `Model: ${model.providerID}/${model.modelID}   Time: ${(elapsedMs / 1000).toFixed(1)}s   Mode: ${gate.mode}`,
+    `Model: ${model.providerID}/${model.modelID}   Effort: ${effort}   Time: ${(elapsedMs / 1000).toFixed(1)}s   Mode: ${gate.mode}`,
   );
   console.log("─".repeat(64));
 

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -112,6 +112,7 @@ const OPTIONS = {
   base: { type: "string" as const },
   head: { type: "string" as const },
   model: { type: "string" as const },
+  effort: { type: "string" as const },
   "import-lore-md": { type: "boolean" as const },
   gate: { type: "boolean" as const },
   "dry-run": { type: "boolean" as const },

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -21,6 +21,8 @@
 
 import type { LLMClient } from "@loreai/core";
 import { log } from "@loreai/core";
+import { anthropicThinkingBudget, openAIReasoningEffort } from "@loreai/core";
+import type { ReasoningEffort } from "@loreai/core";
 import * as Sentry from "@sentry/bun";
 import type { AuthCredential } from "./auth";
 import { authHeaders, markAuthStale, markGlobalAuthStale } from "./auth";
@@ -384,6 +386,11 @@ const DEFAULT_MAX_RETRIES = 8;
  */
 const DEFAULT_WORKER_MAX_TOKENS = 16384;
 
+// Visible-output headroom added on top of an extended-thinking budget so the
+// model has room for the actual answer after reasoning (Anthropic counts thinking
+// against max_tokens). Mirrors pipeline.ts's THINKING_OUTPUT_HEADROOM.
+const THINKING_OUTPUT_HEADROOM = 8192;
+
 /**
  * Resolve the retry budget. `LORE_MAX_RETRIES` overrides the default; values
  * that are non-numeric, negative, or zero fall back to the default (we never
@@ -729,6 +736,7 @@ function buildAnthropicWorkerRequest(
   sessionID?: string,
   temperature?: number,
   disableThinking = false,
+  reasoningEffort?: ReasoningEffort,
 ): { url: string; headers: Record<string, string>; body: string } {
   // For bearer tokens (Claude Code OAuth), inject the billing header
   // as the first system block with a cch=00000 placeholder that gets
@@ -778,11 +786,31 @@ function buildAnthropicWorkerRequest(
   // accepted (and a no-op) by all current Claude models; a rare model that
   // rejects the param (older claude-3.x) is learned via a one-shot 400 retry in
   // the loop, which then passes `disableThinking=false` here.
+  // Extended thinking, opt-in via reasoning effort. When a budget is set the
+  // caller wants the model to reason — this OVERRIDES the default worker
+  // disable-thinking suppression. Anthropic constraints when thinking is on:
+  //   1. max_tokens MUST exceed budget_tokens — the judge's tiny 256-token cap
+  //      would otherwise 400, so we raise max_tokens to budget + headroom.
+  //   2. temperature must be unset (only the default is allowed) — so we drop it.
+  // Caveat: budget+headroom for `xhigh` is ~41K; a model whose output ceiling is
+  // below that would 400. Not guarded here (we lack the per-model ceiling on the
+  // worker path), but the effort budgets stay well under the common 64K ceiling
+  // and the invariant-check judge — the only effort caller — degrades a judge 400
+  // to a safe "no finding" (advisory: never fails the build).
+  const thinkingBudget = anthropicThinkingBudget(reasoningEffort);
+  const thinkingEnabled = thinkingBudget != null;
+  const effectiveMaxTokens = thinkingEnabled
+    ? Math.max(maxTokens, thinkingBudget + THINKING_OUTPUT_HEADROOM)
+    : maxTokens;
+
   let body = JSON.stringify({
     model: upstreamModelID,
-    max_tokens: maxTokens,
-    ...(temperature != null && { temperature }),
-    ...(disableThinking && { thinking: { type: "disabled" } }),
+    max_tokens: effectiveMaxTokens,
+    // temperature is incompatible with extended thinking — omit when enabled.
+    ...(temperature != null && !thinkingEnabled && { temperature }),
+    ...(thinkingEnabled
+      ? { thinking: { type: "enabled", budget_tokens: thinkingBudget } }
+      : disableThinking && { thinking: { type: "disabled" } }),
     system: systemPayload,
     messages: [{ role: "user", content: user }],
   });
@@ -873,6 +901,7 @@ function buildOpenAIWorkerRequest(
   user: string,
   maxTokens: number,
   temperature?: number,
+  reasoningEffort?: ReasoningEffort,
 ): { url: string; headers: Record<string, string>; body: string } {
   const messages: Array<{ role: string; content: string }> = [];
   if (system) messages.push({ role: "system", content: system });
@@ -895,6 +924,11 @@ function buildOpenAIWorkerRequest(
       ? { provider: { sort: "price" } }
       : undefined;
 
+  // Reasoning models honor `reasoning_effort`; non-reasoning models (gpt-4o-mini,
+  // the CI default) silently ignore it. `off`/undefined → omit. `xhigh` clamps to
+  // `high` (not a standard OpenAI value) inside openAIReasoningEffort.
+  const effort = openAIReasoningEffort(reasoningEffort);
+
   return {
     // Background workers have no original request to forward verbatim, so the
     // URL is reconstructed host-aware (GitHub Copilot omits `/v1`, issue #1052;
@@ -912,6 +946,7 @@ function buildOpenAIWorkerRequest(
       max_completion_tokens: maxTokens,
       stream: false,
       ...(temperature != null && { temperature }),
+      ...(effort != null && { reasoning_effort: effort }),
       messages,
       ...providerPrefs,
     }),
@@ -1191,6 +1226,7 @@ async function buildVertexWorkerRequest(
   vertexProject?: string,
   temperature?: number,
   disableThinking = false,
+  reasoningEffort?: ReasoningEffort,
 ): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   const region = vertexRegionFromUrl(target.url) ?? "global";
   const project = await resolveVertexProject(vertexProject ?? "");
@@ -1203,6 +1239,8 @@ async function buildVertexWorkerRequest(
   }
   const vertexModel = toVertexModelId(model.modelID);
   const token = await getVertexAccessToken();
+  const vertexThinkingBudget = anthropicThinkingBudget(reasoningEffort) ?? 0;
+  const vertexThinkingEnabled = vertexThinkingBudget > 0;
   // Worker system prompt is static across bursts → cache it. Use bare ephemeral
   // (5m) rather than the 1h extended-ttl beta of uncertain Vertex support.
   const systemBlocks = system
@@ -1216,13 +1254,18 @@ async function buildVertexWorkerRequest(
     : undefined;
   const body = JSON.stringify(
     toVertexBody({
-      max_tokens: maxTokens,
-      ...(temperature != null && { temperature }),
+      max_tokens: vertexThinkingEnabled
+        ? Math.max(maxTokens, vertexThinkingBudget + THINKING_OUTPUT_HEADROOM)
+        : maxTokens,
+      // temperature is incompatible with extended thinking — omit when enabled.
+      ...(temperature != null && !vertexThinkingEnabled && { temperature }),
       // Vertex serves Claude over the Anthropic Messages body shape, so the same
-      // adaptive-thinking-on-by-default applies (sonnet-5). `thinking:{type:
-      // "disabled"}` passes through toVertexBody and turns it off. See
-      // buildAnthropicWorkerRequest for the full rationale.
-      ...(disableThinking && { thinking: { type: "disabled" } }),
+      // adaptive-thinking-on-by-default applies (sonnet-5). A reasoning-effort
+      // budget enables thinking (overriding the default disable); otherwise
+      // `thinking:{type:"disabled"}` turns it off. See buildAnthropicWorkerRequest.
+      ...(vertexThinkingEnabled
+        ? { thinking: { type: "enabled", budget_tokens: vertexThinkingBudget } }
+        : disableThinking && { thinking: { type: "disabled" } }),
       system: systemBlocks,
       messages: [{ role: "user", content: user }],
     }),
@@ -1260,6 +1303,7 @@ async function buildWorkerRequest(
   temperature?: number,
   vertexProject?: string,
   disableThinking = false,
+  reasoningEffort?: ReasoningEffort,
 ): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   switch (target.protocol) {
     case "openai-codex-responses":
@@ -1282,6 +1326,7 @@ async function buildWorkerRequest(
         user,
         maxTokens,
         temperature,
+        reasoningEffort,
       );
     case "vertex":
       return buildVertexWorkerRequest(
@@ -1293,6 +1338,7 @@ async function buildWorkerRequest(
         vertexProject,
         temperature,
         disableThinking,
+        reasoningEffort,
       );
     case "gemini":
       return buildGeminiWorkerRequest(
@@ -1315,6 +1361,7 @@ async function buildWorkerRequest(
         sessionID,
         temperature,
         disableThinking,
+        reasoningEffort,
       );
   }
 }
@@ -1686,6 +1733,12 @@ export function createGatewayLLMClient(
         workerThinkingOnByDefault(model) &&
         !isThinkingUnsupportedModel(model);
 
+      // Reasoning effort (a cost/depth dial). When set to a non-`off` value the
+      // builders enable native reasoning (OpenAI reasoning_effort / Anthropic
+      // thinking budget) — and the Anthropic/Vertex builders let it override
+      // effectiveDisableThinking. `off`/undefined preserves prior behavior.
+      const reasoningEffort = opts?.reasoningEffort;
+
       // The credential in effect for the CURRENT attempt. Starts as `cred`; an
       // auth-error refresh reassigns it so every later rebuild in the retry loop
       // (e.g. the temperature-strip rebuild) signs with the fresh key rather
@@ -1705,6 +1758,7 @@ export function createGatewayLLMClient(
         effectiveTemperature,
         factoryVertexProject,
         effectiveDisableThinking,
+        reasoningEffort,
       );
 
       // Track this call so temporal capture can skip it
@@ -2078,6 +2132,7 @@ export function createGatewayLLMClient(
                     effectiveTemperature,
                     factoryVertexProject,
                     effectiveDisableThinking,
+                    reasoningEffort,
                   );
                   retryCount++;
                   continue;
@@ -2217,6 +2272,7 @@ export function createGatewayLLMClient(
                     effectiveTemperature,
                     factoryVertexProject,
                     effectiveDisableThinking,
+                    reasoningEffort,
                   );
                   // Rebuilding restores the freshly-built header set, which
                   // resurrects a beta we may have already stripped at runtime
@@ -2264,6 +2320,7 @@ export function createGatewayLLMClient(
                     effectiveTemperature,
                     factoryVertexProject,
                     effectiveDisableThinking,
+                    reasoningEffort,
                   );
                   // Preserve a runtime beta strip across this rebuild (same
                   // reasoning as the temperature-strip path above).

--- a/packages/gateway/test/worker-effort.test.ts
+++ b/packages/gateway/test/worker-effort.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Reasoning-effort → worker request body mapping (invariant-check `--effort`).
+ *
+ * The effort dial is provider-specific:
+ *   - OpenAI Chat Completions → `reasoning_effort` (xhigh clamps to high; off omits)
+ *   - Anthropic Messages → extended-thinking `budget_tokens`, which also raises
+ *     max_tokens above the budget and drops temperature (both Anthropic rules).
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+import type { ReasoningEffort } from "@loreai/core";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+function okOpenAI() {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" } }],
+      model: "gpt-5",
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function okAnthropic() {
+  return new Response(
+    JSON.stringify({
+      content: [{ type: "text", text: "ok" }],
+      model: "claude-sonnet-4-6",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function bodyOf(n: number): Record<string, unknown> {
+  const raw = mockFetch.mock.calls[n][1]?.body;
+  return JSON.parse(typeof raw === "string" ? raw : "{}") as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("reasoning-effort → OpenAI reasoning_effort", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okOpenAI());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  async function run(effort: ReasoningEffort | undefined) {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-openai" }),
+      { providerID: "openai", modelID: "gpt-5" },
+    );
+    await client.prompt("system", "user", {
+      sessionID: "s",
+      workerID: "lore-invariant-check",
+      model: { providerID: "openai", modelID: "gpt-5" },
+      reasoningEffort: effort,
+    });
+    return bodyOf(0);
+  }
+
+  test("high passes through", async () => {
+    expect((await run("high")).reasoning_effort).toBe("high");
+  });
+  test("low passes through", async () => {
+    expect((await run("low")).reasoning_effort).toBe("low");
+  });
+  test("xhigh clamps to high", async () => {
+    expect((await run("xhigh")).reasoning_effort).toBe("high");
+  });
+  test("off omits the param", async () => {
+    expect((await run("off")).reasoning_effort).toBeUndefined();
+  });
+  test("undefined omits the param", async () => {
+    expect((await run(undefined)).reasoning_effort).toBeUndefined();
+  });
+});
+
+describe("reasoning-effort → Anthropic thinking budget", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okAnthropic());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  async function run(effort: ReasoningEffort | undefined, maxTokens = 256) {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-key" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    );
+    await client.prompt("system", "user", {
+      sessionID: "s",
+      workerID: "lore-invariant-check",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+      reasoningEffort: effort,
+      maxTokens,
+      temperature: 0,
+    });
+    return bodyOf(0);
+  }
+
+  test("high enables thinking with a budget and raises max_tokens above it", async () => {
+    const body = run;
+    const b = await body("high", 256);
+    const thinking = b.thinking as { type: string; budget_tokens: number };
+    expect(thinking.type).toBe("enabled");
+    expect(thinking.budget_tokens).toBeGreaterThanOrEqual(1024);
+    // max_tokens must exceed the thinking budget (Anthropic rule); the tiny 256
+    // judge cap is raised to budget + headroom.
+    expect(b.max_tokens as number).toBeGreaterThan(thinking.budget_tokens);
+  });
+
+  test("temperature is dropped when thinking is enabled", async () => {
+    const b = await run("medium", 256);
+    expect(b.temperature).toBeUndefined();
+    expect((b.thinking as { type: string }).type).toBe("enabled");
+  });
+
+  test("off keeps the disabled-thinking suppression and preserves temperature/max_tokens", async () => {
+    const b = await run("off", 256);
+    // effort off → no enabled-thinking block; worker disable path applies.
+    const thinking = b.thinking as { type: string } | undefined;
+    if (thinking) expect(thinking.type).toBe("disabled");
+    expect(b.max_tokens).toBe(256);
+  });
+});

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -53,6 +53,7 @@ The cleanest way to override a single field is via env var if Lore reads it, or 
 - [`agentsFile`](#agentsFile) — AGENTS.md/CLAUDE.md export/import configuration.
 - [`loreFile`](#loreFile) — `.lore.md` export/import configuration.
 - [`user`](#user) — User identity for the self-entity. Falls back to git config user.name / user.email if omitted.
+- [`invariantCheck`](#invariantCheck) — `lore invariant-check` (semantic linter) tuning.
 
 ## `model`
 
@@ -265,4 +266,13 @@ User identity for the self-entity. Falls back to git config user.name / user.ema
 | `email` | string | — |  | Email address. Overrides git config user.email. |
 | `aliases` | array<{ type, value }> | `[]` |  | Additional aliases for the self entity. |
 | `metadata` | Record<string, unknown> | — |  | Metadata for the self entity (description, role, notes, etc.). |
+
+
+## `invariantCheck`
+
+`lore invariant-check` (semantic linter) tuning.
+
+| Field | Type | Default | Constraints | Description |
+|---|---|---|---|---|
+| `effort` | enum | `"off"` |  | Reasoning effort for the invariant-check judge (off\|low\|medium\|high\|xhigh). Trades cost for depth on reasoning-capable models. Default: off. Override per-run with --effort. |
 


### PR DESCRIPTION
Adds a reasoning-**effort** dial to the `lore invariant-check` judge — a cost/depth trade on reasoning-capable models, without swapping the model. Vocabulary matches [Warden](https://warden.sentry.dev/)'s (`off | low | medium | high | xhigh`) so the two tools speak the same language.

## Why
Warden's benchmark shows judge quality is model-capability-bound. Effort lets a repo dial up depth on a capable model (or leave it `off` on cheap CI defaults like `github-models/openai/gpt-4o-mini`, which ignore the param) — a knob to tune recall vs. spend per repo.

## What
- **`core/effort.ts`** — `ReasoningEffort` + per-protocol mappings:
  - OpenAI → `reasoning_effort` (low/medium/high passthrough; `xhigh`→`high` clamp; `off`→omit)
  - Anthropic/Vertex → extended-thinking `budget_tokens` (low=2048 … xhigh=32768; `off`→none)
- **`LLMClient.prompt`** gains `reasoningEffort`; gateway worker builders honor it. When a thinking budget is set it **overrides** the default worker disable-thinking, raises `max_tokens` above the budget, and drops `temperature` (Anthropic rules). `undefined` → **byte-identical** to prior behavior for every existing worker caller.
- **`checkInvariants`** takes `effort`; judge `max_tokens` scales to budget+headroom when on.
- **Config** — `invariantCheck.effort` (enum, default `off`). **CLI** — `--effort` overrides config; invalid value is a pre-judge usage error (exit 1, swallowed by the advisory action). Surfaced in `--json` + report header. **GHA** — `effort` action input.

## Safety
Advisory contract preserved: effort never touches the gate/exit code. Existing background workers (distillation/curation/query-expansion) are unaffected — the review proved serialized request bodies are `===` for the `undefined`-effort case.

## Tests
Effort mapping unit table + config default/validation + gateway request-body **seam tests** (OpenAI `reasoning_effort` passthrough/clamp/omit; Anthropic budget + `max_tokens` bump + `temperature` drop). Mutation-verified: removing the `reasoning_effort` spread / `max_tokens` bump / `temperature` drop each kills tests. Core suite: 146 files pass; worker/llm-adapter gateway suite (8 files) pass.

## Review
Adversarial correctness review: **SHIP-WITH-FOLLOWUPS**, no BLOCKERs. Hot-path byte-identity proven, advisory-safe. The `xhigh`-ceiling SHOULD-FIX is documented and the headroom-constant NIT reconciled in this PR.