### PR TITLE
feat(gateway): wire discover→invite + auto-deploy Edge Functions (E-5-d-2, #630)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,49 @@
+name: Deploy Supabase Functions
+
+# Auto-deploy the Edge Functions on merge to main so we never rely on someone remembering to run
+# `supabase functions deploy` from a local branch (unsafe + unsustainable). Migrations already deploy
+# via the Supabase↔GitHub integration; this covers the functions, which that integration does NOT.
+#
+# One-time setup (required): add a repo secret SUPABASE_ACCESS_TOKEN
+#   (Supabase dashboard → Account → Access Tokens → generate; then
+#    `gh secret set SUPABASE_ACCESS_TOKEN`). Function SECRETS (e.g. SMTP2GO_API_KEY) are set
+#   separately via `supabase secrets set` and are NOT managed here.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/functions/**"
+      - "supabase/config.toml"
+      - ".github/workflows/deploy-functions.yml"
+  # Manual re-deploy escape hatch.
+  workflow_dispatch:
+
+# Never let two deploys race; the newest merge wins.
+concurrency:
+  group: deploy-functions
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Edge Functions
+    runs-on: ubuntu-latest
+    # The project ref is not a secret (it's in supabase/config.toml); the access token is.
+    env:
+      SUPABASE_PROJECT_REF: jlwxsrmvomocgngbxmcf
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Fail fast if the access token is missing
+        run: |
+          if [ -z "${SUPABASE_ACCESS_TOKEN}" ]; then
+            echo "::error::SUPABASE_ACCESS_TOKEN is not set. Add it as a repo secret (Supabase → Account → Access Tokens)."
+            exit 1
+          fi
+      # Deploy every function under supabase/functions. `deploy` with no function name deploys all of
+      # them; --project-ref avoids needing an interactive `supabase link`.
+      - name: Deploy all Edge Functions
+        run: supabase functions deploy --project-ref "${SUPABASE_PROJECT_REF}"

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -4205,6 +4205,21 @@ export function resolveWritableScope(
   return scope;
 }
 
+/**
+ * The caller's role in a scope from the local registry mirror, or null if they are not a member.
+ * A read-only convenience over the mirror — the authoritative role check is always server-side (RLS
+ * / RPC). Used e.g. to pre-check "only admins may invite" client-side before firing per-member RPCs.
+ */
+export function scopeMemberRole(
+  scopeId: string,
+  userId: string,
+): string | null {
+  const m = db()
+    .query("SELECT role FROM scope_members WHERE scope_id = ? AND user_id = ?")
+    .get(scopeId, userId) as { role: string } | null;
+  return m?.role ?? null;
+}
+
 /** Look up a project's display name by its internal ID. */
 export function projectName(id: string): string | null {
   const row = db().query("SELECT name FROM projects WHERE id = ?").get(id) as {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,7 @@ export {
   setProjectPromotionPolicy,
   effectivePromotionPolicy,
   resolveWritableScope,
+  scopeMemberRole,
   resolveProjectByRemoteOrPath,
   mergeProjectInternal,
   convergeProjectsByRemote,

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -136,6 +136,8 @@ const OPTIONS = {
   email: { type: "string" as const },
   role: { type: "string" as const },
   offline: { type: "boolean" as const },
+  // `lore team discover --invite <scope>` (E-5-d-2): mint invites for discovered collaborators.
+  invite: { type: "string" as const },
   verify: { type: "boolean" as const },
   "no-browser": { type: "boolean" as const },
   // Hidden diagnostic: prints the vendored-model registration set by

--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -8,7 +8,9 @@ import {
   keystore,
   ltm,
   projectId,
+  projectScope,
   resolveWritableScope,
+  scopeMemberRole,
   setProjectPromotionPolicy,
   setProjectScope,
   syncData,
@@ -23,6 +25,7 @@ import {
   createTeam,
   createTeamInvite,
   discoverGitHubCollaborators,
+  distinctCollaborators,
   isEmailAddress,
   listDomainJoinRequests,
   listTeams,
@@ -35,7 +38,7 @@ import {
 } from "../team";
 
 const USAGE =
-  "Usage: lore team [list | members <scope> | discover [repo...] | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite <scope> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>] | domain <claim <org> <domain> [--role member] | request <org> <domain> | requests <org> | approve <request-id> | reject <request-id>>]";
+  "Usage: lore team [list | members <scope> | discover [repo...] [--invite <scope>] [--role editor|viewer] | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite <scope> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>] | domain <claim <org> <domain> [--role member] | request <org> <domain> | requests <org> | approve <request-id> | reject <request-id>>]";
 
 export async function commandTeam(
   positionals: string[],
@@ -134,9 +137,84 @@ export async function commandTeam(
             );
           }
         }
+
+        // E-5-d-2: --invite <scope> mints an invite per DISTINCT collaborator so the admin can hand
+        // out join links. Invite-only for everyone (on-Lore or not) — we never expose Lore user_ids,
+        // so there is no direct auto-add; an on-Lore invitee just gets a frictionless `accept`.
+        // GitHub's API returns no collaborator emails, so links are printed rather than auto-emailed.
+        const inviteRef = values.invite as string | undefined;
+        if (inviteRef !== undefined) {
+          // A trailing `--invite` with no value parses as `true` under strict:false — reject it
+          // clearly instead of letting a non-string reach the scope lookup.
+          if (typeof inviteRef !== "string") {
+            console.error("`--invite` requires a team name or id.");
+            process.exitCode = 1;
+            return;
+          }
+          const user = await getCurrentUser();
+          if (!user) {
+            console.error("Not logged in — run `lore login` first.");
+            process.exitCode = 1;
+            return;
+          }
+          // Resolve the target scope: an explicit team name/id, or — when the value doesn't resolve
+          // and the cwd is a project already linked to a team — that linked scope (repo→scope corr.).
+          let scope = resolveWritableScope(inviteRef, user.user_id);
+          if (!scope) {
+            const pid = projectId(process.cwd());
+            const linked = pid ? projectScope(pid) : null;
+            if (linked) scope = resolveWritableScope(linked, user.user_id);
+          }
+          if (!scope) {
+            console.error(
+              `\nNo team "${inviteRef}" you can invite to. Pass a team name/id you administer ` +
+                "(see `lore team list`), or run this from a project linked with `lore team link`.",
+            );
+            process.exitCode = 1;
+            return;
+          }
+          // Only admins may mint invites (server enforces this too). Pre-check the local mirror so an
+          // editor gets ONE clear message instead of N identical per-collaborator RPC rejections.
+          if (scopeMemberRole(scope.id, user.user_id) !== "admin") {
+            console.error(
+              `\nYou must be an admin of "${scope.name ?? scope.id}" to invite members.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const inviteRole =
+            (values.role as string) === "viewer" ? "viewer" : "editor";
+          const people = distinctCollaborators(found);
+          console.log(
+            `\nMinting ${inviteRole} invites to "${scope.name ?? scope.id}" for ${people.length} collaborator${people.length === 1 ? "" : "s"}:`,
+          );
+          for (const c of people) {
+            try {
+              const token = await createTeamInvite(
+                client,
+                scope.id,
+                inviteRole,
+              );
+              console.log(
+                `  ${c.login}${c.onLore ? " (on Lore)" : ""}:\n    lore team accept ${token}`,
+              );
+            } catch (e) {
+              console.error(
+                `  ${c.login}: invite failed — ${(e as Error).message}`,
+              );
+            }
+          }
+          console.log(
+            "\nShare each link with the matching collaborator (GitHub doesn't expose their email). " +
+              "To email an address directly, use `lore team invite <scope> --email <addr>`.",
+          );
+          break;
+        }
+
         console.log(
           `\n${onLoreTotal} collaborator${onLoreTotal === 1 ? "" : "s"} already on Lore, ` +
-            `${offLoreTotal} not yet. Invite them with \`lore team invite <scope>\` (share the link).`,
+            `${offLoreTotal} not yet. Invite them with \`lore team discover --invite <scope>\` ` +
+            "or `lore team invite <scope> --email <addr>`.",
         );
         break;
       }

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -75,6 +75,23 @@ export async function discoverGitHubCollaborators(
   }));
 }
 
+/**
+ * The DISTINCT collaborators across all discovered repos, deduped by GitHub login (a person on
+ * several repos should get one invite, not one per repo). Sorted for stable output. Used by
+ * `lore team discover --invite` to mint one invite per person (E-5-d-2).
+ */
+export function distinctCollaborators(
+  repos: DiscoveredRepo[],
+): DiscoveredCollaborator[] {
+  const byLogin = new Map<string, DiscoveredCollaborator>();
+  for (const r of repos)
+    for (const c of r.collaborators)
+      if (!byLogin.has(c.login)) byLogin.set(c.login, c);
+  return Array.from(byLogin.values()).sort((a, b) =>
+    a.login.localeCompare(b.login),
+  );
+}
+
 async function selfUserId(): Promise<string> {
   const u = await getCurrentUser();
   if (!u) throw new Error("not logged in — run `lore login` first");

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -28,6 +28,24 @@ vi.mock("../src/team", () => ({
   sendInviteEmail: vi.fn(),
   // Pure predicate — use the real implementation so --email routing behaves in tests.
   isEmailAddress: (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.trim()),
+  // Pure dedupe helper — real impl so the discover --invite path yields the expected people.
+  distinctCollaborators: (
+    repos: Array<{ collaborators: Array<{ login: string }> }>,
+  ) => {
+    const seen = new Map<string, { login: string }>();
+    for (const r of repos)
+      for (const c of r.collaborators)
+        if (!seen.has(c.login)) seen.set(c.login, c);
+    return Array.from(seen.values()).sort((a, b) =>
+      a.login.localeCompare(b.login),
+    );
+  },
+}));
+
+// `lore team discover` re-runs GitHub OAuth for a fresh provider_token; mock it so the CLI test can
+// exercise the discover/--invite flow without a real OAuth dance.
+vi.mock("../src/cli/login", () => ({
+  acquireGitHubProviderToken: vi.fn(),
 }));
 
 import {
@@ -40,6 +58,7 @@ import {
 } from "@loreai/core";
 import { getAuthedClient, getCurrentUser } from "../src/supabase";
 import { commandTeam } from "../src/cli/team-cmd";
+import { acquireGitHubProviderToken } from "../src/cli/login";
 import * as team from "../src/team";
 
 const FAKE_CLIENT = { id: "client" } as never;
@@ -584,5 +603,101 @@ describe("review / approve / reject / policy (E-5-F3-2)", () => {
     await commandTeam(["policy", "bogus"], { project: PROJECT });
     expect(process.exitCode).toBe(1);
     expect(errs.join("\n")).toMatch(/Usage: lore team/);
+  });
+});
+
+describe("discover --invite (E-5-d-2)", () => {
+  beforeEach(() => {
+    db().exec("DELETE FROM scopes");
+    db().exec("DELETE FROM scope_members");
+    db()
+      .query(
+        "INSERT INTO scopes (id, org_id, kind, name, promotion_policy, created_at, updated_at) VALUES ('s9','o1','team','Rockets','manual',0,0)",
+      )
+      .run();
+    db()
+      .query(
+        "INSERT INTO scope_members (scope_id, user_id, role, created_at, updated_at) VALUES ('s9','u1','admin',0,0)",
+      )
+      .run();
+    vi.mocked(getCurrentUser).mockResolvedValue({ user_id: "u1" } as never);
+    vi.mocked(acquireGitHubProviderToken).mockResolvedValue({
+      client: FAKE_CLIENT,
+      providerToken: "gho_x",
+    });
+    vi.mocked(team.discoverGitHubCollaborators).mockResolvedValue([
+      {
+        repo: "o/a",
+        collaborators: [
+          { login: "alice", githubId: 1, onLore: true },
+          { login: "bob", githubId: 2, onLore: false },
+        ],
+      },
+      {
+        repo: "o/b",
+        collaborators: [{ login: "bob", githubId: 2, onLore: false }],
+      },
+    ] as never);
+  });
+
+  it("mints ONE invite per distinct collaborator and prints accept links", async () => {
+    vi.mocked(team.createTeamInvite)
+      .mockResolvedValueOnce("tok-alice")
+      .mockResolvedValueOnce("tok-bob");
+    await commandTeam(["discover", "--invite", "Rockets"], {
+      invite: "Rockets",
+    });
+    // bob appears on two repos → deduped to a single invite (2 people, not 3).
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledTimes(2);
+    // resolved to the team scope id + default editor role.
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s9",
+      "editor",
+    );
+    const out = logs.join("\n");
+    expect(out).toMatch(/lore team accept tok-alice/);
+    expect(out).toMatch(/lore team accept tok-bob/);
+    expect(out).toMatch(/alice \(on Lore\)/);
+  });
+
+  it("honors --role viewer", async () => {
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok");
+    await commandTeam(["discover", "--invite", "Rockets"], {
+      invite: "Rockets",
+      role: "viewer",
+    });
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s9",
+      "viewer",
+    );
+  });
+
+  it("refuses when the scope can't be resolved (no team, no linked project) → exit 1", async () => {
+    await commandTeam(["discover", "--invite", "Nonexistent"], {
+      invite: "Nonexistent",
+    });
+    expect(process.exitCode).toBe(1);
+    expect(errs.join("\n")).toMatch(/No team "Nonexistent"/);
+    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+  });
+
+  it("refuses an editor caller (only admins may invite) before firing any RPC → exit 1", async () => {
+    db()
+      .query("UPDATE scope_members SET role='editor' WHERE scope_id='s9'")
+      .run();
+    await commandTeam(["discover", "--invite", "Rockets"], {
+      invite: "Rockets",
+    });
+    expect(process.exitCode).toBe(1);
+    expect(errs.join("\n")).toMatch(/must be an admin/);
+    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+  });
+
+  it("without --invite, only lists (no invites minted)", async () => {
+    await commandTeam(["discover"], {});
+    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+    expect(logs.join("\n")).toMatch(/already on Lore/);
   });
 });

--- a/packages/gateway/test/team.test.ts
+++ b/packages/gateway/test/team.test.ts
@@ -32,6 +32,7 @@ import {
   claimOrgDomain,
   createTeam,
   createTeamInvite,
+  distinctCollaborators,
   listTeams,
   rejectDomainJoin,
   removeTeamMember,
@@ -591,5 +592,54 @@ describe("domain auto-join RPC wrappers (E-5-b)", () => {
       name: "reject_domain_join",
       params: { p_request_id: "req-9" },
     });
+  });
+});
+
+describe("distinctCollaborators (E-5-d-2)", () => {
+  const repo = (name: string, cols: Array<[string, boolean]>) => ({
+    repo: name,
+    collaborators: cols.map(([login, onLore]) => ({
+      login,
+      githubId: login.length,
+      onLore,
+    })),
+  });
+
+  it("dedupes a person appearing on multiple repos by login", () => {
+    const out = distinctCollaborators([
+      repo("o/a", [
+        ["alice", true],
+        ["bob", false],
+      ]),
+      repo("o/b", [
+        ["bob", false],
+        ["carol", false],
+      ]),
+    ]);
+    expect(out.map((c) => c.login)).toEqual(["alice", "bob", "carol"]);
+  });
+
+  it("keeps the FIRST occurrence's data on a login collision (stable dedupe)", () => {
+    const out = distinctCollaborators([
+      repo("o/a", [["bob", true]]),
+      repo("o/b", [["bob", false]]),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].onLore).toBe(true); // first-seen wins
+  });
+
+  it("sorts by login for stable output", () => {
+    const out = distinctCollaborators([
+      repo("o/a", [
+        ["zed", false],
+        ["amy", false],
+      ]),
+    ]);
+    expect(out.map((c) => c.login)).toEqual(["amy", "zed"]);
+  });
+
+  it("returns [] for no repos / no collaborators", () => {
+    expect(distinctCollaborators([])).toEqual([]);
+    expect(distinctCollaborators([repo("o/empty", [])])).toEqual([]);
   });
 });

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -26,3 +26,15 @@ enable_signup = true
 # E-5-a (#827): mirrors GitHub org/team memberships into Lore teams. verify_jwt=true so only a
 # signed-in user can invoke it; it then uses their provider_token to read memberships from GitHub.
 verify_jwt = true
