### PR TITLE
feat(recall): surface resolved code anchors + discoverable-title guidance

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -179,6 +179,9 @@
 <!-- lore:019efa1b-973b-7f5a-a92e-3be491e5b46f -->
 * **libSQL DiskANN embedded npm build is impractical — 113s build for 5k vectors**: Trap: libSQL's \`vector\_top\_k\` ANN index looks like a drop-in replacement for sqlite-vec. Fix: the embedded npm addon builds DiskANN graph per-row on insert — 113s build for 5k vectors (~38 min for 100k), only 2× query speedup, 62% recall@10 at N=5k. Creating index before insert forces per-row graph update on disk (~273ms/insert). Genuine test requires libsql-server (Rust), not npm addon. Random uniform 768-dim vectors are worst case for ANN (real embeddings cluster better). Deferred to issue #955.
 
+<!-- lore:019f81c5-c723-791a-8809-3c69559af4f5 -->
+* **Lore Website check:social hard-fails on og:description >160 decoded chars**: Trap: a blog post \`description\` frontmatter that looks like it fits (counting escaped HTML source, e.g. \`\&quot;\` entities) can still fail — \`pnpm run check:social\` (\`scripts/check-social-meta.mjs\`) measures the DECODED/rendered string length, not markup source length, and hard-fails (exit 1, breaks the pipeline) if any page's og:description exceeds 160 chars. This check runs across ALL built pages, including blog posts. Fix: count decoded text length when trimming, then rebuild and re-run \`check:social\` iteratively — manual character counts are unreliable, trust the checker's own count.
+
 <!-- lore:019ef947-54d5-73d6-8a1b-06575dddcf2f -->
 * **Lore website: Vite transformIndexHtml is dead code for Astro static generation**: Trap: adding a Vite \`transformIndexHtml\` plugin to \`astro.config.mjs\` looks like the right way to rewrite HTML links at build time — Vite is Astro's bundler. Fix: Astro's static generation pipeline does NOT route through Vite's HTML transform hook. The plugin is silently ignored; links are never rewritten. Confirmed by grep of built HTML showing unmodified hrefs despite plugin being active. Use \`astro:build:done\` integration hook instead — it receives the final output directory and can rewrite HTML files directly.
 
@@ -286,6 +289,9 @@
 <!-- lore:019eec48-01c5-78bd-b7f9-6cd8b7ddfada -->
 * **Lore gateway deploy procedure on production host**: 🔴 Deploy procedure (Burak Yigit Kaya directive): \`git stash save && git pull && git stash pop && pnpm install && pnpm build && pnpm --filter @loreai/gateway run bundle && sudo service opencode restart && journalctl -u opencode -f\`. Plugin file at \`~/.config/opencode/plugins/lore.ts\` contains only \`export { LorePlugin as default } from "opencode-lore";\`. opencode-lore resolves from \`/home/byk/.config/opencode/node\_modules/opencode-lore\` (active built repo) — NOT the cached version at \`~/.cache/opencode/packages/opencode-lore@\*/\`.
 
+<!-- lore:019f81c5-c77a-7102-a6a2-a94f09fadc80 -->
+* **Lore Website blog post: build + verify workflow before pushing**: Steps: 1. Edit blog markdown only in a throwaway worktree (e.g. /tmp/opencode/blog) — never touch the real repo files directly. 2. \`pnpm install --frozen-lockfile\` in that worktree. 3. \`pnpm --filter @loreai/website run build\` — confirm expected page count and 'Complete!'. 4. \`pnpm run check:links\` — must report 'OK: 0 broken links'. 5. \`pnpm run check:social\` — must report 'OK: N page(s) with complete OG + Twitter Card meta tags'; a >160-char og:description fails this (see gotcha). 6. grep the built dist HTML for \`\<title>\` and byline (\`eyebrow\` class) to confirm frontmatter changes actually rendered. 7. Push only after all checks pass. Gotchas: - og:description length is checked on decoded text, not escaped markup — see check:social gotcha. Verify: - \[ ] build exits 0 with expected page count - \[ ] check:links reports 0 broken - \[ ] check:social reports OK for all pages - \[ ] dist HTML title/byline match intended frontmatter
+
 <!-- lore:019f14f5-5edb-7bd1-bc31-9b10062ce1a3 -->
 * **Pi real-runtime e2e: console spy must be installed BEFORE resourceLoader.reload()**: Trap: installing \`console.\*\` spies after \`resourceLoader.reload()\` looks correct — the test body runs after setup. Fix: Pi's extension factory executes during \`reload()\`, so any \`console.\*\` calls in the factory are missed by late-installed spies. Additionally, Vitest intercepts \`console.\*\` away from \`process.stdout.write\`, so \`process.stdout/stderr.write\` spies also miss console output. Both traps look safe because the test passes — it just silently misses the mutation. Fix: install direct \`console.\*\` method spies BEFORE \`resourceLoader.reload()\` so the entire reload + \`createAgentSession\` + prompt window is captured. Mutation A (inject \`console.info("pi: ...")\` at line 99 of index.ts) confirmed this kills the markers test when spies are correctly placed.
 
@@ -363,14 +369,20 @@
 <!-- lore:019f6f38-a1ff-7b4b-b941-36b22f5dd4e7 -->
 * **Avoid re-embedding identical text every CI run**: Avoid re-embedding identical text every CI run. User stated re-embedding identical text every run is wasteful. This is a CI optimization preference. Directive preference.
 
-<!-- lore:019f81bb-f56a-73e0-bb8f-8e544e99978b -->
-* **Bump hardcoded schema-version test assertions after adding a new migration**: Whenever a new migration is added to packages/core/src/db.ts (raising MIGRATIONS.length / schema version), the user expects the assistant to grep/search for all hardcoded schema-version assertions in tests (e.g., packages/core/test/db.test.ts, ltm-versioning.test.ts) — such as \`expect(row.version).toBe(N)\`, \`expect(ver.version).toBe(N)\`, and \`test('schema version is N')\` — and update them to the new version number. This includes 'partial apply / boot-loop' regression tests that reopen the db after simulating a crash. Additionally, when a new sidecar table/column is introduced, the user expects a parallel recovery test to be added mirroring the existing pattern (drop the object, reopen db, assert recoverMissingObjects restores it), placed alongside the analogous prior version's test. Always verify the full test suite passes after these updates.
+<!-- lore:019f81c9-8d17-7152-8db6-7e94b09b1781 -->
+* **Blog post titles: prefer active-claim sentences over slogans; byline uses real name for first-person posts**: When choosing blog post titles/subtitles for byk.github.io, prefer complete-sentence active claims that invite pushback (e.g. 'Automating reviews doesn't mean losing taste') over gerund phrases or imperative slogans (e.g. 'Automate the review, keep the human in it') — imperative/slogan phrasing reads as an AI tell. Burak Yigit Kaya rejected abstract thesis-paraphrase subtitles outright ('I hate that subtitle'). Byline (\`author\` frontmatter, free-text z.string) must use his real name (Burak Yigit Kaya), never 'Lore Team', whenever the post is written in first person. Complements blog voice guidance \[\[019f81b2-2817-76ec-b7cd-79a5b4c51601]].
 
 <!-- lore:019f70c1-61b7-7c02-823a-aebcac38b39b -->
 * **CommandAdmin never reads \_values from OPTIONS map**: User stated that commandAdmin takes \_values and never reads it — so no OPTIONS-map/flag concern applies to admin at all. This is a directive preference.
 
 <!-- lore:019f7af2-a15c-74bf-873d-f2270c47516c -->
 * **Do the other runs with DeepSeek and competitors and give a full update to the blog**: User stated: 'Do the other runs with DeepSeek and competitors and give a full update to the blog'. This is a directive preference.
+
+<!-- lore:019f81cf-c359-7baa-9519-b4f5feeaf9ff -->
+* **Enforce mandatory adversarial pre-merge PR reviews with strict read-only and inline-execution constraints**: User repeatedly requests skeptical, adversarial staff-engineer-style correctness/logic reviews of PRs in the loreai monorepo before merge. Each time, the user mandates: (1) READ-ONLY constraints — never edit, stage, commit, or run state-changing git commands on the working tree; (2) any mutation testing must be done in a throwaway git worktree/workspace (e.g., under /tmp/opencode), with node\_modules symlinked, then verified byte-identical to the main tree via sha256sum and removed afterward; (3) trace code line-by-line rather than trusting comments or PR descriptions; (4) never return an empty report — partial findings are acceptable; (5) run any tests inline and synchronously, never deferring with phrases like 'I'll wait'. When asked to review a PR, treat it as a mandatory pre-merge gate, follow these constraints precisely, and produce a thorough written report of findings.
+
+<!-- lore:019f81c5-539e-7493-9383-3080256eece6 -->
+* **Follow the established git workflow (branch, PR, review)**: Behavioral pattern detected across 122 sessions (action: enforced-workflow). The user consistently demonstrates this behavior.
 
 <!-- lore:019f6fde-efd1-7f32-82db-76eb9454a990 -->
 * **Invariant-check action is advisory-only and never fails the build**: The invariant-check action is advisory-only and NEVER fails the build — it reports findings as annotations and a job summary; humans decide. The action should NEVER fail the build: capture exit, always continue. A non-zero exit from the CLI means a TOOLING failure (no range) — we log it and pass. This is a directive preference.
@@ -392,9 +404,6 @@
 
 <!-- lore:019f7af2-a1b1-799f-83ea-01e3e46feb85 -->
 * **Last time you got a custom build yourself, why not that again?**: User stated: 'Last time you got a custom build yourself, why not that again?'. This is a directive preference.
-
-<!-- lore:019f81b1-08f5-7518-99e8-0c0930e6d093 -->
-* **Load and follow the jj-guide skill for jj/git repo operations**: Whenever working in this repo (BYK/loreai), first determine if it's a jj repo (colocated .jj+.git) or plain git worktree, then load the jj-guide skill for jj repos before making any mutations. Follow its rules strictly: never use interactive flags (-i/--interactive) or \`jj resolve\` since they hang agents; always pass \`-m "msg"\` to describe/commit; verify mutations with \`jj st\`/\`jj log\` after squash/abandon/rebase/restore; prefer change IDs over commit hex IDs; never rebase/describe immutable commits like main (target above it or use main@origin); remember 'jj never fails on conflict' — conflicts are recorded in commits and resolved by hand-editing conflict markers, not via \`jj resolve\`. For .lore.md conflicts specifically, resolve by restoring main's version. Use \`jj undo\`/\`jj op log\`/\`jj op restore\` for recovery. For plain git repos, apply the analogous rigor: proper branch creation, PR creation, and CI monitoring before merging.
 
 <!-- lore:019f71b3-f4b0-7ddb-91ff-b8a54acc8e99 -->
 * **Never a different provider's credential**: User stated: 'never a different provider's credential.' This is a directive preference.
@@ -483,6 +492,9 @@
 <!-- lore:019f7b4f-e0a6-7249-8ab7-d932661eb85a -->
 * **Never match — only the leading string**: User consistently requires that only the leading string is matched in certain contexts. This pattern has appeared in 27 prior sessions and is a directive preference.
 
+<!-- lore:019f81c5-dde6-7ffd-a96f-34e3ccde0a5e -->
+* **Never poll pty sessions with sleep+pty\_read loops**: When a pty/background process is spawned for builds, tests, typechecks, or installs, wait for the \`\<pty\_exited>\` completion signal rather than polling via sleep+pty\_read loops. Only call pty\_read before exit if live output is needed immediately, the user explicitly requests logs, or the exit notification reports a non-zero status requiring investigation. This directive is attached as a standing system reminder to pty spawns and applies across all sessions involving long-running shell commands (pnpm install, build, test, typecheck, lint).
+
 <!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
 * **Never re-read — so excluded**: User stated never re-read — so excluded.
 
@@ -537,6 +549,9 @@
 <!-- lore:019f7af2-a0ff-7363-bbb3-3802fab59406 -->
 * **Never written to any intermediate file**: User stated: 'never written to any intermediate file,'. This is a directive preference.
 
+<!-- lore:019f81c5-c6c2-7dab-8e63-eb653b78d255 -->
+* **Perform structured adversarial correctness reviews of PRs/diffs in this monorepo**: When asked to review a PR or diff (BYK/loreai, opencode-lore), the user consistently expects: (1) an adversarial, assume-a-bug-exists stance covering off-by-one errors, missing awaits, transaction misuse, migration idempotency/partial-apply safety, cross-project data leaks, SQL injection, and stale/orphaned state guards; (2) verification that tests are non-vacuous — check each test would actually FAIL if the corresponding code were reverted/broken, using mutation testing where useful; (3) explicit named scrutiny points enumerated up front (e.g., specific functions/files/invariants to check), each requiring a PASS/FAIL/CONCERN verdict with concrete file:line evidence; (4) strict read-only discipline — never edit tracked files or the working branch, perform any mutation probes only in a throwaway /tmp git worktree, verify byte-identical restoration, and remove the worktree afterward; (5) a final ship/no-ship verdict. Trace helper implementations to source rather than trusting comments, and flag dead code or comment/behavior mismatches even if out of scope.
+
 <!-- lore:019f8126-b8d1-78d6-bc66-9403838dfb13 -->
 * **Prefers git\_remote first, only falls back over path**: prefers git\_remote first, only falls back to path
 
@@ -549,8 +564,8 @@
 <!-- lore:019f81a2-21af-76ff-9e84-a56f05f0bcac -->
 * **Prefers same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e**: prefer same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e.
 
-<!-- lore:019f81b1-07c7-7355-9648-2efc295f2312 -->
-* **Respect explicitly rejected approaches**: Behavioral pattern detected across 44 sessions (action: rejected-approach). The user consistently demonstrates this behavior.
+<!-- lore:019f81c8-6f3c-71e3-99c0-f3d58217dfdd -->
+* **Respect explicitly rejected approaches**: Behavioral pattern detected across 46 sessions (action: rejected-approach). The user consistently demonstrates this behavior.
 
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
@@ -558,8 +573,8 @@
 <!-- lore:019f70c1-6205-7d8b-9766-44b11a1e6f51 -->
 * **Service-role key never round-tripped through sessionToPersisted**: User stated that service-role key 'never round-tripped through sessionToPersisted'. This is a directive preference.
 
-<!-- lore:019f81bd-acbf-7d80-8fa7-ea9904bf7284 -->
-* **Use isolated git worktrees for feature branch development**: When implementing a new feature or working on a specific task (e.g., 'engram-import'), the user works within a dedicated, isolated git worktree (e.g., under ~/.local/share/lore-worktrees/\<feature-name>) rather than the main repository checkout. When editing files or running commands as part of a feature implementation, check for and use the appropriate isolated worktree directory corresponding to the feature name rather than assuming the primary repo path. This keeps in-progress feature work separated from the main working directory and other concurrent tasks.
+<!-- lore:019f81cb-345a-70ad-8109-b16d517f2c63 -->
+* **Uses an apprentice, learns their style and habits, and can (to an extent) enforce them for code reviews**: Uses an apprentice metaphor for Lore: Lore watches the user like an apprentice, learning their style and habits, and can (to an extent) enforce them in code reviews. For blog posts pitching this idea, avoid subtitles that reference 'writing it down' — preferred subtitles: 'You set the standard. Automation keeps it.' or 'Automation is for keeping the standards you set.' Framing angle: 'You are what you do, not what you say' — it's nearly impossible to explicitly write down one's taste/approach, so Lore learns it by observation instead. Complements blog-voice guidance \[\[019f81b2-2817-76ec-b7cd-79a5b4c51601]].
 
 <!-- lore:019f7b66-8ff8-7d82-9ee8-fcd3a9521686 -->
 * **Warden analysis: acknowledge genuine utility before extracting ideas**: User consistently requires acknowledging Warden's genuine utility before extracting ideas. This pattern has appeared in 3 prior sessions and is a directive preference.

--- a/.lore.md
+++ b/.lore.md
@@ -111,6 +111,9 @@
 <!-- lore:019efa1b-96f8-7702-8ddb-ccbc2fece37e -->
 * **sqlite-vec: native extension chosen over WASM; vec0 virtual table deferred**: Chose native extension + JS fallback over WASM-first for sqlite-vec. WASM build targets browser sqlite-wasm engine only — using it in node:sqlite/bun:sqlite would require replacing the entire SQLite engine, slowing ALL queries. Drop-in \`vec\_distance\_cosine()\` over existing BLOB columns chosen for PR #967 scope; \`vec0\` virtual table migration rejected as first step. Portability strategy: keep embeddings as F32 BLOB columns (byte-compatible with libSQL's \`F32\_BLOB\`); when hosted gateway becomes real, add \`driver.libsql.ts\` behind existing \`#db/driver\` map backed by \`vector\_top\_k\` — no data migration, no caller changes.
 
+<!-- lore:019f81bf-c9a0-7a34-86fb-b590fd1ccc96 -->
+* **Use isolated jj workspace when default workspace has concurrent git mutation risk**: Chose to rebuild lost work in an isolated jj workspace (\`jj workspace add "$MAIN\_REPO/.worktrees/\<feature>" --name \<feature>\`) over redoing it in the default workspace, because the default workspace was being actively mutated by concurrent/manual git operations (checkout between branches, \`git reset\`, \`git clean -fd\`) that had already destroyed unsnapshotted work once. Rebuilding in-place risked the identical wipe recurring mid-rebuild. Procedure: \`MAIN\_REPO=$(jj root)\`; create workspace dir under \`.worktrees/\`; \`jj workspace add\`; wire \`$GIT\_DIR\`/\`$GIT\_WORK\_TREE\` via generated \`.envrc\` for colocated repos. Reference: jj-guide skill file \`references/workflow-new-workspace.md\`.
+
 ### Gotcha
 
 <!-- lore:019ef645-24ae-7562-ace6-3b0d343cdb3f -->
@@ -169,6 +172,9 @@
 
 <!-- lore:019ef35a-01ce-7c91-a77a-e81e9f1f537b -->
 * **isVerifierCall: bare \`ci\` keyword matches \`npm ci\` (clean install) — false positive corrupts knowledge confidence**: Trap: \`(?:run\s+)?(?:test|...|ci|...)\` in \`VERIFIER\_LEADING\` looks correct — \`ci\` is a valid script name. Fix: \`npm ci\` (clean install, not a verifier) matches the optional-run group → false positive → confidence penalty. Fix (PR #927): move \`ci\` and other script keywords (\`verify\`, \`validate\`, \`e2e\`, \`coverage\`, \`spec\`) into a dedicated branch requiring explicit \`run\`/\`exec\`/\`dlx\` prefix: \`(?:npm|pnpm|yarn|bun)\s+(?:run|exec|dlx)\s+(?:test|ci|verify|...)\b\`. Bare \`npm ci\` no longer matches; \`pnpm run ci\` still does. \`ci\` retained for \`make\`/\`just\`/\`task\`/\`rake\` targets (always explicit). Confirmed via 51-case empirical test suite in PR #927 adversarial review.
+
+<!-- lore:019f81bf-c8d1-7c66-93d4-b19abc62e7b2 -->
+* **Jujutsu (jj) colocated repo: unsnapshotted edits can be silently wiped**: Trap: running a long work session using only \`git status\`/\`git diff\`/shell tools (no \`jj\` command) looks safe because git reflects the edits. Fix: Jujutsu (jj) only snapshots the working tree into \`@\` when a \`jj\` command runs — Edit/Write tool changes sit as loose, un-snapshotted files indefinitely otherwise. In this colocated repo, concurrent/raw git operations (checkout, pull --ff, reset --hard, clean -fd) in the same working tree can overwrite those files with zero recovery path: no jj commit, no git blob, no reflog entry ever existed for them. Burak Yigit Kaya has run \`git clean -fd\`/\`git reset\` directly in the default workspace to fix urgent build issues, assuming other work was saved elsewhere — this destroyed unsnapshotted agent work. Always run \`jj describe -m "..."\` or \`jj commit\` early and periodically during any session touching this repo.
 
 <!-- lore:019efa1b-973b-7f5a-a92e-3be491e5b46f -->
 * **libSQL DiskANN embedded npm build is impractical — 113s build for 5k vectors**: Trap: libSQL's \`vector\_top\_k\` ANN index looks like a drop-in replacement for sqlite-vec. Fix: the embedded npm addon builds DiskANN graph per-row on insert — 113s build for 5k vectors (~38 min for 100k), only 2× query speedup, 62% recall@10 at N=5k. Creating index before insert forces per-row graph update on disk (~273ms/insert). Genuine test requires libsql-server (Rust), not npm addon. Random uniform 768-dim vectors are worst case for ANN (real embeddings cluster better). Deferred to issue #955.
@@ -271,6 +277,9 @@
 <!-- lore:019f1cc8-b65e-7a6e-97ae-f48d1a7d542b -->
 * **forProjectOffloaded / entitiesForSessionOffloaded: timeout must fall back to in-process scan, never return \[]**: All offloaded variants of frozen-baseline builders (\`ltm.forProjectOffloaded\`, \`entities.forProjectOffloaded\`, \`entities.entitiesForSessionOffloaded\`) must fall back to the synchronous in-process scan on \`READ\_JOB\_TIMED\_OUT\` — never return \`\[]\`. Trap: returning \`\[]\` on timeout looks safe (same as \`forSession\` degrade). Fix: unlike \`forSession\` (reruns every turn), these results are frozen into \`stableLtmCache\` + \`saveSessionTracking\` for the entire session lifetime. A spurious empty baseline permanently breaks the knowledge catalog for that session. \`forSession\` can safely return \`\[]\` because it reruns every turn. Mutation test: force timeout branch to return \`\[]\` → timeout test must fail.
 
+<!-- lore:019f81bf-c945-7586-b4d1-55bf64657b08 -->
+* **Jujutsu (jj) workflow rules (jj-guide skill)**: Steps/rules from the project's jj-guide skill: 1. Never use interactive flags (\`-i\`/\`--interactive\`) on any jj command — TUI prompts hang non-interactive agents. 2. Always pass \`-m "msg"\` explicitly to \`jj describe\`/\`jj commit\`. 3. After any mutating op (squash/abandon/rebase/restore/commit), verify with \`jj st\` and \`jj log\`. 4. Prefer change IDs (letters, e.g. \`ltlpkwxz\`) over commit hex IDs when referencing revisions. 5. Never rebase or describe immutable commits like \`main\` — target the commit above it, or use \`main@origin\`. 6. \`jj never fails on conflict\` — rebase/new/squash record conflicts inside the resulting commit instead of erroring; resolve by editing files directly, not via \`jj resolve\` (interactive). 7. Recovery: \`jj undo\` reverses the last operation; \`jj op log\` + \`jj op restore \<op-id>\` restores full repo state to any prior operation.
+
 <!-- lore:019ef39c-72e1-77c0-b39c-2c145ca5fd05 -->
 * **knowledge\_meta invariants: sync-silence for markInjected, content-only update must not churn sync clock**: Three sync-silence invariants for \`knowledge\_meta\`: (1) \`markInjected()\` updates \`last\_reinforced\_at\` but NEVER bumps \`updated\_at\` — selection ≠ certainty, mirrors prior HASH\_EXCLUDE behavior. (2) Content-only \`update()\` (no \`input.confidence\`) must NOT bump \`meta.updated\_at\` — only confidence changes churn the sync clock. (3) \`create()\` calls \`insertMeta(id, confidence, now, now)\` with \`ON CONFLICT DO UPDATE\` — idempotent for cross-machine re-create but never destroys a converged confidence value (fresh UUIDv7 logical\_id guarantees no collision in practice). A \`knowledge\_meta\` row with no live \`knowledge\_current\` row is inert — never crashes a read.
 
@@ -330,9 +339,6 @@
 <!-- lore:019f6fdd-fd1b-7c97-a870-80edf21b66f1 -->
 * **Always remove obvious statements from drafted replies**: Always remove obvious statements from drafted replies. User requested removal of sentence about subscription rate window resets from Erica reply draft, stating it's obvious.
 
-<!-- lore:019f810a-5749-7d1e-9fe1-1342a2232052 -->
-* **Always request mandatory adversarial correctness reviews before merge in loreai monorepo**: When the user asks for a code review in the loreai (opencode-lore) TypeScript monorepo, they consistently frame it as a MANDATORY, adversarial correctness-only pass (not style/security), asking 'what state makes this break?' They expect the assistant to: (1) read any specified review-bar/spec doc first (e.g., quality/REVIEW.md) and apply it rigorously; (2) scope review strictly to the diff/PR/uncommitted changes specified, often via git diff/show/log against a named base branch or PR number, in a specific repo path or worktree; (3) respect READ-ONLY constraints when stated—no edits, no state-changing git commands, use throwaway /tmp worktrees for mutation testing and verify byte-identical via sha256sum afterward; (4) verify claims by actually reading code, not assuming; (5) categorize findings by severity (BLOCKER/SHOULD-FIX/NIT) and avoid nitpicking style; (6) treat this as a distinct pass from security review, which is handled separately. Always confirm repo path, branch, and diff base before starting.
-
 <!-- lore:019f7080-f5bc-7da4-8008-44ec5998ff2f -->
 * **Always runs locally for lore run**: User stated: 'always runs locally — agent is on the same machine.' This is a directive preference for \`lore run\` operations.
 
@@ -354,14 +360,11 @@
 <!-- lore:019f7766-9f32-757d-bbf8-b709eb759894 -->
 * **Always warm-start embedding worker at gateway startup**: User consistently requires warm-starting the embedding worker at gateway startup to avoid cold model load delays causing incomplete distillation embeddings. This pattern has appeared in 35 prior sessions and is a directive preference.
 
-<!-- lore:019f8116-9c9e-7df2-9277-58cddfc27ea9 -->
-* **Always write tests alongside implementation**: Behavioral pattern detected across 28 sessions (action: requested-tests). The user consistently demonstrates this behavior.
-
-<!-- lore:019f70a4-93ca-7b63-8ff1-277c6772b3b8 -->
-* **Assertion patterns should match correctly without consuming punctuation**: Assertion patterns should match correctly without consuming punctuation. User stated that the leading prose prefix is always kept during blob reduction. This is a directive preference.
-
 <!-- lore:019f6f38-a1ff-7b4b-b941-36b22f5dd4e7 -->
 * **Avoid re-embedding identical text every CI run**: Avoid re-embedding identical text every CI run. User stated re-embedding identical text every run is wasteful. This is a CI optimization preference. Directive preference.
+
+<!-- lore:019f81bb-f56a-73e0-bb8f-8e544e99978b -->
+* **Bump hardcoded schema-version test assertions after adding a new migration**: Whenever a new migration is added to packages/core/src/db.ts (raising MIGRATIONS.length / schema version), the user expects the assistant to grep/search for all hardcoded schema-version assertions in tests (e.g., packages/core/test/db.test.ts, ltm-versioning.test.ts) — such as \`expect(row.version).toBe(N)\`, \`expect(ver.version).toBe(N)\`, and \`test('schema version is N')\` — and update them to the new version number. This includes 'partial apply / boot-loop' regression tests that reopen the db after simulating a crash. Additionally, when a new sidecar table/column is introduced, the user expects a parallel recovery test to be added mirroring the existing pattern (drop the object, reopen db, assert recoverMissingObjects restores it), placed alongside the analogous prior version's test. Always verify the full test suite passes after these updates.
 
 <!-- lore:019f70c1-61b7-7c02-823a-aebcac38b39b -->
 * **CommandAdmin never reads \_values from OPTIONS map**: User stated that commandAdmin takes \_values and never reads it — so no OPTIONS-map/flag concern applies to admin at all. This is a directive preference.
@@ -369,44 +372,11 @@
 <!-- lore:019f7af2-a15c-74bf-873d-f2270c47516c -->
 * **Do the other runs with DeepSeek and competitors and give a full update to the blog**: User stated: 'Do the other runs with DeepSeek and competitors and give a full update to the blog'. This is a directive preference.
 
-<!-- lore:019f8112-fa2d-7568-be94-b9d9f362d3f5 -->
-* **Enforce advisory-only, non-blocking behavior for the semantic-linter/invariant-check feature**: When building or reviewing the semantic-linter (invariant-check) feature and its GHA workflow, the user consistently insists it must NEVER fail or block a PR build by default — findings should only surface as annotations/job summaries unless explicitly gated. The user also enforces strict review discipline: read-only reviews (no modifying tracked files), isolated testing only in throwaway dirs (e.g., /tmp/opencode) with verification the main tree is unchanged, and rigorous tracing of exit codes, flag parsing, and process lifecycle to guarantee advisory mode cannot exit non-zero. The user actively drives root-cause debugging of CI failures (e.g., missing builds, module resolution errors) by supplying detailed logs/output rather than accepting surface fixes. Documentation requests follow a similar pattern: prefer one combined, neutral how-to guide over fragmented docs, plus a follow-up blog post. Always confirm advisory/non-blocking guarantees and isolation constraints are preserved before proposing changes.
-
-<!-- lore:019f813d-2959-7816-8e28-546eb156a694 -->
-* **Enforce fail-closed, provider-agnostic correctness in llm-adapter.ts worker retry/routing logic**: When working on packages/gateway/src/llm-adapter.ts, the user consistently demands that worker call handling (protocol resolution, request building, retries, error/empty-response classification) be correct and consistent across ALL providers (Anthropic, OpenAI, Vertex, OpenAI-Codex, and third-party/aggregator routes like MiniMax) rather than special-cased or defaulting silently. Key expectations: (1) never silently fall back to a foreign/default endpoint (e.g. api.anthropic.com) — fail closed instead; (2) always attribute failures correctly to the worker-health ladder, even for session-less paths; (3) distinguish retryable conditions (length/max\_tokens truncation, transient HTTP codes) from true capability signals, and actually implement retries with adjusted parameters (e.g. raised token budget) rather than just classifying and returning null; (4) align all protocol-specific builders/parsers so new providers are added explicitly rather than falling through to defaults. When asked to fix a bug in this file, investigate all provider code paths, verify via git history/config which fixes are already merged, and implement holistic, symmetric fixes rather than provider-specific patches.
-
-<!-- lore:019f814c-a851-7eeb-8710-a257bff46844 -->
-* **Enforce per-worker (not per-model) scoping for worker-health state and safety invariants**: When working on packages/gateway/src/worker-health.ts and related worker-selection logic (worker-model.ts, pipeline.ts), the user consistently insists that failure/empty-response streaks, incapable-marking, and other worker-health state be scoped per (providerID, modelID, workerID) — never per model alone — so that one curator/worker's empty-response streak cannot be reset or masked by another worker's success on the same model. The user also repeatedly enforces strict safety invariants via code comments/directives: workers must match the session's provider (never cross-provider), cost-aware selection must never exceed the session's price tier or upgrade to a pricier variant, and failures must always be recorded so the health ladder observes them (never silently swallowed or TTL-evicted incorrectly). When reviewing or implementing fixes here, verify keying is per-worker-instance, check that directives embedded as code comments are honored exactly, and treat these invariants as hard requirements to test against (race conditions, edge cases, regressions).
-
-<!-- lore:019f8120-f192-70f3-adcf-360424861847 -->
-* **Enforce read-only adversarial pre-merge correctness reviews**: When asking for a pre-merge/adversarial correctness review of a PR or uncommitted changeset, the user consistently requires: (1) STRICT READ-ONLY constraint — never modify, stage, or commit tracked files in the working repo; any mutation testing (e.g., to verify a test catches a bug) must be done in a throwaway copy or git worktree under /tmp/opencode, verified byte-identical to the original via sha256sum, and removed afterward; (2) act as a skeptical/adversarial staff engineer assuming bugs exist, backing every claim with file:line evidence and empirical verification (actual command output, not assumptions); (3) never return an empty or deferred report — provide partial findings if time-constrained, and never say 'I'll wait', run everything synchronously; (4) deliver a structured verdict only (e.g., PASS/FAIL/CONCERN or BLOCKER/SHOULD-FIX/NIT per point) plus an overall merge decision (MERGE/DO-NOT-MERGE, SHIP/CHANGES-REQUIRED, etc.) — do not write fixes unless asked.
-
-<!-- lore:019f8137-17d1-72d1-9dc6-99da755a9af2 -->
-* **Enforce REVIEW.md regression-test and review-workflow discipline on every PR**: This project maintains a strict PR review standard codified in quality/REVIEW.md, which the assistant must consult and enforce before any merge. Key requirements: (1) every adversarial-review finding that surfaces a defect must land a deterministic regression test in the same PR, which fails on base branch, passes on the fix, and drives the real precondition rather than artificial state — 'Never trust the fix without seeing it fail' (TDD failing-first); tests must fail when the guard they test is deleted. (2) Set up preconditions in adversarial order (state-present-before-op, delete-then-recreate, modify-while-off). (3) Maintain fan-out registry test coverage (SYNCED\_TABLES, MIGRATIONS, AGENTS registries each have dedicated contract tests). (4) Reviews require two separate passes — adversarial/correctness and security/pentest — each running pnpm test/typecheck/lint/format:check, verifying property-test stability across 10 runs, confirming an unmodified working tree, and reporting per-point PASS/FAIL/CONCERN/MUST-FIX verdicts with file:line evidence plus an overall MERGE/DO-NOT-MERGE verdict — never a bare 'LGTM'.
-
-<!-- lore:019f702c-6f1c-7e7d-b41d-ef88c60d20f9 -->
-* **Enumeration invariants always advisory, never fail build**: Enumeration invariants are always advisory and never fail the build. This is a directive preference.
-
-<!-- lore:019f8117-492d-750d-a5b0-12e51b5cf818 -->
-* **Follow the established git workflow (branch, PR, review)**: Behavioral pattern detected across 121 sessions (action: enforced-workflow). The user consistently demonstrates this behavior.
-
-<!-- lore:019f702c-6eba-7447-a242-3d26d5e82727 -->
-* **GHA action never fails, supports opt-in gate input**: The GHA action never fails but supports opt-in gate input. This is a directive preference.
-
 <!-- lore:019f6fde-efd1-7f32-82db-76eb9454a990 -->
 * **Invariant-check action is advisory-only and never fails the build**: The invariant-check action is advisory-only and NEVER fails the build — it reports findings as annotations and a job summary; humans decide. The action should NEVER fail the build: capture exit, always continue. A non-zero exit from the CLI means a TOOLING failure (no range) — we log it and pass. This is a directive preference.
 
-<!-- lore:019f7bb8-b560-7907-b406-e0cf0215f27d -->
-* **Invariant-check judge: always exits 0, gate fail is separate action**: User stated: ALWAYS exits 0 — failing a blocked build is a separate action step. This is a directive preference.
-
-<!-- lore:019f7bb8-b58a-7c4d-aa34-106c5e05fbfb -->
-* **Invariant-check judge: never fails build, gate fail is separate**: User stated: never fails the build. This is a directive preference.
-
 <!-- lore:019f7bb8-b4da-72b7-92a1-079377550ba4 -->
 * **Invariant-check judge: never import outside driver**: User stated: never be imported outside driver. This is a directive preference.
-
-<!-- lore:019f7bb8-b48b-7498-97cf-b3cf801ad1ce -->
-* **Invariant-check judge: never modify tracked files in working repo**: User stated: Do NOT modify any tracked file in the working repo. If you need to test, use a throwaway git worktree under /tmp/opencode. Verify the main tree is unchanged (sha256sum) afterward. Report exit codes. This is a directive preference.
 
 <!-- lore:019f7bb8-b461-77f2-ab92-bb1502b3ec63 -->
 * **Invariant-check judge: never produce false violation, never throw uncaught, never fail build**: User stated: NEVER produce a false \`violates:true\` finding, NEVER throw uncaught, NEVER fail the build. This is a directive preference.
@@ -422,6 +392,9 @@
 
 <!-- lore:019f7af2-a1b1-799f-83ea-01e3e46feb85 -->
 * **Last time you got a custom build yourself, why not that again?**: User stated: 'Last time you got a custom build yourself, why not that again?'. This is a directive preference.
+
+<!-- lore:019f81b1-08f5-7518-99e8-0c0930e6d093 -->
+* **Load and follow the jj-guide skill for jj/git repo operations**: Whenever working in this repo (BYK/loreai), first determine if it's a jj repo (colocated .jj+.git) or plain git worktree, then load the jj-guide skill for jj repos before making any mutations. Follow its rules strictly: never use interactive flags (-i/--interactive) or \`jj resolve\` since they hang agents; always pass \`-m "msg"\` to describe/commit; verify mutations with \`jj st\`/\`jj log\` after squash/abandon/rebase/restore; prefer change IDs over commit hex IDs; never rebase/describe immutable commits like main (target above it or use main@origin); remember 'jj never fails on conflict' — conflicts are recorded in commits and resolved by hand-editing conflict markers, not via \`jj resolve\`. For .lore.md conflicts specifically, resolve by restoring main's version. Use \`jj undo\`/\`jj op log\`/\`jj op restore\` for recovery. For plain git repos, apply the analogous rigor: proper branch creation, PR creation, and CI monitoring before merging.
 
 <!-- lore:019f71b3-f4b0-7ddb-91ff-b8a54acc8e99 -->
 * **Never a different provider's credential**: User stated: 'never a different provider's credential.' This is a directive preference.
@@ -468,9 +441,6 @@
 <!-- lore:019f7155-c46a-71d1-a8da-43efe31d9751 -->
 * **Never consume entire maxSegments embed budget**: Never consume entire maxSegments embed budget. User stated: 'never consume the entire \`maxSegments\` embed budget (e.'. This is a directive preference.
 
-<!-- lore:019f6fba-0e4f-75b0-bb52-11d28d23b966 -->
-* **Never converges and never repeats**: Never converges (fixed by trimming html-node trailing whitespace). This was a directive preference.
-
 <!-- lore:019f70c1-6166-74a9-ac25-8f4257e9a523 -->
 * **Never delete another member's real wrap through scope\_keys migration**: User stated that scope\_keys migration has security guarantees: 'NEVER delete another member's real wrap through this'. This is a directive preference.
 
@@ -479,9 +449,6 @@
 
 <!-- lore:019f702c-6ef3-717a-b329-7a050a717b77 -->
 * **Never drop exact evidence in candidate selection**: Never drop exact evidence in candidate selection. This is a directive preference.
-
-<!-- lore:019f7ae8-a590-7a19-8eff-639e6afc1a90 -->
-* **Never edit the real repo; if experiments/mutations are needed**: User stated to never edit the real repo; if experiments/mutations are needed,
 
 <!-- lore:019f7cad-c1c7-75d7-9683-b577f9d3cd39 -->
 * **Never exceed the driver's variable limit**: Never exceed the driver's variable limit. This is a directive preference.
@@ -516,9 +483,6 @@
 <!-- lore:019f7b4f-e0a6-7249-8ab7-d932661eb85a -->
 * **Never match — only the leading string**: User consistently requires that only the leading string is matched in certain contexts. This pattern has appeared in 27 prior sessions and is a directive preference.
 
-<!-- lore:019f8121-719f-7810-a217-95fe8323ba57 -->
-* **Never poll pty\_read while waiting on long-running commands; wait for exit notification**: When running long shell commands (e.g., full test suites via pty spawn), the user expects the assistant to wait for the \`\<pty\_exited>\` notification rather than repeatedly calling \`pty\_read\` or sleeping in a loop to check progress. Only call \`pty\_read\` if: (1) live output is needed right now, (2) the user explicitly asks for logs, or (3) the exit notification reports a non-zero status requiring investigation. This applies especially in plan-mode workflows where the assistant schedules a follow-up to check test results and continue with commit/push/PR steps once the suite is confirmed green. Also, always call \`plan\_exit\` (or ask a question) to properly end a plan-mode turn per the enforced workflow — never leave a plan-mode turn hanging without one of these two actions.
-
 <!-- lore:019f65ca-91df-708f-a856-e6dd16610be7 -->
 * **Never re-read — so excluded**: User stated never re-read — so excluded.
 
@@ -528,9 +492,6 @@
 <!-- lore:019f6fba-0e22-7d6f-9f5f-306eeb20e1cf -->
 * **Never reaches a fixpoint**: Never reaches a fixpoint — iterateToFixpoint hit its cap (fixed by trimming html-node trailing whitespace). This was a directive preference.
 
-<!-- lore:019f6f42-41cf-7f36-b839-9f6d29623810 -->
-* **Never read a dropped column).**: User stated never read a dropped column). This is a directive preference.
-
 <!-- lore:019f70c1-618e-7f32-9e38-adfe833b06db -->
 * **Never reap real member wraps in tombstone reaper**: User stated that 'NEVER a real member wrap 6ms' is a critical security requirement for the tombstone reaper. This is a directive preference.
 
@@ -539,9 +500,6 @@
 
 <!-- lore:019f7ccd-ee40-7b83-abcb-4594b6d52ad6 -->
 * **Never rely on someone remembering to run**: User consistently requires that critical processes are automated rather than relying on human memory to run them. This ensures reliability. Directive preference.
-
-<!-- lore:019f811f-6761-704e-9ccf-5ad78c4e5bc6 -->
-* **Never respond without first reading recall.ts and related core files in full**: Before answering questions or making changes related to Lore's recall/search/context pipeline, always read the actual source files in full (e.g., packages/core/src/recall.ts, search.ts, prompt.ts, sync.ts, ltm.ts, curator.ts) rather than relying on assumptions or summaries. The user consistently wants end-to-end understanding of how recall.ts orchestrates searches, ranks/combines results, and interacts with related modules (FTS5 tokenization, BM25 scoring, message alternation rules, embeddings) before proceeding. This applies both to read-only exploration tasks and to implementation/PR work touching these files. When investigating, read large chunks or the entire file (often 1000+ lines) rather than snippets, and cross-reference multiple related files in parallel to build a complete picture before responding or editing.
 
 <!-- lore:019f7cad-c19c-7635-bf05-b29f0ff820e9 -->
 * **Never revert a resolved row back to**: Never revert a resolved row back to. This is a directive preference.
@@ -567,9 +525,6 @@
 <!-- lore:019f7121-344f-75fe-99b5-d18253381602 -->
 * **Never touch the real repo files**: Never touch the real repo files. User stated to NEVER touch the real repo files. This is a directive preference.
 
-<!-- lore:019f8153-3331-7b8d-9c4c-e3f2e21702dd -->
-* **Never trust logic without grep-verified call sites and mutation-tested tests**: Before accepting an implementation or claiming a fix is correct, the user consistently expects the assistant to: (1) grep the codebase for all call sites/exports/usages of the relevant function, constant, or module to build a complete picture of impact and callers; (2) trace actual values/behavior at each site rather than assuming; and (3) mutation-test any related unit tests (e.g., remove/invert a guard or swap a call) to prove the test is non-vacuous and genuinely fails when the logic is broken. This applies especially in the gateway/pipeline codebase when investigating model specs, auth/credential logic, usage scaling, or guard conditions. When asked to verify or fix something, proactively run exhaustive grep searches across the package, cross-reference exact line numbers/definitions, and follow up with mutation tests on any test files touched, rather than declaring completion based on a single passing test run.
-
 <!-- lore:019f7b4f-df75-7bf3-9725-8b4f00c384bb -->
 * **Never trust the fix without seeing it fail**: User consistently requires seeing a fix fail before trusting it. This pattern has appeared in 33 prior sessions and is a directive preference.
 
@@ -582,9 +537,6 @@
 <!-- lore:019f7af2-a0ff-7363-bbb3-3802fab59406 -->
 * **Never written to any intermediate file**: User stated: 'never written to any intermediate file,'. This is a directive preference.
 
-<!-- lore:019f812a-851e-7ce5-8f02-52a77cc250d7 -->
-* **Perform deep, systematic code tracing before flagging concerns**: The user repeatedly engages in (or expects the assistant to perform) exhaustive, line-by-line code tracing of database/import logic (ensureProject, resolveProjectByRemoteOrPath, ltm.create, \_importEntries, dedup guards) across multiple sessions, cross-referencing prior findings and code comments. When analyzing code, the assistant should: (1) read the actual source with specific line numbers rather than assuming behavior, (2) trace edge cases fully (e.g., dedup miscounts, foreign-project overwrites, dry-run vs remote paths) to a definitive PASS/CONCERN verdict, (3) preserve and cite existing code comments/invariants (e.g., 'never gets backed up', 'never shows a bare session ID') as authoritative behavioral contracts, (4) distinguish security-relevant findings (🔴) from informational ones (🟡), and (5) revisit the same core functions (ensureProject, resolveProjectByRemoteOrPath, projectPath) across sessions, building cumulative understanding rather than re-deriving from scratch.
-
 <!-- lore:019f8126-b8d1-78d6-bc66-9403838dfb13 -->
 * **Prefers git\_remote first, only falls back over path**: prefers git\_remote first, only falls back to path
 
@@ -594,17 +546,11 @@
 <!-- lore:019f7331-e703-7ae9-aa16-093875aeb481 -->
 * **Prefers recall over assuming you don't have the information**: prefer recall over assuming you don't have the information.
 
-<!-- lore:019f8140-3c45-7628-bfcc-e56d660bd447 -->
-* **Provide precise file:line references when investigating code**: When exploring or explaining code (especially in packages/gateway/src/llm-adapter.ts and related retry/backoff/DB-sync logic in the loreai monorepo), the user expects exact file paths with line ranges and function-level detail rather than vague summaries. When reading or searching files, cite specific line numbers (e.g., 'lines 100-299', 'llm-adapter.ts:398') and describe exact behavior of each function/constant found (parameters, defaults, control flow). The user frequently investigates retry/backoff mechanisms (DEFAULT\_MAX\_RETRIES, backoffMs, parseRetryAfter) and synchronous database operations on the hot path, so maintain a habit of producing precise, line-anchored inventories when asked to locate or explain logic, rather than high-level paraphrases.
+<!-- lore:019f81a2-21af-76ff-9e84-a56f05f0bcac -->
+* **Prefers same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e**: prefer same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e.
 
-<!-- lore:019f814a-6288-7944-95fc-187fe7a9a20c -->
-* **Require adversarial, mutation-tested PR reviews with strict worktree isolation**: When asked to review a PR/branch for correctness (llm-adapter.ts, gateway retry logic, embedding backoff, etc.), the user consistently expects: (1) a read-only, adversarial review that assumes a bug exists and tries to falsify the change; (2) all mutation/experimentation happens in a throwaway /tmp git worktree, never on the tracked repo/branch — verify byte-identical (sha256) before/after and remove the worktree when done; (3) mutation testing proves tests are non-vacuous (specific mutants must kill specific tests); (4) full test suite run (no -t filters) plus typecheck; (5) findings reported as structured scrutiny points or NIT/SHOULD-FIX/BLOCKER items with concrete file:line evidence; (6) final verdict issued as MERGE / SHIP-WITH-FOLLOWUPS / BLOCKER. Always follow this rigorous, isolated, evidence-based review protocol for any PR/correctness review request.
-
-<!-- lore:019f810f-82d0-7958-84eb-60dd79013955 -->
-* **Respect explicitly rejected approaches**: Behavioral pattern detected across 42 sessions (action: rejected-approach). The user consistently demonstrates this behavior.
-
-<!-- lore:019f8116-9ce8-746b-90aa-3eaacf0ec7e5 -->
-* **Review code before committing**: Behavioral pattern detected across 86 sessions (action: requested-review). The user consistently demonstrates this behavior.
+<!-- lore:019f81b1-07c7-7355-9648-2efc295f2312 -->
+* **Respect explicitly rejected approaches**: Behavioral pattern detected across 44 sessions (action: rejected-approach). The user consistently demonstrates this behavior.
 
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
@@ -612,23 +558,8 @@
 <!-- lore:019f70c1-6205-7d8b-9766-44b11a1e6f51 -->
 * **Service-role key never round-tripped through sessionToPersisted**: User stated that service-role key 'never round-tripped through sessionToPersisted'. This is a directive preference.
 
-<!-- lore:019f7b4f-dfc0-7519-8f40-46eb29afc29a -->
-* **Switch to WASM when native fails**: User consistently requires switching to WASM when native runtime fails. This pattern has appeared in 27 prior sessions and is a directive preference.
-
-<!-- lore:019f702c-6f46-7a12-a71c-1507abeb6e0c -->
-* **Tooling failures like no commit range are not findings**: Tooling failures like inability to resolve commit range are not findings. This is a directive preference.
-
-<!-- lore:019f8114-a52e-7592-863d-faee8e33310e -->
-* **Track ltm.ts knowledge schema and versioning internals repeatedly**: The user repeatedly investigates the same core area of the codebase (packages/core/src/ltm.ts and related db.ts) — specifically the \`knowledge\`/\`knowledge\_current\`/\`knowledge\_meta\` table schemas, the \`logical\_id\`-based versioning scheme, confidence/decay lifecycle fields (\`confidence\`, \`last\_reinforced\_at\`, \`base\_confidence\`), worker attribution columns (\`worker\_provider\_id\`/\`worker\_model\_id\`), and the exact INSERT/SELECT column lists. When working in this file, treat these as stable, well-understood invariants: \`logical\_id\` is the immutable cross-version identity (equals \`id\` for v1 rows), confidence/decay metadata lives in \`knowledge\_meta\` keyed by \`logical\_id\` (not on the immutable knowledge row), and the knowledge table is append-only. Assistant should recall and reuse this schema knowledge rather than re-deriving it from scratch, and flag any changes to these columns/semantics as significant since the user tracks them closely across sessions.
-
-<!-- lore:019f811e-7f7b-7cc5-ad3f-0d6c5691f36b -->
-* **Treat ltm.ts versioning/update invariants as authoritative design constraints**: This user is working on a long-term-memory (LTM) storage layer (packages/core/src/ltm.ts) with a strict, recurring set of invariants that must be preserved across all edits and reviews: (1) content is immutable per version—any content change appends a new version via appendVersion(), copying forward confidence/metadata; (2) confidence, updated\_by, sensitivity, metadata are mutable fields updated in place on the current version row; (3) updated\_at always bumps on any update, even without content change (a 're-confirmation'); (4) any update resets last\_reinforced\_at, the decay clock, so a freshly-touched entry never ages out (v48 behavior); (5) never leave two is\_current=1 rows for one logical\_id; (6) confidence changes are clamped to \[0,1] and outcome-boost ceilings (e.g., 0.8) are never exceeded automatically. When reading, reviewing, or modifying ltm.ts, always verify and preserve these invariants, cite the relevant design references (A2 #823, v48, v55), and treat associated code comments as authoritative documentation of intended behavior.
-
-<!-- lore:019f812b-0a1c-780b-b559-d4cf40277aa4 -->
-* **Use grep to trace all call sites and exports before modifying shared functions**: Before editing or reasoning about a function, type, or export in the opencode-lore codebase (especially in packages/core and packages/gateway), always run a grep/search across the codebase to enumerate every definition, export, re-export, and call site. This includes checking barrel files (index.ts), dist type declarations, and cross-package usages (e.g., gradient.ts, cache-warmer.ts, pipeline.ts). The goal is to build a complete picture of where a symbol is defined, exported, and consumed before making changes, verifying whether usages are live/behavioral or just shadow/comment references. Report findings with specific file paths and line numbers.
-
-<!-- lore:019f8139-90fb-7e21-90e9-f296a4f14561 -->
-* **Verify code review claims via empirical mutation/probe testing before accepting them**: When reviewing a PR, diff, or specific code branch/logic, the user expects the assistant to empirically verify claims rather than reasoning abstractly. This includes: writing probe/mutation test scripts to check reachability of specific branches (e.g., 'if (live) return false'), running byte/hash verification on files to confirm integrity after changes, testing edge cases (empty input, ordering dependencies, UNIQUE constraints) with real execution, and confirming test suites pass after modifications. The assistant should construct targeted test scenarios (e.g., decayed entries with shared titles, insert-order violations) and run them to confirm or refute assumptions, document exact pass/fail results with concrete values (hashes, counts, error messages), and use these empirical results to justify decisions about whether specific code paths/checks are necessary or already covered by existing behavior.
+<!-- lore:019f81bd-acbf-7d80-8fa7-ea9904bf7284 -->
+* **Use isolated git worktrees for feature branch development**: When implementing a new feature or working on a specific task (e.g., 'engram-import'), the user works within a dedicated, isolated git worktree (e.g., under ~/.local/share/lore-worktrees/\<feature-name>) rather than the main repository checkout. When editing files or running commands as part of a feature implementation, check for and use the appropriate isolated worktree directory corresponding to the feature name rather than assuming the primary repo path. This keeps in-progress feature work separated from the main working directory and other concurrent tasks.
 
 <!-- lore:019f7b66-8ff8-7d82-9ee8-fcd3a9521686 -->
 * **Warden analysis: acknowledge genuine utility before extracting ideas**: User consistently requires acknowledging Warden's genuine utility before extracting ideas. This pattern has appeared in 3 prior sessions and is a directive preference.
@@ -660,11 +591,8 @@
 <!-- lore:019f7b66-90c3-79a4-8a85-0197fd5b1d20 -->
 * **Warden analysis: propose concrete ideas from analysis**: User consistently requires proposing concrete ideas from Warden analysis. This pattern has appeared in 3 prior sessions and is a directive preference.
 
-<!-- lore:019f7b66-904c-7c39-83c2-37f352644161 -->
-* **Warden analysis: pull benchmark data for concrete analysis**: User consistently requires pulling benchmark data for concrete analysis of Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
-
 <!-- lore:019f7b66-9162-772a-bdc5-591ba0ddbf86 -->
-* **Warden analysis: use benchmark data to show value**: User consistently requires using benchmark data to show value when analyzing Warden. This pattern has appeared in 3 prior sessions and is a directive preference.
+* **Warden analysis: use benchmark data to show value**: Warden analysis: pull and use benchmark data to make the analysis concrete and demonstrate value. This pattern has appeared in 3 prior sessions and is a directive preference.
 
 <!-- lore:019f77f9-b84c-7c77-9bd6-baa0e69a9bdc -->
 * **Warmup embedding never blocks startup**: User consistently requires that embedding warmup never blocks startup. This pattern has appeared in 40 prior sessions and is a directive preference.

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1854,6 +1854,29 @@ const MIGRATIONS: string[] = [
    ALTER TABLE session_state ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0;
    ALTER TABLE session_state ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0;
    `,
