### PR TITLE
perf(core): batch recordToolCalls tool_use seeds into one multi-row upsert (#1178 / 3G)

### DIFF
--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -163,37 +163,86 @@ export function recordToolCalls(input: {
   const pid = ensureProject(input.projectPath);
   const createdAt = input.info.time.created;
 
-  // Phase A: assistant tool_use parts — seed name + status. May already be
-  // resolved (e.g. host delivers completed state directly). On conflict, only
-  // overwrite outcome fields when the existing row is still `pending` — never
-  // revert a resolved row back to pending on a re-seed (retry / re-delivery).
-  const seedStmt = db().query(
-    `INSERT INTO tool_calls
-       (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(call_id) DO UPDATE SET
-       status = CASE WHEN tool_calls.status = 'pending' THEN excluded.status ELSE tool_calls.status END,
-       error_type = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_type ELSE tool_calls.error_type END,
-       error_message = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_message ELSE tool_calls.error_message END,
-       duration_ms = COALESCE(excluded.duration_ms, tool_calls.duration_ms),
-       -- verifier is derived from the tool_use input (stable across re-seeds);
-       -- keep the first non-null classification.
-       verifier = COALESCE(tool_calls.verifier, excluded.verifier)`,
-  );
+  // Split into the two phases up front so the seed (tool_use) phase can be
+  // flattened into ONE multi-row upsert instead of one INSERT per part. The
+  // per-part loop was flagged as an N+1 (LOREAI-GATEWAY-3G, #1178): each tool_use
+  // part emitted its own db.query.run span. tool_result parts stay per-part
+  // UPDATEs — each carries distinct outcome values keyed by its own call_id, so
+  // batching them buys little and complicates the INSERT-vs-UPDATE branching.
+  //
+  // INVARIANT the phase-split relies on: a single `parts` array never contains a
+  // tool_result AND the tool_use seed for the SAME call_id. tool_use blocks land
+  // only on assistant messages; tool_result blocks only on user messages (see
+  // contentBlockToPart), and each caller passes exactly one message's parts. So
+  // reordering "all seeds, then all results" can never move a result ahead of
+  // its own seed — the outcome is identical to the old in-order loop. If a future
+  // caller ever passes a mixed array, restore in-order processing.
+  const seeds = toolParts.filter((p) => p.tool !== "result");
+  const resultParts = toolParts.filter((p) => p.tool === "result");
+
+  // Phase A: assistant tool_use parts — seed name + status in a single
+  // multi-row INSERT (chunked). May already be resolved (e.g. host delivers
+  // completed state directly). On conflict, only overwrite outcome fields when
+  // the existing row is still `pending` — never revert a resolved row back to
+  // pending on a re-seed (retry / re-delivery). SQLite applies the VALUES rows
+  // in order and fires ON CONFLICT row-by-row, so a duplicate call_id within one
+  // batch resolves identically to the old sequential loop.
+  if (seeds.length) {
+    const COLS_PER_ROW = 11;
+    // Chunk the multi-row INSERT so a pathological batch can never exceed
+    // SQLite's bound-variable ceiling. We use the conservative ~900-param budget
+    // from the #796 chunking convention in db.ts (portable across SQLite builds,
+    // whose historical minimum ceiling is 999) — well under the ≥3.32 default of
+    // 32766. 81 rows × 11 cols = 891 params. A real turn has far fewer tool_use
+    // parts; this only matters for a pathological batch.
+    const CHUNK = Math.floor(900 / COLS_PER_ROW); // 81
+    const rowSql = `(${Array.from({ length: COLS_PER_ROW }, () => "?").join(", ")})`;
+    for (let i = 0; i < seeds.length; i += CHUNK) {
+      const batch = seeds.slice(i, i + CHUNK);
+      const seedStmt = db().query(
+        `INSERT INTO tool_calls
+           (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier)
+         VALUES ${Array.from({ length: batch.length }, () => rowSql).join(", ")}
+         ON CONFLICT(call_id) DO UPDATE SET
+           status = CASE WHEN tool_calls.status = 'pending' THEN excluded.status ELSE tool_calls.status END,
+           error_type = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_type ELSE tool_calls.error_type END,
+           error_message = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_message ELSE tool_calls.error_message END,
+           duration_ms = COALESCE(excluded.duration_ms, tool_calls.duration_ms),
+           -- verifier is derived from the tool_use input (stable across re-seeds);
+           -- keep the first non-null classification.
+           verifier = COALESCE(tool_calls.verifier, excluded.verifier)`,
+      );
+      const params: Array<string | number | null> = [];
+      for (const p of batch) {
+        const outcome = toolOutcome(p.tool, p.state);
+        params.push(
+          p.callID,
+          input.info.id,
+          pid,
+          input.info.sessionID,
+          p.tool,
+          outcome.status,
+          outcome.errorType,
+          outcome.errorMessage,
+          outcome.duration,
+          createdAt,
+          isVerifierCall(p.state.input) ? 1 : 0,
+        );
+      }
+      seedStmt.run(...params);
+    }
+  }
+
   // Phase B: user tool_result parts — update outcome by call_id, preserving
   // the previously-seeded tool name and message_id.
-  const updateStmt = db().query(
-    `UPDATE tool_calls
-       SET status = ?, error_type = ?, error_message = ?, duration_ms = ?
-     WHERE call_id = ?`,
-  );
-
-  for (const p of toolParts) {
-    const st = p.state;
-    const outcome = toolOutcome(p.tool, st);
-
-    if (p.tool === "result") {
-      // Outcome-only update; the tool name was seeded by the tool_use phase.
+  if (resultParts.length) {
+    const updateStmt = db().query(
+      `UPDATE tool_calls
+         SET status = ?, error_type = ?, error_message = ?, duration_ms = ?
+       WHERE call_id = ?`,
+    );
+    for (const p of resultParts) {
+      const outcome = toolOutcome(p.tool, p.state);
       updateStmt.run(
         outcome.status,
         outcome.errorType,
@@ -201,22 +250,7 @@ export function recordToolCalls(input: {
         outcome.duration,
         p.callID,
       );
-      continue;
     }
-
-    seedStmt.run(
-      p.callID,
-      input.info.id,
-      pid,
-      input.info.sessionID,
-      p.tool,
-      outcome.status,
-      outcome.errorType,
-      outcome.errorMessage,
-      outcome.duration,
-      createdAt,
-      isVerifierCall(st.input) ? 1 : 0,
-    );
   }
 }
 

--- a/packages/core/test/temporal.test.ts
+++ b/packages/core/test/temporal.test.ts
@@ -427,15 +427,17 @@ describe("temporal", () => {
     function rows(pid: string) {
       return db()
         .query(
-          "SELECT call_id, tool, status, error_type, error_message, duration_ms FROM tool_calls WHERE project_id = ? ORDER BY call_id",
+          "SELECT call_id, message_id, tool, status, error_type, error_message, duration_ms, verifier FROM tool_calls WHERE project_id = ? ORDER BY call_id",
         )
         .all(pid) as Array<{
         call_id: string;
+        message_id: string;
         tool: string;
         status: string;
         error_type: string | null;
         error_message: string | null;
         duration_ms: number | null;
+        verifier: number;
       }>;
     }
 
@@ -569,6 +571,214 @@ describe("temporal", () => {
       const r = rows(pid);
       expect(r[0].error_type).toBe("unknown");
       expect(r[0].error_message).toBeNull();
+    });
+
+    // --- Batching (LOREAI-GATEWAY-3G, #1178) -------------------------------
+    // The seed phase is now ONE multi-row INSERT for all tool_use parts. These
+    // tests pin the behavior that must survive the batch: many seeds in one
+    // call, mixed use+result parts in one call, the pending-guard on conflict,
+    // and duplicate call_ids within a single batch.
+
+    test("batches many tool_use seeds from one call into distinct rows", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      const info = makeMessage("tm-batch", "assistant", "sess-tool");
+      const parts: LorePart[] = [
+        toolPart("tm-batch", "b0", "read", { status: "pending", input: {} }),
+        toolPart("tm-batch", "b1", "bash", { status: "pending", input: {} }),
+        toolPart("tm-batch", "b2", "edit", { status: "pending", input: {} }),
+        toolPart("tm-batch", "b3", "grep", { status: "pending", input: {} }),
+        toolPart("tm-batch", "b4", "glob", { status: "pending", input: {} }),
+      ];
+      temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+
+      const r = rows(pid);
+      expect(r.length).toBe(5);
+      expect(r.map((x) => x.tool)).toEqual([
+        "read",
+        "bash",
+        "edit",
+        "grep",
+        "glob",
+      ]);
+      expect(r.every((x) => x.status === "pending")).toBe(true);
+    });
+
+    test("handles mixed tool_use + result parts in a single call", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      // Seed one call first (prior turn).
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-mix-a", "assistant", "sess-tool"),
+        parts: [
+          toolPart("tm-mix-a", "m0", "read", { status: "pending", input: {} }),
+        ],
+      });
+      // Now a single call that BOTH resolves m0 (result) AND seeds a new use m1.
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-mix-b", "assistant", "sess-tool"),
+        parts: [
+          toolPart("tm-mix-b", "m0", "result", {
+            status: "completed",
+            input: null,
+            output: "ok",
+            time: { start: 10, end: 40 },
+          }),
+          toolPart("tm-mix-b", "m1", "bash", { status: "pending", input: {} }),
+        ],
+      });
+
+      const r = rows(pid);
+      expect(r.length).toBe(2);
+      const m0 = r.find((x) => x.call_id === "m0");
+      expect(m0?.tool).toBe("read"); // seeded name preserved through result
+      expect(m0?.status).toBe("completed");
+      expect(m0?.duration_ms).toBe(30);
+      const m1 = r.find((x) => x.call_id === "m1");
+      expect(m1?.tool).toBe("bash");
+      expect(m1?.status).toBe("pending");
+    });
+
+    test("re-seed does NOT revert a resolved row to pending (pending-guard)", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      // Seed + resolve.
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-g-a", "assistant", "sess-tool"),
+        parts: [
+          toolPart("tm-g-a", "g0", "read", { status: "pending", input: {} }),
+        ],
+      });
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-g-b", "user", "sess-tool"),
+        parts: [
+          toolPart("tm-g-b", "g0", "result", {
+            status: "completed",
+            input: null,
+            output: "done",
+            time: { start: 1, end: 5 },
+          }),
+        ],
+      });
+      // A duplicate tool_use re-seed (retry / stream re-delivery) alongside a new
+      // seed — the batched INSERT must keep g0 completed, not revert to pending.
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-g-c", "assistant", "sess-tool"),
+        parts: [
+          toolPart("tm-g-c", "g0", "read", { status: "pending", input: {} }),
+          toolPart("tm-g-c", "g1", "bash", { status: "pending", input: {} }),
+        ],
+      });
+
+      const r = rows(pid);
+      expect(r.find((x) => x.call_id === "g0")?.status).toBe("completed");
+      expect(r.find((x) => x.call_id === "g1")?.status).toBe("pending");
+    });
+
+    test("batches the verifier flag and message_id per row", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      // One batch with a verifier call (leading `npm test`) and a non-verifier
+      // call — the per-row verifier classification must survive batching.
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-vf", "assistant", "sess-tool"),
+        parts: [
+          toolPart("tm-vf", "v0", "bash", {
+            status: "pending",
+            input: { command: "npm test" },
+          }),
+          toolPart("tm-vf", "v1", "bash", {
+            status: "pending",
+            input: { command: "ls -la" },
+          }),
+        ],
+      });
+      const r = rows(pid);
+      expect(r.find((x) => x.call_id === "v0")?.verifier).toBe(1);
+      expect(r.find((x) => x.call_id === "v1")?.verifier).toBe(0);
+      // message_id seeded from the assistant message on every batched row.
+      expect(r.every((x) => x.message_id === "tm-vf")).toBe(true);
+    });
+
+    test("result update preserves the batched seed's message_id", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-mid-asst", "assistant", "sess-tool"),
+        parts: [
+          toolPart("tm-mid-asst", "p0", "read", {
+            status: "pending",
+            input: {},
+          }),
+        ],
+      });
+      // Result comes on a DIFFERENT (user) message; the seeded message_id must
+      // be preserved (the UPDATE does not touch message_id).
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info: makeMessage("tm-mid-user", "user", "sess-tool"),
+        parts: [
+          toolPart("tm-mid-user", "p0", "result", {
+            status: "completed",
+            input: null,
+            output: "ok",
+            time: { start: 1, end: 3 },
+          }),
+        ],
+      });
+      const r = rows(pid);
+      expect(r.length).toBe(1);
+      expect(r[0].message_id).toBe("tm-mid-asst"); // seed's id, not the result's
+      expect(r[0].status).toBe("completed");
+    });
+
+    test("inserts every row when the seed batch spans multiple chunks", () => {
+      // The seed INSERT is chunked (CHUNK=81) so a pathological batch can never
+      // exceed SQLite's conservative ~999 bound-variable ceiling (the #796
+      // convention). This asserts the chunk LOOP is correct: a batch larger than
+      // one chunk still inserts every distinct row across the boundary.
+      const pid = ensureProject(TOOL_PROJECT);
+      const info = makeMessage("tm-chunk", "assistant", "sess-tool");
+      const N = 200; // > 2 chunks
+      const parts: LorePart[] = Array.from({ length: N }, (_, i) =>
+        toolPart("tm-chunk", `c${i}`, "read", {
+          status: "pending",
+          input: {},
+        }),
+      );
+      temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+
+      const r = rows(pid);
+      expect(r.length).toBe(N);
+      // Every call_id present exactly once, all seeded pending.
+      const ids = new Set(r.map((x) => x.call_id));
+      expect(ids.size).toBe(N);
+      expect(r.every((x) => x.status === "pending" && x.tool === "read")).toBe(
+        true,
+      );
+    });
+
+    test("duplicate call_id within one batch resolves like the sequential loop", () => {
+      const pid = ensureProject(TOOL_PROJECT);
+      // Same call_id twice in a single seed batch: first inserts pending, second
+      // hits ON CONFLICT — since the row is pending, the (identical) values apply
+      // and the net result is a single pending row (last-writer within batch).
+      const info = makeMessage("tm-dup", "assistant", "sess-tool");
+      temporal.recordToolCalls({
+        projectPath: TOOL_PROJECT,
+        info,
+        parts: [
+          toolPart("tm-dup", "d0", "read", { status: "pending", input: {} }),
+          toolPart("tm-dup", "d0", "read", { status: "pending", input: {} }),
+        ],
+      });
+      const r = rows(pid);
+      expect(r.length).toBe(1);
+      expect(r[0].call_id).toBe("d0");
+      expect(r[0].tool).toBe("read");
+      expect(r[0].status).toBe("pending");
     });
   });
 });


