### PR TITLE
feat(gradient): per-model quality knee from config + literature-seeded family table (#1404)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -125,6 +125,21 @@ export const LoreConfig = z.object({
         .describe(
           "@deprecated Ignored. Tier-based bust-vs-continue replaces static cap.",
         ),
+      /** Manual override for the per-model quality knee: the context fill
+       *  fraction (tokens / context window) past which lost-in-the-middle
+       *  degradation is treated as material and compression ramps up. When set,
+       *  it overrides the built-in literature-seeded per-model-family table for
+       *  ALL models. Lower = compress earlier (safer quality, higher cost);
+       *  higher = hold raw context longer. Must be in (0, 1). Default: undefined
+       *  (use the per-family seed table, falling back to 0.4). */
+      qualityKnee: z
+        .number()
+        .gt(0)
+        .lt(1)
+        .optional()
+        .describe(
+          "Manual override for the per-model quality knee (fill fraction where compression ramps). (0,1). Default: undefined (use the built-in per-model-family seed table, fallback 0.4).",
+        ),
     })
     .default({
       distilled: 0.25,

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -234,6 +234,79 @@ export function getQualityKnee(): number {
 }
 
 /**
+ * Literature-seeded per-model-family quality knees (fill fraction where
+ * lost-in-the-middle degradation becomes material). These are NOT empirically
+ * measured on our own eval yet (#1404-B / #1402 will replace them with measured
+ * values); they are conservative priors read off the public long-context
+ * degradation literature so per-model compression is at least directionally
+ * right instead of a flat 0.4 for everyone:
+ *
+ *   - "Lost in the Middle" (Liu et al., TACL 2023, arXiv:2307.03172)
+ *   - Chroma "Context Rot" (Hong et al., 2025, 18 models incl. Claude 4 /
+ *     GPT-4.1 / Gemini 2.5) — degradation is continuous, model-specific, and
+ *     begins well before a window is full; frontier models hold quality longer.
+ *
+ * Keyed by a lowercased family stem matched as a PREFIX of the bare model id
+ * (the last `/`-segment). LONGEST matching prefix wins, so entries may be listed
+ * in any order — a broad stem (`claude-`) and a more specific one
+ * (`claude-opus`) can coexist and the specific one is chosen. Frontier families
+ * get a higher knee (degrade later); cheaper/smaller models a lower one.
+ * Anything unmatched falls back to the default. Deliberately listed
+ * broad-before-specific so the longest-prefix logic is load-bearing (a plain
+ * first-match would return the broad entry).
+ */
+const QUALITY_KNEE_BY_FAMILY: ReadonlyArray<readonly [string, number]> = [
+  // Broad family stems (older / non-frontier members degrade earlier).
+  ["claude-", 0.45],
+  ["gpt-", 0.45],
+  ["gemini-", 0.45],
+  // Frontier long-context members — hold quality furthest into the window.
+  ["claude-opus", 0.5],
+  ["claude-sonnet", 0.5],
+  ["gpt-5", 0.5],
+  ["gemini-2.5", 0.5],
+  ["gemini-3", 0.5],
+  // Cheaper / smaller "everyday" models — degrade earlier under context load.
+  ["deepseek", 0.35],
+  ["minimax", 0.35],
+  ["qwen", 0.35],
+  ["mistral", 0.35],
+  ["llama", 0.35],
+];
+
+/**
+ * Resolve the quality knee for a model: an explicit config override wins;
+ * otherwise the literature-seeded family table (longest prefix match); otherwise
+ * the literature-grounded default. The override and table entries are validated
+ * the same way `setQualityKnee` validates — out-of-range / non-finite falls
+ * through to the next source. Pure; safe to call on the hot path.
+ *
+ * NOTE: the returned value is a PRIOR, not a measured knee (#1404-A). #1402's
+ * rot-curve A/B is expected to replace the table with empirical per-model values
+ * (#1404-B). Keeping the seed table here (core, next to the default and the
+ * multiplier that consumes it) keeps the prior testable without the gateway.
+ */
+export function resolveQualityKnee(modelID: string, override?: number): number {
+  const valid = (v: number | undefined): v is number =>
+    v != null && Number.isFinite(v) && v > 0 && v < 1;
+  if (valid(override)) return override;
+  // req.model is often provider-qualified (e.g. "anthropic/claude-opus-4.8",
+  // "openrouter/deepseek/deepseek-v4-flash"). Match the family stem against the
+  // LAST path segment (the bare model id) so a leading provider/aggregator
+  // prefix never hides the family.
+  const bare = modelID.toLowerCase().split("/").pop() ?? modelID.toLowerCase();
+  let best: number | null = null;
+  let bestLen = -1;
+  for (const [stem, knee] of QUALITY_KNEE_BY_FAMILY) {
+    if (bare.startsWith(stem) && stem.length > bestLen) {
+      best = knee;
+      bestLen = stem.length;
+    }
+  }
+  return best ?? DEFAULT_QUALITY_KNEE_FRACTION;
+}
+
+/**
  * Continuous quality penalty applied to the "continue" cost in shouldCompress.
  *
  * Quality degradation ("lost in the middle") is a function of how FULL the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -198,6 +198,7 @@ export {
   getCachePricing,
   setQualityKnee,
   getQualityKnee,
+  resolveQualityKnee,
   DEFAULT_QUALITY_KNEE_FRACTION,
   shouldCompress,
   getTier,

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -44,6 +44,7 @@ import {
   qualityCostMultiplier,
   setQualityKnee,
   getQualityKnee,
+  resolveQualityKnee,
   DEFAULT_QUALITY_KNEE_FRACTION,
   isFreeWriteSession,
   getTier,
@@ -4456,6 +4457,58 @@ describe("tier-based context management", () => {
       expect(getQualityKnee()).toBe(0.7);
       resetCalibration();
       expect(getQualityKnee()).toBe(DEFAULT_QUALITY_KNEE_FRACTION);
+    });
+
+    describe("resolveQualityKnee — per-model seeded knees (#1404-A)", () => {
+      test("frontier families get a higher knee (degrade later)", () => {
+        expect(resolveQualityKnee("claude-opus-4-8")).toBe(0.5);
+        expect(resolveQualityKnee("claude-sonnet-5")).toBe(0.5);
+        expect(resolveQualityKnee("gpt-5.2")).toBe(0.5);
+        expect(resolveQualityKnee("gemini-3-pro")).toBe(0.5);
+      });
+
+      test("cheaper/smaller families get a lower knee (degrade earlier)", () => {
+        expect(resolveQualityKnee("deepseek-v4-flash")).toBe(0.35);
+        expect(resolveQualityKnee("minimax-m3")).toBe(0.35);
+        expect(resolveQualityKnee("qwen3.5-9b")).toBe(0.35);
+      });
+
+      test("provider-qualified ids match on the bare last segment", () => {
+        expect(resolveQualityKnee("anthropic/claude-opus-4.8")).toBe(0.5);
+        expect(
+          resolveQualityKnee("openrouter/deepseek/deepseek-v4-flash"),
+        ).toBe(0.35);
+      });
+
+      test("longest-prefix wins (specific family stem beats broad)", () => {
+        // "claude-opus" (0.5) is more specific than the broad "claude-" (0.45).
+        expect(resolveQualityKnee("claude-opus-4-8")).toBe(0.5);
+        // A claude model NOT matching a frontier stem falls to the broad "claude-".
+        expect(resolveQualityKnee("claude-haiku-4")).toBe(0.45);
+      });
+
+      test("unknown family falls back to the default", () => {
+        expect(resolveQualityKnee("some-unknown-model-xyz")).toBe(
+          DEFAULT_QUALITY_KNEE_FRACTION,
+        );
+      });
+
+      test("valid config override wins over the seed table", () => {
+        // deepseek would seed 0.35; an explicit override takes precedence.
+        expect(resolveQualityKnee("deepseek-v4-flash", 0.6)).toBe(0.6);
+      });
+
+      test("invalid override is ignored, falls through to the table", () => {
+        // Out-of-range / non-finite overrides must not win.
+        expect(resolveQualityKnee("deepseek-v4-flash", 0)).toBe(0.35);
+        expect(resolveQualityKnee("deepseek-v4-flash", 1)).toBe(0.35);
+        expect(resolveQualityKnee("deepseek-v4-flash", 1.5)).toBe(0.35);
+        expect(resolveQualityKnee("deepseek-v4-flash", Number.NaN)).toBe(0.35);
+        // Invalid override + unknown family → default.
+        expect(resolveQualityKnee("unknown-xyz", 2)).toBe(
+          DEFAULT_QUALITY_KNEE_FRACTION,
+        );
+      });
     });
   });
 

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -45,6 +45,7 @@ import {
   computeLayer0Cap,
   setCachePricing,
   setQualityKnee,
+  resolveQualityKnee,
   DEFAULT_QUALITY_KNEE_FRACTION,
   distillLimiter,
   curatorLimiter,
@@ -1914,10 +1915,11 @@ type ModelSpec = {
   /**
    * Per-model quality knee: the context fill fraction (tokens / context) past
    * which lost-in-the-middle degradation is treated as material and the
-   * compression quality penalty begins to ramp. Undefined → gradient uses its
-   * literature-grounded default (0.4). Reserved for empirically-measured
-   * per-model knees (via the eval harness); no reliable per-model signal exists
-   * in models.dev today, so this is currently left undefined for all models.
+   * compression quality penalty begins to ramp. Resolved by `getModelSpec` via
+   * `resolveQualityKnee(model, cfg.budget.qualityKnee)`: config override →
+   * literature-seeded per-family table → 0.4 default. These are priors;
+   * empirically-measured per-model knees (via the eval harness / #1402) will
+   * replace the seed table (#1404-B). Undefined only when explicitly unset.
    */
   qualityKneeFraction?: number;
 };
@@ -1953,6 +1955,14 @@ export function getModelSpec(model: string, providerID?: string): ModelSpec {
           ? (entry.cost.input * 1.25) / 1_000_000 // Anthropic: cache_write = 1.25× input
           : undefined,
     inputCostPerMillion: entry.cost?.input ?? undefined,
+    // Per-model quality knee: config override wins, else the literature-seeded
+    // per-family table (frontier models degrade later, cheaper models earlier),
+    // else the 0.4 default. These are priors, not yet empirically measured
+    // (#1404-A); #1402's rot-curve A/B will replace the table (#1404-B).
+    qualityKneeFraction: resolveQualityKnee(
+      model,
+      loreConfig().budget.qualityKnee,
+    ),
   };
 }
 