+
+  `
+  -- Version 74: knowledge_ref_anchor — the currently-RESOLVABLE code anchors
+  -- (file:line / symbol) cited by a knowledge entry, so recall can point the
+  -- agent straight at the code instead of making it grep (#627 follow-on;
+  -- Modem "how coding agents read your code"). The reference-validity pass
+  -- (validateProjectReferences) already resolves every cited ref to ok/missing/
+  -- unknown; this table PERSISTS the resolved-ok file/symbol anchors (previously
+  -- discarded — only broken/total counts survived in knowledge_ref_validity).
+  -- Rewritten in full for an entry on each check pass, so a removed/renamed ref
+  -- naturally drops out (never a stale jump target). Commands are NOT anchors
+  -- (not a code location). Keyed by the stable logical_id (matches
+  -- knowledge_ref_validity / knowledge_symbol_presence / knowledge_meta) so it
+  -- survives version edits between checks. A sidecar table — never touches the
+  -- frozen append-only knowledge table.
+  CREATE TABLE IF NOT EXISTS knowledge_ref_anchor (
+    logical_id TEXT NOT NULL,
+    kind       TEXT NOT NULL,
+    anchor     TEXT NOT NULL,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (logical_id, kind, anchor)
+  );
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -3059,6 +3082,13 @@ function recoverMissingObjects(database: Database) {
       symbol          TEXT NOT NULL,
       last_present_at INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (logical_id, symbol)
+    );
+    CREATE TABLE IF NOT EXISTS knowledge_ref_anchor (
+      logical_id TEXT NOT NULL,
+      kind       TEXT NOT NULL,
+      anchor     TEXT NOT NULL,
+      updated_at INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (logical_id, kind, anchor)
     );
     CREATE TABLE IF NOT EXISTS knowledge_contradictions (
       logical_id_a TEXT NOT NULL,

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -803,6 +803,7 @@ export function update(
 export const LOGICAL_ID_BOOKKEEPING_TABLES = [
   "knowledge_ref_validity",
   "knowledge_symbol_presence",
+  "knowledge_ref_anchor",
 ] as const;
 
 export function remove(id: string, metadata?: KnowledgeMetadata) {
@@ -1545,6 +1546,23 @@ export async function validateProjectReferences(
   const wasSymbolPresent = db().query(
     `SELECT 1 FROM knowledge_symbol_presence WHERE logical_id = ? AND symbol = ?`,
   );
+  // Code anchors (#627 follow-on / Modem "how coding agents read your code"):
+  // the file:line / symbol refs that resolve OK this pass are persisted so recall
+  // can point the agent straight at the code instead of making it grep. Rewritten
+  // in full per entry each pass (DELETE + re-INSERT) so a removed/renamed ref
+  // drops out and can never become a stale jump target. Only entries we actually
+  // resolved this pass (total > 0) are rewritten — an all-"unknown" entry keeps
+  // its prior anchors (cannot verify ≠ broken applies to anchors too: a probe
+  // that couldn't reach the FS must not wipe a good jump target). Commands are
+  // never anchors (not a code location).
+  const clearAnchors = db().query(
+    `DELETE FROM knowledge_ref_anchor WHERE logical_id = ?`,
+  );
+  const insertAnchor = db().query(
+    `INSERT INTO knowledge_ref_anchor (logical_id, kind, anchor, updated_at)
+       VALUES (?, ?, ?, ?)
+     ON CONFLICT(logical_id, kind, anchor) DO UPDATE SET updated_at = excluded.updated_at`,
+  );
   // Stamp the 24h gate in a `finally`, OUTSIDE the penalty transaction. If a
   // write inside the transaction throws, `withTransaction` rolls back the whole
   // batch — but the gate MUST still advance, otherwise the next idle tick re-runs
@@ -1556,6 +1574,10 @@ export async function validateProjectReferences(
       for (const [logicalId, refs] of perEntry) {
         let broken = 0;
         let total = 0; // refs with a DEFINITIVE status (ok|missing); excludes unknown
+        // OK code anchors gathered this pass (file:line / symbol), deduped by
+        // "kind\x1fanchor" so a `foo.ts` and `foo.ts:10` are distinct entries but
+        // an exact repeat collapses.
+        const anchors = new Map<string, { kind: string; anchor: string }>();
         for (const ref of refs) {
           const st = statusMap.get(ref.raw);
           if (ref.kind === "symbol") {
@@ -1564,6 +1586,10 @@ export async function validateProjectReferences(
               // drift. Counts as a definitive (verifiable) ref, never broken.
               recordSymbolPresent.run(logicalId, ref.name, now);
               total++;
+              anchors.set(`symbol\x1f${ref.name}`, {
+                kind: "symbol",
+                anchor: ref.name,
+              });
             } else if (st === "missing") {
               // Confirmed ABSENT. Only drift (broken) if we have proof it was
               // present before; otherwise a strict no-op (never-present mention).
@@ -1581,11 +1607,23 @@ export async function validateProjectReferences(
             total++;
           } else if (st === "ok") {
             total++;
+            // Only file refs are code anchors (commands are not a location).
+            if (ref.kind === "file") {
+              const anchor =
+                ref.line != null ? `${ref.path}:${ref.line}` : ref.path;
+              anchors.set(`file\x1f${anchor}`, { kind: "file", anchor });
+            }
           }
           // "unknown" / absent → neutral, not counted
         }
         if (total === 0) continue; // every ref unverifiable for this entry — neutral
         checked++;
+        // Rewrite this entry's anchors in full: a removed/renamed ref drops out,
+        // never leaving a stale jump target. Runs for every resolved entry (incl.
+        // those with zero OK anchors, which clears any prior anchors).
+        clearAnchors.run(logicalId);
+        for (const { kind, anchor } of anchors.values())
+          insertAnchor.run(logicalId, kind, anchor, now);
         db()
           .query(
             `INSERT INTO knowledge_ref_validity (logical_id, broken, total, checked_at)
