### PR TITLE
ci: bump Node 20 actions to Node 24 majors (deprecation)

### DIFF
--- a/.github/actions/invariant-check/action.yml
+++ b/.github/actions/invariant-check/action.yml
@@ -87,7 +87,7 @@ runs:
 
     - name: Restore derived invariant DB
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ runner.temp }}/lore-ci
         key: ${{ steps.key.outputs.key }}

--- a/.github/workflows/cch-seed-check.yml
+++ b/.github/workflows/cch-seed-check.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           fetch-tags: true  # fetch all tag refs for craft changelog
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -531,7 +531,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -564,7 +564,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -596,7 +596,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -627,7 +627,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -654,7 +654,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -694,7 +694,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -795,7 +795,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -878,7 +878,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -1386,7 +1386,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -1417,7 +1417,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install lore-hermes with test extras
@@ -1448,7 +1448,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install real hermes-agent + lore-hermes

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -53,7 +53,7 @@ jobs:
       models: read
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -98,12 +98,12 @@ jobs:
       models: read
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "24"

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           # Full history so merge-base against the PR base resolves.
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "24"


### PR DESCRIPTION
GitHub is [deprecating the Node 20 runner](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for Actions — node20 actions are being force-run on Node 24 with a warning. It surfaced on our `invariant-check` job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, pnpm/action-setup@v4

Rather than fix only the flagged job, this bumps **every** action still built on node20 across all workflows so the warning is gone repo-wide:

| Action | Before | After | Uses |
|---|---|---|---|
| `pnpm/action-setup` | v4 (node20) | **v6** (node24) | 19 across 7 workflows |
| `actions/cache` | v4 (node20) | **v5** (node24) | 1 (invariant-check composite; all others already v5) |
| `actions/setup-python` | v5 (node20) | **v6** (node24) | 3 (ci.yml, eval.yml) |

## Drop-in safety
- `pnpm/action-setup@v6`: no usage passes a `version:` input; pnpm resolves from `packageManager` (`pnpm@10.28.0`) — identical behavior to v4.
- `actions/setup-python@v6`: all 3 usages only pass `python-version` — unaffected by v6's changes.

## Audit
Verified every remaining action's runtime: `checkout@v6`, `setup-node@v6`, `upload-artifact@v7`, `download-artifact@v8`, `cache@v5`, `create-github-app-token@v3`, `dorny/paths-filter@v4`, `JamesIves/github-pages-deploy-action@v4` are all node24; `getsentry/craft@v2` and `rossjrw/pr-preview-action@v1` are composite. **No node20 actions remain.** `actionlint` clean.