--- a/packages/website/src/content/docs/docs/configuration.md
+++ b/packages/website/src/content/docs/docs/configuration.md
@@ -90,6 +90,7 @@ Context-window budget fractions. Sum plus LTM ≈ 1.0.
 | `maxLayer0Tokens` | number | — | min 0 | Direct override for the layer-0 token cap. 0 = disabled (use full context). Default: undefined (use cost-aware auto). |
 | `targetBustCost` | number | `1` | min 0 | @deprecated Ignored. Tier-based bust-vs-continue replaces static cap. |
 | `maxContextTokens` | number | — | min 0 | @deprecated Ignored. Tier-based bust-vs-continue replaces static cap. |
+| `qualityKnee` | number | — | min 0, max 1 | Manual override for the per-model quality knee (fill fraction where compression ramps). (0,1). Default: undefined (use the built-in per-model-family seed table, fallback 0.4). |
 
 
 ## `idleResumeMinutes`


### PR DESCRIPTION
Part of #1404 (Workstream C plumbing half). Depends on #1401 (merged as #1408) so a per-model knee can never be raced in `isLargeColdStart`. (Recreated from the auto-closed #1409 after its stacked base branch was deleted on merge; now based directly on main.)

## What
#1400 added `qualityKneeFraction` plumbing through `ModelSpec`/`ModelBudget`, but every model still resolved to the flat `0.4` default. This wires an actual per-model value:

