### PR TITLE
fix(gateway): lineage-aware worker model selection + data-policy 404 auto-recovery

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -90,9 +90,6 @@
 <!-- lore:019f3974-7c6a-7091-8602-b4ec0bb763a4 -->
 * **Chose next task: knowledge\_meta seed-order alignment (self-contained, low-risk, completes value-ranked seed coherence work started with knowledge #1189 and entities #1194) — over #1191b (continuous top-N eviction)**: Completed value-ranked seed coherence work in sequence: #1189 (knowledge seed value-ranking) → PR #1194 (entity-graph seed: entities ranked by knowledge\_entity\_refs count DESC then recency; entity\_relations by recency; entity\_aliases by created\_at DESC) → PR #1196 (knowledge\_meta seed aligned to knowledge's ORDER BY: confidence DESC, COALESCE(last\_reinforced\_at, updated\_at) DESC, logical\_id tiebreak). Deferred #1191b (continuous top-N eviction for remote) as a separate larger/riskier task needing a design doc first (remote eviction, cap discovery, thrash guards, concurrency) — not suitable for autonomous same-session implementation. Follow-up issue #1197 filed for a known non-blocking edge case: a deleted high-confidence entry's orphaned knowledge\_meta row can outrank a live entry's meta row under the cap (self-healing, not data loss).
 
-<!-- lore:019f3d0e-5602-7457-b4d3-a36993bd7b9b -->
-* **Chose to run real A/B eval scenario cm-1-early-detail (context dimension, real recall questions with cumulativeTokens for rot curve) over cost-2**: chose to run real A/B eval scenario cm-1-early-detail (context dimension, real recall questions with cumulativeTokens for rot curve) over cost-2
-
 <!-- lore:019f4629-d9d0-7c59-924c-dc7341e57c77 -->
 * **Closed #1231 (distillation value-retention): reuse knowledge\_refs + file reads instead of memorizing repo-resident values**: Chose to close PR #1231 (feat: retain exact literal/style values in observations) over building a value-extractor. Rationale: a stored value is a cache of the file — the moment the file changes, every distillation that memorized the old value is confidently wrong. A pointer + file Read is always correct and costs the same tool call. \`knowledge\_refs\` + \`knowledge\_ref\_validity\` already store and validate file:line pointers. The value-extractor would duplicate this and add staleness. Boundary: ephemeral facts (test run counts, stated numbers, decisions) have no file to read → those belong in memory via distillation/knowledge. Code-resident specifics → pointer + read.
 
@@ -182,9 +179,6 @@
 <!-- lore:019efc12-5bea-700b-87dd-615866d86741 -->
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
 
-<!-- lore:019f5e0a-59a7-7ee7-8ec1-5b7c7c721853 -->
-* **OpenAI-protocol cache hit rate issue**: Trap: OpenAI-protocol requests to OpenRouter show 100% cache miss rate because OpenRouter honors Anthropic-style breakpoints on OpenAI Chat Completions API but not on OpenAI requests. Fix: add Anthropic-style \`cache\_control\` breakpoints.
-
 <!-- lore:019ef39c-72c4-7a00-bce7-4456e479867c -->
 * **Partial v55 migration boot-loop: DROP COLUMN before backfill SELECT causes unrecoverable crash**: Trap: v55 migration runs via \`database.exec()\` (auto-commits each statement) — looks safe because migrations are idempotent. Fix: if interrupted after \`DROP COLUMN confidence\` but before completion, \`schema\_version\` stays <55. Next boot retries migration; backfill \`SELECT logical\_id, confidence FROM knowledge\` throws \`no such column: confidence\`. Catch block only matches \`/duplicate column name/i\` — this error re-throws → \`migrate()\` throws → boot loop. \`recoverMissingObjects\` unreachable (needs \`current>=55\`). \`stripAppliedAlters\` only handles ADD COLUMN. Fix: make backfill column-presence-aware (mirror \`recoverMissingObjects\`' \`hasConfidence\` check) OR wrap the DROP+backfill in a single transaction-safe block. Empirically confirmed with \`node:sqlite\`.
 
@@ -232,9 +226,6 @@
 
 <!-- lore:019edff0-4721-7514-9ddf-f9eac54de7da -->
 * **sync integration tests: hand-written mocks cannot exercise RLS/triggers/quotas — integration tests are the only valid gate**: sync integration tests: hand-written mocks cannot exercise RLS/triggers/quotas — integration tests are the only valid gate. \`sync-security.integration.test.ts\` runs against real Postgres+PostgREST via Docker; gated on \`LORE\_INTEGRATION=1\`. Test suites: (1) multi-tenant RLS isolation — cross-tenant read, scope\_id forge (42501), re-parent steal/donate, anon access; (2) tier server-only — column grant blocks tier UPDATE, service\_role can upgrade; (3) quota enforcement — row cap, byte cap, revival bypass, tombstone flood. \`FREE\_LIMITS\` constant mirrors 0003 caps. \`afterEach\` restores \`max\_rows\` but NOT \`max\_bytes\` — \`setByteCap()\` calls at lines 330, 346 leak into subsequent tests (benign due to test ordering; SHOULD-FIX). \`dockerReady()\` is synchronous. \`beforeAll\` timeout: 180,000ms. 30 concurrent INSERTs at \`max\_rows=10\`: exactly 10 committed, advisory lock serializes growth correctly.
-
-<!-- lore:019f5e40-af17-749d-82a0-898b7b8cd2a9 -->
-* **sync\_conflicts schema mismatch**: Trap: Live DB sync\_conflicts schema is missing local\_content column. Fix: add recovery step to recoverMissingObjects to add local\_content column to sync\_conflicts table.
 
 <!-- lore:019eea22-b8cc-76d1-b547-eba90b324c95 -->
 * **sync-data.ts reconcile(): stale upsert below push cursor blocks delete tombstone — row never deleted on remote**: sync-data.ts seedOutbox + reconcile(): stale upsert below push cursor blocks re-sync/delete — orphaned row bug. (a) seedOutbox: old \`NOT EXISTS (any pending outbox entry)\` skips rows with any pending entry including a trailing delete or stale already-pushed upsert (seq ≤ push cursor). Modified-while-sync-off rows never re-sync. Fix (PR #868): rewrite as JS loop; read \`latestUnpushed\` = latest op with \`seq > pushCursor\`; if upsert→skip; if delete→enqueue trailing upsert; if none→enqueue only when \`contentHash(row) != sync\_state.content\_hash\`. Wrap in \`withTransaction\`; hoist \`columns(table)\` outside per-row loop (\`syncedColumns\` runs PRAGMA on every call). (b) reconcile(): old guard blocks tombstone INSERT if ANY outbox entry exists including stale upsert that survived pruning (prune floor pinned by lower-seq table per #828). Stale upsert pushes as no-op → delete NEVER reaches remote. Fix (PR #866): change guard to \`COALESCE((SELECT op ... ORDER BY seq DESC LIMIT 1), 'none') <> 'delete'\` — only blocks if latest op is already a delete (idempotent). \`seq\` is \`INTEGER PRIMARY KEY AUTOINCREMENT\` so \`ORDER BY seq DESC LIMIT 1\` reliably identifies latest op.
@@ -309,6 +300,9 @@
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
 * **Always a remote gateway — it has no shared filesystem with its clients**: User consistently requires that the gateway is always remote and has no shared filesystem with clients. This pattern has appeared in 27 prior sessions and is a directive preference.
 
+<!-- lore:019f7b95-0983-77a0-9bc8-cfb83b8882c3 -->
+* **Always clear the local session**: User stated to always clear the local session.
+
 <!-- lore:019f6fba-0d21-7410-894e-4933b29e8518 -->
 * **Always converges**: User stated: 'always converges'. This is a directive preference.
 
@@ -318,14 +312,8 @@
 <!-- lore:019f7766-9f0a-787b-8afd-96740e7d81a4 -->
 * **Always drain outstanding embedding promises on shutdown**: User consistently requires that outstanding \`trackDocEmbed\` promises be drained on shutdown to prevent silent recall degradation from incomplete distillation embeddings. This pattern has appeared in 22 prior sessions and is a directive preference.
 
-<!-- lore:019f6f42-4108-76fd-9501-47bac31948fd -->
-* **Always implies the embedding columns**: User stated always implies the embedding columns. This is a directive preference.
-
 <!-- lore:019f7155-c3b2-7ddf-8dc5-f9c97f3904e0 -->
 * **Always keep pinned segments in distillation**: Always keep head segments in distillation. User stated: 'always kept\*\* (0 >= budget is false for budget>0),'. This is a directive preference.
-
-<!-- lore:019f76d7-40de-713c-a0c5-04296caebd35 -->
-* **Always match remote row for tombstone reaper**: The user consistently requires that tombstone reaper operations match their remote row. This pattern has appeared in 33 prior sessions and is a directive preference.
 
 <!-- lore:019f6fd7-3931-76ae-93b7-cbcec8c69643 -->
 * **Always normalize to MIGRATIONS.length for database migrations**: Always normalize to MIGRATIONS.length for database migrations to ensure consistency. This was a directive preference.
@@ -333,11 +321,14 @@
 <!-- lore:019f7766-9f85-7a5c-b3d3-1917618602bd -->
 * **Always position delta block before assistant tool\_use**: User consistently requires that delta blocks be positioned before any assistant \`tool\_use\` in the prompt, never between \`tool\_use\` and its \`tool\_result\`. This pattern has appeared in 36 prior sessions and is a directive preference.
 
-<!-- lore:019f6f42-408e-7635-81d6-4d51ec94a3c9 -->
-* **Always prefer f-strings over .**: User stated always prefer f-strings over . This is a directive preference.
-
 <!-- lore:019f7766-9f5b-72e8-9567-531f800edfd0 -->
 * **Always re-index missing distillation\_vec rows on next boot**: User consistently requires re-indexing missing \`distillation\_vec\` rows on next boot to recover from incomplete embeddings due to early session termination. This pattern has appeared in 39 prior sessions and is a directive preference.
+
+<!-- lore:019f7cad-c1f4-7921-875d-978a292ca8bb -->
+* **Always record structured tool-call traces — even when the assistant**: Always record structured tool-call traces — even when the assistant. This is a directive preference.
+
+<!-- lore:019f7c6a-f652-7412-a3ae-bd0975f89d1a -->
+* **Always record the auth failure so the worker-health ladder sees it even for session-less paths (the adapter is the single owner of transport-failure attribution)**: User stated to always record the auth failure so the worker-health ladder sees it even for session-less paths (the adapter is the single owner of transport-failure attribution).
 
 <!-- lore:019f6fdd-fd1b-7c97-a870-80edf21b66f1 -->
 * **Always remove obvious statements from drafted replies**: Always remove obvious statements from drafted replies. User requested removal of sentence about subscription rate window resets from Erica reply draft, stating it's obvious.
@@ -357,9 +348,6 @@
 <!-- lore:019f76d7-4108-7e96-95f3-468dca0b097f -->
 * **Always use 'document' inputType for backfill to avoid self-gating**: The user consistently requires using 'document' inputType for backfill operations to ensure \`isRecall\` is always false and avoid self-gating. This pattern has appeared in 35 prior sessions and is a directive preference.
 
-<!-- lore:019f76d7-4130-7451-9577-e41c9c4533fe -->
-* **Always use worker-model for worker path to avoid empty completions**: The user consistently requires using worker-model for worker path operations to avoid empty completions. This pattern has appeared in 27 prior sessions and is a directive preference.
-
 <!-- lore:019f6fba-0dc9-787f-a62e-b86b43f939a0 -->
 * **Always valid for JSON**: User stated: 'always valid for JSON.' This is a directive preference.
 
@@ -372,9 +360,6 @@
 <!-- lore:019f6f38-a1ff-7b4b-b941-36b22f5dd4e7 -->
 * **Avoid re-embedding identical text every CI run**: Avoid re-embedding identical text every CI run. User stated re-embedding identical text every run is wasteful. This is a CI optimization preference. Directive preference.
 
-<!-- lore:019f6f38-a17c-7356-a948-2769779627a0 -->
-* **checkInvariants should accept invariant source (DB or snapshot)**: User stated checkInvariants should accept invariant source (DB or snapshot). This is a CI design constraint. Directive preference.
-
 <!-- lore:019f70c1-61b7-7c02-823a-aebcac38b39b -->
 * **CommandAdmin never reads \_values from OPTIONS map**: User stated that commandAdmin takes \_values and never reads it — so no OPTIONS-map/flag concern applies to admin at all. This is a directive preference.
 
@@ -384,23 +369,38 @@
 <!-- lore:019f702c-6f1c-7e7d-b41d-ef88c60d20f9 -->
 * **Enumeration invariants always advisory, never fail build**: Enumeration invariants are always advisory and never fail the build. This is a directive preference.
 
-<!-- lore:019f6f38-a0d4-7b52-a225-361b24fb926f -->
-* **Exclude cross\_project=1 entries from .lore.md**: User stated .lore.md excludes cross\_project=1 entries. This is a CI design constraint. Directive preference.
-
 <!-- lore:019f702c-6eba-7447-a242-3d26d5e82727 -->
 * **GHA action never fails, supports opt-in gate input**: The GHA action never fails but supports opt-in gate input. This is a directive preference.
 
 <!-- lore:019f6fde-efd1-7f32-82db-76eb9454a990 -->
 * **Invariant-check action is advisory-only and never fails the build**: The invariant-check action is advisory-only and NEVER fails the build — it reports findings as annotations and a job summary; humans decide. The action should NEVER fail the build: capture exit, always continue. A non-zero exit from the CLI means a TOOLING failure (no range) — we log it and pass. This is a directive preference.
 
+<!-- lore:019f7bb8-b560-7907-b406-e0cf0215f27d -->
+* **Invariant-check judge: always exits 0, gate fail is separate action**: User stated: ALWAYS exits 0 — failing a blocked build is a separate action step. This is a directive preference.
+
+<!-- lore:019f7bb8-b58a-7c4d-aa34-106c5e05fbfb -->
+* **Invariant-check judge: never fails build, gate fail is separate**: User stated: never fails the build. This is a directive preference.
+
+<!-- lore:019f7bb8-b4da-72b7-92a1-079377550ba4 -->
+* **Invariant-check judge: never import outside driver**: User stated: never be imported outside driver. This is a directive preference.
+
+<!-- lore:019f7bb8-b48b-7498-97cf-b3cf801ad1ce -->
+* **Invariant-check judge: never modify tracked files in working repo**: User stated: Do NOT modify any tracked file in the working repo. If you need to test, use a throwaway git worktree under /tmp/opencode. Verify the main tree is unchanged (sha256sum) afterward. Report exit codes. This is a directive preference.
+
+<!-- lore:019f7bb8-b461-77f2-ab92-bb1502b3ec63 -->
+* **Invariant-check judge: never produce false violation, never throw uncaught, never fail build**: User stated: NEVER produce a false \`violates:true\` finding, NEVER throw uncaught, NEVER fail the build. This is a directive preference.
+
+<!-- lore:019f7bb8-b4b3-71ad-95e9-7328fccb31cd -->
+* **Invariant-check judge: never send more than MAX\_JUDGE\_PAIRS\_PER\_RUN**: User stated: Never send more than this many pairs to the judge in one run. This is a directive preference.
+
+<!-- lore:019f7bb8-b5b2-7e13-a7f4-3d3b63d66595 -->
+* **Invariant-check judge: never throws on request path**: User stated: never throws on the request path. This is a directive preference.
+
 <!-- lore:019f7135-8b8a-7abe-bd3c-29ae8ff474fa -->
 * **Junk never embedded in Stage 1 paste-junk filtering**: User stated that 'junk never embedded' is a key requirement for Stage 1 paste-junk filtering. This is a directive preference.
 
 <!-- lore:019f7af2-a1b1-799f-83ea-01e3e46feb85 -->
 * **Last time you got a custom build yourself, why not that again?**: User stated: 'Last time you got a custom build yourself, why not that again?'. This is a directive preference.
-
-<!-- lore:019f6f38-a1a3-7dbe-ad09-badf91b29dcf -->
-* **loadInvariantVecs should read from snapshot**: User stated loadInvariantVecs should read from snapshot. This is a CI design constraint. Directive preference.
 
 <!-- lore:019f71b3-f4b0-7ddb-91ff-b8a54acc8e99 -->
 * **Never a different provider's credential**: User stated: 'never a different provider's credential.' This is a directive preference.
@@ -414,8 +414,14 @@
 <!-- lore:019f7155-c3fc-7e42-b047-d4176cd09568 -->
 * **Never alert on structural cache busts**: Never fire hook on structural cache busts. User stated: 'never fires the hook)'. This is a directive preference.
 
+<!-- lore:019f7ccd-ede8-7421-9a84-10ab02fd612f -->
+* **Never auto-promote to a team**: User consistently requires that the system never automatically promotes users to team membership. This maintains the invite-only model integrity. Directive preference.
+
 <!-- lore:019f72d7-dda3-70f6-b2e1-baf051675a0c -->
 * **Never block a PR**: User stated never block a PR.
+
+<!-- lore:019f7b95-09b2-7577-a9d2-b952b3df0a76 -->
+* **Never block login on QR rendering**: User stated to never block login on QR rendering.
 
 <!-- lore:019f77f9-b7d6-7f6c-9431-9f4fd9a443a3 -->
 * **Never block shutdown longer than hard deadline**: User consistently requires that shutdown procedures never block longer than a hard deadline to avoid Ctrl+C hangs. This pattern has appeared in 36 prior sessions and is a directive preference.
@@ -456,8 +462,14 @@
 <!-- lore:019f7ae8-a590-7a19-8eff-639e6afc1a90 -->
 * **Never edit the real repo; if experiments/mutations are needed**: User stated to never edit the real repo; if experiments/mutations are needed,
 
+<!-- lore:019f7cad-c1c7-75d7-9683-b577f9d3cd39 -->
+* **Never exceed the driver's variable limit**: Never exceed the driver's variable limit. This is a directive preference.
+
 <!-- lore:019f749f-147f-7645-a1ec-0821e1476840 -->
 * **Never exceed total budget**: Never exceed total budget. This is a directive preference.
+
+<!-- lore:019f7ccd-edbd-7491-a405-3d76962c83c0 -->
+* **Never expose or transmit Lore user\_ids**: User consistently requires that Lore user\_ids are never exposed, printed, or transmitted. This is a security requirement for the invite-only model. Directive preference.
 
 <!-- lore:019f749f-1424-7faf-8acc-44fa2494533b -->
 * **Never filters bug**: Never filters bug. This is a directive preference.
@@ -471,8 +483,8 @@
 <!-- lore:019f70c1-6116-7798-bde9-7dbaf926a516 -->
 * **Never grant UPDATE on profiles to service\_role**: User stated that service\_role was 'never granted UPDATE on profiles' regarding tier guards. This is a directive preference.
 
-<!-- lore:019f6f42-4141-74f4-967f-8c00ee9cb428 -->
-* **Never has it set — but calling it at**: User stated never has it set — but calling it at. This is a directive preference.
+<!-- lore:019f7ccd-ee15-739b-bbff-4d4664a4c845 -->
+* **Never let two deploys race; newest merge wins**: User consistently requires that deployment processes never race, with the newest merge always winning. This prevents inconsistent deployments. Directive preference.
 
 <!-- lore:019f7b4f-e07e-7962-83e0-85b40dfd63ce -->
 * **Never lets N workers sum past the host's**: User consistently requires that the number of workers never exceeds the host's capacity. This pattern has appeared in 27 prior sessions and is a directive preference.
@@ -501,11 +513,11 @@
 <!-- lore:019f7b4f-e00a-7ba1-b6a4-8bea4adebc0a -->
 * **Never rejects in practice; swallow to be safe**: User consistently requires swallowing errors in practice for safety, even if they should never reject. This pattern has appeared in 27 prior sessions and is a directive preference.
 
-<!-- lore:019f6f42-4168-79ae-a6fc-bc736d12b2a0 -->
-* **Never reverts to blob),**: User stated never reverts to blob). This is a directive preference.
+<!-- lore:019f7ccd-ee40-7b83-abcb-4594b6d52ad6 -->
+* **Never rely on someone remembering to run**: User consistently requires that critical processes are automated rather than relying on human memory to run them. This ensures reliability. Directive preference.
 
-<!-- lore:019f6f42-40bf-7804-9d05-2b7b182e5191 -->
-* **Never runs and Lore falls back to temporal-only recall**: User stated never runs and Lore falls back to temporal-only recall. This is a directive preference.
+<!-- lore:019f7cad-c19c-7635-bf05-b29f0ff820e9 -->
+* **Never revert a resolved row back to**: Never revert a resolved row back to. This is a directive preference.
 
 <!-- lore:019f70c1-613e-7caf-a1c9-cd7a330cd0c2 -->
 * **Never self-upgrade team via client**: User stated that a client can 'never self-upgrade a team' regarding org tier guards. This is a directive preference.
@@ -534,9 +546,6 @@
 <!-- lore:019f66a2-5938-7fd4-b581-90d256a820c4 -->
 * **Never TTL-evicted**: User stated never TTL-evicted.
 
-<!-- lore:019f6f42-4193-7f4e-b2e5-0328bc5ebdde -->
-* **Never vec0->blob) ===**: User stated never vec0->blob) ===. This is a directive preference.
-
 <!-- lore:019f70c1-61df-7837-a22e-2aee503b0b98 -->
 * **Never write service-role key to disk**: User stated that service-role key 'never touches that path — it is never written to disk'. This is a directive preference.
 
@@ -549,26 +558,17 @@
 <!-- lore:019f7331-e703-7ae9-aa16-093875aeb481 -->
 * **Prefers recall over assuming you don't have the information**: prefer recall over assuming you don't have the information.
 
-<!-- lore:019f6f38-a151-7f51-8e1c-6cf644642f8f -->
-* **Restore snapshot with actions/cache in CI**: User stated CI should restore snapshot with actions/cache. This is a CI optimization preference. Directive preference.
-
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
 
 <!-- lore:019f70c1-6205-7d8b-9766-44b11a1e6f51 -->
 * **Service-role key never round-tripped through sessionToPersisted**: User stated that service-role key 'never round-tripped through sessionToPersisted'. This is a directive preference.
 
-<!-- lore:019f6f38-a127-7d59-bd32-486bd71ac328 -->
-* **Snapshot should include text, vectors, confidence, cross\_project**: User stated snapshot should include text, vectors, confidence, cross\_project. This is a CI design constraint. Directive preference.
-
 <!-- lore:019f7b4f-dfc0-7519-8f40-46eb29afc29a -->
 * **Switch to WASM when native fails**: User consistently requires switching to WASM when native runtime fails. This pattern has appeared in 27 prior sessions and is a directive preference.
 
 <!-- lore:019f702c-6f46-7a12-a71c-1507abeb6e0c -->
 * **Tooling failures like no commit range are not findings**: Tooling failures like inability to resolve commit range are not findings. This is a directive preference.
-
-<!-- lore:019f6f38-a1cd-7870-a091-21d36f40386f -->
-* **Use forProject(path, true) to include cross-project entries**: User stated checkInvariants uses forProject(path, true) which includes cross-project. This is a CI design constraint. Directive preference.
 
 <!-- lore:019f7b66-8ff8-7d82-9ee8-fcd3a9521686 -->
 * **Warden analysis: acknowledge genuine utility before extracting ideas**: User consistently requires acknowledging Warden's genuine utility before extracting ideas. This pattern has appeared in 3 prior sessions and is a directive preference.

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -65,7 +65,11 @@ import {
   vertexRegionFromUrl,
 } from "./translate/vertex";
 import { getVertexAccessToken, resolveVertexProject } from "./vertex-auth";
-import { getModelEntrySync, getWorkerModel } from "./worker-model";
+import {
+  getModelEntrySync,
+  getModelEntrySyncForProvider,
+  getWorkerModel,
+} from "./worker-model";
 import { recordWarmupCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
 import { emitWarmupCircuitBreakerMetric } from "./sentry";
@@ -1054,13 +1058,17 @@ export function buildAnthropicProfile(
   ttl: "5m" | "1h",
   upstreamBase?: string,
   prefixTokens = 0,
+  providerID?: string,
 ): CacheWarmingProfile {
   const route = resolveUpstreamRoute(model);
   // || (not ??): an empty-string upstreamBase (header-less Anthropic sessions)
   // must coalesce to the model route, not produce a base of "".
   const base = upstreamBase || route?.url || "https://api.anthropic.com";
 
-  const entry = getModelEntrySync(model);
+  // Price from the provider the session is routed to when known (aggregators
+  // publish the same bare id at different cache prices); falls back to the flat
+  // last-write-wins entry when the provider is unknown/undefined.
+  const entry = getModelEntrySyncForProvider(providerID, model);
   const cacheReadCost =
     entry.cost?.cache_read ?? (entry.cost?.input ?? 3) * 0.1;
   // Base cache_write is the 5m TTL price. Anthropic charges 2× for 1h TTL writes.
@@ -1216,6 +1224,7 @@ export function resolveProfile(
       ttl ?? "5m",
       upstreamBase,
       prefixTokens,
+      providerID,
     );
   }
 
@@ -1224,7 +1233,13 @@ export function resolveProfile(
     (!!warmupHost && isAnthropicFirstPartyHost(warmupHost));
   if (!isAnthropic) return null;
 
-  return buildAnthropicProfile(model, ttl ?? "5m", upstreamBase, prefixTokens);
+  return buildAnthropicProfile(
+    model,
+    ttl ?? "5m",
+    upstreamBase,
+    prefixTokens,
+    providerID,
+  );
 }
 
 /**

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1992,6 +1992,42 @@ export function createGatewayLLMClient(
                   return null;
                 }
 
+                // Data-policy error surfaced as an HTTP 200 error-envelope
+                // (some aggregators return the upstream 404 body with a 200 wire
+                // status — see the transient-envelope handling above). The
+                // status-keyed 4xx branch never sees these, so mirror the
+                // data-policy handling here: a body that carries the
+                // data-policy/guardrail marker AND an embedded 404 is the same
+                // per-account availability fact. Blocklist + re-resolve; classify
+                // data-policy (no outage ladder, no credit-pause). We pass the
+                // embedded code (or 404 when the phrase is present but no code is
+                // parseable) so the strict detector's status gate is satisfied.
+                if (
+                  !isSSE &&
+                  isDataPolicyBlocked404(bodyErrCode ?? 404, bodyText)
+                ) {
+                  log.warn(
+                    `worker model ${model.providerID}/${model.modelID} blocked by account data policy ` +
+                      `(HTTP 200 error-envelope) — blocklisting and re-resolving ` +
+                      `(worker=${opts?.workerID ?? "unknown"}, ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}): ${bodyText.slice(0, 160)}`,
+                  );
+                  markWorkerIncapable(model.providerID, model.modelID);
+                  if (model.modelID.endsWith(":free")) {
+                    markFreeModelsDataBlocked(model.providerID);
+                  }
+                  span.setStatus({
+                    code: 2,
+                    message: "data-policy (HTTP 200 envelope)",
+                  });
+                  recordWorkerFailure(
+                    opts?.sessionID ?? "_unknown",
+                    opts?.workerID ?? "unknown",
+                    "data-policy",
+                  );
+                  return null;
+                }
+
                 // Parse response based on protocol
                 // SSE → accumulate the full stream; JSON → parse the body.
                 const parsed = isSSE

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1996,15 +1996,21 @@ export function createGatewayLLMClient(
                 // (some aggregators return the upstream 404 body with a 200 wire
                 // status — see the transient-envelope handling above). The
                 // status-keyed 4xx branch never sees these, so mirror the
-                // data-policy handling here: a body that carries the
-                // data-policy/guardrail marker AND an embedded 404 is the same
-                // per-account availability fact. Blocklist + re-resolve; classify
-                // data-policy (no outage ladder, no credit-pause). We pass the
-                // embedded code (or 404 when the phrase is present but no code is
-                // parseable) so the strict detector's status gate is satisfied.
+                // data-policy handling here.
+                //
+                // 🔴 Gate on a REAL embedded error code (`bodyErrCode === 404`),
+                // NOT `bodyErrCode ?? 404`. A normal successful completion has
+                // `bodyErrCode === null`; the `?? 404` fallback would then run
+                // the phrase check against ordinary assistant text and
+                // FALSE-POSITIVE blocklist a model whenever the reply happened
+                // to mention "no endpoints … data policy" (e.g. the model
+                // explaining OpenRouter's own error). An HTTP-200 envelope is
+                // only a data-policy failure when it actually carries the 404
+                // error code AND the data-policy phrase. (Seer #1407.)
                 if (
                   !isSSE &&
-                  isDataPolicyBlocked404(bodyErrCode ?? 404, bodyText)
+                  bodyErrCode === 404 &&
+                  isDataPolicyBlocked404(bodyErrCode, bodyText)
                 ) {
                   log.warn(
                     `worker model ${model.providerID}/${model.modelID} blocked by account data policy ` +

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -67,6 +67,8 @@ import {
   recordWorkerFailure,
   markWorkerPaused,
   isWorkerIncapable,
+  markWorkerIncapable,
+  markFreeModelsDataBlocked,
   recordEmptyWorkerResponse,
   clearEmptyWorkerStreak,
 } from "./worker-health";
@@ -227,6 +229,30 @@ export function isTemperatureUnsupported400(body: string): boolean {
     /\b(deprecated|unsupported|no\s+longer\s+supported|not\s+(?:a\s+)?support(?:ed)?|removed|not\s+allowed|cannot\s+be\s+(?:set|used|specified))\b/i.test(
       body,
     )
+  );
+}
+
+/**
+ * True when an upstream response indicates the worker MODEL is unavailable
+ * because it is gated by the account's data policy — specifically OpenRouter's
+ *   404 "No endpoints available matching your guardrail restrictions and data
+ *   policy. Configure: https://openrouter.ai/settings/privacy"
+ * returned for `:free` models when the account has not opted into prompt
+ * logging/training.
+ *
+ * This is a per-account availability fact about THIS model, not a transient
+ * outage: retrying is futile and the fix is to blocklist the model and
+ * re-resolve worker selection to a usable same-family sibling. Kept strict
+ * (status 404 AND a "no endpoints" phrase AND a data-policy/guardrail/privacy
+ * marker) so an ordinary 404 (wrong URL, unknown model) cannot trigger it.
+ */
+export function isDataPolicyBlocked404(status: number, body: string): boolean {
+  if (status !== 404) return false;
+  if (!/no\s+endpoints/i.test(body)) return false;
+  return (
+    /data\s+policy/i.test(body) ||
+    /guardrail/i.test(body) ||
+    /settings\/privacy/i.test(body)
   );
 }
 
@@ -2333,6 +2359,41 @@ export function createGatewayLLMClient(
                   );
                   retryCount++;
                   continue;
+                }
+
+                // Data-policy 404: the selected worker model (typically an
+                // OpenRouter `:free` model) is unavailable because the account
+                // has not opted into the provider's data-collection policy.
+                // This is a per-account availability fact about THIS model, not
+                // an outage — retrying is futile. Blocklist the model (and, for
+                // a `:free` model, the whole `:free` tier on this provider per
+                // the "assume all :free collect data" directive) and classify
+                // as `data-policy` so it does NOT feed the Sentry outage ladder
+                // or credit-pause the session. Worker-model selection re-resolves
+                // to a usable same-family sibling on the next pass; the next real
+                // worker call against that sibling is the recovery probe.
+                if (isDataPolicyBlocked404(response.status, text)) {
+                  log.warn(
+                    `worker model ${model.providerID}/${model.modelID} blocked by account data policy (404) — ` +
+                      `blocklisting and re-resolving (worker=${opts?.workerID ?? "unknown"}, ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}): ${text.slice(0, 160)}`,
+                  );
+                  markWorkerIncapable(model.providerID, model.modelID);
+                  if (model.modelID.endsWith(":free")) {
+                    markFreeModelsDataBlocked(model.providerID);
+                  }
+                  span.setStatus({
+                    code: 2,
+                    message: `HTTP ${response.status} (data-policy)`,
+                  });
+                  recordWorkerFailure(
+                    opts?.sessionID ?? "_unknown",
+                    opts?.workerID ?? "unknown",
+                    "data-policy",
+                  );
+                  // Do NOT markWorkerPaused: the fix is re-resolution to a
+                  // different model, not pausing the session's workers.
+                  return null;
                 }
 
                 log.error(

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -243,6 +243,7 @@ import {
   fetchModelData,
   ensureModelDataReady,
   getModelEntrySync,
+  getModelEntrySyncForProvider,
   isModelDataLoaded,
   lookupProviderRoute,
 } from "./worker-model";
@@ -1928,9 +1929,16 @@ const DEFAULT_MODEL_SPEC: ModelSpec = { context: 200_000, output: 8_192 };
  *
  * Uses the sync cache populated by `fetchModelData()` during init.
  * Falls back to sensible defaults if the cache isn't warm yet.
+ *
+ * `providerID` (when known from the request route) selects the
+ * provider-qualified pricing entry so a bare id published by many providers at
+ * different cache prices (e.g. `deepseek/deepseek-v4-flash` on openrouter vs
+ * zenmux) is priced from the provider the session is ACTUALLY routed to — the
+ * flat map is last-write-wins across providers and would otherwise corrupt
+ * `cacheReadCost` → `computeLayer0Cap`.
  */
-function getModelSpec(model: string): ModelSpec {
-  const entry = getModelEntrySync(model);
+function getModelSpec(model: string, providerID?: string): ModelSpec {
+  const entry = getModelEntrySyncForProvider(providerID, model);
   return {
     context: entry.limit?.context ?? DEFAULT_MODEL_SPEC.context,
     output: entry.limit?.output ?? DEFAULT_MODEL_SPEC.output,
@@ -6881,7 +6889,14 @@ async function handleConversationTurn(
   // getModelEntrySync sites — worker selection, cost metrics — intentionally
   // keep using the sync fallback on the very first turn; they self-correct.)
   await ensureModelDataReady();
-  const modelSpec = getModelSpec(req.model);
+  // Price the session model from the provider it is actually routed to (the
+  // X-Lore-Provider header), not the flat last-write-wins entry — a bare id
+  // published by several providers at different cache prices would otherwise
+  // corrupt cacheReadCost → computeLayer0Cap.
+  const modelSpec = getModelSpec(
+    req.model,
+    extractProviderHeader(req.rawHeaders),
+  );
   const cfg = loreConfig();
 
   // Cost-aware layer-0 cap: explicit config wins > cost formula > disabled.

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1937,7 +1937,7 @@ const DEFAULT_MODEL_SPEC: ModelSpec = { context: 200_000, output: 8_192 };
  * flat map is last-write-wins across providers and would otherwise corrupt
  * `cacheReadCost` → `computeLayer0Cap`.
  */
-function getModelSpec(model: string, providerID?: string): ModelSpec {
+export function getModelSpec(model: string, providerID?: string): ModelSpec {
   const entry = getModelEntrySyncForProvider(providerID, model);
   return {
     context: entry.limit?.context ?? DEFAULT_MODEL_SPEC.context,

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -68,7 +68,16 @@ export type FailureReason =
   // capability limitation of the model, NOT an outage — it must not drive the
   // degraded/critical Sentry ladder or the circuit breaker. We record it for
   // visibility and cache the verdict so we stop calling that model.
-  | "worker-incapable";
+  | "worker-incapable"
+  // Non-escalating: the selected worker model is rejected by the account's
+  // data policy (e.g. an OpenRouter `:free` model returns a 404 "No endpoints
+  // available matching your guardrail restrictions and data policy" for an
+  // account that has not opted into prompt logging). This is a per-account
+  // config/availability fact, NOT an outage — the model is blocklisted and
+  // selection re-resolves to a usable same-family sibling on the next pass, so
+  // it must not drive the degraded/critical Sentry ladder or the circuit
+  // breaker. Recorded (warn) for visibility.
+  | "data-policy";
 
 /**
  * Failure reasons that are credential/config conditions rather than upstream
@@ -194,6 +203,44 @@ const creditPaused: Map<string, { lastProbe: number }> = new Map();
  */
 const incapableModels: Set<string> = new Set();
 
+/**
+ * Providers whose OpenRouter-style `:free` worker models are blocked by the
+ * account's data policy. Populated when {@link markFreeModelsDataBlocked} is
+ * called after a data-policy 404 (see `isDataPolicyBlocked404` in llm-adapter).
+ *
+ * User directive: once we observe ONE data-policy 404 on a `:free` model, we
+ * assume ALL `:free` models on that provider are data-collection-gated and
+ * therefore unusable on this account, so worker-model selection skips the
+ * entire `:free` tier for that provider. This is provider-scoped (not global)
+ * and only ever LEARNED from an actual 404 — we never statically exclude
+ * `:free`, since a different account may have opted in.
+ *
+ * In-memory only: resets on process restart and is re-learned on the first
+ * data-policy 404 after a restart. This self-heals if the account later opts
+ * into the provider's data policy (a restart clears the block; the newly-usable
+ * `:free` model simply stops 404ing).
+ */
+const freeModelsDataBlocked: Set<string> = new Set();
+
+/**
+ * Monotonic counter bumped whenever the model blocklist changes
+ * ({@link markWorkerIncapable} adds a new verdict, or
+ * {@link markFreeModelsDataBlocked} adds a new provider). Worker-model
+ * selection memoizes resolutions keyed on the models.dev snapshot version; it
+ * must ALSO key on this generation so a freshly-blocklisted model is not served
+ * from a stale memo entry. Read via {@link blocklistGeneration}.
+ */
+let blocklistGen = 0;
+
+/**
+ * Current blocklist generation. Bumped by {@link markWorkerIncapable} and
+ * {@link markFreeModelsDataBlocked}. Consumed by worker-model.ts to invalidate
+ * its resolution memo when the set of usable models changes.
+ */
+export function blocklistGeneration(): number {
+  return blocklistGen;
+}
+
 let sweepTimer: ReturnType<typeof setInterval> | null = null;
 
 /** Injectable time source — tests can override. */
@@ -209,6 +256,8 @@ export function _resetForTest(): void {
   state.clear();
   creditPaused.clear();
   incapableModels.clear();
+  freeModelsDataBlocked.clear();
+  blocklistGen = 0;
   consecutiveEmpty.clear();
   if (sweepTimer) {
     clearInterval(sweepTimer);
@@ -332,6 +381,7 @@ export function markWorkerIncapable(
   const key = modelKey(providerID, modelID, workerID);
   if (incapableModels.has(key)) return;
   incapableModels.add(key);
+  blocklistGen++;
   log.warn(
     `[worker-health] model ${providerID}/${modelID} marked worker-incapable ` +
       `for worker=${workerID} — it returned no usable text after the ` +
@@ -347,6 +397,35 @@ export function isWorkerIncapable(
   workerID: WorkerID | (string & {}) = ANY_WORKER,
 ): boolean {
   return incapableModels.has(modelKey(providerID, modelID, workerID));
+}
+
+/**
+ * Record that the given provider's `:free` worker models are blocked by the
+ * account's data policy (learned from a data-policy 404 — see
+ * `isDataPolicyBlocked404`). Idempotent per provider; bumps the blocklist
+ * generation on the first observation so memoized resolutions re-resolve.
+ *
+ * User directive: assume ALL `:free` models on the provider collect data once
+ * we see this error, so the whole `:free` tier is skipped for that provider.
+ */
+export function markFreeModelsDataBlocked(providerID: string): void {
+  if (freeModelsDataBlocked.has(providerID)) return;
+  freeModelsDataBlocked.add(providerID);
+  blocklistGen++;
+  log.warn(
+    `[worker-health] provider ${providerID} :free worker models blocked by ` +
+      `account data policy — skipping the :free tier for this provider and ` +
+      `re-resolving to a paid same-family sibling (in-memory; re-learned after ` +
+      `restart)`,
+  );
+}
+
+/**
+ * True when the given provider's `:free` worker models have been observed to be
+ * data-policy-blocked for this account this process.
+ */
+export function areFreeModelsDataBlocked(providerID: string): boolean {
+  return freeModelsDataBlocked.has(providerID);
 }
 
 // ---------------------------------------------------------------------------
@@ -419,6 +498,20 @@ export function recordWorkerFailure(
   if (reason === "worker-incapable") {
     log.warn(
       `[worker-health] ${workerID} skipped (worker-incapable) for session=${sessionID.slice(0, 16)}`,
+    );
+    return;
+  }
+
+  // data-policy is a per-account availability fact (a :free model gated by the
+  // account's data policy), not an outage. Like worker-incapable, it must never
+  // drive the degraded/critical Sentry ladder or the circuit breaker: the model
+  // is blocklisted (markFreeModelsDataBlocked / markWorkerIncapable at the call
+  // site) and selection re-resolves to a usable same-family sibling on the next
+  // pass, so a sustained-failure warning would be both alarming and wrong.
+  // Recorded (warn) for visibility.
+  if (reason === "data-policy") {
+    log.warn(
+      `[worker-health] ${workerID} skipped (data-policy) for session=${sessionID.slice(0, 16)} — worker model re-resolving`,
     );
     return;
   }

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -11,6 +11,11 @@
 import { workerModel, config as loreConfig, log } from "@loreai/core";
 import type { ProviderRoute } from "./config";
 import { upstreamFetch } from "./fetch";
+import {
+  isWorkerIncapable,
+  areFreeModelsDataBlocked,
+  blocklistGeneration,
+} from "./worker-health";
 
 // ---------------------------------------------------------------------------
 // Cost lookup — models.dev
@@ -54,15 +59,29 @@ const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
  */
 let resolutionMemo = new Map<string, string | undefined>();
 let resolutionMemoVersion = -1;
+let resolutionMemoBlocklistGen = -1;
 
 /**
  * Return the resolution memo valid for the current models.dev snapshot,
- * rebuilding it when the snapshot version (`cachedModelDataAt`) has advanced.
+ * rebuilding it when the snapshot version (`cachedModelDataAt`) OR the
+ * worker-health blocklist generation has advanced.
+ *
+ * The blocklist generation is load-bearing: a resolution is a pure function of
+ * the models.dev snapshot AND the set of usable (non-blocklisted) models. When
+ * a model is marked worker-incapable or a provider's `:free` tier is
+ * data-policy-blocked, the correct answer changes even though the snapshot did
+ * not — so the memo must be invalidated or a just-blocklisted model would keep
+ * being served from a stale entry, defeating auto-recovery.
  */
 function currentResolutionMemo(): Map<string, string | undefined> {
-  if (resolutionMemoVersion !== cachedModelDataAt) {
+  const gen = blocklistGeneration();
+  if (
+    resolutionMemoVersion !== cachedModelDataAt ||
+    resolutionMemoBlocklistGen !== gen
+  ) {
     resolutionMemo = new Map();
     resolutionMemoVersion = cachedModelDataAt;
+    resolutionMemoBlocklistGen = gen;
   }
   return resolutionMemo;
 }
@@ -538,6 +557,7 @@ export function clearModelDataCache(): void {
   lastReadyAttemptAt = 0;
   resolutionMemo = new Map();
   resolutionMemoVersion = -1;
+  resolutionMemoBlocklistGen = -1;
 }
 
 /**
@@ -552,6 +572,7 @@ export function _setModelDataForTest(
   cachedModelDataAt = Date.now();
   resolutionMemo = new Map();
   resolutionMemoVersion = -1;
+  resolutionMemoBlocklistGen = -1;
 }
 
 // ---------------------------------------------------------------------------
@@ -559,23 +580,75 @@ export function _setModelDataForTest(
 // ---------------------------------------------------------------------------
 
 /**
- * Find a cheaper model from the same provider using models.dev pricing data.
+ * The vendor "namespace" of a model id — the segment before the first `/`.
  *
- * For providers without hardcoded WORKER_DEFAULTS (Google, MiniMax, xAI, etc.),
- * this is family-aware so a discovered worker tracks new generations the same
- * way the hardcoded WORKER_DEFAULTS do (via `resolveNewestInFamily`):
+ * Aggregators like OpenRouter namespace every model by vendor
+ * (`anthropic/claude-opus-4.8`, `cohere/north-mini-code:free`). Direct
+ * providers use bare ids (`claude-opus-4.8`) → empty namespace. Used to keep
+ * worker selection inside the session model's OWN vendor on an aggregator, so
+ * an Opus session never resolves a Cohere worker.
+ */
+function modelNamespace(modelID: string): string {
+  const slash = modelID.indexOf("/");
+  return slash > 0 ? modelID.slice(0, slash) : "";
+}
+
+/**
+ * The "lineage key" of a models.dev family — the family string up to its first
+ * `-`. Groups sibling tiers of one vendor lineage:
+ *   claude-opus / claude-sonnet / claude-haiku → "claude"
+ *   gpt-mini / gpt-codex / gpt-nano            → "gpt"
+ *   gemini-2.5-pro / gemini-3-flash            → "gemini"
+ * Derived purely from models.dev data — no hardcoded vendor names.
+ */
+function lineageKey(family: string): string {
+  const dash = family.indexOf("-");
+  return dash > 0 ? family.slice(0, dash) : family;
+}
+
+/**
+ * True when a candidate worker model id is currently usable for selection:
+ * not marked worker-incapable, and — when the provider's `:free` tier is
+ * data-policy-blocked — not a `:free` model. Both signals come from
+ * worker-health and only ever tighten AFTER an observed failure, so this never
+ * statically excludes `:free` (a different account may have opted in).
+ */
+function isSelectableWorkerModel(providerID: string, modelID: string): boolean {
+  if (isWorkerIncapable(providerID, modelID)) return false;
+  if (modelID.endsWith(":free") && areFreeModelsDataBlocked(providerID)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Find a cheaper same-provider worker model, staying inside the session model's
+ * OWN vendor lineage and choosing the "closest cheaper tier".
  *
- *   1. Pass 1 — find the absolute cheapest same-provider model strictly cheaper
- *      than the session (input price). Its family identifies the cheapest TIER.
- *   2. Pass 2 — within that cheapest family, return the NEWEST member that is
- *      still cheaper than the session. This avoids pinning an obsolete model
- *      just because it's a few cents cheaper than its modern sibling (e.g.
- *      gemini-2.5-flash-lite over a newer gemini-3-flash-lite), while staying
- *      in the same cost tier and never exceeding the session price.
+ * This matters for aggregators (OpenRouter, etc.) whose provider index mixes
+ * many vendors: the old "globally cheapest model in the provider" rule crossed
+ * lineages, picking e.g. a `$0` `cohere/...:free` model for an
+ * `anthropic/claude-opus-4.8` session. That free model is then data-policy
+ * blocked on accounts that haven't opted into prompt logging.
  *
- * Falls back to the Pass-1 cheapest when the cheapest model has no family
- * metadata (preserving the original cheapest-by-cost behavior offline).
- * Returns undefined if no cheaper model exists.
+ * Algorithm (all data-driven, no hardcoded vendor names):
+ *   1. Resolve the session model's own models.dev entry → its `family` and id
+ *      `namespace`. Derive the vendor `lineageKey` (family up to first `-`).
+ *   2. Candidate set = same-provider, SELECTABLE (see
+ *      {@link isSelectableWorkerModel}) models that match the session's
+ *      namespace (when namespaced) AND whose family shares the lineage key AND
+ *      that are strictly cheaper than the session.
+ *   3. Group candidates by family; judge each family's tier by its NEWEST
+ *      member's input cost. Pick the family with the MAXIMUM tier cost still
+ *      `< sessionInputCost` — the "closest cheaper tier" (opus → sonnet, not
+ *      haiku). Ties broken toward the family whose newest member is newest.
+ *   4. Within that family return the newest member still cheaper than the
+ *      session (release_date desc, then numeric-aware id desc).
+ *
+ * Falls back to the legacy global-cheapest-in-provider behavior when the
+ * session model has no family/namespace metadata OR the lineage candidate set
+ * is empty, so unknown/edge providers are never regressed. Returns undefined
+ * when no cheaper selectable model exists.
  */
 function findCheaperSameProviderModel(
   providerID: string,
@@ -589,7 +662,84 @@ function findCheaperSameProviderModel(
   const memoKey = `cheaper\x1f${providerID}\x1f${sessionModelID}\x1f${sessionInputCost}`;
   if (memo.has(memoKey)) return memo.get(memoKey);
 
-  // Pass 1: cheapest same-provider model cheaper than the session.
+  const sessionEntry = matchModelEntry(cachedModelData, sessionModelID);
+  const sessionNamespace = modelNamespace(sessionModelID);
+  const sessionLineage = sessionEntry?.family
+    ? lineageKey(sessionEntry.family)
+    : undefined;
+
+  // ----- Lineage-aware path: same vendor, closest cheaper tier. -----
+  if (sessionLineage) {
+    // Group cheaper same-lineage selectable candidates by family, tracking each
+    // family's newest member (by date, then numeric-aware id) and that member's
+    // cost as the family's tier cost.
+    type Fam = { newestId: string; newestDate: string; tierCost: number };
+    const families = new Map<string, Fam>();
+    for (const modelId of providerModelIds) {
+      if (modelId === sessionModelID) continue;
+      if (sessionNamespace && modelNamespace(modelId) !== sessionNamespace) {
+        continue;
+      }
+      const entry = cachedModelData.get(modelId);
+      if (!entry?.family || lineageKey(entry.family) !== sessionLineage) {
+        continue;
+      }
+      const cost = entry.cost?.input;
+      if (cost == null || cost >= sessionInputCost) continue;
+      if (!isSelectableWorkerModel(providerID, modelId)) continue;
+
+      const date = entry.release_date ?? "";
+      const fam = families.get(entry.family);
+      if (
+        !fam ||
+        date > fam.newestDate ||
+        (date === fam.newestDate &&
+          modelId.localeCompare(fam.newestId, "en", { numeric: true }) > 0)
+      ) {
+        families.set(entry.family, {
+          newestId: modelId,
+          newestDate: date,
+          tierCost: cost,
+        });
+      }
+    }
+
+    if (families.size > 0) {
+      // Closest cheaper tier: the family whose newest member is the most
+      // expensive while still cheaper than the session. Tie-break toward the
+      // newer family tier so a fresh generation wins a cost tie.
+      let best: (Fam & { family: string }) | undefined;
+      for (const [family, fam] of families) {
+        if (
+          !best ||
+          fam.tierCost > best.tierCost ||
+          (fam.tierCost === best.tierCost && fam.newestDate > best.newestDate)
+        ) {
+          best = { ...fam, family };
+        }
+      }
+      // families.size > 0 guarantees `best` is assigned; the guard also
+      // narrows the type without a non-null assertion.
+      if (best) {
+        const resolvedId = best.newestId;
+        log.info(
+          `dynamic worker model: ${providerID}/${resolvedId} ($${best.tierCost}/M, ` +
+            `lineage ${sessionLineage}, family ${best.family}, closest cheaper tier) ` +
+            `instead of ${sessionModelID} ($${sessionInputCost}/M)`,
+        );
+        memo.set(memoKey, resolvedId);
+        return resolvedId;
+      }
+    }
+    // No usable same-lineage candidate — fall through to the legacy path below
+    // (e.g. all lineage siblings blocklisted, or lineage has no cheaper tier).
+  }
+
+  // ----- Legacy fallback path: global cheapest selectable in the provider. ---
+  // Preserves original behavior for sessions whose model has no family metadata
+  // (unknown providers) or whose lineage yielded no cheaper selectable sibling.
+
+  // Pass 1: cheapest same-provider selectable model cheaper than the session.
   let cheapestId: string | undefined;
   let cheapestCost = sessionInputCost;
   let cheapestFamily: string | undefined;
@@ -597,11 +747,11 @@ function findCheaperSameProviderModel(
     if (modelId === sessionModelID) continue;
     const entry = cachedModelData.get(modelId);
     if (entry?.cost?.input == null) continue;
-    if (entry.cost.input < cheapestCost) {
-      cheapestCost = entry.cost.input;
-      cheapestId = modelId;
-      cheapestFamily = entry.family;
-    }
+    if (entry.cost.input >= cheapestCost) continue;
+    if (!isSelectableWorkerModel(providerID, modelId)) continue;
+    cheapestCost = entry.cost.input;
+    cheapestId = modelId;
+    cheapestFamily = entry.family;
   }
   if (!cheapestId) {
     memo.set(memoKey, undefined);
@@ -621,6 +771,7 @@ function findCheaperSameProviderModel(
       if (entry.cost?.input == null || entry.cost.input >= sessionInputCost) {
         continue;
       }
+      if (!isSelectableWorkerModel(providerID, modelId)) continue;
       const date = entry.release_date ?? "";
       if (
         date > bestDate ||
@@ -690,6 +841,10 @@ function resolveNewestInFamily(
     const entry = cachedModelData.get(id);
     if (!entry || entry.family !== family) continue;
     if (!isCheapVariant(id)) continue;
+    // Skip models blocklisted this process (worker-incapable, or a
+    // data-policy-blocked :free tier) so a bad model isn't re-picked and
+    // selection advances to the next candidate on re-resolution.
+    if (!isSelectableWorkerModel(providerID, id)) continue;
     // Cost guard: skip family members priced at/above the session model, and
     // members with unknown pricing — we cannot prove they clear the cap, so we
     // fall back to the known-cheap hardcoded default instead of guessing.

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -32,6 +32,16 @@ const MODELS_DEV_API = "https://models.dev/api.json";
 
 /** Cached models.dev data: model entries keyed by modelID (all providers). */
 let cachedModelData: Map<string, ModelsDevEntry> | null = null;
+/**
+ * Cached models.dev data keyed by `${providerID}/${modelID}` so a bare id that
+ * many providers publish at DIFFERENT prices (e.g. `deepseek/deepseek-v4-flash`
+ * on openrouter vs zenmux vs alibaba-cn, each with a different `cache_read`) can
+ * be priced from the provider the session is actually routed to. The flat
+ * {@link cachedModelData} map is last-write-wins across providers, so a session
+ * on openrouter would otherwise be priced with whichever provider appeared last
+ * in the JSON — corrupting `cacheReadCostPerToken` → `computeLayer0Cap`.
+ */
+let cachedModelDataByProvider: Map<string, ModelsDevEntry> | null = null;
 /** Cached provider → model IDs index for same-provider cheaper-model lookup. */
 let cachedProviderModels: Map<string, string[]> | null = null;
 /** Cached provider routing data extracted from the models.dev response. */
@@ -358,6 +368,7 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
 
       const data = (await response.json()) as ModelsDevResponse;
       const modelData = new Map<string, ModelsDevEntry>();
+      const modelDataByProvider = new Map<string, ModelsDevEntry>();
       const providerModelsIndex = new Map<string, string[]>();
       const providerRoutes = new Map<string, ProviderRoute>();
       const loadedProviders: string[] = [];
@@ -374,7 +385,11 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
         if (providerModels && typeof providerModels === "object") {
           const modelIds: string[] = [];
           for (const [modelId, entry] of Object.entries(providerModels)) {
-            modelData.set(modelId, normalizeModelEntry(modelId, entry));
+            const normalized = normalizeModelEntry(modelId, entry);
+            modelData.set(modelId, normalized);
+            // Provider-qualified entry: never last-write-wins across providers,
+            // so a session's cost is read from the provider it is routed to.
+            modelDataByProvider.set(`${providerID}/${modelId}`, normalized);
             modelIds.push(modelId);
           }
           providerModelsIndex.set(providerID, modelIds);
@@ -403,7 +418,9 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
         const providerModels = data[providerID]?.models;
         if (!providerModels || typeof providerModels !== "object") continue;
         for (const [modelId, entry] of Object.entries(providerModels)) {
-          modelData.set(modelId, normalizeModelEntry(modelId, entry));
+          const normalized = normalizeModelEntry(modelId, entry);
+          modelData.set(modelId, normalized);
+          modelDataByProvider.set(`${providerID}/${modelId}`, normalized);
         }
       }
 
@@ -417,6 +434,7 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
       cachedProviderRoutes = providerRoutes;
       cachedProviderModels = providerModelsIndex;
       cachedModelData = modelData;
+      cachedModelDataByProvider = modelDataByProvider;
       cachedModelDataAt = Date.now();
 
       log.info(
@@ -496,6 +514,29 @@ export function getModelEntrySync(modelID: string): ModelsDevEntry {
   return matchModelEntry(cachedModelData, modelID) ?? fallbackEntry(modelID);
 }
 
+/**
+ * Provider-aware synchronous model entry lookup. Prefers the provider-qualified
+ * entry (`${providerID}/${modelID}`) so a bare id published by multiple
+ * providers at different prices is read from the provider the session is
+ * actually routed to — NOT the last-write-wins flat entry. Falls back to the
+ * bare {@link getModelEntrySync} lookup when the provider is unknown/undefined
+ * or has no matching entry, so it is fully backward-compatible.
+ *
+ * Only an EXACT `${providerID}/${modelID}` hit uses the qualified map; prefix/
+ * family matching stays on the flat map (the qualified map is a pure pricing
+ * override for exactly-known routes, never a new matcher).
+ */
+export function getModelEntrySyncForProvider(
+  providerID: string | undefined,
+  modelID: string,
+): ModelsDevEntry {
+  if (providerID && cachedModelDataByProvider) {
+    const qualified = cachedModelDataByProvider.get(`${providerID}/${modelID}`);
+    if (qualified) return qualified;
+  }
+  return getModelEntrySync(modelID);
+}
+
 /** True when models.dev data has been loaded into the in-memory cache. */
 export function isModelDataLoaded(): boolean {
   return cachedModelData !== null;
@@ -550,6 +591,7 @@ export async function ensureModelDataReady(timeoutMs = 2_000): Promise<void> {
 /** Clear cached data (for testing). */
 export function clearModelDataCache(): void {
   cachedModelData = null;
+  cachedModelDataByProvider = null;
   cachedProviderModels = null;
   cachedProviderRoutes = null;
   cachedModelDataAt = 0;
@@ -564,11 +606,18 @@ export function clearModelDataCache(): void {
  * Test-only: seed the models.dev cache directly (no network) so
  * `getModelEntrySync` returns known capability entries. Bumps the snapshot
  * version so any resolution memo is invalidated.
+ *
+ * `byProvider` optionally seeds the provider-qualified map (keys are
+ * `${providerID}/${modelID}`) consumed by {@link getModelEntrySyncForProvider}.
  */
 export function _setModelDataForTest(
   entries: Record<string, ModelsDevEntry>,
+  byProvider?: Record<string, ModelsDevEntry>,
 ): void {
   cachedModelData = new Map(Object.entries(entries));
+  cachedModelDataByProvider = byProvider
+    ? new Map(Object.entries(byProvider))
+    : null;
   cachedModelDataAt = Date.now();
   resolutionMemo = new Map();
   resolutionMemoVersion = -1;
@@ -713,7 +762,12 @@ function findCheaperSameProviderModel(
         if (
           !best ||
           fam.tierCost > best.tierCost ||
-          (fam.tierCost === best.tierCost && fam.newestDate > best.newestDate)
+          (fam.tierCost === best.tierCost &&
+            (fam.newestDate > best.newestDate ||
+              (fam.newestDate === best.newestDate &&
+                fam.newestId.localeCompare(best.newestId, "en", {
+                  numeric: true,
+                }) > 0)))
         ) {
           best = { ...fam, family };
         }
@@ -731,13 +785,19 @@ function findCheaperSameProviderModel(
         return resolvedId;
       }
     }
-    // No usable same-lineage candidate — fall through to the legacy path below
-    // (e.g. all lineage siblings blocklisted, or lineage has no cheaper tier).
+    // The session model HAS a known vendor lineage but no usable cheaper
+    // same-vendor sibling exists (all siblings blocklisted, or the lineage has
+    // no cheaper tier). Do NOT fall through to the cross-vendor legacy path — a
+    // worker must stay inside the session model's own vendor. Return undefined
+    // so the caller falls back to the session model itself (safe, just pricier)
+    // rather than silently routing to an unrelated vendor's model.
+    memo.set(memoKey, undefined);
+    return undefined;
   }
 
   // ----- Legacy fallback path: global cheapest selectable in the provider. ---
-  // Preserves original behavior for sessions whose model has no family metadata
-  // (unknown providers) or whose lineage yielded no cheaper selectable sibling.
+  // Reached ONLY when the session model has no family/lineage metadata (unknown
+  // or edge providers). Preserves the original cheapest-by-cost behavior.
 
   // Pass 1: cheapest same-provider selectable model cheaper than the session.
   let cheapestId: string | undefined;

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1143,6 +1143,60 @@ describe("worker data-policy 404: blocklist + re-resolve, not an outage", () => 
     );
     expect(mockMarkPaused).toHaveBeenCalledWith("sess-plain-404");
   });
+
+  test("a data-policy error surfaced as HTTP 200 + {error:{code:404}} envelope is blocklisted as data-policy (not miscounted as empty/incapable)", async () => {
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              message:
+                "No endpoints available matching your guardrail restrictions and data policy. Configure: https://openrouter.ai/settings/privacy",
+              code: 404,
+            },
+          }),
+          {
+            // Misleading 200 wire status — the real signal is the embedded code.
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+        openrouter: "https://openrouter.ai/api",
+      } as unknown as { anthropic: string; openai: string },
+      () => ({ scheme: "bearer", value: "sk-or-test" }),
+      { providerID: "openrouter", modelID: "cohere/north-mini-code:free" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+      sessionID: "sess-dp-200",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+    });
+
+    expect(result).toBeNull();
+    // Mutation: remove the HTTP-200-envelope data-policy branch → this is
+    // recorded via the empty-response path (worker-incapable eventually), NOT
+    // data-policy, and the :free tier is never blocked → RED.
+    expect(mockMarkIncapable).toHaveBeenCalledWith(
+      "openrouter",
+      "cohere/north-mini-code:free",
+    );
+    expect(mockMarkFreeBlocked).toHaveBeenCalledWith("openrouter");
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      "sess-dp-200",
+      "lore-distill",
+      "data-policy",
+    );
+    expect(mockMarkPaused).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -12,6 +12,8 @@ vi.mock("../src/worker-health", async (importOriginal) => {
     ...actual,
     recordWorkerFailure: vi.fn(actual.recordWorkerFailure),
     markWorkerPaused: vi.fn(actual.markWorkerPaused),
+    markWorkerIncapable: vi.fn(actual.markWorkerIncapable),
+    markFreeModelsDataBlocked: vi.fn(actual.markFreeModelsDataBlocked),
   };
 });
 
@@ -24,6 +26,7 @@ import {
   AUTH_ERROR_CODES,
   isTemperatureUnsupportedModel,
   isAnthropicClaudeModel,
+  isDataPolicyBlocked404,
   isThinkingUnsupportedModel,
   markThinkingUnsupported,
   workerThinkingOnByDefault,
@@ -39,6 +42,10 @@ import {
 import { upstreamFetch } from "../src/fetch";
 import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
 import { recordWorkerFailure, markWorkerPaused } from "../src/worker-health";
+import {
+  markWorkerIncapable,
+  markFreeModelsDataBlocked,
+} from "../src/worker-health";
 import { captureSessionHeaders, captureBillingPrefix } from "../src/cch";
 import { _setTestVertexTokenProvider } from "../src/vertex-auth";
 
@@ -937,6 +944,204 @@ describe("worker 402 insufficient credit handling", () => {
     expect(result).toBeNull();
     expect(mockMarkPaused).not.toHaveBeenCalled();
     expect(mockRecordFailure).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data-policy 404 detection + :free auto-recovery
+//
+// REGRESSION: an OpenRouter session auto-selected a $0 `:free` worker model,
+// which OpenRouter 404s for accounts that haven't opted into its data policy
+// ("No endpoints available matching your guardrail restrictions and data
+// policy"). The old code classified it as retriable `upstream-error`, causing a
+// tight retry storm + a misleading "upstream failing" degradation warning. The
+// fix blocklists the model + :free tier and classifies it as `data-policy`.
+// ---------------------------------------------------------------------------
+
+describe("isDataPolicyBlocked404 detector", () => {
+  const OR_BODY = JSON.stringify({
+    error: {
+      message:
+        "No endpoints available matching your guardrail restrictions and data policy. Configure: https://openrouter.ai/settings/privacy",
+      code: 404,
+    },
+  });
+
+  test("true for OpenRouter data-policy 404", () => {
+    expect(isDataPolicyBlocked404(404, OR_BODY)).toBe(true);
+  });
+
+  test("matches on guardrail / privacy phrasing too", () => {
+    expect(
+      isDataPolicyBlocked404(404, "no endpoints matching your guardrail rules"),
+    ).toBe(true);
+    expect(
+      isDataPolicyBlocked404(404, "No endpoints; see /settings/privacy"),
+    ).toBe(true);
+  });
+
+  test("false for an ordinary 404 (wrong URL / unknown model)", () => {
+    expect(isDataPolicyBlocked404(404, "model not found")).toBe(false);
+    expect(isDataPolicyBlocked404(404, "404 page not found")).toBe(false);
+  });
+
+  test("false for the same body on a non-404 status", () => {
+    expect(isDataPolicyBlocked404(429, OR_BODY)).toBe(false);
+    expect(isDataPolicyBlocked404(400, OR_BODY)).toBe(false);
+  });
+});
+
+describe("worker data-policy 404: blocklist + re-resolve, not an outage", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const mockRecordFailure = vi.mocked(recordWorkerFailure);
+  const mockMarkPaused = vi.mocked(markWorkerPaused);
+  const mockMarkIncapable = vi.mocked(markWorkerIncapable);
+  const mockMarkFreeBlocked = vi.mocked(markFreeModelsDataBlocked);
+
+  const DATA_POLICY_404 = JSON.stringify({
+    error: {
+      message:
+        "No endpoints available matching your guardrail restrictions and data policy. Configure: https://openrouter.ai/settings/privacy",
+      code: 404,
+    },
+  });
+
+  beforeEach(() => {
+    mockRecordFailure.mockClear();
+    mockMarkPaused.mockClear();
+    mockMarkIncapable.mockClear();
+    mockMarkFreeBlocked.mockClear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+  });
+
+  test("a :free model data-policy 404 blocklists the model + provider :free tier, records data-policy (NOT upstream-error), and does NOT credit-pause", async () => {
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(DATA_POLICY_404, { status: 404, statusText: "Not Found" }),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+        openrouter: "https://openrouter.ai/api",
+      } as unknown as { anthropic: string; openai: string },
+      () => ({ scheme: "bearer", value: "sk-or-test" }),
+      { providerID: "openrouter", modelID: "cohere/north-mini-code:free" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+      sessionID: "sess-dp-test",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+    });
+
+    expect(result).toBeNull();
+    // Not retried — a data-policy 404 is permanent for this model.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Specific model blocklisted.
+    expect(mockMarkIncapable).toHaveBeenCalledWith(
+      "openrouter",
+      "cohere/north-mini-code:free",
+    );
+    // Whole :free tier blocked for the provider (it IS a :free model).
+    expect(mockMarkFreeBlocked).toHaveBeenCalledWith("openrouter");
+    // Classified as data-policy, NOT upstream-error.
+    // Mutation: classify as upstream-error → this assertion RED.
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      "sess-dp-test",
+      "lore-distill",
+      "data-policy",
+    );
+    expect(mockRecordFailure).not.toHaveBeenCalledWith(
+      "sess-dp-test",
+      "lore-distill",
+      "upstream-error",
+    );
+    // The fix is re-resolution, not pausing the session.
+    expect(mockMarkPaused).not.toHaveBeenCalled();
+  });
+
+  test("a NON-:free model data-policy 404 blocklists the model but NOT the :free tier", async () => {
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(DATA_POLICY_404, { status: 404, statusText: "Not Found" }),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+        openrouter: "https://openrouter.ai/api",
+      } as unknown as { anthropic: string; openai: string },
+      () => ({ scheme: "bearer", value: "sk-or-test" }),
+      { providerID: "openrouter", modelID: "some/paid-model" },
+    );
+
+    await client.prompt("system", "user", {
+      workerID: "lore-distill",
+      sessionID: "sess-dp-paid",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+    });
+
+    expect(mockMarkIncapable).toHaveBeenCalledWith(
+      "openrouter",
+      "some/paid-model",
+    );
+    expect(mockMarkFreeBlocked).not.toHaveBeenCalled();
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      "sess-dp-paid",
+      "lore-distill",
+      "data-policy",
+    );
+  });
+
+  test("an ordinary 404 (not data-policy) stays upstream-error + credit-pause", async () => {
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({ error: { message: "model not found" } }),
+          {
+            status: 404,
+            statusText: "Not Found",
+          },
+        ),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+        openrouter: "https://openrouter.ai/api",
+      } as unknown as { anthropic: string; openai: string },
+      () => ({ scheme: "bearer", value: "sk-or-test" }),
+      { providerID: "openrouter", modelID: "some/model" },
+    );
+
+    await client.prompt("system", "user", {
+      workerID: "lore-distill",
+      sessionID: "sess-plain-404",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+    });
+
+    // Ordinary 404 keeps the legacy behavior: upstream-error + soft-pause.
+    expect(mockMarkIncapable).not.toHaveBeenCalled();
+    expect(mockMarkFreeBlocked).not.toHaveBeenCalled();
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      "sess-plain-404",
+      "lore-distill",
+      "upstream-error",
+    );
+    expect(mockMarkPaused).toHaveBeenCalledWith("sess-plain-404");
   });
 });
 

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1197,6 +1197,59 @@ describe("worker data-policy 404: blocklist + re-resolve, not an outage", () => 
     );
     expect(mockMarkPaused).not.toHaveBeenCalled();
   });
+
+  test("a NORMAL 200 completion whose text mentions the data-policy phrase is NOT blocklisted (no embedded error code)", async () => {
+    // Seer #1407 false-positive guard: a successful reply (bodyErrCode === null)
+    // that happens to contain "No endpoints … data policy" — e.g. the model
+    // explaining OpenRouter's own error to the user — must be returned normally,
+    // NEVER blocklisted. Mutation: revert the gate to `bodyErrCode ?? 404` →
+    // this reply is treated as a data-policy failure → RED.
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "cmpl-normal",
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content:
+                    "OpenRouter returns 'No endpoints available matching your guardrail restrictions and data policy' when your account has not opted into prompt logging.",
+                },
+                finish_reason: "stop",
+              },
+            ],
+            usage: { prompt_tokens: 20, completion_tokens: 30 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+        openrouter: "https://openrouter.ai/api",
+      } as unknown as { anthropic: string; openai: string },
+      () => ({ scheme: "bearer", value: "sk-or-test" }),
+      { providerID: "openrouter", modelID: "cohere/north-mini-code:free" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      workerID: "lore-distill",
+      sessionID: "sess-dp-falsepos",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+    });
+
+    // The completion text is returned; nothing is blocklisted or recorded.
+    expect(result).toContain("OpenRouter returns");
+    expect(mockMarkIncapable).not.toHaveBeenCalled();
+    expect(mockMarkFreeBlocked).not.toHaveBeenCalled();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    expect(mockMarkPaused).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/test/model-spec-provider-pricing.test.ts
+++ b/packages/gateway/test/model-spec-provider-pricing.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression guard for the provider-qualified session-model pricing fix
+ * (PR #1407 follow-up).
+ *
+ * A bare model id published by MULTIPLE providers at DIFFERENT cache prices
+ * (e.g. `deepseek/deepseek-v4-flash` on openrouter vs zenmux) was priced
+ * last-write-wins by the flat models.dev map, corrupting the session's
+ * `cacheReadCost` → `computeLayer0Cap`. `getModelSpec(model, providerID)` now
+ * threads the routed provider so pricing comes from the provider the session is
+ * ACTUALLY routed to.
+ *
+ * This drives the REAL `getModelSpec` (exported from pipeline.ts) rather than
+ * only the `worker-model` helper in isolation, so dropping the provider arg at
+ * the pipeline layer fails here — the helper-only test in worker-model.test.ts
+ * would still pass on such a revert.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { getModelSpec } from "../src/pipeline";
+import {
+  _setModelDataForTest,
+  clearModelDataCache,
+  type ModelsDevEntry,
+} from "../src/worker-model";
+
+const LIMIT = { context: 200_000, output: 64_000 };
+
+// The same bare id, published by two providers at different cache_read prices.
+const OPENROUTER_ENTRY: ModelsDevEntry = {
+  id: "deepseek/deepseek-v4-flash",
+  cost: { input: 0.098, output: 0.4, cache_read: 0.0196 },
+  limit: LIMIT,
+};
+const ZENMUX_ENTRY: ModelsDevEntry = {
+  id: "deepseek/deepseek-v4-flash",
+  cost: { input: 0.14, output: 0.6, cache_read: 0.0028 },
+  limit: LIMIT,
+};
+
+describe("getModelSpec provider-qualified pricing (pipeline call site)", () => {
+  beforeEach(() => {
+    // Flat map is last-write-wins → zenmux (seeded second) wins the bare id.
+    // Provider-qualified map carries the true per-provider prices.
+    _setModelDataForTest(
+      { "deepseek/deepseek-v4-flash": ZENMUX_ENTRY },
+      {
+        "openrouter/deepseek/deepseek-v4-flash": OPENROUTER_ENTRY,
+        "zenmux/deepseek/deepseek-v4-flash": ZENMUX_ENTRY,
+      },
+    );
+  });
+  afterEach(() => {
+    clearModelDataCache();
+  });
+
+  test("prices from the ROUTED provider, not the last-write-wins flat entry", () => {
+    // Mutation: revert the call site to getModelSpec(req.model) (drop the
+    // provider arg) → both return zenmux's 0.0028/1e6 → RED.
+    const or = getModelSpec("deepseek/deepseek-v4-flash", "openrouter");
+    expect(or.cacheReadCost).toBeCloseTo(0.0196 / 1_000_000, 15);
+
+    const zm = getModelSpec("deepseek/deepseek-v4-flash", "zenmux");
+    expect(zm.cacheReadCost).toBeCloseTo(0.0028 / 1_000_000, 15);
+
+    // The two routed prices must differ — proves the provider arg is load-bearing.
+    expect(or.cacheReadCost).not.toBeCloseTo(zm.cacheReadCost ?? 0, 15);
+  });
+
+  test("falls back to the flat last-write-wins entry when provider is undefined (prefix-routed / header-less sessions)", () => {
+    // Documents the intended no-op fallback: sessions routed by model-prefix or
+    // X-Lore-Upstream-URL carry no X-Lore-Provider header → provider undefined →
+    // legacy flat pricing (unchanged behavior).
+    const spec = getModelSpec("deepseek/deepseek-v4-flash");
+    expect(spec.cacheReadCost).toBeCloseTo(0.0028 / 1_000_000, 15);
+  });
+});

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -13,6 +13,9 @@ import {
   clearWorkerPaused,
   markWorkerIncapable,
   isWorkerIncapable,
+  markFreeModelsDataBlocked,
+  areFreeModelsDataBlocked,
+  blocklistGeneration,
   isCapabilityEmpty,
   recordEmptyWorkerResponse,
   clearEmptyWorkerStreak,
@@ -539,6 +542,53 @@ describe("worker-health", () => {
       markWorkerIncapable("opencode", "mimo-v2.5-free");
       _resetForTest();
       expect(isWorkerIncapable("opencode", "mimo-v2.5-free")).toBe(false);
+    });
+  });
+
+  describe("data-policy :free block", () => {
+    test("mark + query a provider's :free tier as data-policy-blocked", () => {
+      expect(areFreeModelsDataBlocked("openrouter")).toBe(false);
+      markFreeModelsDataBlocked("openrouter");
+      expect(areFreeModelsDataBlocked("openrouter")).toBe(true);
+      // Scoped per provider.
+      expect(areFreeModelsDataBlocked("opencode")).toBe(false);
+    });
+
+    test("data-policy failure does NOT escalate the failure ladder or Sentry", () => {
+      // A per-account availability fact, not an outage — like worker-incapable.
+      for (let i = 0; i < 10; i++) {
+        recordWorkerFailure("s1", "lore-distill", "data-policy");
+      }
+      expect(getStatus("s1")).toBe("healthy");
+      expect(allowWorkerProbe("s1")).toBe(true);
+      expect(getDegradationWarning("s1")).toBeNull();
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    test("blocklistGeneration bumps on first incapable mark and first free-block, and is idempotent", () => {
+      const g0 = blocklistGeneration();
+      markWorkerIncapable("openrouter", "anthropic/claude-sonnet-5");
+      const g1 = blocklistGeneration();
+      expect(g1).toBeGreaterThan(g0);
+      // Idempotent — re-marking the same verdict does not bump.
+      markWorkerIncapable("openrouter", "anthropic/claude-sonnet-5");
+      expect(blocklistGeneration()).toBe(g1);
+
+      markFreeModelsDataBlocked("openrouter");
+      const g2 = blocklistGeneration();
+      expect(g2).toBeGreaterThan(g1);
+      markFreeModelsDataBlocked("openrouter");
+      expect(blocklistGeneration()).toBe(g2);
+    });
+
+    test("_resetForTest clears the free-block and resets the generation", () => {
+      markFreeModelsDataBlocked("openrouter");
+      markWorkerIncapable("openrouter", "x");
+      expect(blocklistGeneration()).toBeGreaterThan(0);
+      _resetForTest();
+      expect(areFreeModelsDataBlocked("openrouter")).toBe(false);
+      expect(blocklistGeneration()).toBe(0);
     });
   });
 

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -14,6 +14,7 @@ import {
   isModelDataLoaded,
   getModelEntry,
   getModelEntrySync,
+  getModelEntrySyncForProvider,
   getWorkerModel,
   resetWorkerModelState,
   clearModelDataCache,
@@ -1983,6 +1984,24 @@ describe("lineage-aware worker selection (aggregator providers)", () => {
     expect(result?.modelID).toBe("anthropic/claude-haiku-4.5");
   });
 
+  test("when the ENTIRE claude lineage is blocklisted, echoes the session model — never crosses to a different vendor", async () => {
+    await warm(openrouterResponse());
+    markWorkerIncapable("openrouter", "anthropic/claude-sonnet-5");
+    markWorkerIncapable("openrouter", "anthropic/claude-sonnet-4.6");
+    markWorkerIncapable("openrouter", "anthropic/claude-haiku-4.5");
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+    // A session WITH a known vendor lineage must NOT fall through to the legacy
+    // global-cheapest path (which could pick mistralai/... or a cohere:free);
+    // it echoes the session model instead. Mutation: fall through to legacy on
+    // lineage exhaustion → picks a non-claude vendor → RED.
+    expect(result?.modelID).toBe("anthropic/claude-opus-4.8");
+    expect(result?.modelID).not.toBe("mistralai/mistral-large");
+    expect(result?.modelID).not.toBe("cohere/north-mini-code:free");
+  });
+
   test("memo invalidation: resolve → blocklist → resolve returns a DIFFERENT model", async () => {
     await warm(openrouterResponse());
     const first = getWorkerModel({
@@ -2141,5 +2160,108 @@ describe("lineage-aware worker selection (aggregator providers)", () => {
       model: "expensive-model",
     });
     expect(result?.modelID).toBe("cheap-model");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider-qualified pricing: same bare id at different prices per provider
+//
+// REGRESSION: getModelEntrySync reads a flat last-write-wins map, so a bare id
+// (e.g. `deepseek/deepseek-v4-flash`) published by openrouter, zenmux, and
+// alibaba-cn at different cache_read prices gets priced with whichever provider
+// appeared LAST in the models.dev JSON — corrupting a session's
+// cacheReadCostPerToken -> computeLayer0Cap. getModelEntrySyncForProvider reads
+// the routed provider's real price.
+// ---------------------------------------------------------------------------
+
+describe("provider-qualified pricing (getModelEntrySyncForProvider)", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  const LIMIT = { context: 200_000, output: 64_000 };
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    resetWorkerModelState();
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    resetWorkerModelState();
+  });
+
+  async function warm(): Promise<void> {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+            openrouter: {
+              api: "https://openrouter.ai/api/v1",
+              models: {
+                "deepseek/deepseek-v4-flash": {
+                  id: "deepseek/deepseek-v4-flash",
+                  cost: { input: 0.098, output: 0.4, cache_read: 0.0196 },
+                  limit: LIMIT,
+                },
+              },
+            },
+            // Published LAST -> wins the flat last-write-wins map.
+            zenmux: {
+              api: "https://zenmux.example.com/v1",
+              models: {
+                "deepseek/deepseek-v4-flash": {
+                  id: "deepseek/deepseek-v4-flash",
+                  cost: { input: 0.14, output: 0.6, cache_read: 0.0028 },
+                  limit: LIMIT,
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+    resetWorkerModelState();
+    await fetchModelData();
+  }
+
+  test("provider-qualified lookup returns the ROUTED provider's price, not last-write-wins", async () => {
+    await warm();
+    // Mutation: revert getModelSpec to bare getModelEntrySync / drop the
+    // qualified branch -> this returns zenmux's 0.0028 -> RED.
+    const or = getModelEntrySyncForProvider(
+      "openrouter",
+      "deepseek/deepseek-v4-flash",
+    );
+    expect(or.cost?.cache_read).toBe(0.0196);
+
+    const zm = getModelEntrySyncForProvider(
+      "zenmux",
+      "deepseek/deepseek-v4-flash",
+    );
+    expect(zm.cost?.cache_read).toBe(0.0028);
+  });
+
+  test("bare getModelEntrySync is unchanged (last-write-wins across providers)", async () => {
+    await warm();
+    // zenmux appears last -> its price wins the flat map. Documents that the
+    // fix is additive and does not alter the legacy bare lookup.
+    expect(
+      getModelEntrySync("deepseek/deepseek-v4-flash").cost?.cache_read,
+    ).toBe(0.0028);
+  });
+
+  test("falls back to the bare lookup when provider is undefined or unknown", async () => {
+    await warm();
+    expect(
+      getModelEntrySyncForProvider(undefined, "deepseek/deepseek-v4-flash").cost
+        ?.cache_read,
+    ).toBe(0.0028);
+    // Unknown provider -> no qualified entry -> bare fallback (last-write-wins).
+    expect(
+      getModelEntrySyncForProvider(
+        "no-such-provider",
+        "deepseek/deepseek-v4-flash",
+      ).cost?.cache_read,
+    ).toBe(0.0028);
   });
 });

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -27,6 +27,11 @@ import {
   modelRejectsTemperatureByData,
   workerThinkingOnByDefault,
 } from "../src/llm-adapter";
+import {
+  markWorkerIncapable,
+  markFreeModelsDataBlocked,
+  _resetForTest as resetWorkerHealth,
+} from "../src/worker-health";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1449,10 +1454,13 @@ describe("family-based worker resolution", () => {
     expect(result?.modelID).toBe("claude-sonnet-5");
   });
 
-  test("unknown provider: family-aware pick favors the NEWEST member of the cheapest family", async () => {
+  test("unknown provider: lineage-aware pick favors the closest cheaper tier, newest member", async () => {
     // google isn't in WORKER_DEFAULTS → findCheaperSameProviderModel path.
-    // The absolute-cheapest is an OLD flash-lite; a NEWER flash-lite is still
-    // cheaper than the session. Family-aware resolution must pick the newer one.
+    // All candidates share the `gemini` lineage. "Closest cheaper tier" picks
+    // the most-expensive family still cheaper than the session (gemini-flash,
+    // $1), NOT the absolute-cheapest flash-lite tier ($0.15) — a higher-quality
+    // worker that is still cheaper than the session model. Within the chosen
+    // tier the newest member wins.
     await warmCache({
       anthropic: { api: "https://api.anthropic.com/v1", models: {} },
       google: {
@@ -1465,7 +1473,7 @@ describe("family-based worker resolution", () => {
             cost: { input: 4, output: 20 },
             limit: LIMIT,
           },
-          // Cheapest model overall, but an OLD generation.
+          // Absolute-cheapest family — NOT chosen under closest-cheaper-tier.
           "gemini-2.5-flash-lite": {
             id: "gemini-2.5-flash-lite",
             family: "gemini-flash-lite",
@@ -1473,7 +1481,6 @@ describe("family-based worker resolution", () => {
             cost: { input: 0.1, output: 0.4 },
             limit: LIMIT,
           },
-          // Same (cheapest) family, NEWER, still far cheaper than the session.
           "gemini-3-flash-lite": {
             id: "gemini-3-flash-lite",
             family: "gemini-flash-lite",
@@ -1481,8 +1488,15 @@ describe("family-based worker resolution", () => {
             cost: { input: 0.15, output: 0.6 },
             limit: LIMIT,
           },
-          // Cheaper than session but a DIFFERENT (pricier) family — must lose
-          // to the flash-lite family chosen by lowest cost.
+          // Older member of the closest cheaper tier (gemini-flash).
+          "gemini-2.5-flash": {
+            id: "gemini-2.5-flash",
+            family: "gemini-flash",
+            release_date: "2025-06-15",
+            cost: { input: 1, output: 5 },
+            limit: LIMIT,
+          },
+          // Newest member of the closest cheaper tier — the winner.
           "gemini-3-flash": {
             id: "gemini-3-flash",
             family: "gemini-flash",
@@ -1500,9 +1514,9 @@ describe("family-based worker resolution", () => {
     });
 
     expect(result?.providerID).toBe("google");
-    // Newest in the cheapest (flash-lite) family — NOT the older
-    // gemini-2.5-flash-lite, NOT the pricier gemini-3-flash family.
-    expect(result?.modelID).toBe("gemini-3-flash-lite");
+    // Closest cheaper tier is gemini-flash ($1, not flash-lite $0.15); newest
+    // member is gemini-3-flash (not the older gemini-2.5-flash).
+    expect(result?.modelID).toBe("gemini-3-flash");
   });
 
   test("unknown provider: without family metadata, falls back to absolute cheapest", async () => {
@@ -1782,5 +1796,350 @@ describe("resetWorkerModelState", () => {
     const beforeReset = callCount;
     await fetchModelData();
     expect(callCount).toBeGreaterThanOrEqual(beforeReset + 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lineage-aware selection + data-policy :free auto-recovery
+//
+// Reproduces the production bug: an OpenRouter session
+// (anthropic/claude-opus-4.8) resolved the globally-cheapest model in the
+// provider — a $0 `cohere/...:free` model from an unrelated vendor — which
+// OpenRouter 404s on accounts that haven't opted into its data policy. The fix
+// keeps selection inside the session model's own vendor lineage and picks the
+// "closest cheaper tier" (opus → sonnet), and blocklists a :free model +
+// re-resolves once a data-policy 404 is observed.
+// ---------------------------------------------------------------------------
+
+describe("lineage-aware worker selection (aggregator providers)", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  const LIMIT = { context: 1_000_000, output: 128_000 };
+
+  /** models.dev response mirroring OpenRouter's mixed-vendor provider index. */
+  function openrouterResponse() {
+    return {
+      anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+      openrouter: {
+        api: "https://openrouter.ai/api/v1",
+        npm: "@openrouter/ai-sdk-provider",
+        models: {
+          "anthropic/claude-opus-4.8": {
+            id: "anthropic/claude-opus-4.8",
+            family: "claude-opus",
+            release_date: "2026-05-28",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "anthropic/claude-sonnet-5": {
+            id: "anthropic/claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-06-30",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+          "anthropic/claude-sonnet-4.6": {
+            id: "anthropic/claude-sonnet-4.6",
+            family: "claude-sonnet",
+            release_date: "2026-02-17",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+          "anthropic/claude-haiku-4.5": {
+            id: "anthropic/claude-haiku-4.5",
+            family: "claude-haiku",
+            release_date: "2025-10-15",
+            cost: { input: 1, output: 5, cache_read: 0.1 },
+            limit: LIMIT,
+          },
+          // Unrelated vendor, globally cheapest ($0 :free). The OLD code picked
+          // this; the lineage filter must exclude it (different namespace).
+          "cohere/north-mini-code:free": {
+            id: "cohere/north-mini-code:free",
+            family: "north",
+            release_date: "2026-05-01",
+            cost: { input: 0, output: 0, cache_read: 0 },
+            limit: { context: 200_000, output: 8_192 },
+          },
+          // Unrelated vendor priced BETWEEN opus ($5) and sonnet ($2) — $4.
+          // Without the namespace/lineage filter this would win "closest
+          // cheaper tier" (it's the most expensive model still < $5) and be
+          // selected, sending an anthropic session to a mistral worker. The
+          // lineage filter must exclude it so sonnet-5 still wins. This makes
+          // the namespace/lineage filter NON-VACUOUS.
+          "mistralai/mistral-large": {
+            id: "mistralai/mistral-large",
+            family: "mistral-large",
+            release_date: "2026-05-15",
+            cost: { input: 4, output: 12, cache_read: 0.4 },
+            limit: LIMIT,
+          },
+        },
+      },
+    };
+  }
+
+  async function warm(response: unknown): Promise<void> {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(new Response(JSON.stringify(response), { status: 200 })),
+    ) as unknown as typeof fetch;
+    resetWorkerModelState();
+    resetWorkerHealth();
+    await fetchModelData();
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    resetWorkerModelState();
+    resetWorkerHealth();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    resetWorkerModelState();
+    resetWorkerHealth();
+  });
+
+  test("Opus 4.8 OpenRouter session resolves to Sonnet 5 (same vendor, closest cheaper tier), NOT the cross-vendor :free model", async () => {
+    await warm(openrouterResponse());
+
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+
+    expect(result?.providerID).toBe("openrouter");
+    // Closest cheaper tier within the claude lineage is sonnet ($2), NOT the
+    // cheaper haiku ($1) and NOT the cross-vendor cohere:free ($0).
+    // Mutation: reverting the lineage filter → picks cohere/...:free → RED.
+    expect(result?.modelID).toBe("anthropic/claude-sonnet-5");
+  });
+
+  test("closest cheaper tier picks sonnet ($2) over the absolute-cheapest sibling haiku ($1)", async () => {
+    await warm(openrouterResponse());
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+    // Mutation: switching to "cheapest tier" → haiku-4.5 → RED.
+    expect(result?.modelID).toBe("anthropic/claude-sonnet-5");
+    expect(result?.modelID).not.toBe("anthropic/claude-haiku-4.5");
+  });
+
+  test("newest member wins within the chosen tier (sonnet-5 over older sonnet-4.6)", async () => {
+    await warm(openrouterResponse());
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+    expect(result?.modelID).toBe("anthropic/claude-sonnet-5");
+    expect(result?.modelID).not.toBe("anthropic/claude-sonnet-4.6");
+  });
+
+  test("after a data-policy block on the :free tier, selection still returns a paid same-lineage sibling", async () => {
+    await warm(openrouterResponse());
+    markFreeModelsDataBlocked("openrouter");
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+    // Lineage selection is unaffected (sonnet is paid), and the :free model is
+    // never reachable anyway now.
+    expect(result?.modelID).toBe("anthropic/claude-sonnet-5");
+  });
+
+  test("after Sonnet 5 is marked incapable, selection advances to the next cheaper sibling (not the same model)", async () => {
+    await warm(openrouterResponse());
+    // First resolution → sonnet-5.
+    expect(
+      getWorkerModel({
+        providerID: "openrouter",
+        model: "anthropic/claude-opus-4.8",
+      })?.modelID,
+    ).toBe("anthropic/claude-sonnet-5");
+
+    // Sonnet 5 turns out incapable → blocklist it.
+    markWorkerIncapable("openrouter", "anthropic/claude-sonnet-5");
+
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+    // sonnet-4.6 is the next-newest sonnet still cheaper than opus.
+    // Mutation: dropping the blocklist generation from the memo key → stale
+    // sonnet-5 returned → RED. Dropping isSelectableWorkerModel → sonnet-5 → RED.
+    expect(result?.modelID).toBe("anthropic/claude-sonnet-4.6");
+    expect(result?.modelID).not.toBe("anthropic/claude-sonnet-5");
+  });
+
+  test("when the entire sonnet tier is incapable, closest cheaper tier falls to haiku", async () => {
+    await warm(openrouterResponse());
+    markWorkerIncapable("openrouter", "anthropic/claude-sonnet-5");
+    markWorkerIncapable("openrouter", "anthropic/claude-sonnet-4.6");
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+    expect(result?.modelID).toBe("anthropic/claude-haiku-4.5");
+  });
+
+  test("memo invalidation: resolve → blocklist → resolve returns a DIFFERENT model", async () => {
+    await warm(openrouterResponse());
+    const first = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    })?.modelID;
+    expect(first).toBeDefined();
+    markWorkerIncapable("openrouter", first as string);
+    const second = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    })?.modelID;
+    expect(second).toBeDefined();
+    expect(second).not.toBe(first);
+  });
+
+  test("direct anthropic (WORKER_DEFAULTS family path): a blocklisted newest sonnet advances to the older sonnet", async () => {
+    // Exercises the isSelectableWorkerModel guard inside resolveNewestInFamily
+    // (the WORKER_DEFAULTS path used by direct providers), which is DISTINCT
+    // from the aggregator lineage path. Mutation: remove that guard → the
+    // incapable claude-sonnet-5 is still returned → RED.
+    await warm({
+      anthropic: {
+        api: "https://api.anthropic.com/v1",
+        models: {
+          "claude-opus-4-8": {
+            id: "claude-opus-4-8",
+            family: "claude-opus",
+            release_date: "2026-05-28",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-06-30",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-4.6": {
+            id: "claude-sonnet-4.6",
+            family: "claude-sonnet",
+            release_date: "2026-02-17",
+            cost: { input: 3, output: 15, cache_read: 0.3 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+    markWorkerIncapable("anthropic", "claude-sonnet-5");
+    const result = getWorkerModel({
+      providerID: "anthropic",
+      model: "claude-opus-4-8",
+    });
+    expect(result?.modelID).toBe("claude-sonnet-4.6");
+    expect(result?.modelID).not.toBe("claude-sonnet-5");
+  });
+
+  test("direct (non-namespaced) anthropic session still resolves to sonnet via the family path (no regression)", async () => {
+    await warm({
+      anthropic: {
+        api: "https://api.anthropic.com/v1",
+        models: {
+          "claude-opus-4-8": {
+            id: "claude-opus-4-8",
+            family: "claude-opus",
+            release_date: "2026-05-28",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-06-30",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+    const result = getWorkerModel({
+      providerID: "anthropic",
+      model: "claude-opus-4-8",
+    });
+    expect(result?.modelID).toBe("claude-sonnet-5");
+  });
+
+  test("lineage filter excludes a cheaper different-lineage sibling when the namespace cannot (non-namespaced ids)", async () => {
+    // Direct provider (empty namespace ⇒ namespace filter is a no-op), so ONLY
+    // the lineageKey check keeps selection inside the claude lineage. A cheaper,
+    // higher-tier NON-claude model (`grok-fast` $4, lineage "grok") sits between
+    // opus ($5) and sonnet ($2); under closest-cheaper-tier it would win if the
+    // lineage filter were removed. It must be excluded so sonnet-5 wins.
+    // Mutation: drop the `lineageKey(...) !== sessionLineage` guard → grok-fast
+    // is selected → RED.
+    await warm({
+      "custom-agg": {
+        api: "https://api.custom-agg.com/v1",
+        models: {
+          "claude-opus-4-8": {
+            id: "claude-opus-4-8",
+            family: "claude-opus",
+            release_date: "2026-05-28",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "claude-sonnet-5": {
+            id: "claude-sonnet-5",
+            family: "claude-sonnet",
+            release_date: "2026-06-30",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+          // Different lineage, cheaper than opus but pricier than sonnet.
+          "grok-fast": {
+            id: "grok-fast",
+            family: "grok-fast",
+            release_date: "2026-06-01",
+            cost: { input: 4, output: 12, cache_read: 0.4 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+    const result = getWorkerModel({
+      providerID: "custom-agg",
+      model: "claude-opus-4-8",
+    });
+    expect(result?.modelID).toBe("claude-sonnet-5");
+    expect(result?.modelID).not.toBe("grok-fast");
+  });
+
+  test("unknown-provider session whose model has no family metadata falls back to global-cheapest (legacy path, no regression)", async () => {
+    await warm({
+      anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+      "custom-provider": {
+        api: "https://api.custom.com/v1",
+        models: {
+          "expensive-model": {
+            id: "expensive-model",
+            // no family
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          "cheap-model": {
+            id: "cheap-model",
+            // no family
+            cost: { input: 1, output: 5, cache_read: 0.1 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+    const result = getWorkerModel({
+      providerID: "custom-provider",
+      model: "expensive-model",
+    });
+    expect(result?.modelID).toBe("cheap-model");
   });
 });

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -2002,6 +2002,52 @@ describe("lineage-aware worker selection (aggregator providers)", () => {
     expect(result?.modelID).not.toBe("cohere/north-mini-code:free");
   });
 
+  test("deterministic id tie-break: two same-lineage families with equal tierCost AND equal newestDate resolve to the numeric-aware id winner regardless of JSON order", async () => {
+    // Two DIFFERENT families in the same lineage, same tier cost, same newest
+    // release date. Insertion order is deliberately reversed (lower id first)
+    // so a Map-insertion-order tie-break would pick the wrong one. The
+    // localeCompare(numeric) tie-break must pick the higher id deterministically.
+    // Mutation: drop the newestId localeCompare tie-break clause → the answer
+    // becomes Map-insertion-order dependent and this asserts the wrong winner → RED.
+    await warm({
+      anthropic: { api: "https://api.anthropic.com/v1", models: {} },
+      openrouter: {
+        api: "https://openrouter.ai/api/v1",
+        models: {
+          "anthropic/claude-opus-4.8": {
+            id: "anthropic/claude-opus-4.8",
+            family: "claude-opus",
+            release_date: "2026-05-28",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+          // Seeded FIRST but is the LOWER id — must lose the tie-break.
+          "anthropic/claude-sonnet-2": {
+            id: "anthropic/claude-sonnet-2",
+            family: "claude-sonnet-a",
+            release_date: "2026-06-30",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+          // Seeded SECOND, HIGHER id, SAME tier cost ($2) AND SAME date.
+          "anthropic/claude-sonnet-10": {
+            id: "anthropic/claude-sonnet-10",
+            family: "claude-sonnet-b",
+            release_date: "2026-06-30",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+    const result = getWorkerModel({
+      providerID: "openrouter",
+      model: "anthropic/claude-opus-4.8",
+    });
+    // "claude-sonnet-10" > "claude-sonnet-2" under numeric-aware compare.
+    expect(result?.modelID).toBe("anthropic/claude-sonnet-10");
+  });
+
   test("memo invalidation: resolve → blocklist → resolve returns a DIFFERENT model", async () => {
     await warm(openrouterResponse());
     const first = getWorkerModel({


### PR DESCRIPTION
## Problem

Background workers on an **OpenRouter** session (`anthropic/claude-opus-4.8`) were auto-selecting the *globally-cheapest* model in the provider index — a `$0` `cohere/north-mini-code:free` model from an unrelated vendor. OpenRouter returns a hard **404** for that model on accounts that haven't opted into its data policy:

```
"No endpoints available matching your guardrail restrictions and data policy.
 Configure: https://openrouter.ai/settings/privacy"  (code 404)
