### PR TITLE
fix(gradient): thread budget snapshot into isLargeColdStart to kill limits/knee race (#1401)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -3225,7 +3225,18 @@ export function isLargeColdStart(input: {
   sessionID?: string;
   /** Override the session's in-flight LTM token count (see docstring). */
   ltmTokens?: number;
+  /**
+   * Per-request model budget snapshot. When provided it is applied atomically
+   * (synchronously, same as transform()) BEFORE the layer-0 computation, so the
+   * module globals this predicate reads (contextLimit, outputReserved,
+   * maxLayer0Tokens, qualityKnee) cannot be clobbered by a concurrent request
+   * for a different model during the pipeline's intervening awaits between
+   * setting the budget and calling this. Omit only in tests that set the
+   * globals directly. (#1401)
+   */
+  budget?: ModelBudget;
 }): boolean {
+  if (input.budget) applyModelBudget(input.budget);
   const sid = input.sessionID ?? input.messages[0]?.info.sessionID;
   const sessState = sid ? getSessionState(sid) : makeSessionState();
   if (sessState.lastKnownInput > 0) return false;

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -6871,6 +6871,36 @@ describe("issue #796: isLargeColdStart + cold-start force-compress", () => {
     resetBaseline();
   });
 
+  test("isLargeColdStart budget snapshot overrides raced module globals (#1401)", () => {
+    // Simulate a concurrent request for a DIFFERENT (huge-window) model having
+    // clobbered the module globals between this request setting its budget and
+    // calling isLargeColdStart: globals say 1M context / no cap, so this ~30-msg
+    // session would be judged NOT large (well under a 968K ceiling).
+    setModelLimits({ context: 1_000_000, output: 32_000 });
+    setMaxLayer0Tokens(0);
+    setCachePricing(0, 0);
+    calibrate(0);
+
+    const sid = `cold-race-${crypto.randomUUID()}`;
+    const messages = bulk(sid, 30, "padding text to take up token space here");
+
+    // Without a budget snapshot: reads the raced globals → not large.
+    expect(isLargeColdStart({ messages, sessionID: sid })).toBe(false);
+
+    // With THIS request's budget snapshot (small window + tight l0cap), the
+    // predicate applies it atomically and correctly judges the session large —
+    // independent of whatever the globals currently hold.
+    const budget = {
+      contextLimit: 6_000,
+      outputReserved: 1_000,
+      maxLayer0Tokens: 500,
+      cacheWriteCostPerToken: 0,
+      cacheReadCostPerToken: 0,
+    };
+    expect(isLargeColdStart({ messages, sessionID: sid, budget })).toBe(true);
+    resetBaseline();
+  });
+
   describe("effectiveMetaThreshold — bust-pressure meta-threshold override", () => {
     // Regression for the ses_10f932a26ffe… (lore 0XrHNdlsWwgVkX4MH) false
     // "unsustainable" warning: bust pressure (consecutiveBusts >= 3) crossed

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -7282,6 +7282,10 @@ async function handleConversationTurn(
           messages: loreMessages,
           sessionID,
           ltmTokens: stable?.tokenCount ?? 0,
+          // Re-apply this request's budget atomically: intervening awaits since
+          // the module globals were set (ltm/entity fetches above) could have
+          // let a concurrent request for a different model clobber them. (#1401)
+          budget: modelBudget,
         });
 
       // --- system[2]: Context-bound LTM (non-preference entries) ---


### PR DESCRIPTION
Closes #1401.

## Problem
`isLargeColdStart` (the pipeline's turn-1 LTM-injection predictor) reads the gradient module globals — `contextLimit`, `outputReserved`, `maxLayer0Tokens`, and (since #1400) `qualityKnee` — which the pipeline sets **per request**. Between those setters (`pipeline.ts` ~6946-6949) and the `isLargeColdStart` call (~7281) there are several `await`s (ltm/entity fetches). A concurrent request for a **different model** can clobber the globals in that window, so the turn-1 prediction is computed with the wrong model's budget.

`transform()` is immune because it re-applies the per-request budget atomically via `applyModelBudget(budget)` at its synchronous top. `isLargeColdStart` had no such snapshot.

Currently latent (all models resolve `qualityKnee` to the same default, and window/l0cap differences between concurrent models are what would actually flip the prediction), but it becomes a real mispredict as soon as per-model budgets diverge — which is exactly what #1404 (per-model knee) will introduce. #1401 is the blocking gate for that work.

## Fix
Give `isLargeColdStart` an optional `budget: ModelBudget` that it applies atomically (synchronously, single-threaded → no interleaving) before computing. The pipeline passes the same `modelBudget` snapshot it hands to `transform()`. This preserves the 🔴 "isLargeColdStart and transformInner MUST NOT diverge" invariant (#961 Seer 15319715): both now apply the identical budget.

Tests calling `isLargeColdStart` without a budget still read the globals (unchanged behavior).

## Tests
- New regression: globals set to a huge-window model (would judge the session NOT large); passing this request's small-window `budget` makes the verdict correctly `true`, independent of the raced globals.
- **Mutation-verified**: removing `if (input.budget) applyModelBudget(input.budget)` turns the test RED.
- Full gradient + pipeline suites green (268 tests); tsc clean for core + gateway.

Unblocks #1404 (per-model quality knee).