- **`resolveQualityKnee(modelID, override?)`** (gradient.ts): config override → literature-seeded per-family table → `DEFAULT_QUALITY_KNEE_FRACTION` (0.4). Longest-prefix match on the **bare** model id (last `/`-segment), so provider-qualified ids (`anthropic/claude-opus-4.8`, `openrouter/deepseek/deepseek-v4-flash`) match correctly.
- **`budget.qualityKnee`** (config.ts): optional `(0,1)` manual override for all models.
- **`getModelSpec`** resolves `qualityKneeFraction` via `resolveQualityKnee(model, cfg.budget.qualityKnee)`, flowing through the existing `ModelBudget` → `transform()`/`isLargeColdStart` path.

## Seed table (priors, not measured)
Frontier (`claude-opus`, `claude-sonnet`, `gpt-5`, `gemini-2.5/3`) → 0.5; broad/older (`claude-`, `gpt-`, `gemini-`) → 0.45; cheaper/smaller (`deepseek`, `minimax`, `qwen`, `mistral`, `llama`) → 0.35. Grounded in *Lost in the Middle* (Liu et al., TACL 2023) and Chroma *Context Rot* (2025).

⚠️ **Priors, not measured.** #1402's rot-curve A/B will replace the table with empirically-measured per-model knees (#1404-B). This is the plumbing half so per-model compression is directionally right now.

## Tests
- `resolveQualityKnee`: frontier vs cheap families, provider-qualified ids, longest-prefix precedence, unknown→default, valid override wins, invalid override falls through.
- Table listed **broad-before-specific** so longest-prefix is load-bearing.
- **Mutation-verified**: neutering override-precedence AND breaking longest-prefix each turn their tests RED.
- gradient + config + pipeline suites green (311); tsc clean core + gateway.

Kill-switch: `budget.qualityKnee` override; unmatched families keep 0.4.