### PR TITLE
fix(import): make `lore import` authenticate + stop zero-result imports poisoning the auto-import gate

### DIFF
--- a/packages/core/src/import/extract.ts
+++ b/packages/core/src/import/extract.ts
@@ -51,6 +51,16 @@ export type ExtractionResult = {
   chunksProcessed: number;
   /** Chunks that failed (LLM error) */
   chunksFailed: number;
+  /**
+   * Chunks for which the LLM actually returned a response (non-null). A no-auth
+   * call returns null WITHOUT throwing, so it counts as neither processed-error
+   * nor answered. Callers use this to distinguish "the model answered but found
+   * nothing worth keeping" (safe to mark the source imported) from "the model
+   * never answered — auth/capability failure" (do NOT mark imported, so a later
+   * run retries). `chunksAnswered === 0` on a non-empty chunk set means the
+   * extraction never authenticated / never ran for real.
+   */
+  chunksAnswered: number;
 };
 
 /**
@@ -74,6 +84,7 @@ export async function extractKnowledge(input: {
     deleted: 0,
     chunksProcessed: 0,
     chunksFailed: 0,
+    chunksAnswered: 0,
   };
 
   // Sort chunks chronologically so knowledge builds up naturally
@@ -111,6 +122,7 @@ export async function extractKnowledge(input: {
       );
 
       if (response) {
+        result.chunksAnswered++;
         const ops = parseOps(response);
         const applied = applyOps(ops, {
           projectPath: input.projectPath,

--- a/packages/core/test/import/extract.test.ts
+++ b/packages/core/test/import/extract.test.ts
@@ -54,6 +54,7 @@ describe("extractKnowledge", () => {
     expect(result.updated).toBe(0);
     expect(result.chunksProcessed).toBe(1);
     expect(result.chunksFailed).toBe(0);
+    expect(result.chunksAnswered).toBe(1);
 
     // Verify entry was actually created
     const entries = ltm.forProject(PROJECT_PATH, false);
@@ -74,6 +75,9 @@ describe("extractKnowledge", () => {
     expect(result.created).toBe(0);
     expect(result.chunksProcessed).toBe(1);
     expect(result.chunksFailed).toBe(0);
+    // The model answered (with an empty list) — this counts as answered, so a
+    // caller may safely mark the source imported (nothing worth keeping).
+    expect(result.chunksAnswered).toBe(1);
   });
 
   test("handles null LLM response", async () => {
@@ -88,6 +92,10 @@ describe("extractKnowledge", () => {
     expect(result.created).toBe(0);
     expect(result.chunksProcessed).toBe(1);
     expect(result.chunksFailed).toBe(0);
+    // A null response is the no-auth signal (prompt returns null without
+    // throwing). chunksAnswered stays 0 so callers do NOT mark the source
+    // imported — a later run with a credential retries.
+    expect(result.chunksAnswered).toBe(0);
   });
 
   test("handles LLM errors gracefully", async () => {
@@ -104,6 +112,7 @@ describe("extractKnowledge", () => {
     expect(result.created).toBe(0);
     expect(result.chunksProcessed).toBe(0);
     expect(result.chunksFailed).toBe(1);
+    expect(result.chunksAnswered).toBe(0);
   });
 
   test("processes multiple chunks sequentially", async () => {

--- a/packages/gateway/src/cli/import-auto.ts
+++ b/packages/gateway/src/cli/import-auto.ts
@@ -109,17 +109,23 @@ export async function maybeAutoImport(
       "[lore] Import knowledge from them?",
   );
 
-  // Record decline sentinels BEFORE any background work — prevents a second
-  // `lore run` from re-prompting while the background import is still running.
-  // On accept, the sentinels are harmless: real recordImport() rows (with actual
-  // session source_ids) are written later and hasAgentImportRecord() returns true
-  // regardless. This mirrors the old per-project setLastImportAt() which also
-  // ran before checking the user's answer.
-  for (const result of results) {
-    recordDecline(projectPath, result.agentName);
+  // On DECLINE: record per-agent decline sentinels so we don't re-prompt.
+  //
+  // On ACCEPT: do NOT pre-record anything here. The import is now DEFERRED until
+  // the first authenticated turn (#1366) and may not run in this invocation at
+  // all (e.g. the agent never proxies a turn through this gateway). Recording a
+  // sentinel up-front would set hasAgentImportRecord()=true and permanently
+  // suppress the offer even though nothing was ever imported — the exact trap a
+  // user hit (accepted, import never fired, project stayed empty forever).
+  // Instead, only a completed extraction records the agent (recordImport in
+  // runBackgroundImport), so an unfinished/never-fired import is re-offered on
+  // the next `lore run`.
+  if (!ok) {
+    for (const result of results) {
+      recordDecline(projectPath, result.agentName);
+    }
+    return;
   }
-
-  if (!ok) return;
 
   const cfg = loreConfig();
   const defaultModel = cfg.model ?? {
@@ -225,6 +231,14 @@ async function runBackgroundImport(
       chunks,
       model,
     });
+
+    // Only mark these sessions imported if the LLM actually answered at least
+    // one chunk. A no-auth run returns null per chunk without throwing (0
+    // answered) — recording it would set hasAgentImportRecord()=true and
+    // permanently suppress a real import on the next run. Skip recording so it
+    // is retried. (created/updated can legitimately be 0 when the model
+    // answered but found nothing worth keeping — that DOES record.)
+    if (extractResult.chunksAnswered === 0) continue;
 
     // Record imports
     for (const sess of result.sessions) {

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -20,7 +20,7 @@ import {
 type DetectionResult =
   import("@loreai/core").conversationImport.DetectionResult;
 import { createGatewayLLMClient } from "../llm-adapter";
-import { resolveAuth } from "../auth";
+import { resolveAuth, workerKeyScheme, type AuthCredential } from "../auth";
 import { exportLoreFile } from "@loreai/core";
 import { startGateway, type StartOptions } from "./start";
 import {
@@ -403,9 +403,45 @@ export async function commandImport(
     providerID: "anthropic",
     modelID: "claude-sonnet-4-6",
   };
+
+  // Extraction needs a usable credential. `lore import` is a standalone CLI
+  // process: it never proxies a conversation turn, so no client credential is
+  // ever captured under a session. The ONLY credential it can use is a
+  // dedicated worker key (LORE_WORKER_API_KEY). Without one, every extraction
+  // call resolves no-auth and `llm.prompt` returns null — the import would
+  // silently create ZERO knowledge while reporting success (the exact trap a
+  // user hit). Fail loudly with actionable guidance instead.
+  const workerApiKey = config.workerApiKey;
+  const getImportAuth: (
+    sessionID?: string,
+    providerID?: string,
+  ) => AuthCredential | null = workerApiKey
+    ? (_sessionID, providerID) => ({
+        scheme: workerKeyScheme(providerID),
+        value: workerApiKey,
+      })
+    : resolveAuth;
+
+  if (
+    !workerApiKey &&
+    getImportAuth(undefined, defaultModel.providerID) == null
+  ) {
+    console.error(
+      `\n[lore] Can't import: no ${defaultModel.providerID} credential available.\n` +
+        `[lore] \`lore import\` runs as a standalone command with no conversation\n` +
+        `[lore] to borrow a credential from, so it needs a dedicated worker key.\n` +
+        `[lore] Set one and retry:\n` +
+        `[lore]   export LORE_WORKER_API_KEY=<your ${defaultModel.providerID} key>\n` +
+        `[lore]   lore import\n` +
+        `[lore] Or skip manual import: \`lore run\` auto-imports after your first message.`,
+    );
+    if (owned) await shutdown();
+    return;
+  }
+
   const llm = createGatewayLLMClient(
     { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI },
-    resolveAuth,
+    getImportAuth,
     defaultModel,
   );
 
@@ -449,6 +485,20 @@ export async function commandImport(
 
       // Clear the progress line
       process.stderr.write("\n");
+
+      // Only mark sessions imported if the LLM actually answered a chunk. A
+      // no-auth run returns null per chunk (0 answered) without throwing — the
+      // pre-flight guard above catches the common case, but a credential can go
+      // stale mid-run. Recording a never-answered run would permanently
+      // suppress a real re-import via hasAgentImportRecord().
+      if (extractResult.chunksAnswered === 0) {
+        console.log(
+          `[lore] No response from the model for ${result.agentDisplayName} — ` +
+            `skipping (will retry on next import).`,
+        );
+        totalFailed += extractResult.chunksFailed;
+        continue;
+      }
 
       // Record imports for each session
       for (const sess of result.sessions) {

--- a/packages/gateway/test/import-auto.test.ts
+++ b/packages/gateway/test/import-auto.test.ts
@@ -4,11 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// Auto-accept the Y/n prompt without touching real stdin: stub readline's
-// createInterface so question() immediately answers "y" and close() is a no-op.
+// Auto-answer the Y/n prompt without touching real stdin. `promptAnswer` lets
+// individual tests choose accept ("y") vs decline ("n").
+let promptAnswer = "y";
 vi.mock("node:readline", () => ({
   createInterface: () => ({
-    question: (_q: string, cb: (answer: string) => void) => cb("y"),
+    question: (_q: string, cb: (answer: string) => void) => cb(promptAnswer),
     close: () => {},
   }),
 }));
@@ -20,7 +21,10 @@ import {
   _resetPendingImportForTest,
 } from "../src/pending-import";
 import { setLastSeenAuth, _resetAuthForTest } from "../src/auth";
+import { conversationImport } from "@loreai/core";
 import type { GatewayConfig } from "../src/config";
+
+const { hasAgentImportRecord } = conversationImport;
 
 const AIDER_FIXTURE = join(
   fileURLToPath(new URL(".", import.meta.url)),
@@ -52,6 +56,7 @@ describe("maybeAutoImport — credential-aware scheduling", () => {
   beforeEach(() => {
     _resetPendingImportForTest();
     _resetAuthForTest();
+    promptAnswer = "y";
     project = mkdtempSync(join(tmpdir(), "lore-autoimport-"));
     // The tmp dir is intentionally NOT a git repo: detectAll(..., {worktrees:true})
     // runs `git worktree list`, which fails open to [projectPath] here — so
@@ -149,5 +154,20 @@ describe("maybeAutoImport — credential-aware scheduling", () => {
     const out = logs.join("\n");
     expect(out).toContain("Skipping knowledge import");
     expect(out).toContain("no usable anthropic credential");
+  });
+
+  test("ACCEPT with deferred import does NOT pre-record the agent (no permanent suppression)", async () => {
+    // No credential → import defers. The agent must NOT be marked handled yet,
+    // or a never-fired import would suppress the offer forever (the user trap).
+    await maybeAutoImport(baseConfig());
+    expect(hasPendingImport()).toBe(true);
+    expect(hasAgentImportRecord(project, "aider")).toBe(false);
+  });
+
+  test("DECLINE records the agent so it is not re-offered", async () => {
+    promptAnswer = "n";
+    await maybeAutoImport(baseConfig());
+    expect(hasPendingImport()).toBe(false);
+    expect(hasAgentImportRecord(project, "aider")).toBe(true);
   });
 });

--- a/packages/gateway/test/import-command-local.test.ts
+++ b/packages/gateway/test/import-command-local.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, copyFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Local-mode commandImport: mock the gateway start so no real server boots.
+// `owned:true` so the command calls shutdown() on the way out. The returned
+// config controls the auth pre-flight (workerApiKey).
+const shutdownMock = vi.fn(async () => {});
+let startConfig: Record<string, unknown> = {
+  upstreamAnthropic: "https://api.anthropic.com",
+  upstreamOpenAI: "https://api.openai.com",
+};
+vi.mock("../src/cli/start", () => ({
+  startGateway: vi.fn(async () => ({
+    config: startConfig,
+    owned: true,
+    shutdown: shutdownMock,
+  })),
+}));
+
+// Stub the LLM client so the positive (guard-passed) paths never make a real
+// network call — the curator returns [] (answered, nothing to create).
+vi.mock("../src/llm-adapter", () => ({
+  createGatewayLLMClient: () => ({
+    prompt: vi.fn(async () => "[]"),
+  }),
+}));
+
+import { commandImport } from "../src/cli/import";
+import { setLastSeenAuth, _resetAuthForTest } from "../src/auth";
+
+const AIDER_FIXTURE = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "..",
+  "..",
+  "core",
+  "test",
+  "import",
+  "fixtures",
+  "aider-history.md",
+);
+
+describe("commandImport (local mode) — auth pre-flight", () => {
+  let project: string;
+  const logs: string[] = [];
+  const errs: string[] = [];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  const prevRemote = process.env.LORE_REMOTE_URL;
+
+  beforeEach(() => {
+    delete process.env.LORE_REMOTE_URL; // force local mode
+    _resetAuthForTest();
+    startConfig = {
+      upstreamAnthropic: "https://api.anthropic.com",
+      upstreamOpenAI: "https://api.openai.com",
+    };
+    project = mkdtempSync(join(tmpdir(), "lore-cmdimport-local-"));
+    copyFileSync(AIDER_FIXTURE, join(project, ".aider.chat.history.md"));
+    logs.length = 0;
+    errs.length = 0;
+    logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
+      logs.push(a.join(" "));
+    });
+    errSpy = vi.spyOn(console, "error").mockImplementation((...a) => {
+      errs.push(a.join(" "));
+    });
+    shutdownMock.mockClear();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    vi.restoreAllMocks();
+    rmSync(project, { recursive: true, force: true });
+    _resetAuthForTest();
+    if (prevRemote === undefined) delete process.env.LORE_REMOTE_URL;
+    else process.env.LORE_REMOTE_URL = prevRemote;
+  });
+
+  test("no credential and no worker key → fails loudly, never extracts, shuts down", async () => {
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    const out = errs.join("\n");
+    expect(out).toContain("Can't import");
+    expect(out).toContain("LORE_WORKER_API_KEY");
+    // Never got past the guard to read/extract, and cleaned up the owned gateway.
+    expect(logs.join("\n")).not.toContain("Reading");
+    expect(shutdownMock).toHaveBeenCalled();
+  });
+
+  test("worker key set → passes the guard and proceeds to read/extract", async () => {
+    startConfig.workerApiKey = "sk-worker-test";
+
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    expect(errs.join("\n")).not.toContain("Can't import");
+    // Guard passed → proceeds to read conversations (extraction then runs
+    // against the real curator; no assertion on its result here).
+    expect(logs.join("\n")).toContain("Reading");
+    expect(shutdownMock).toHaveBeenCalled();
+  });
+
+  test("session credential present → passes the guard and proceeds to read/extract", async () => {
+    setLastSeenAuth({ scheme: "bearer", value: "sk-ant-oat" }, "anthropic");
+
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    expect(errs.join("\n")).not.toContain("Can't import");
+    expect(logs.join("\n")).toContain("Reading");
+  });
+});


### PR DESCRIPTION
Follow-up to #1366. A user upgraded to the nightly, ran `lore import`, and still saw an empty project (dashboard: KNOWLEDGE=0, SESSIONS=0). Root-caused to **two more bugs** behind the same "import produces nothing" symptom.

## Bug 1 — `lore import` (standalone CLI) can never authenticate

It starts a gateway with `local:true` but never proxies a conversation turn, so **no client credential is ever captured**; the only credential it could use is a dedicated worker key. It built the LLM client with bare `resolveAuth`, and on no-auth `llm.prompt` returns `null` (no throw) → every chunk silently produced nothing while the command printed `Import complete: 0 entries created` as if it succeeded.

**Fix:**
- Build the import client with a worker-aware resolver (honors `LORE_WORKER_API_KEY`, mirroring the pipeline's `getWorkerAuth`).
- Add a **pre-flight guard**: if no worker key AND `resolveAuth(undefined, provider)` is null → fail loudly with actionable guidance (set `LORE_WORKER_API_KEY`, or use `lore run` which auto-imports after your first message) and shut down the owned gateway. No more silent zero-knowledge "success".

## Bug 2 — a failed/never-run import permanently suppressed the `lore run` offer

`maybeAutoImport` pre-recorded a decline sentinel for **every** agent *before* the deferred import ran (leftover from when import was synchronous). Since #1366 defers import to the first authenticated turn, an accepted-but-never-fired import left the agent marked handled forever (`hasAgentImportRecord → true`), so a later `lore run` never re-offered it — the user's exact stuck state. (A project delete doesn't clear `import_history`, so re-creating wouldn't help either.)

**Fix:**
- On **accept**: record nothing up-front. Only a *completed extraction* records the agent, so an unfinished/never-fired import is re-offered next run.
- On **decline**: record the decline sentinel (unchanged intent).
- Gate `recordImport` on **`chunksAnswered > 0`** in both the auto and explicit paths: a no-auth run (null responses, 0 answered) never marks sources imported → it retries; a genuine empty result (model answered, nothing worth keeping) still records. New `ExtractionResult.chunksAnswered` counts non-null LLM responses — the signal that distinguishes "answered with nothing" from "never authenticated".

## Tests
- `extract.test.ts`: `chunksAnswered` = 1 on response/empty-list, 0 on null/error.
- `import-command-local.test.ts` (new): no-cred → loud fail + no extraction + owned-gateway shutdown; worker-key / session-cred → passes guard and proceeds.
- `import-auto.test.ts`: ACCEPT+deferred does **not** pre-record the agent (mutation-verified); DECLINE records it.
- Full suite: **6241 passed**, 0 failures. typecheck / lint / format clean.

## Scope
Local import path only. The remote-import path (`importRemote`) authenticates on the remote gateway and is unaffected.