### PR DESCRIPTION
Closes the remaining item in #1178. **3E (per-candidate FTS N+1) was already fixed and merged in PR #1265** (`searchDistillationsFTSBatch`, single `UNION ALL`), so only 3G remained.

## 3G — per-tool-call `tool_calls` upsert (`recordToolCalls`)

`temporal.ts` looped `seedStmt.run(...)` once per `tool_use` part, so Sentry saw an N+1 (one `db.query.run` span per part) under `POST /v1/chat/completions`.

### Change
- Split the parts up front: `tool_use` **seeds** vs `tool_result` **outcome updates**.
- **Seed phase** is now ONE multi-row `INSERT ... VALUES (…),(…) ON CONFLICT(call_id) DO UPDATE …`, chunked at 81 rows (11 cols/row) to stay under SQLite's conservative ~999 bound-variable ceiling — following the existing #796 chunking convention in `db.ts`. All original upsert semantics preserved verbatim: the pending-guard (`CASE WHEN status='pending'`), `duration_ms`/`verifier` `COALESCE`, and name preservation.
- **Result phase** stays per-part `UPDATE`s — each carries distinct outcome values keyed by its own `call_id`, so batching them buys little and complicates the INSERT-vs-UPDATE branching (per the issue's own note).
- Still runs inside the caller's single `withSavepoint("post_response_temporal", …)`; no transaction-nesting change.

SQLite applies multi-row VALUES in order and fires `ON CONFLICT` row-by-row, so a duplicate `call_id` within one batch resolves identically to the old sequential loop.

### Tests (`temporal.test.ts`, all 33 pass; core suite 3065 pass)
New coverage on top of the existing 6:
- batches many seeds into distinct rows;
- mixed `tool_use` + `result` parts in a single call;
- re-seed does NOT revert a resolved row to pending (pending-guard, across the batch);
- inserts every row when the batch spans multiple chunks (chunk-loop correctness);
- duplicate `call_id` within one batch behaves like the sequential loop.

Non-vacuous: reverting the pending-guard fails the guard test; treating results as seeds fails the orphan-no-op test; an off-by-one in the chunk loop fails the multi-chunk test. typecheck + oxlint + format clean.