+
+[functions.github-discover]
+# E-5-d (#630): discovers which of the caller's GitHub repo collaborators already have a Lore
+# account. verify_jwt=true so only a signed-in user can invoke it; it binds their provider_token to
+# their identity and reads collaborators with the caller's own GitHub access.
+verify_jwt = true
+
+[functions.send-invite-email]
+# E-5-e (#630/#827): emails a team invitee their join link via SMTP2GO. verify_jwt=true; the function
+# authorizes on the invite token (caller must be the scope admin who created it). Requires the
+# SMTP2GO_API_KEY function secret.
+verify_jwt = true


### PR DESCRIPTION
Closes the loop from E-5-d Slice 1 (#1388): `lore team discover [repo...] --invite <scope>` now **mints team invites** for the discovered collaborators. Also adds **auto-deploy** for the Supabase Edge Functions (so we stop relying on manual `supabase functions deploy`).

## discover → invite
- **Invite-only for everyone** (on-Lore or not): mints one `create_scope_invite` per **distinct** collaborator (deduped by GitHub login via `distinctCollaborators`) and prints a `lore team accept <token>` link each. We never expose Lore user_ids → no direct auto-add; an on-Lore invitee just gets a frictionless accept.
- **Scope resolution**: `--invite <team-name-or-id>` via `resolveWritableScope`; if that doesn't resolve and the cwd is a project linked with `lore team link`, falls back to that linked scope (**repo→scope correlation**). `--role editor|viewer` (default editor). `invite` declared in the global OPTIONS map (undeclared string flags silently become booleans under `strict:false` — #696).
- GitHub's `/collaborators` returns no email → links are printed; use `lore team invite <scope> --email <addr>` (E-5-e) to email a known address.

## Auto-deploy Edge Functions 🔧 (sustainability)
- New **`.github/workflows/deploy-functions.yml`**: on push to `main` touching `supabase/functions/**` or `config.toml`, runs `supabase functions deploy` for the project. Migrations already deploy via the Supabase↔GitHub integration; **functions did not** — they relied on a human remembering to deploy from a local branch (unsafe/unsustainable).
  - **⚠️ One-time setup required:** add a `SUPABASE_ACCESS_TOKEN` repo secret (Supabase → Account → Access Tokens; `gh secret set SUPABASE_ACCESS_TOKEN`). The job fails fast with a clear message if absent. Function *secrets* (e.g. `SMTP2GO_API_KEY`) are still set via `supabase secrets set` — not managed by CI.
- Added `[functions.github-discover]` + `[functions.send-invite-email]` to `config.toml` (verify_jwt=true) so all three functions are declared (matching github-provision).

## Tests
- `distinctCollaborators` unit (dedupe across repos / first-occurrence wins / sort / empty).
- CLI `discover --invite`: one invite per distinct person (bob on 2 repos → 1 invite), `--role viewer`, scope-resolution failure → exit 1, and no-`--invite` lists only.
- Typecheck / lint / format clean; 205 gateway unit tests green across the touched suites.