### PR TITLE
fix(team): empty-discover guard + prod env for fn deploy + deflake reaper test (#1396/#1397)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -4,10 +4,11 @@ name: Deploy Supabase Functions
 # `supabase functions deploy` from a local branch (unsafe + unsustainable). Migrations already deploy
 # via the Supabase↔GitHub integration; this covers the functions, which that integration does NOT.
 #
-# One-time setup (required): add a repo secret SUPABASE_ACCESS_TOKEN
-#   (Supabase dashboard → Account → Access Tokens → generate; then
-#    `gh secret set SUPABASE_ACCESS_TOKEN`). Function SECRETS (e.g. SMTP2GO_API_KEY) are set
-#   separately via `supabase secrets set` and are NOT managed here.
+# One-time setup (required): add SUPABASE_ACCESS_TOKEN as a secret on the `production` GitHub
+#   Environment (Settings → Environments → production → Secrets), NOT as a plain repo secret — this
+#   job runs with `environment: production` so the token is only exposed to it.
+#   (Supabase dashboard → Account → Access Tokens → generate the value.) Function SECRETS
+#   (e.g. SMTP2GO_API_KEY) are set separately via `supabase secrets set` and are NOT managed here.
 
 on:
   push:
@@ -28,6 +29,9 @@ jobs:
   deploy:
     name: Deploy Edge Functions
     runs-on: ubuntu-latest
+    # Run in the `production` environment so the SUPABASE_ACCESS_TOKEN secret — scoped to that
+    # environment for security (not a plain repo secret) — is available to this job only.
+    environment: production
     # The project ref is not a secret (it's in supabase/config.toml); the access token is.
     env:
       SUPABASE_PROJECT_REF: jlwxsrmvomocgngbxmcf

--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -185,6 +185,12 @@ export async function commandTeam(
           const inviteRole =
             (values.role as string) === "viewer" ? "viewer" : "editor";
           const people = distinctCollaborators(found);
+          if (people.length === 0) {
+            console.log(
+              "\nNo collaborators to invite (the accessible repos have none). Nothing minted.",
+            );
+            break;
+          }
           console.log(
             `\nMinting ${inviteRole} invites to "${scope.name ?? scope.id}" for ${people.length} collaborator${people.length === 1 ? "" : "s"}:`,
           );

--- a/packages/gateway/test/sync-security.integration.test.ts
+++ b/packages/gateway/test/sync-security.integration.test.ts
@@ -1582,8 +1582,12 @@ describe.skipIf(SKIP)(
       );
       expect(Number(rr[0].n)).toBeGreaterThanOrEqual(1); // >= our 1 stale eph (reap is global)
 
-      // Real wrap survives; recent eph survives; stale eph gone.
-      expect(await remainingKeys(a)).toEqual([a, "eph:NEWPUB"]);
+      // Real wrap survives; recent eph survives; stale eph gone. Compare as a SET — `remainingKeys`
+      // orders by member_user_id, and a random user UUID can sort before OR after the "eph:" literal,
+      // which previously made this assertion flaky (#1397).
+      expect(new Set(await remainingKeys(a))).toEqual(
+        new Set([a, "eph:NEWPUB"]),
+      );
     });
 
     it("retention_days=0 reaps every eph row but NEVER a real member wrap", async () => {
@@ -1591,7 +1595,7 @@ describe.skipIf(SKIP)(
       await insKey(a, a, recentTs()); // real wrap, even recent → never touched
       await insKey(a, "eph:P", recentTs()); // recent eph, but window 0 → reaped
       await h.client.query("select public.reap_ephemeral_scope_keys(0)");
-      expect(await remainingKeys(a)).toEqual([a]); // only the real wrap remains
+      expect(new Set(await remainingKeys(a))).toEqual(new Set([a])); // only the real wrap remains
     });
 
     it("is not executable by a normal (authenticated) user — system task only", async () => {

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -700,4 +700,17 @@ describe("discover --invite (E-5-d-2)", () => {
     expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
     expect(logs.join("\n")).toMatch(/already on Lore/);
   });
+
+  it("with --invite but repos have no collaborators: mints nothing, says so (no confusing '0 collaborators')", async () => {
+    vi.mocked(team.discoverGitHubCollaborators).mockResolvedValue([
+      { repo: "o/empty", collaborators: [] },
+    ] as never);
+    await commandTeam(["discover", "--invite", "Rockets"], {
+      invite: "Rockets",
+    });
+    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+    const out = logs.join("\n");
+    expect(out).toMatch(/No collaborators to invite/);
+    expect(out).not.toMatch(/for 0 collaborators/);
+  });
 });


### PR DESCRIPTION
Three small follow-ups after E-5-d-2 (#1396):

1. **#1396 review (LOW bug):** `lore team discover --invite <scope>` on repos that exist but have **no collaborators** printed `Minting … for 0 collaborators:` + share instructions — implying an action when nothing happened. Now guards `people.length === 0` and prints `No collaborators to invite (…). Nothing minted.` before the mint loop. (+1 CLI test.)

2. **prod environment for the deploy workflow:** `SUPABASE_ACCESS_TOKEN` is stored as a secret on the `production` GitHub Environment (scoped, not a plain repo secret) for security. Added `environment: production` to the deploy job so the token is exposed only there; header docs updated.

3. **#1397 (flaky test):** the ephemeral-invite reaper integration test asserted `remainingKeys(a)` (ordered by `member_user_id`) `toEqual([a, "eph:NEWPUB"])`. A random user UUID can sort before **or** after the `"eph:"` literal, so the order flipped intermittently (observed `[ 'eph:NEWPUB', … ]` on #1396's CI run). Switched both reaper tests to order-independent `Set` comparison. Root-caused in #1397.

Typecheck / lint / format / actionlint clean; team-cmd 57→58; reaper describe block green locally.