```

So every `lore-distill` / `lore-curator` call failed. The 404 was mis-classified as a retriable `upstream-error`, producing a tight retry storm (20–40+ failures/session within seconds) and the misleading *"the upstream is failing background worker calls"* degradation warning after 30 min. (Diagnosed from production logs: the selector switched from `nousresearch/hermes-4-405b` $1/M to `cohere/north-mini-code:free` $0/M and 404'd continuously.)

The user is on a **company OpenRouter account and cannot opt into data collection**, so `:free` models are permanently unavailable to them — but a different account may have opted in, so `:free` must not be statically excluded.

## Fix

### Part A — lineage-aware selection (`worker-model.ts`)
`findCheaperSameProviderModel` now stays inside the session model's **own vendor lineage** (id namespace + models.dev family stem — both data-driven, no hardcoded vendor names) and picks the **closest cheaper tier** (Opus → Sonnet, not Haiku), then the newest member of that tier. `anthropic/claude-opus-4.8` → `anthropic/claude-sonnet-5`. Falls back to the legacy global-cheapest path when the session model has no family/namespace metadata, so unknown/edge providers are **not regressed**.

### Part B — data-policy 404 auto-recovery (`llm-adapter.ts` + `worker-health.ts`)
- New strict detector `isDataPolicyBlocked404(status, body)` (404 + "no endpoints" + data-policy/guardrail/privacy marker).
- On hit: `markWorkerIncapable(provider, model)` and, for a `:free` model, `markFreeModelsDataBlocked(provider)` — per the *"assume all `:free` collect data once we see this"* directive.
- New non-escalating `data-policy` failure reason: **no** Sentry ladder, **no** credit-pause, **no** degradation warning (early-return before `reasons.add`).
- Selection consumes the blocklist and re-resolves to a paid same-lineage sibling on the next pass; the next real worker call is the recovery "probe". The resolution memo is keyed on a worker-health **blocklist generation** so a freshly-blocklisted model is never served stale.
- **In-memory only** — self-heals on restart if the account later opts in.

## Tests
Mutation-verified per `quality/REVIEW.md`: namespace filter, lineage filter (non-namespaced ids), closest-cheaper-tier vs cheapest-tier, advance-past-incapable in **both** the aggregator lineage path and the `WORKER_DEFAULTS` `resolveNewestInFamily` path, memo invalidation, detector unit cases, and e2e wiring (reason is `data-policy` not `upstream-error`; session not credit-paused; `:free` tier blocked only for `:free` models). Full suite: **6258 passed / 226 skipped**. typecheck + lint + format clean.

## Note
This fixes future selection; the currently-running gateway keeps using the bad model until restarted with this build.