@@ -1920,6 +1958,55 @@ export function refValidity(logicalId: string): RefValidity | null {
     | undefined;
   if (!row) return null;
   return { broken: row.broken, total: row.total, checkedAt: row.checked_at };
+}
+
+/** A resolved code anchor cited by a knowledge entry (persisted by the
+ *  reference-validity pass when it resolved OK). `file` anchors carry an optional
+ *  `:line`; `symbol` anchors are a bare identifier. */
+export type KnowledgeRefAnchor = { kind: "file" | "symbol"; anchor: string };
+
+/** Max anchors surfaced per entry in recall — enough to point at the code
+ *  without bloating the result line. File anchors are preferred over symbols. */
+export const MAX_RECALL_ANCHORS_PER_ENTRY = 3;
+
+/**
+ * Batch-load the resolved code anchors (file:line / symbol) for a set of entries
+ * by logical_id, so recall can point the agent straight at the code instead of
+ * making it grep (Modem "how coding agents read your code"). Returns a Map from
+ * logical_id to its anchors, file anchors first (the more useful jump target),
+ * capped at MAX_RECALL_ANCHORS_PER_ENTRY. Entries with no resolved anchors are
+ * absent from the map. Read-only. Empty input → empty map (no query).
+ */
+export function knowledgeRefAnchors(
+  logicalIds: string[],
+): Map<string, KnowledgeRefAnchor[]> {
+  const out = new Map<string, KnowledgeRefAnchor[]>();
+  if (logicalIds.length === 0) return out;
+  const placeholders = logicalIds.map(() => "?").join(",");
+  // 'file' < 'symbol' lexically, so ORDER BY kind puts file anchors first; a
+  // stable secondary sort by anchor keeps output deterministic (cache-friendly).
+  const rows = db()
+    .query(
+      `SELECT logical_id, kind, anchor FROM knowledge_ref_anchor
+        WHERE logical_id IN (${placeholders})
+        ORDER BY logical_id, kind, anchor`,
+    )
+    .all(...logicalIds) as Array<{
+    logical_id: string;
+    kind: string;
+    anchor: string;
+  }>;
+  for (const r of rows) {
+    if (r.kind !== "file" && r.kind !== "symbol") continue;
+    let arr = out.get(r.logical_id);
+    if (!arr) {
+      arr = [];
+      out.set(r.logical_id, arr);
+    }
+    if (arr.length >= MAX_RECALL_ANCHORS_PER_ENTRY) continue;
+    arr.push({ kind: r.kind, anchor: r.anchor });
+  }
+  return out;
 }
 
 /**

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -356,6 +356,24 @@ INCLUDE THE "WHY" — decisions and gotchas without rationale get undone:
 - Any standard or rule without its rationale is vulnerable to being optimized away by
   a session that doesn't know what problem it was solving.
 
+DISCOVERABLE TITLES — the title is the entry's search key, weight it accordingly:
+- A future session finds this entry by SEARCHING its title (the title is the highest-
+  weighted field in recall, ~3x the content). Put the SPECIFIC, discriminative terms a
+  future session will actually type into the title: the symbol / file / error code /
+  config key / tool / proper noun — not a generic noun. A generic title buries the entry
+  in a haystack the same way grepping "create" returns hundreds of hits; a specific one
+  lands in a single hop.
+- Aim for a title that names its subject in 2-4 words, at least one of them a concrete
+  domain term (an exact identifier, filename, or error code beats a category word).
+- The title is ALSO the dedup identity — a vague title risks silently merging with an
+  unrelated entry. Distinctive titles keep distinct facts distinct.
+  BAD:  "Client creation bug"
+  GOOD: "createStripeClient drops Authorization header on retry"
+  BAD:  "Migration gotcha"
+  GOOD: "v55 knowledge_meta migration boot-loops if DROP COLUMN precedes backfill"
+  BAD:  "Caching improvement"
+  GOOD: "gradient.ts l0cap governs compression trigger, not layer-1 window size"
+
 PROCEDURAL PATTERNS — recurring procedures get a runbook shape, not a flat fact:
 - When the captured pattern is a recurring *procedure* (deploy, release, review,
   debug-X, setup, migration, hand-off), structure the content as:
@@ -566,7 +584,11 @@ IMPORTANT:
 8. Resolve ambiguous references (pronouns, nicknames, abbreviations) to canonical names from
    the entity list. If you detect new recurring entities, include them in the "entities" field.
 9. If the conversation reveals relationships between entities (friend, colleague, manager, etc.),
-   include them in the "relations" field. Only explicit statements — not inferred from context.`;
+   include them in the "relations" field. Only explicit statements — not inferred from context.
+10. Title every create with the SPECIFIC terms a future session will search — the exact
+    symbol / file / error code / tool, not a generic noun (the title is the top-weighted
+    recall field AND the dedup key). "createStripeClient drops auth header on retry", not
+    "Client bug".`;
 }
 
 /**

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -414,6 +414,20 @@ function formatFusedResults(
   const lowScore = kept[kept.length - 1].score;
   const lines: string[] = [];
 
+  // Batch-load the resolved code anchors (file:line / symbol) for every knowledge
+  // hit ONCE, so recall can point the agent straight at the code instead of
+  // making it grep (Modem "how coding agents read your code"). One query for the
+  // whole result set; entries with no resolved anchors are simply absent.
+  const knowledgeLogicalIds: string[] = [];
+  for (const r of tiered) {
+    if (r.item.source === "knowledge" || r.item.source === "cross-knowledge")
+      knowledgeLogicalIds.push(r.item.item.logical_id);
+  }
+  const anchorsByLogicalId =
+    knowledgeLogicalIds.length > 0
+      ? ltm.knowledgeRefAnchors(knowledgeLogicalIds)
+      : undefined;
+
   lines.push(`## Recall Results`);
   lines.push(``);
   lines.push(
@@ -442,7 +456,7 @@ function formatFusedResults(
         lines.push(`#### ${SOURCE_LABELS[currentSource]}`);
       }
 
-      const line = renderResultLine(r.item, r.charBudget);
+      const line = renderResultLine(r.item, r.charBudget, anchorsByLogicalId);
       lines.push(line);
     }
   }
@@ -552,7 +566,22 @@ function getDistillationSourceIds(distillId: string): string[] {
   }
 }
 
-function renderResultLine(tagged: TaggedResult, charBudget: number): string {
+/** Render an entry's resolved code anchors as a compact ` \u21b3 a, b` suffix the
+ *  agent can jump to instead of grepping. Empty/absent → "". Symbol anchors get a
+ *  trailing `()` so they read as identifiers. */
+function renderAnchors(anchors?: ltm.KnowledgeRefAnchor[]): string {
+  if (!anchors || anchors.length === 0) return "";
+  const parts = anchors.map((a) =>
+    a.kind === "symbol" ? `${a.anchor}()` : a.anchor,
+  );
+  return ` \u21b3 ${parts.join(", ")}`;
+}
+
+function renderResultLine(
+  tagged: TaggedResult,
+  charBudget: number,
+  anchorsByLogicalId?: Map<string, ltm.KnowledgeRefAnchor[]>,
+): string {
   const id = taggedResultKey(tagged);
 
   switch (tagged.source) {
@@ -560,19 +589,27 @@ function renderResultLine(tagged: TaggedResult, charBudget: number): string {
       const k = tagged.item;
       const age = relativeAge(k.updated_at);
       const titlePart = `**${inline(k.title)}** (${age}): `;
-      const contentBudget = Math.max(40, charBudget - titlePart.length);
+      const anchors = renderAnchors(anchorsByLogicalId?.get(k.logical_id));
+      const contentBudget = Math.max(
+        40,
+        charBudget - titlePart.length - anchors.length,
+      );
       const content = truncateAtSentence(inline(k.content), contentBudget);
       const wasTruncated = inline(k.content).length > contentBudget;
-      return `- ${titlePart}${content}${wasTruncated ? ` (${id})` : ""}`;
+      return `- ${titlePart}${content}${anchors}${wasTruncated ? ` (${id})` : ""}`;
     }
     case "cross-knowledge": {
       const k = tagged.item;
       const age = relativeAge(k.updated_at);
       const titlePart = `**${inline(k.title)}** (${age}, from: ${tagged.projectLabel}): `;
-      const contentBudget = Math.max(40, charBudget - titlePart.length);
+      const anchors = renderAnchors(anchorsByLogicalId?.get(k.logical_id));
+      const contentBudget = Math.max(
+        40,
+        charBudget - titlePart.length - anchors.length,
+      );
       const content = truncateAtSentence(inline(k.content), contentBudget);
       const wasTruncated = inline(k.content).length > contentBudget;
-      return `- ${titlePart}${content}${wasTruncated ? ` (${id})` : ""}`;
+      return `- ${titlePart}${content}${anchors}${wasTruncated ? ` (${id})` : ""}`;
     }
     case "distillation": {
       const d = tagged.item;
@@ -1446,11 +1483,14 @@ export function recallById(id: string): string {
       // entry (A2, #823) — a recalled id may be the stable logical_id.
       const entry = ltm.get(rawId) ?? ltm.getByLogical(ltm.logicalIdOf(rawId));
       if (!entry) return `No entry found for id: ${id}`;
+      const detailAnchors = renderAnchors(
+        ltm.knowledgeRefAnchors([entry.logical_id]).get(entry.logical_id),
+      );
       return [
         `## Recall Detail: ${id}`,
         ``,
         `#### Knowledge`,
-        `- **${inline(entry.title)}** (${entry.category}): ${inline(entry.content)}`,
+        `- **${inline(entry.title)}** (${entry.category}): ${inline(entry.content)}${detailAnchors}`,
       ].join("\n");
     }
     case "d": {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -119,7 +119,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(73);
+    expect(row.version).toBe(74);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -176,7 +176,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(73);
+    expect(ver.version).toBe(74);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh
@@ -216,6 +216,21 @@ describe("db", () => {
       name: string;
     }>;
     expect(pcols.some((c) => c.name === "last_refcheck_at")).toBe(true);
+  });
+
+  test("v74: knowledge_ref_anchor table exists / is restored after recovery", () => {
+    // Drop the sidecar table, reopen, confirm recoverMissingObjects restores it
+    // idempotently (same self-heal contract as knowledge_ref_validity /
+    // knowledge_symbol_presence).
+    db().exec("DROP TABLE IF EXISTS knowledge_ref_anchor");
+    close();
+    const fresh = db();
+    const cols = fresh
+      .query("PRAGMA table_info(knowledge_ref_anchor)")
+      .all() as Array<{ name: string }>;
+    expect(cols.map((c) => c.name)).toEqual(
+      expect.arrayContaining(["logical_id", "kind", "anchor", "updated_at"]),
+    );
   });
 
   test("session_prompt_deltas persist ordered selector/content rows (v42)", () => {

--- a/packages/core/test/ltm-reference-validity.test.ts
+++ b/packages/core/test/ltm-reference-validity.test.ts
@@ -245,6 +245,30 @@ describe("knowledge_ref_anchor persistence (recall code anchors)", () => {
     expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/real.ts:3" }]);
   });
 
+  test("an all-UNKNOWN entry (total===0, non-null resolver) keeps its prior anchors", async () => {
+    // Distinct from the null-resolver case above: here the resolver runs but
+    // every ref resolves to "unknown" (an absolute, out-of-tree path), so the
+    // entry reaches the transaction with total===0. The `total===0 continue`
+    // guard must fire BEFORE clearAnchors — otherwise a probe that merely can't
+    // verify a ref this pass would wipe a good jump target. Regression guard for
+    // the exact ordering of that guard vs the anchor rewrite.
+    const id = seed("logic lives at /opt/out-of-tree/gone.ts:1 (absolute)");
+    const lid = ltm.get(id)!.logical_id;
+    // Pre-seed an anchor as if a prior pass had resolved one.
+    db()
+      .query(
+        `INSERT INTO knowledge_ref_anchor (logical_id, kind, anchor, updated_at)
+           VALUES (?, 'file', 'src/prior.ts:7', ?)`,
+      )
+      .run(lid, Date.now());
+    const res = await ltm.validateProjectReferences(root, resolver());
+    // The absolute ref is unverifiable → total===0 → entry not checked, not
+    // penalized, and the pre-existing anchor survives untouched.
+    expect(res.checked).toBe(0);
+    expect(res.penalized).toBe(0);
+    expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/prior.ts:7" }]);
+  });
+
   test("a removed ref drops out on the next pass (anchors rewritten in full)", async () => {
     // Seed content citing two files; only real.ts exists.
     const id = seed("see src/real.ts:1 and src/second.ts:1");

--- a/packages/core/test/ltm-reference-validity.test.ts
+++ b/packages/core/test/ltm-reference-validity.test.ts
@@ -188,6 +188,110 @@ describe("validateProjectReferences (#627 Phase 0)", () => {
   });
 });
 
+// Code-anchor persistence (Modem "how coding agents read your code"): the
+// reference-validity pass persists the file:line refs that resolve OK into
+// knowledge_ref_anchor so recall can point the agent straight at the code
+// instead of making it grep. (Symbol anchors are covered in the git-backed
+// symbol describe below.)
+describe("knowledge_ref_anchor persistence (recall code anchors)", () => {
+  const anchorsOf = (id: string) =>
+    ltm
+      .knowledgeRefAnchors([ltm.get(id)!.logical_id])
+      .get(ltm.get(id)!.logical_id) ?? [];
+
+  test("an OK file:line ref is persisted as a jump anchor", async () => {
+    const id = seed("see src/real.ts:3 for the impl");
+    await ltm.validateProjectReferences(root, resolver());
+    expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/real.ts:3" }]);
+  });
+
+  test("an OK file ref with NO line is persisted without a line suffix", async () => {
+    const id = seed("logic lives in src/real.ts (no line cited)");
+    await ltm.validateProjectReferences(root, resolver());
+    expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/real.ts" }]);
+  });
+
+  test("a MISSING file ref is NOT persisted as an anchor", async () => {
+    const id = seed("the fix is in src/gone.ts:10");
+    await ltm.validateProjectReferences(root, resolver());
+    expect(anchorsOf(id)).toEqual([]);
+  });
+
+  test("an out-of-range line (missing) is NOT persisted as an anchor", async () => {
+    const id = seed("see src/real.ts:999 (past EOF)");
+    await ltm.validateProjectReferences(root, resolver());
+    expect(anchorsOf(id)).toEqual([]);
+  });
+
+  test("commands are never anchors (not a code location)", async () => {
+    const id = seed("run `pnpm run lint` to format"); // resolves OK, but not an anchor
+    await ltm.validateProjectReferences(root, resolver());
+    expect(anchorsOf(id)).toEqual([]);
+  });
+
+  test("an unverifiable batch (null resolver) does NOT wipe prior anchors", async () => {
+    const id = seed("see src/real.ts:3 for the impl");
+    const now = Date.now();
+    await ltm.validateProjectReferences(root, resolver(), now);
+    expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/real.ts:3" }]);
+    // A later pass where the whole batch is unverifiable must be a strict no-op —
+    // "cannot verify ≠ broken" applies to anchors too (don't drop a good jump
+    // target just because a probe couldn't reach the FS this time).
+    await ltm.validateProjectReferences(
+      root,
+      new NoopResolver(),
+      now + ltm.REFCHECK_INTERVAL_MS + 1,
+    );
+    expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/real.ts:3" }]);
+  });
+
+  test("a removed ref drops out on the next pass (anchors rewritten in full)", async () => {
+    // Seed content citing two files; only real.ts exists.
+    const id = seed("see src/real.ts:1 and src/second.ts:1");
+    writeFileSync(join(root, "src", "second.ts"), "x\ny\n");
+    const now = Date.now();
+    await ltm.validateProjectReferences(root, resolver(), now);
+    expect(anchorsOf(id)).toEqual([
+      { kind: "file", anchor: "src/real.ts:1" },
+      { kind: "file", anchor: "src/second.ts:1" },
+    ]);
+    // second.ts is deleted; the next pass must drop its anchor (not leave a stale
+    // jump target). A fresh resolver so the file walk is re-read.
+    rmSync(join(root, "src", "second.ts"));
+    await ltm.validateProjectReferences(
+      root,
+      new DirectFsResolver(root),
+      now + ltm.REFCHECK_INTERVAL_MS + 1,
+    );
+    expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/real.ts:1" }]);
+  });
+
+  test("anchors are capped per entry at MAX_RECALL_ANCHORS_PER_ENTRY", async () => {
+    for (let i = 1; i <= 5; i++)
+      writeFileSync(join(root, "src", `f${i}.ts`), "x\n");
+    const id = seed(
+      "src/f1.ts:1 src/f2.ts:1 src/f3.ts:1 src/f4.ts:1 src/f5.ts:1",
+    );
+    await ltm.validateProjectReferences(root, resolver());
+    expect(anchorsOf(id).length).toBe(ltm.MAX_RECALL_ANCHORS_PER_ENTRY);
+  });
+
+  test("deleting an entry purges its anchors (no orphan)", async () => {
+    const id = seed("see src/real.ts:3 for the impl");
+    const lid = ltm.get(id)!.logical_id;
+    await ltm.validateProjectReferences(root, resolver());
+    expect(anchorsOf(id)).toEqual([{ kind: "file", anchor: "src/real.ts:3" }]);
+    // remove() must sweep knowledge_ref_anchor via LOGICAL_ID_BOOKKEEPING_TABLES.
+    ltm.remove(id);
+    const orphans = db()
+      .query(
+        "SELECT COUNT(*) AS n FROM knowledge_ref_anchor WHERE logical_id = ?",
+      )
+      .get(lid) as { n: number };
+    expect(orphans.n).toBe(0);
+  });
+});
+
 // Cited-symbol validation end-to-end (#911): symbols use a presence HISTORY. A
 // symbol only decays confidence when it was PREVIOUSLY confirmed present and is
 // now absent (genuine rename/removal drift). A never-present mention (external
@@ -269,6 +373,35 @@ describe.skipIf(process.platform === "win32")(
       const res = await ltm.validateProjectReferences(root, resolver());
       expect(res.penalized).toBe(0);
       expect(conf(id)).toBe(1.0);
+    });
+
+    test("a present symbol is persisted as a symbol anchor (after the file anchor)", async () => {
+      writeFileSync(
+        join(root, "src", "real.ts"),
+        "export const keptHelper = 1;\n",
+      );
+      const id = seed("`keptHelper` lives in src/real.ts:1");
+      gitInit();
+      await ltm.validateProjectReferences(root, resolver());
+      const lid = ltm.get(id)!.logical_id;
+      const anchors = ltm.knowledgeRefAnchors([lid]).get(lid) ?? [];
+      // File anchor is ordered first (the more useful jump target), symbol next.
+      expect(anchors).toEqual([
+        { kind: "file", anchor: "src/real.ts:1" },
+        { kind: "symbol", anchor: "keptHelper" },
+      ]);
+    });
+
+    test("a symbol confirmed ABSENT is NOT persisted as an anchor", async () => {
+      // real.ts exists (file anchor OK) but the cited symbol is absent from the
+      // tree → symbol "missing" → no symbol anchor (only the file anchor).
+      writeFileSync(join(root, "src", "real.ts"), "a\nb\nc\n");
+      const id = seed("`goneSymbol` lives in src/real.ts:1");
+      gitInit();
+      await ltm.validateProjectReferences(root, resolver());
+      const lid = ltm.get(id)!.logical_id;
+      const anchors = ltm.knowledgeRefAnchors([lid]).get(lid) ?? [];
+      expect(anchors).toEqual([{ kind: "file", anchor: "src/real.ts:1" }]);
     });
   },
 );

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 73", () => {
+  test("schema version is 74", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(73);
+    expect(v.version).toBe(74);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/prompt.test.ts
+++ b/packages/core/test/prompt.test.ts
@@ -335,6 +335,23 @@ describe("consolidationUser — value annotation (#497)", () => {
   });
 });
 
+describe("CURATOR_SYSTEM — discoverable titles (Modem)", () => {
+  test("declares a DISCOVERABLE TITLES section", () => {
+    expect(CURATOR_SYSTEM).toContain("DISCOVERABLE TITLES");
+  });
+
+  test("tells the curator the title is the search key / dedup identity", () => {
+    // The load-bearing rationale: a specific title is what makes an entry
+    // retrievable (top-weighted recall field) and keeps distinct facts distinct
+    // (dedup key). Pin both so the guidance can't silently drop back to a bare
+    // "Short descriptive title".
+    expect(CURATOR_SYSTEM).toMatch(
+      /search key|highest-weighted|dedup identity/i,
+    );
+    expect(CURATOR_SYSTEM).toMatch(/BAD:[\s\S]{0,200}GOOD:/);
+  });
+});
+
 describe("CURATOR_SYSTEM — procedural pattern runbooks (#914)", () => {
   test("declares a PROCEDURAL PATTERNS section heading", () => {
     expect(CURATOR_SYSTEM).toContain("PROCEDURAL PATTERNS");

--- a/packages/core/test/recall-code-anchors.test.ts
+++ b/packages/core/test/recall-code-anchors.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+import { runRecall } from "../src/recall";
+
+// Recall renders the persisted code anchors (file:line / symbol) for a knowledge
+// entry so the agent can jump straight to the code instead of grepping (Modem
+// "how coding agents read your code"). The id-detail path (runRecall({ id }))
+// bypasses search entirely, giving a deterministic, flake-free rendering test.
+
+const PROJECT = "/test/recall-code-anchors/project";
+
+function seed(title: string, content: string): string {
+  return ltm.create({
+    projectPath: PROJECT,
+    scope: "project",
+    crossProject: false,
+    category: "gotcha",
+    title,
+    content,
+  });
+}
+
+function insertAnchor(
+  logicalId: string,
+  kind: "file" | "symbol",
+  anchor: string,
+): void {
+  db()
+    .query(
+      `INSERT INTO knowledge_ref_anchor (logical_id, kind, anchor, updated_at)
+         VALUES (?, ?, ?, ?)
+       ON CONFLICT(logical_id, kind, anchor) DO UPDATE SET updated_at = excluded.updated_at`,
+    )
+    .run(logicalId, kind, anchor, Date.now());
+}
+
+describe("recall renders code anchors (id-detail path)", () => {
+  beforeEach(() => {
+    ensureProject(PROJECT);
+    db().exec("DELETE FROM knowledge_ref_anchor");
+  });
+
+  test("a file anchor is appended after the content with a ↳ marker", async () => {
+    const id = seed("Auth header dropped on retry", "the retry path re-signs");
+    const lid = ltm.get(id)!.logical_id;
+    insertAnchor(lid, "file", "src/auth/retry.ts:42");
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).toContain("\u21b3 src/auth/retry.ts:42");
+  });
+
+  test("a symbol anchor renders with a trailing ()", async () => {
+    const id = seed("Signer entry point", "the signer lives in one place");
+    const lid = ltm.get(id)!.logical_id;
+    insertAnchor(lid, "symbol", "signPayload");
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).toContain("\u21b3 signPayload()");
+  });
+
+  test("file anchors are ordered before symbol anchors", async () => {
+    const id = seed("Mixed anchors", "both a file and a symbol are cited");
+    const lid = ltm.get(id)!.logical_id;
+    insertAnchor(lid, "symbol", "signPayload");
+    insertAnchor(lid, "file", "src/sign.ts:10");
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).toContain("\u21b3 src/sign.ts:10, signPayload()");
+  });
+
+  test("an entry with no anchors renders no ↳ marker", async () => {
+    const id = seed("No anchors here", "purely prose, nothing to jump to");
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).not.toContain("\u21b3");
+  });
+
+  test("knowledgeRefAnchors caps a single entry at MAX_RECALL_ANCHORS_PER_ENTRY", () => {
+    const id = seed("Many anchors", "lots of cited files");
+    const lid = ltm.get(id)!.logical_id;
+    for (let i = 1; i <= 6; i++) insertAnchor(lid, "file", `src/f${i}.ts:${i}`);
+    const anchors = ltm.knowledgeRefAnchors([lid]).get(lid) ?? [];
+    expect(anchors.length).toBe(ltm.MAX_RECALL_ANCHORS_PER_ENTRY);
+  });
+
+  test("knowledgeRefAnchors with empty input returns an empty map (no query)", () => {
+    expect(ltm.knowledgeRefAnchors([]).size).toBe(0);
+  });
+});

--- a/quality/plans/modem-recall-code-anchors.md
+++ b/quality/plans/modem-recall-code-anchors.md
@@ -1,0 +1,229 @@
+# Learning from Modem's "How coding agents read your code" → Lore
+
+Source: https://modem.dev/blog/how-coding-agents-read-your-code (Ben Vinegar, Modem, Jul 20 2026)
+
+## EXECUTION STATUS (branch `feat/recall-code-anchors`)
+
+- ✅ **Direction 2 (code anchors in recall)** — IMPLEMENTED. Closes the half-built
+  file:line-pointer loop: the reference-validity pass already resolved every cited ref
+  but discarded the result; now it persists resolved-OK anchors and recall renders them.
+  - `db.ts`: migration v74 + `recoverMissingObjects` self-heal — new `knowledge_ref_anchor`
+    table (logical_id, kind, anchor, updated_at).
+  - `ltm.ts` `validateProjectReferences`: persist resolved-OK file (with line) + symbol
+    anchors, rewritten in full per resolved entry (removed refs drop out). `total===0`
+    (all-unknown) entries keep prior anchors — "cannot verify ≠ broken" applies to anchors.
+  - `ltm.ts` `knowledgeRefAnchors(logicalIds)` batch loader + `KnowledgeRefAnchor` type +
+    `MAX_RECALL_ANCHORS_PER_ENTRY=3` (file anchors ordered before symbols).
+  - `recall.ts`: `renderAnchors` helper; knowledge + cross-knowledge + id-detail branches
+    append ` ↳ src/foo.ts:42, bar()`. Batch-loaded once per result set in `formatFusedResults`.
+    NOT wired into `formatKnowledge` (system prompt) — avoids prompt-cache churn.
+  - Tests: `ltm-reference-validity.test.ts` (anchor persistence, rewrite, cap, symbol,
+    neutral-on-unknown) + new `recall-code-anchors.test.ts` (rendering). 34 passing.
+- ✅ **Direction 1a (curator title guidance)** — IMPLEMENTED. `prompt.ts`: DISCOVERABLE
+  TITLES section in `CURATOR_SYSTEM` + item 10 in `curatorUser` IMPORTANT list. Test in
+  `prompt.test.ts`.
+- ⬜ Remaining (follow-ups): D1b (re-titleable updates), D1c (pattern-extract titles),
+  D2c (entry↔file association), D3 (blog post).
+
+---
+
+## The article's thesis (one line)
+
+Coding agents navigate code by **literal text search** (grep/ripgrep), not by semantic
+graphs. So **discoverability is a property of the words you write**: specific names grep to
+one place (`createStripeClient` → 43 hits), generic names bury the answer in a haystack
+(`create` → 1,585 hits). Better names/types/comments/file-organization measurably cut
+tokens, turns, and confidently-wrong answers. Their experiments: 6–66% fewer tokens on
+weak-author code, wrong answers went to zero, bug-hunt accuracy 23/32 → 32/32 after a
+discoverability refactor.
+
+## Why this is directly relevant to Lore
+
+Lore is *also* a search-driven retrieval system over text. The exact same principle governs
+Lore's own recall — and the evidence is in Lore's own code:
+
+- Knowledge search is **FTS5 BM25 + vector, fused with RRF** (`recall.ts:642`,
+  `search.ts:516`). The keyword half is literal-token prefix matching — grep with ranking.
+- **A knowledge entry's `title` is weighted 3× its content**: `bm25(knowledge_fts, 6.0,
+  2.0, 3.0)` over columns `(title, content, category)` (`config.ts:750`, `db.ts:207`).
+  Title is *also* the exact-match dedup identity key (`ltm.ts:317`) and the lead token the
+  agent sees in every recall hit (`recall.ts:562`).
+- The relaxed query cascade drops the **least-discriminative** term first by IDF
+  (`search.ts:190,309`) and boosts exact matches (`search.ts:555`) — Lore already rewards
+  discriminative terms exactly the way grep rewards specific names.
+
+**So a knowledge entry's title is to Lore's recall what a function name is to a grep-first
+agent.** A specific title ("createStripeClient auth header injection") retrieves in one hop;
+a generic title ("Client creation bug") drops the agent into the multi-hit haystack.
+
+**The gap:** Lore's retrieval mechanically *rewards* discoverable titles, but nothing that
+*writes* titles is told to make them discoverable. The curator prompt's entire title
+instruction is `"title": "Short descriptive title"` (`prompt.ts:460`). Every quality bullet
+(the "why" requirement `:350`, brevity `:397`, entity grounding `:479`) targets **content**.
+
+Lore also already tells the agent the right thing about *user code* — the recall tool
+description says memory is "a POINTER, not the source of truth… find WHERE something is (the
+file path / file:line / symbol), then READ that file" (`recall.ts:1594`). But it can't
+deliver on that promise structurally: the `references.ts` machinery extracts file:line/symbol
+refs **only for staleness validation**, then discards them (only broken/total counts survive
+in `knowledge_ref_validity`, `db.ts:1501`). Refs are **never rendered** into recall output
+(`recall.ts:558`) or the injected knowledge block (`formatKnowledge`, `prompt.ts:990`).
+
+---
+
+## Direction 1 — Make Lore's OWN knowledge discoverable (highest leverage, lowest risk)
+
+### 1a. Add a "DISCOVERABLE TITLES" section to the curator prompt  ⭐ primary win
+
+Insert a new section in `CURATOR_SYSTEM` (`prompt.ts`, after the "WHY" block ~L357 or before
+`BREVITY IS CRITICAL` ~L397), matching the existing ALL-CAPS-header + dashed-bullet +
+`BAD:`/`GOOD:` house style already used in `DISTILLATION_SYSTEM` (`prompt.ts:70-85`).
+
+Guidance to encode (this is the article's lesson, translated to titles):
+- Put the **specific, discriminative terms a future session will search** into the title:
+  the symbol name, file, error code, tool, or proper noun — not a generic noun.
+- Aim for **2–3 content words**, at least one a domain term (mirrors Modem's uniqueness
+  data: 1 word ~61% unique, 2 words ~88%, 3 words ~96%).
+- The title is the highest-weighted search key AND the dedup identity — a vague title both
+  hides the entry and risks colliding/merging with unrelated entries.
+
+Example contrast to include:
+```
+BAD:  "Client creation bug"
+GOOD: "createStripeClient drops Authorization header on retry"
+BAD:  "Migration gotcha"
+GOOD: "v55 knowledge_meta migration boot-loops if DROP COLUMN precedes backfill"
+```
+
+Also update the `curatorUser` numbered `IMPORTANT` list (`prompt.ts:554-569`) with a one-line
+reminder, since it currently covers updates/brevity/entities/relations but never titles.
+
+**Risk:** low — prompt-only. **Verify:** existing curator tests still pass; optionally a
+prompt-content assertion. Real signal is qualitative (future entry titles get specific).
+
+### 1b. Allow the `update` op to rewrite a stale title
+
+The curator `update` op schema has **no `title` field** (`prompt.ts:467-471`), and
+consolidation keeps the survivor's original title even after merging broadens its content
+(`CONSOLIDATION_SYSTEM:637`, `CONSOLIDATION_MERGE_SYSTEM:682`). So a merged/expanded entry
+carries a title that no longer describes it — a discoverability regression baked into the
+data model.
+
+- Add optional `title` to the `update` op schema + curator apply path (`curator.applyOps`).
+- Confirm `ltm.update()` can change title without breaking append-only versioning, the
+  `LOWER(title)` dedup key (`ltm.ts:317`), and FTS re-index. **This needs a code check** —
+  title is an identity key, so re-titling must not orphan refs or collide.
+- Add a consolidation instruction: when merging, rewrite the survivor's title to cover the
+  merged scope.
+
+**Risk:** medium — touches identity/dedup/versioning. Needs adversarial review. Could ship
+1a first (pure win) and 1b as a follow-up.
+
+### 1c. Improve non-LLM pattern-extraction titles
+
+`pattern-extract.ts` builds titles as `prefix + raw capture group` bounded by
+`(.+?)(?:\.|,|$)` (`:44-139`, applied `:176`) — captures can be long, noisy prose ("Always
+the same: the agent never called the save step in the first"; several such entries already
+exist in this repo's `.lore.md`). Code-only fix (no LLM here):
+- Cap/normalize captured text (length cap, trim trailing prose), prefer the first
+  tech token.
+- Consider gating: if a capture is too generic/long, skip minting rather than create a
+  low-discoverability entry (pattern-extract is already best-effort).
+
+**Risk:** low-medium. **Verify:** `pattern-extract` tests + add cases for noisy captures.
+
+---
+
+## Direction 2 — Help the agent navigate the USER's code (medium leverage, more design)
+
+Lore's recall tool *promises* to be a file:line/symbol locator but structurally can't
+deliver — the refs it extracts are thrown away after validation. Close that loop so recall
+hits point the agent straight at code, cutting its grep/read loops (the article's core cost).
+
+### 2a. Persist extracted references instead of discarding them
+Today `extractReferences()` (`references.ts`) parses `file:line`/command/symbol refs at
+validation time; only broken/total **counts** persist (`knowledge_ref_validity`, `db.ts:1501`).
+Persist the resolved `Reference[]` (path, line, symbol, last-resolved status) in a new
+`knowledge_ref` table so they're available to render. (Aligns with the closed-#1231 decision:
+pointer + Read beats memorized value — but the pointer must actually reach the agent.)
+
+### 2b. Render resolved refs in recall output + knowledge block
+- `renderResultLine` knowledge branch (`recall.ts:559`): append resolved anchors, e.g.
+  `↳ src/auth/stripe-client.ts:42`, so the agent can jump instead of grepping.
+- Optionally in `formatKnowledge` (`prompt.ts:990`) for system-prompt entries — but weigh
+  prompt-cache stability (that block is byte-stable-sorted; adding volatile refs could churn
+  the cache). Likely recall-output-only to start.
+- Only render refs currently resolvable (respect "cannot verify ≠ broken",
+  `references.ts:12`) — never show a stale/broken pointer as a jump target.
+
+**Risk:** medium — new table + migration + rendering + cache-stability consideration.
+Sequence after Direction 1. Adversarial review required (cross-project leak risk in any new
+query path — cf. `vectorSearchDistillations` not being project-scoped, k:019f43a4).
+
+### 2c. (Optional, larger) associate entries with the files they concern
+No stored knowledge↔file association exists today (`tool_calls` has no path column,
+`db.ts:856`; no `source_files`). Issue #627 scoped this. Out of scope here — note as a
+dependency if 2b's ref coverage proves too sparse.
+
+---
+
+## Direction 3 — Blog post: Lore's take on "Writing for Agents"
+
+Angle: Modem argues **discoverability is a property of the words in your source, because
+agents search, not parse.** Lore's insight: **the same is true of an agent's *memory*.** A
+memory system is a search index over your project's history; if its entries aren't written as
+good search terms, recall degrades exactly like a grep over generic names.
+
+Post structure:
+- Lead with the shared root: retrieval (code or memory) is search-first; the words decide.
+- Show Lore's mechanics as in-house proof: BM25 title weight 6.0, IDF relaxed cascade,
+  exact-match boost — Lore independently arrived at "reward discriminative terms."
+- The reflexive move: Lore *reads* discoverable titles well, so Lore should *write* them
+  well (Direction 1) — dogfooding the article's thesis on its own knowledge base.
+- Complementary framing (per house style, cf. Warden analysis prefs): credit Modem's work;
+  position as "the memory-layer corollary," not a competitor. Acknowledge Modem's genuine
+  utility before extending the idea.
+- Tie to Lore's existing "pointer not source of truth" stance (closed #1231) — memory
+  should point at code, which is the same discipline the article preaches for names/types.
+- Avoid the "not X, but Y" counterargument-first pattern (AI tell, blog pref). Generous close.
+
+**Deliverable:** draft in the website package (Astro) or as a standalone markdown for review.
+Depends on nothing; can be drafted in parallel, but is strongest if it can reference 1a shipped.
+
+---
+
+## Recommended sequencing
+
+1. **1a** (curator title guidance) — ship first. Pure prompt win, low risk, immediately
+   improves every new entry's discoverability. Highest leverage-to-risk ratio.
+2. **1c** (pattern-extract title cleanup) — small code fix, independent.
+3. **1b** (re-titleable updates + consolidation) — needs a versioning/dedup code check +
+   adversarial review.
+4. **2a→2b** (persist + render refs) — new table/migration/rendering; sequence after D1;
+   adversarial review for cross-project leaks + cache stability.
+5. **3** (blog post) — draft anytime; publish after 1a lands so it can cite dogfooding.
+
+## Open questions for the user
+
+- Scope of this execution session: just **1a** (fast, safe), or 1a+1c, or the whole D1?
+- Direction 2: is closing the file:line-pointer loop worth a migration now, or park it as a
+  tracked issue until D1 shows whether title discoverability alone is enough?
+- Blog post: internal draft for review, or website-ready Astro page? Part of the Modem
+  "Writing for Agents" response, or standalone?
+
+## Key evidence (file:line)
+
+- Title weight 3× content: `config.ts:750` (`ftsWeights {title:6.0,content:2.0,category:3.0}`),
+  `db.ts:207` (fts5 column order `title,content,category`).
+- Curator title guidance (the gap): `prompt.ts:460` (`"Short descriptive title"`),
+  `update` op has no title `prompt.ts:467-471`, `curatorUser` list `prompt.ts:554-569`.
+- Distillation house style to mirror: `prompt.ts:70-85` (verbatim artifacts + BAD/GOOD).
+- Consolidation keeps stale titles: `prompt.ts:637,682`.
+- Pattern-extract titles: `pattern-extract.ts:44-139`, applied `:176`; `tagToTitle` `:246`.
+- Recall renders title first, no refs: `recall.ts:559-567`; recall tool "pointer not source"
+  description `recall.ts:1594`.
+- Refs extracted then discarded: `references.ts` `extractReferences`; only counts persist
+  `knowledge_ref_validity` `db.ts:1501`; read only by CLI `data.ts:275`.
+- `formatKnowledge` has no refs field: `prompt.ts:912-995`.
+- Query discriminativeness: IDF cascade `search.ts:190,309`; exact-match boost `search.ts:555`;
+  RRF `search.ts:516`.


### PR DESCRIPTION
## What

Applies the lesson from Modem's ["How coding agents read your code"](https://modem.dev/blog/how-coding-agents-read-your-code) — agents navigate by literal text search, so **discoverability is a property of the words you write** — to Lore's *own* memory, in two directions.

### Direction 2 — code anchors in recall (closes a half-built loop)

Lore's `recall` tool description already promises to be a file:line/symbol locator ("memory is a POINTER... find WHERE something is, then READ that file"), and `references.ts` already extracts + resolves `file:line`/symbol refs. But the reference-validity pass **discarded** every resolved ref — only `broken`/`total` counts survived in `knowledge_ref_validity`. So the pointers never reached the agent.

This wires the loop shut: resolved-OK anchors are persisted and rendered, so a recall hit points the agent straight at the code instead of making it grep.

- **`db.ts`**: migration **v74** + `recoverMissingObjects` self-heal — new `knowledge_ref_anchor(logical_id, kind, anchor, updated_at)`, a local-only sidecar keyed on the stable `logical_id` (mirrors `knowledge_ref_validity` / `knowledge_symbol_presence`).
- **`ltm.ts`**: `validateProjectReferences` persists resolved-OK **file (with line)** + **symbol** anchors, **rewritten in full per resolved entry** so a removed/renamed ref drops out (never a stale jump target). Entries where every ref is `unknown` (`total===0`) **keep** their prior anchors — *cannot-verify ≠ broken* applies to anchors too. New `knowledgeRefAnchors(logicalIds)` batch loader + `KnowledgeRefAnchor` type + `MAX_RECALL_ANCHORS_PER_ENTRY=3` (file anchors first). Added to `LOGICAL_ID_BOOKKEEPING_TABLES` so all hard-delete paths purge it (no orphan).
- **`recall.ts`**: `renderAnchors` helper; knowledge + cross-knowledge + id-detail branches append `` ↳ src/foo.ts:42, bar()``. Batch-loaded **once** per result set in `formatFusedResults`. **Not** wired into `formatKnowledge` (system-prompt injection) to avoid prompt-cache churn.

### Direction 1a — discoverable titles

A knowledge entry's `title` is the top-weighted recall field (BM25 `title:6.0` vs `content:2.0`) **and** the dedup identity key — yet the curator's entire title instruction was `"Short descriptive title"`. `CURATOR_SYSTEM` now has a **DISCOVERABLE TITLES** section (with BAD/GOOD pairs in the house style) + a `curatorUser` reminder, so future entries are titled with the specific symbol/file/error-code terms a session will actually search — the memory-layer corollary of the article's thesis.

## Tests

- `ltm-reference-validity.test.ts`: anchor persistence, full rewrite (removed ref drops out), per-entry cap, symbol anchor ordering, absent-symbol not persisted, neutral-on-unknown (null resolver doesn't wipe), delete purges anchors.
- `recall-code-anchors.test.ts` (new): rendering via the deterministic id-detail path — file anchor, symbol `()`, file-before-symbol ordering, no-anchor → no marker, cap, empty-input.
- `db.test.ts`: v74 recovery + schema-version pin 73→74.
- `prompt.test.ts`: DISCOVERABLE TITLES guidance pinned.

Full `@loreai/core` suite green (147 files / 3113 tests). Typecheck, lint, format all clean.

## Notes / follow-ups (not in this PR)

- Known residual (matches existing `knowledge_ref_validity` behavior): an entry edited to remove *all* refs keeps its last anchors until re-checked — the anchor is resolved-OK, just possibly no-longer-cited. Low severity.
- Deferred from the plan: D1b (re-titleable `update` op), D1c (pattern-extract title cleanup), D2c (entry↔file association), D3 (blog post).

Plan: `quality/plans/modem-recall-code-anchors.md`.