### PR TITLE
feat(import): structured-memory import lane for migrating Engram memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,26 @@ When more than one agent has history, `lore import` shows a numbered list and le
 
 **Worktrees & monorepos:** agent history is keyed by the directory the agent ran in, so a repo's conversations are spread across its main checkout and every git worktree. `lore import` finds them all by default (via `git worktree list`) — pass `--no-worktrees` to restrict to the current directory.
 
+### Migrating from another memory system (Engram, mem0)
+
+Already using a dedicated memory tool? `lore import` also migrates **already-curated** memories directly into Lore's knowledge store (no LLM pass — the entries are already structured):
+
+```bash
+# Auto-detect and import Engram memory (runs `engram export` for you)
+lore import --source engram
+
+# Or import from an explicit export file
+engram export engram.json
+lore import --source engram --file engram.json
+
+# Import everything as global (cross-project) knowledge
+lore import --source engram --global
+```
+
+Engram observation types map onto Lore categories (`bugfix`/`discovery` → `gotcha`, `config` → `architecture`, etc.), and each observation's project is recovered from its session directory. Idempotent — re-running dedups by title and only updates entries whose content changed.
+
+> mem0 migration is coming in a follow-up release.
+
 ### Web dashboard
 
 When the gateway is running, visit **http://localhost:3207/ui** for a web-based dashboard that lets you:

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -41,6 +41,32 @@ export {
   type ImportRecord,
 } from "./history";
 
+// Structured-memory import (Engram, mem0, ...) — direct-to-LTM lane, no curator
+export {
+  LoreImportDoc,
+  LoreImportEntry,
+  LORE_IMPORT_VERSION,
+  MAX_IMPORT_CONTENT_LENGTH,
+  IMPORT_CATEGORIES,
+  parseImportDoc,
+  safeParseImportDoc,
+} from "./schema";
+export {
+  importStructuredEntries,
+  type StructuredImportOptions,
+  type StructuredImportResult,
+  type StructuredImportEntryResult,
+} from "./structured";
+export { parseEngramExport } from "./sources/engram";
+export {
+  engramSource,
+  getStructuredSources,
+  getStructuredSource,
+  detectStructuredSources,
+  type StructuredSource,
+  type StructuredSourceName,
+} from "./structured-sources";
+
 // Register built-in providers on first import.
 // Each provider module calls registerProvider() at load time.
 import "./providers/claude-code";

--- a/packages/core/src/import/schema.ts
+++ b/packages/core/src/import/schema.ts
@@ -1,0 +1,114 @@
+/**
+ * Schema for the structured-memory import format (`LoreImportDoc`).
+ *
+ * This is the single trust boundary for all structured imports: adapter output
+ * (Engram, mem0, ...) AND user-supplied `--file` input are validated against
+ * this schema before anything touches the DB. Malformed input fails fast with a
+ * precise, path-annotated error rather than producing garbage knowledge entries.
+ *
+ * `zod@4` already backs `LoreConfig`; we reuse it here for consistency.
+ */
+import { z } from "zod";
+
+/** Bump when the wire format changes incompatibly; the importer branches on it. */
+export const LORE_IMPORT_VERSION = 1;
+
+/**
+ * Hard ceiling on entry `content` length at the schema trust boundary
+ * (defense-in-depth). The importer truncates to 1200 chars downstream; this
+ * larger ceiling only bounds the in-memory parsed doc so a pathological input
+ * can't blow up memory. Source adapters should clamp to this BEFORE building a
+ * doc so a single oversized record is truncated rather than aborting the whole
+ * import with a validation error.
+ */
+export const MAX_IMPORT_CONTENT_LENGTH = 65_536;
+
+/** Lore knowledge categories an imported entry may map to. */
+export const IMPORT_CATEGORIES = [
+  "decision",
+  "pattern",
+  "preference",
+  "architecture",
+  "gotcha",
+] as const;
+
+export const LoreImportEntry = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Entry title; synthesized from content when absent."),
+    content: z
+      .string()
+      .trim()
+      .min(1)
+      // Hard ceiling at the trust boundary (defense-in-depth): the importer
+      // truncates to 1200 chars, but bounding here caps the in-memory parsed
+      // doc so a 100k-entry doc of huge strings can't blow up memory before the
+      // importer ever runs. 64K per entry is far above any real curated memory.
+      .max(MAX_IMPORT_CONTENT_LENGTH)
+      .describe("Entry body. Truncated to 1200 chars by the importer."),
+    category: z
+      .enum(IMPORT_CATEGORIES)
+      .optional()
+      .describe("Lore category; defaults per-source (mem0 → pattern)."),
+    project: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Repo path or name; overridden by --project."),
+    confidence: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .describe("0..1; defaults to 1.0."),
+    created_at: z
+      .union([z.string(), z.number()])
+      .optional()
+      .describe("ISO8601 string or epoch ms; informational."),
+    external_id: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe("Source-native id for idempotency/dedup."),
+  })
+  // Reject unknown keys so a wrong-shape file (e.g. a raw mem0 dump or Engram
+  // export handed in directly) fails clearly instead of importing junk.
+  .strict();
+
+export const LoreImportDoc = z
+  .object({
+    lore_import_version: z
+      .literal(LORE_IMPORT_VERSION)
+      .describe("Format version. Unknown versions are rejected."),
+    source: z
+      .enum(["engram", "mem0", "generic"])
+      .describe("Origin of the entries (informational + routing)."),
+    entries: z.array(LoreImportEntry).max(100_000),
+  })
+  .strict();
+
+export type LoreImportEntry = z.infer<typeof LoreImportEntry>;
+export type LoreImportDoc = z.infer<typeof LoreImportDoc>;
+
+/**
+ * Parse and validate an arbitrary value as a `LoreImportDoc`.
+ * Throws a `ZodError` with a path-annotated message on failure.
+ */
+export function parseImportDoc(value: unknown): LoreImportDoc {
+  return LoreImportDoc.parse(value);
+}
+
+/**
+ * Non-throwing variant. Returns the standard zod `SafeParseReturnType`.
+ * Callers (CLI `--file`, server endpoint) use `z.prettifyError` on failure.
+ */
+export function safeParseImportDoc(value: unknown) {
+  return LoreImportDoc.safeParse(value);
+}

--- a/packages/core/src/import/sources/engram.ts
+++ b/packages/core/src/import/sources/engram.ts
@@ -1,0 +1,149 @@
+/**
+ * Engram source adapter.
+ *
+ * Converts an Engram export (`engram export` / `GET /export`) into a validated
+ * `LoreImportDoc`. Engram is the Go memory system at
+ * github.com/Gentleman-Programming/engram.
+ *
+ * Export shape (verified against Engram `main`):
+ *   { version, exported_at, sessions[], observations[], prompts[] }
+ * with snake_case json tags. We only consume `sessions` (for the project
+ * directory) and `observations` (the actual memory entries); `prompts` are raw
+ * user turns, not curated knowledge, so they are ignored.
+ */
+import {
+  parseImportDoc,
+  MAX_IMPORT_CONTENT_LENGTH,
+  type LoreImportDoc,
+  type LoreImportEntry,
+} from "../schema";
+
+/** A session row from an Engram export (subset we use). */
+type EngramSession = {
+  id: string;
+  project?: string;
+  directory?: string;
+};
+
+/** An observation row from an Engram export (subset we use). */
+type EngramObservation = {
+  session_id?: string;
+  type?: string;
+  title?: string;
+  content?: string;
+  project?: string | null;
+  scope?: string;
+  confidence?: number;
+  created_at?: string;
+  deleted_at?: string | null;
+  sync_id?: string;
+};
+
+type EngramExport = {
+  sessions?: EngramSession[];
+  observations?: EngramObservation[];
+};
+
+/**
+ * Map an Engram observation `type` to a Lore category.
+ * Engram's canonical set is bugfix|decision|architecture|discovery|pattern|
+ * config|preference (no `gotcha` — gotchas are `discovery`).
+ */
+function mapCategory(type: string | undefined): LoreImportEntry["category"] {
+  switch ((type ?? "").toLowerCase()) {
+    case "decision":
+      return "decision";
+    case "architecture":
+      return "architecture";
+    case "config":
+      return "architecture";
+    case "pattern":
+      return "pattern";
+    case "preference":
+      return "preference";
+    case "bugfix":
+    case "discovery":
+      return "gotcha";
+    default:
+      return "pattern";
+  }
+}
+
+/**
+ * Parse a raw Engram export object into a validated `LoreImportDoc`.
+ *
+ * @throws ZodError if the resulting document fails schema validation.
+ */
+export function parseEngramExport(raw: unknown): LoreImportDoc {
+  const exp = (raw ?? {}) as EngramExport;
+  const sessions = Array.isArray(exp.sessions) ? exp.sessions : [];
+  const observations = Array.isArray(exp.observations) ? exp.observations : [];
+
+  // session_id → directory (real filesystem path → Lore project).
+  const sessionDir = new Map<string, string>();
+  for (const s of sessions) {
+    if (
+      s &&
+      typeof s.id === "string" &&
+      typeof s.directory === "string" &&
+      s.directory
+    ) {
+      sessionDir.set(s.id, s.directory);
+    }
+  }
+
+  const entries: LoreImportEntry[] = [];
+  for (const obs of observations) {
+    if (!obs || typeof obs.content !== "string" || obs.content.trim() === "") {
+      continue;
+    }
+    // Skip soft-deleted observations. Engram writes NULL for live rows and a
+    // timestamp string when deleted. Use a truthy check (not `!= null`) so a
+    // falsy-but-present value (empty string) is treated as LIVE — never silently
+    // drop a live observation because of an empty deleted_at.
+    if (obs.deleted_at) continue;
+
+    const scope = (obs.scope ?? "project").toLowerCase();
+    // personal/global observations become global (cross-project) entries; we
+    // signal this by leaving `project` unset so the importer's --global path or
+    // the default project applies. Since the doc format has no per-entry scope,
+    // we resolve project only for `project`-scoped observations.
+    const isGlobalScope = scope === "personal" || scope === "global";
+
+    const directory = obs.session_id
+      ? sessionDir.get(obs.session_id)
+      : undefined;
+    const project = isGlobalScope ? undefined : directory;
+
+    const entry: LoreImportEntry = {
+      // Clamp to the schema ceiling so a single oversized observation is
+      // truncated here rather than failing validation and aborting the entire
+      // import. The importer truncates further (to 1200) downstream.
+      content:
+        obs.content.length > MAX_IMPORT_CONTENT_LENGTH
+          ? obs.content.slice(0, MAX_IMPORT_CONTENT_LENGTH)
+          : obs.content,
+      category: mapCategory(obs.type),
+    };
+    if (typeof obs.title === "string" && obs.title.trim() !== "") {
+      entry.title = obs.title;
+    }
+    if (project) entry.project = project;
+    if (typeof obs.confidence === "number") {
+      entry.confidence = Math.min(1, Math.max(0, obs.confidence));
+    }
+    if (typeof obs.created_at === "string" && obs.created_at) {
+      entry.created_at = obs.created_at;
+    }
+    if (typeof obs.sync_id === "string" && obs.sync_id) {
+      entry.external_id = obs.sync_id;
+    }
+    entries.push(entry);
+  }
+
+  return parseImportDoc({
+    lore_import_version: 1,
+    source: "engram",
+    entries,
+  });
+}

--- a/packages/core/src/import/structured-sources.ts
+++ b/packages/core/src/import/structured-sources.ts
@@ -1,0 +1,122 @@
+/**
+ * Structured-memory sources — detection + document production for import lanes
+ * that read ALREADY-CURATED memory (Engram, mem0, ...) rather than raw
+ * conversation transcripts.
+ *
+ * Unlike `AgentHistoryProvider` (which yields conversation chunks for the
+ * curator LLM), a `StructuredSource` yields a validated `LoreImportDoc` that is
+ * written directly to the knowledge store via `importStructuredEntries`.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseEngramExport } from "./sources/engram";
+import { safeParseImportDoc, type LoreImportDoc } from "./schema";
+
+export type StructuredSourceName = "engram" | "mem0";
+
+export type StructuredSource = {
+  /** Internal name (matches LoreImportDoc.source and --agent filter). */
+  readonly name: StructuredSourceName;
+  /** Human-readable name. */
+  readonly displayName: string;
+  /**
+   * Fast, side-effect-free check: does this source appear to be present on the
+   * machine? Used to surface it in `lore import` auto-detection.
+   */
+  detect(): boolean;
+  /**
+   * Produce a validated LoreImportDoc from this source. When `filePath` is
+   * provided, read/convert that file; otherwise auto-discover (e.g. run the
+   * source's own export CLI). Throws with an actionable message on failure.
+   */
+  produceDoc(opts?: { filePath?: string }): LoreImportDoc;
+};
+
+/** True when `bin` is resolvable on PATH (best-effort, never throws). */
+function hasBinary(bin: string): boolean {
+  try {
+    execFileSync(process.platform === "win32" ? "where" : "which", [bin], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read + JSON-parse a file, returning the parsed value. Throws on error. */
+function readJson(filePath: string): unknown {
+  const raw = readFileSync(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Engram
+// ---------------------------------------------------------------------------
+
+export const engramSource: StructuredSource = {
+  name: "engram",
+  displayName: "Engram",
+
+  detect(): boolean {
+    // Engram is a single Go binary; its default DB lives under ~/.engram.
+    if (hasBinary("engram")) return true;
+    const dbPath = join(homedir(), ".engram", "engram.db");
+    return existsSync(dbPath);
+  },
+
+  produceDoc(opts?: { filePath?: string }): LoreImportDoc {
+    let raw: unknown;
+    if (opts?.filePath) {
+      raw = readJson(opts.filePath);
+    } else if (hasBinary("engram")) {
+      // `engram export` writes the ExportData JSON to stdout.
+      const out = execFileSync("engram", ["export"], {
+        encoding: "utf8",
+        maxBuffer: 256 * 1024 * 1024,
+      });
+      raw = JSON.parse(out);
+    } else {
+      throw new Error(
+        "Engram not found. Install the `engram` binary or pass --file <export.json> " +
+          "(produce it with `engram export export.json`).",
+      );
+    }
+    // If the file is already a LoreImportDoc (generic pass-through), accept it.
+    const asGeneric = safeParseImportDoc(raw);
+    if (asGeneric.success) return asGeneric.data;
+    // Otherwise treat it as a native Engram export.
+    return parseEngramExport(raw);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const sources: StructuredSource[] = [engramSource];
+
+/** All registered structured sources. */
+export function getStructuredSources(): readonly StructuredSource[] {
+  return sources;
+}
+
+/** Look up a structured source by name. */
+export function getStructuredSource(
+  name: string,
+): StructuredSource | undefined {
+  return sources.find((s) => s.name === name);
+}
+
+/** Detect which structured sources are present on this machine. */
+export function detectStructuredSources(): StructuredSource[] {
+  return sources.filter((s) => {
+    try {
+      return s.detect();
+    } catch {
+      return false;
+    }
+  });
+}

--- a/packages/core/src/import/structured.ts
+++ b/packages/core/src/import/structured.ts
@@ -1,0 +1,213 @@
+/**
+ * Structured-memory importer.
+ *
+ * Consumes a validated `LoreImportDoc` (produced by a source adapter such as
+ * Engram/mem0, or supplied directly via `--file`) and writes each entry to the
+ * knowledge store via `ltm.create()`.
+ *
+ * Unlike the conversation-import lane (`extract.ts`), this does NOT go through
+ * the curator LLM — the source is already-curated structured memory, so we map
+ * it directly. Semantics mirror `agents-file._importEntries()`:
+ *   - resolve each distinct project path once,
+ *   - exact-title then fuzzy-title dedup (update on content change, skip when identical),
+ *   - never resurrect a tombstoned entry (by title),
+ *   - enforce the 1200-char content cap ourselves (ltm.create does not),
+ *   - clamp confidence, default 1.0,
+ *   - never set worker attribution (these are user-authored).
+ */
+import * as ltm from "../ltm";
+import { db, ensureProject } from "../db";
+import { MAX_ENTRY_CONTENT_LENGTH } from "../curator";
+import { parseImportDoc, type LoreImportDoc } from "./schema";
+
+const TRUNCATION_SUFFIX = " [truncated — entry too long]";
+
+export type StructuredImportOptions = {
+  /** Fallback project path for entries without an explicit `project`. */
+  defaultProjectPath: string;
+  /** When true, import every entry as a global (cross-project) entry. */
+  global?: boolean;
+  /** When true, compute the outcome without writing to the DB. */
+  dryRun?: boolean;
+};
+
+export type StructuredImportEntryResult = {
+  title: string;
+  category: string;
+  /** "created" | "updated" | "skipped" */
+  action: "created" | "updated" | "skipped";
+  /** Reason for a skip (e.g. "tombstoned", "duplicate"). */
+  reason?: string;
+};
+
+export type StructuredImportResult = {
+  created: number;
+  updated: number;
+  skipped: number;
+  entries: StructuredImportEntryResult[];
+};
+
+/** Truncate content to the knowledge-entry cap, appending a marker when cut. */
+function capContent(content: string): string {
+  if (content.length <= MAX_ENTRY_CONTENT_LENGTH) return content;
+  // Reserve room for the suffix so the final string still fits the cap.
+  const room = MAX_ENTRY_CONTENT_LENGTH - TRUNCATION_SUFFIX.length;
+  return content.slice(0, Math.max(0, room)) + TRUNCATION_SUFFIX;
+}
+
+/** Synthesize a title from content when the source did not provide one. */
+function synthesizeTitle(content: string): string {
+  const firstLine = content.split("\n", 1)[0].trim();
+  const base = firstLine.length > 0 ? firstLine : content.trim();
+  if (base.length <= 60) return base;
+  return base.slice(0, 57).trimEnd() + "...";
+}
+
+function clampConfidence(v: number | undefined): number {
+  if (v == null || Number.isNaN(v)) return 1.0;
+  return Math.min(1, Math.max(0, v));
+}
+
+/**
+ * Find an existing entry with the same title (case-insensitive) visible to this
+ * project — mirrors the exact-title dedup inside `ltm.create()`, but lets us
+ * report created-vs-updated deterministically (create() can't). Checks the
+ * project pool then the cross-project pool. Returns the resolved current-row id.
+ */
+function findExactTitle(title: string, pid: string | null): string | null {
+  const inProject =
+    pid !== null
+      ? (db()
+          .query(
+            "SELECT id FROM knowledge_current WHERE project_id = ? AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+          )
+          .get(pid, title) as { id: string } | null)
+      : (db()
+          .query(
+            "SELECT id FROM knowledge_current WHERE project_id IS NULL AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+          )
+          .get(title) as { id: string } | null);
+  if (inProject) return inProject.id;
+
+  const crossProject = db()
+    .query(
+      "SELECT id FROM knowledge_current WHERE cross_project = 1 AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+    )
+    .get(title) as { id: string } | null;
+  return crossProject?.id ?? null;
+}
+
+/**
+ * Import a structured document into the knowledge store.
+ *
+ * The input is re-validated against `LoreImportDoc` defensively — callers should
+ * already have parsed it, but this guarantees the trust boundary regardless of
+ * entry point.
+ */
+export function importStructuredEntries(
+  doc: LoreImportDoc,
+  opts: StructuredImportOptions,
+): StructuredImportResult {
+  // Defensive re-validation: guarantees the DB never sees an unvalidated doc.
+  const validated = parseImportDoc(doc);
+
+  const result: StructuredImportResult = {
+    created: 0,
+    updated: 0,
+    skipped: 0,
+    entries: [],
+  };
+
+  // Resolve each distinct project path once (loop-invariant cache).
+  const pidCache = new Map<string, string>();
+  const resolvePid = (path: string): string => {
+    const cached = pidCache.get(path);
+    if (cached) return cached;
+    const pid = ensureProject(path);
+    pidCache.set(path, pid);
+    return pid;
+  };
+
+  for (const entry of validated.entries) {
+    const content = capContent(entry.content.trim());
+    const title = entry.title?.trim() || synthesizeTitle(content);
+    const category = entry.category ?? "pattern";
+    const confidence = clampConfidence(entry.confidence);
+    const projectPath = opts.global
+      ? opts.defaultProjectPath
+      : (entry.project ?? opts.defaultProjectPath);
+    const crossProject = opts.global === true;
+    // Global entries are stored with scope "global" (project_id null); project
+    // entries resolve their own pid for the fuzzy-dedup scope check.
+    const pid = crossProject ? null : resolvePid(projectPath);
+
+    // Dedup: an exact title match (deterministic) OR a fuzzy near-title match
+    // (same concept, different wording) means "already present": update on a
+    // content change, otherwise skip. We do the exact check first so we can
+    // report created-vs-updated deterministically; ltm.create() would silently
+    // dedup on exact title and we couldn't tell the difference.
+    const existingId =
+      findExactTitle(title, pid) ??
+      ltm.findFuzzyDuplicate({ title, projectId: pid })?.id ??
+      null;
+    if (existingId) {
+      const existing = ltm.get(existingId);
+      if (existing && existing.content !== content) {
+        if (!opts.dryRun) ltm.update(existing.id, { content });
+        result.updated++;
+        result.entries.push({ title, category, action: "updated" });
+      } else {
+        result.skipped++;
+        result.entries.push({
+          title,
+          category,
+          action: "skipped",
+          reason: "duplicate",
+        });
+      }
+      continue;
+    }
+
+    // Resurrection guard: no live match, but a tombstoned (death-cert) entry with
+    // this title exists in scope. A structured entry carries no logical_id, so we
+    // match by title. Never resurrect a deleted entry — skip it (mirrors the
+    // id-keyed guard in agents-file._importEntries and the create()/FTS behavior
+    // that keeps tombstoned rows out of the dedup pools).
+    if (ltm.findTombstonedByTitle({ title, projectId: pid })) {
+      result.skipped++;
+      result.entries.push({
+        title,
+        category,
+        action: "skipped",
+        reason: "tombstoned",
+      });
+      continue;
+    }
+
+    if (opts.dryRun) {
+      result.created++;
+      result.entries.push({ title, category, action: "created" });
+      continue;
+    }
+
+    // No live match and not tombstoned — create a fresh entry. We mint a new
+    // UUIDv7 (external_id is NOT a Lore logical_id). ltm.create() applies its
+    // own exact-title dedup as a backstop against a concurrent duplicate; the
+    // by-title resurrection guard above (findTombstonedByTitle) is what honors
+    // the "never resurrect a tombstoned entry" invariant for this lane.
+    ltm.create({
+      projectPath: crossProject ? undefined : projectPath,
+      category,
+      title,
+      content,
+      scope: crossProject ? "global" : "project",
+      crossProject,
+      confidence,
+      // Intentionally NO workerProviderID/workerModelID — user-authored import.
+    });
+    result.created++;
+    result.entries.push({ title, category, action: "created" });
+  }
+
+  return result;
+}

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -885,6 +885,56 @@ export function isTombstoned(id: string): boolean {
 }
 
 /**
+ * True when an entry with this exact title (case-insensitive), visible to the
+ * given scope, was deleted (tombstoned) and has NO live current version.
+ *
+ * Structured import (Engram/mem0) carries no logical_id, so it can't call
+ * {@link isTombstoned} by id. This lets that lane honor the "never resurrect a
+ * tombstoned entry" invariant by title: if the only same-title match in scope is
+ * a death-cert (is_current=1 AND is_deleted=1) and there is no live row with that
+ * title, the entry must NOT be re-created.
+ *
+ * Scope mirrors the importer's dedup scope: the project pool (or the global
+ * `project_id IS NULL` pool) PLUS cross-project entries. Reads the base
+ * `knowledge` table (NOT `knowledge_current`) so it can see death-cert rows —
+ * which `knowledge_current` excludes by definition.
+ */
+export function findTombstonedByTitle(input: {
+  title: string;
+  projectId: string | null;
+}): boolean {
+  // A live current version with this title takes precedence — it is an update
+  // target, not a resurrection. Only report "tombstoned" when NO live row exists.
+  const live =
+    input.projectId !== null
+      ? (db()
+          .query(
+            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 0 AND (project_id = ? OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+          )
+          .get(input.projectId, input.title) as { 1: number } | null)
+      : (db()
+          .query(
+            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 0 AND (project_id IS NULL OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+          )
+          .get(input.title) as { 1: number } | null);
+  if (live) return false;
+
+  const deathCert =
+    input.projectId !== null
+      ? (db()
+          .query(
+            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 1 AND (project_id = ? OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+          )
+          .get(input.projectId, input.title) as { 1: number } | null)
+      : (db()
+          .query(
+            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 1 AND (project_id IS NULL OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+          )
+          .get(input.title) as { 1: number } | null);
+  return deathCert != null;
+}
+
+/**
  * Clear a tombstone for the given UUID — called when an entry is legitimately
  * (re-)created with that exact UUID, so a future delete can tombstone it again.
  */

--- a/packages/core/test/import/engram.test.ts
+++ b/packages/core/test/import/engram.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect } from "vitest";
+import { parseEngramExport } from "../../src/import/sources/engram";
+import { MAX_ENTRY_CONTENT_LENGTH } from "../../src/curator";
+
+function engramExport(observations: unknown[], sessions: unknown[] = []) {
+  return {
+    version: "1.0",
+    exported_at: "2026-07-20 14:05:00",
+    sessions,
+    observations,
+    prompts: [],
+  };
+}
+
+describe("parseEngramExport", () => {
+  test("maps observations to entries with category mapping", () => {
+    const doc = parseEngramExport(
+      engramExport([
+        { type: "bugfix", title: "N+1 fix", content: "batched query" },
+        { type: "decision", title: "Chose zod", content: "for validation" },
+        { type: "config", title: "CI setup", content: "gha" },
+        { type: "unknown", title: "Misc", content: "misc body" },
+      ]),
+    );
+    expect(doc.source).toBe("engram");
+    const byTitle = new Map(doc.entries.map((e) => [e.title, e.category]));
+    expect(byTitle.get("N+1 fix")).toBe("gotcha"); // bugfix -> gotcha
+    expect(byTitle.get("Chose zod")).toBe("decision");
+    expect(byTitle.get("CI setup")).toBe("architecture"); // config -> architecture
+    expect(byTitle.get("Misc")).toBe("pattern"); // unknown -> pattern
+  });
+
+  test("resolves project from the session directory", () => {
+    const doc = parseEngramExport(
+      engramExport(
+        [
+          {
+            session_id: "s1",
+            type: "pattern",
+            title: "P",
+            content: "body",
+            scope: "project",
+          },
+        ],
+        [{ id: "s1", project: "engram", directory: "/home/u/code/engram" }],
+      ),
+    );
+    expect(doc.entries[0].project).toBe("/home/u/code/engram");
+  });
+
+  test("skips soft-deleted observations", () => {
+    const doc = parseEngramExport(
+      engramExport([
+        { type: "pattern", title: "Live", content: "kept" },
+        {
+          type: "pattern",
+          title: "Dead",
+          content: "removed",
+          deleted_at: "2026-07-20 10:00:00",
+        },
+      ]),
+    );
+    const titles = doc.entries.map((e) => e.title);
+    expect(titles).toContain("Live");
+    expect(titles).not.toContain("Dead");
+  });
+
+  test("personal/global scope observations get no project (become global)", () => {
+    const doc = parseEngramExport(
+      engramExport(
+        [
+          {
+            session_id: "s1",
+            type: "preference",
+            title: "Global pref",
+            content: "everywhere",
+            scope: "personal",
+          },
+        ],
+        [{ id: "s1", directory: "/home/u/code/engram" }],
+      ),
+    );
+    expect(doc.entries[0].project).toBeUndefined();
+  });
+
+  test("carries sync_id as external_id and preserves long content", () => {
+    const long = "y".repeat(MAX_ENTRY_CONTENT_LENGTH + 300);
+    const doc = parseEngramExport(
+      engramExport([
+        {
+          type: "pattern",
+          title: "Long",
+          content: long,
+          sync_id: "obs-abc123",
+        },
+      ]),
+    );
+    expect(doc.entries[0].external_id).toBe("obs-abc123");
+    // The adapter preserves content; the importer truncates.
+    expect(doc.entries[0].content.length).toBe(long.length);
+  });
+
+  test("skips observations with empty content", () => {
+    const doc = parseEngramExport(
+      engramExport([
+        { type: "pattern", title: "Empty", content: "   " },
+        { type: "pattern", title: "Full", content: "real" },
+      ]),
+    );
+    expect(doc.entries.map((e) => e.title)).toEqual(["Full"]);
+  });
+
+  test("handles missing sessions/observations gracefully", () => {
+    const doc = parseEngramExport({});
+    expect(doc.entries).toEqual([]);
+    expect(doc.source).toBe("engram");
+  });
+
+  test("deleted_at falsy-but-present (empty string) is NOT treated as deleted", () => {
+    // The adapter skips only on a TRUTHY deleted_at (a real timestamp). A
+    // falsy-but-present value (empty string) means "live" → kept. Guards against
+    // silently dropping a live observation because of an empty deleted_at.
+    const doc = parseEngramExport(
+      engramExport([
+        { type: "pattern", title: "EmptyDel", content: "body", deleted_at: "" },
+      ]),
+    );
+    expect(doc.entries.map((e) => e.title)).toEqual(["EmptyDel"]);
+  });
+
+  test("clamps out-of-range Engram confidence into [0,1]", () => {
+    const doc = parseEngramExport(
+      engramExport([
+        { type: "pattern", title: "HiConf", content: "a", confidence: 1.7 },
+        { type: "pattern", title: "LoConf", content: "b", confidence: -0.5 },
+      ]),
+    );
+    const byTitle = new Map(doc.entries.map((e) => [e.title, e.confidence]));
+    expect(byTitle.get("HiConf")).toBe(1);
+    expect(byTitle.get("LoConf")).toBe(0);
+  });
+
+  test("an oversized observation is truncated, not rejected (no whole-import abort)", () => {
+    // A single >64K observation must NOT throw a ZodError that aborts the entire
+    // export. The adapter clamps to the schema ceiling; the importer truncates
+    // further downstream. Other entries in the same export survive.
+    const huge = "h".repeat(80_000);
+    const doc = parseEngramExport(
+      engramExport([
+        { type: "pattern", title: "Huge", content: huge },
+        { type: "pattern", title: "Small", content: "ok" },
+      ]),
+    );
+    const titles = doc.entries.map((e) => e.title);
+    expect(titles).toContain("Huge");
+    expect(titles).toContain("Small");
+    const hugeEntry = doc.entries.find((e) => e.title === "Huge");
+    expect(hugeEntry!.content.length).toBeLessThanOrEqual(65_536);
+  });
+});

--- a/packages/core/test/import/schema.test.ts
+++ b/packages/core/test/import/schema.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from "vitest";
+import {
+  LoreImportDoc,
+  parseImportDoc,
+  safeParseImportDoc,
+  LORE_IMPORT_VERSION,
+} from "../../src/import/schema";
+
+function validDoc(overrides?: Record<string, unknown>) {
+  return {
+    lore_import_version: LORE_IMPORT_VERSION,
+    source: "generic",
+    entries: [{ content: "hello world", category: "pattern" }],
+    ...overrides,
+  };
+}
+
+describe("LoreImportDoc schema", () => {
+  test("accepts a minimal valid document", () => {
+    const parsed = parseImportDoc(validDoc());
+    expect(parsed.entries).toHaveLength(1);
+    expect(parsed.entries[0].content).toBe("hello world");
+  });
+
+  test("rejects a missing content field", () => {
+    const res = safeParseImportDoc(
+      validDoc({ entries: [{ category: "pattern" }] }),
+    );
+    expect(res.success).toBe(false);
+  });
+
+  test("rejects out-of-range confidence", () => {
+    const lo = safeParseImportDoc(
+      validDoc({ entries: [{ content: "x", confidence: -0.1 }] }),
+    );
+    const hi = safeParseImportDoc(
+      validDoc({ entries: [{ content: "x", confidence: 1.5 }] }),
+    );
+    expect(lo.success).toBe(false);
+    expect(hi.success).toBe(false);
+  });
+
+  test("rejects an unknown category", () => {
+    const res = safeParseImportDoc(
+      validDoc({ entries: [{ content: "x", category: "bugfix" }] }),
+    );
+    expect(res.success).toBe(false);
+  });
+
+  test("rejects content over the 64K ceiling", () => {
+    const res = safeParseImportDoc(
+      validDoc({ entries: [{ content: "x".repeat(65_537) }] }),
+    );
+    expect(res.success).toBe(false);
+  });
+
+  test("rejects unknown top-level keys via .strict()", () => {
+    const res = safeParseImportDoc(validDoc({ extra: "nope" }));
+    expect(res.success).toBe(false);
+  });
+
+  test("rejects unknown entry keys via .strict()", () => {
+    const res = safeParseImportDoc(
+      validDoc({ entries: [{ content: "x", weird: 1 }] }),
+    );
+    expect(res.success).toBe(false);
+  });
+
+  test("rejects a wrong lore_import_version", () => {
+    const res = safeParseImportDoc(validDoc({ lore_import_version: 2 }));
+    expect(res.success).toBe(false);
+  });
+
+  test("a raw Engram export fails .strict() (must go through the adapter)", () => {
+    const rawEngram = {
+      version: "1.0",
+      exported_at: "2026-07-20 14:05:00",
+      sessions: [],
+      observations: [{ id: 1, type: "bugfix", title: "t", content: "c" }],
+      prompts: [],
+    };
+    const res = safeParseImportDoc(rawEngram);
+    expect(res.success).toBe(false);
+  });
+
+  test("a raw mem0 dump fails .strict() (must go through the adapter)", () => {
+    const rawMem0 = {
+      results: [{ id: "uuid", memory: "text", hash: "h" }],
+    };
+    const res = safeParseImportDoc(rawMem0);
+    expect(res.success).toBe(false);
+  });
+
+  test("schema is exported as both a value and inferred type", () => {
+    const parsed = LoreImportDoc.parse(validDoc());
+    expect(parsed.source).toBe("generic");
+  });
+});

--- a/packages/core/test/import/structured-sources.test.ts
+++ b/packages/core/test/import/structured-sources.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, afterAll } from "vitest";
+import { fileURLToPath } from "node:url";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  engramSource,
+  getStructuredSource,
+  getStructuredSources,
+} from "../../src/import/structured-sources";
+import { LORE_IMPORT_VERSION } from "../../src/import/schema";
+
+const TMP = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "__tmp_structured_sources__",
+);
+mkdirSync(TMP, { recursive: true });
+
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+function writeFixture(name: string, obj: unknown): string {
+  const p = join(TMP, name);
+  writeFileSync(p, JSON.stringify(obj), "utf8");
+  return p;
+}
+
+describe("structured sources registry", () => {
+  test("registers engram", () => {
+    expect(getStructuredSource("engram")).toBe(engramSource);
+    expect(getStructuredSources().map((s) => s.name)).toContain("engram");
+  });
+
+  test("unknown source returns undefined", () => {
+    expect(getStructuredSource("nope")).toBeUndefined();
+  });
+});
+
+describe("engramSource.produceDoc", () => {
+  test("converts a native Engram export file", () => {
+    const file = writeFixture("engram.json", {
+      version: "1.0",
+      exported_at: "2026-07-20 14:05:00",
+      sessions: [{ id: "s1", directory: "/repo" }],
+      observations: [
+        {
+          session_id: "s1",
+          type: "bugfix",
+          title: "Fix",
+          content: "batched query",
+          scope: "project",
+        },
+      ],
+      prompts: [],
+    });
+    const doc = engramSource.produceDoc({ filePath: file });
+    expect(doc.source).toBe("engram");
+    expect(doc.entries).toHaveLength(1);
+    expect(doc.entries[0].category).toBe("gotcha");
+    expect(doc.entries[0].project).toBe("/repo");
+  });
+
+  test("passes through an already-generic LoreImportDoc file", () => {
+    const file = writeFixture("generic.json", {
+      lore_import_version: LORE_IMPORT_VERSION,
+      source: "generic",
+      entries: [{ content: "already normalized", category: "pattern" }],
+    });
+    const doc = engramSource.produceDoc({ filePath: file });
+    expect(doc.source).toBe("generic");
+    expect(doc.entries[0].content).toBe("already normalized");
+  });
+
+  test("throws a helpful error when neither file nor binary is available", () => {
+    let hasEngram = false;
+    try {
+      hasEngram = engramSource.detect();
+    } catch {
+      hasEngram = false;
+    }
+    if (hasEngram) {
+      expect(hasEngram).toBe(true);
+      return;
+    }
+    expect(() => engramSource.produceDoc()).toThrow(/Engram not found/);
+  });
+});

--- a/packages/core/test/import/structured.test.ts
+++ b/packages/core/test/import/structured.test.ts
@@ -1,0 +1,288 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { db, ensureProject } from "../../src/db";
+import * as ltm from "../../src/ltm";
+import { importStructuredEntries } from "../../src/import/structured";
+import {
+  LORE_IMPORT_VERSION,
+  type LoreImportDoc,
+} from "../../src/import/schema";
+import { MAX_ENTRY_CONTENT_LENGTH } from "../../src/curator";
+
+const PROJECT = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "__tmp_structured__",
+);
+
+function doc(
+  entries: LoreImportDoc["entries"],
+  source = "generic",
+): LoreImportDoc {
+  return {
+    lore_import_version: LORE_IMPORT_VERSION,
+    source: source as LoreImportDoc["source"],
+    entries,
+  };
+}
+
+function entriesForProject(projectPath: string) {
+  return ltm.forProject(projectPath, false);
+}
+
+describe("importStructuredEntries", () => {
+  beforeEach(() => {
+    ensureProject(PROJECT);
+  });
+
+  test("creates knowledge entries", () => {
+    const res = importStructuredEntries(
+      doc([
+        { content: "Use SQLite WAL mode", category: "architecture" },
+        { content: "Prefer zod for validation", category: "preference" },
+      ]),
+      { defaultProjectPath: PROJECT },
+    );
+    expect(res.created).toBe(2);
+    expect(res.updated).toBe(0);
+    expect(res.skipped).toBe(0);
+
+    const rows = entriesForProject(PROJECT);
+    const titles = rows.map((r) => r.title).sort();
+    expect(titles).toContain("Use SQLite WAL mode");
+    expect(titles).toContain("Prefer zod for validation");
+  });
+
+  test("is idempotent — re-running skips duplicates", () => {
+    const d = doc([
+      { content: "Idempotent content here", category: "pattern" },
+    ]);
+    const first = importStructuredEntries(d, { defaultProjectPath: PROJECT });
+    expect(first.created).toBe(1);
+
+    const second = importStructuredEntries(d, { defaultProjectPath: PROJECT });
+    expect(second.created).toBe(0);
+    expect(second.skipped).toBe(1);
+  });
+
+  test("updates when content changes for a title-similar entry", () => {
+    importStructuredEntries(
+      doc([{ title: "Auth flow decision", content: "old content v1" }]),
+      { defaultProjectPath: PROJECT },
+    );
+    const res = importStructuredEntries(
+      doc([{ title: "Auth flow decision", content: "new content v2" }]),
+      { defaultProjectPath: PROJECT },
+    );
+    expect(res.updated).toBe(1);
+    expect(res.created).toBe(0);
+
+    const rows = entriesForProject(PROJECT);
+    const entry = rows.find((r) => r.title === "Auth flow decision");
+    expect(entry?.content).toBe("new content v2");
+  });
+
+  test("truncates content over the 1200-char cap", () => {
+    const long = "x".repeat(MAX_ENTRY_CONTENT_LENGTH + 500);
+    importStructuredEntries(
+      doc([{ title: "Long entry title", content: long }]),
+      { defaultProjectPath: PROJECT },
+    );
+    const rows = entriesForProject(PROJECT);
+    const entry = rows.find((r) => r.title === "Long entry title");
+    expect(entry).toBeDefined();
+    expect(entry!.content.length).toBeLessThanOrEqual(MAX_ENTRY_CONTENT_LENGTH);
+    expect(entry!.content).toContain("[truncated");
+  });
+
+  test("synthesizes a title from content when absent", () => {
+    importStructuredEntries(
+      doc([{ content: "First line becomes the title\nrest of body" }]),
+      { defaultProjectPath: PROJECT },
+    );
+    const rows = entriesForProject(PROJECT);
+    const entry = rows.find((r) => r.title === "First line becomes the title");
+    expect(entry).toBeDefined();
+  });
+
+  test("clamps confidence into [0,1]", () => {
+    importStructuredEntries(
+      doc([{ title: "Conf entry", content: "body", confidence: 0.3 }]),
+      { defaultProjectPath: PROJECT },
+    );
+    const entry = entriesForProject(PROJECT).find(
+      (r) => r.title === "Conf entry",
+    );
+    expect(entry?.confidence).toBeCloseTo(0.3, 5);
+  });
+
+  test("global option imports cross-project entries", () => {
+    const res = importStructuredEntries(
+      doc([{ title: "Global pref", content: "applies everywhere" }]),
+      { defaultProjectPath: PROJECT, global: true },
+    );
+    expect(res.created).toBe(1);
+    const row = db()
+      .query("SELECT cross_project FROM knowledge_current WHERE title = ?")
+      .get("Global pref") as { cross_project: number } | null;
+    expect(row?.cross_project).toBe(1);
+  });
+
+  test("dry run does not write to the DB", () => {
+    const before = entriesForProject(PROJECT).length;
+    const res = importStructuredEntries(
+      doc([{ title: "Dry entry", content: "not persisted" }]),
+      { defaultProjectPath: PROJECT, dryRun: true },
+    );
+    expect(res.created).toBe(1);
+    const after = entriesForProject(PROJECT).length;
+    expect(after).toBe(before);
+  });
+
+  test("rejects an invalid document (defensive re-validation)", () => {
+    expect(() =>
+      importStructuredEntries(
+        { lore_import_version: 1, source: "generic", entries: [{}] } as never,
+        { defaultProjectPath: PROJECT },
+      ),
+    ).toThrow();
+  });
+
+  test("does not resurrect a tombstoned entry with the same title", () => {
+    const P = PROJECT + "_tomb";
+    ensureProject(P);
+    const id = ltm.create({
+      projectPath: P,
+      category: "pattern",
+      title: "Ghost entry",
+      content: "original body",
+      scope: "project",
+    });
+    ltm.remove(id);
+    expect(ltm.isTombstoned(id)).toBe(true);
+
+    const res = importStructuredEntries(
+      doc([{ title: "Ghost entry", content: "resurrected body" }]),
+      { defaultProjectPath: P },
+    );
+    expect(res.created).toBe(0);
+    expect(res.skipped).toBe(1);
+    expect(res.entries[0]?.reason).toBe("tombstoned");
+
+    const live = entriesForProject(P).filter((r) => r.title === "Ghost entry");
+    expect(live).toHaveLength(0);
+  });
+
+  test("does not resurrect a tombstoned global entry with the same title", () => {
+    const id = ltm.create({
+      category: "preference",
+      title: "Ghost global pref",
+      content: "original",
+      scope: "global",
+      crossProject: true,
+    });
+    ltm.remove(id);
+    expect(ltm.isTombstoned(id)).toBe(true);
+
+    const res = importStructuredEntries(
+      doc([{ title: "Ghost global pref", content: "resurrected" }]),
+      { defaultProjectPath: PROJECT, global: true },
+    );
+    expect(res.created).toBe(0);
+    expect(res.skipped).toBe(1);
+    expect(res.entries[0]?.reason).toBe("tombstoned");
+
+    const live = db()
+      .query(
+        "SELECT COUNT(*) AS n FROM knowledge_current WHERE title = ? AND cross_project = 1",
+      )
+      .get("Ghost global pref") as { n: number };
+    expect(live.n).toBe(0);
+  });
+
+  test("intra-batch: two entries with the same title dedup (last wins)", () => {
+    const P = PROJECT + "_intrabatch";
+    ensureProject(P);
+    const res = importStructuredEntries(
+      doc([
+        { title: "Shared title", content: "first body" },
+        { title: "Shared title", content: "second body wins" },
+      ]),
+      { defaultProjectPath: P },
+    );
+    expect(res.created).toBe(1);
+    expect(res.updated).toBe(1);
+
+    const rows = entriesForProject(P).filter((r) => r.title === "Shared title");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe("second body wins");
+  });
+
+  test("confidence-only difference is a skip (content unchanged)", () => {
+    const P = PROJECT + "_confonly";
+    ensureProject(P);
+    importStructuredEntries(
+      doc([{ title: "Conf only", content: "identical body", confidence: 0.9 }]),
+      { defaultProjectPath: P },
+    );
+    const res = importStructuredEntries(
+      doc([{ title: "Conf only", content: "identical body", confidence: 0.2 }]),
+      { defaultProjectPath: P },
+    );
+    expect(res.updated).toBe(0);
+    expect(res.skipped).toBe(1);
+
+    const row = db()
+      .query("SELECT confidence FROM knowledge_current WHERE title = ?")
+      .get("Conf only") as { confidence: number } | null;
+    expect(row?.confidence).toBeCloseTo(0.9, 5);
+  });
+
+  test("re-import of a >cap entry is idempotent (compares truncated content)", () => {
+    const P = PROJECT + "_trunc_reimport";
+    ensureProject(P);
+    const long = "z".repeat(MAX_ENTRY_CONTENT_LENGTH + 800);
+    const d = doc([{ title: "Big one", content: long }]);
+    const first = importStructuredEntries(d, { defaultProjectPath: P });
+    expect(first.created).toBe(1);
+    const second = importStructuredEntries(d, { defaultProjectPath: P });
+    expect(second.updated).toBe(0);
+    expect(second.skipped).toBe(1);
+  });
+
+  test("fuzzy near-title match updates the existing entry (not exact title)", () => {
+    // Guard: findExactTitle misses (titles differ), but findFuzzyDuplicate
+    // matches on word overlap (>=4 shared words, coefficient >=0.7). The entry
+    // must UPDATE the fuzzy match, not create a second near-duplicate. Removing
+    // the fuzzy branch in structured.ts makes this create a duplicate → fails.
+    const P = PROJECT + "_fuzzy";
+    ensureProject(P);
+    importStructuredEntries(
+      doc([
+        {
+          title: "Upgrade binary lock re-entry bug",
+          content: "original description of the lock bug",
+        },
+      ]),
+      { defaultProjectPath: P },
+    );
+
+    const res = importStructuredEntries(
+      doc([
+        {
+          title: "Upgrade binary lock re-entry issue",
+          content: "revised description of the lock bug",
+        },
+      ]),
+      { defaultProjectPath: P },
+    );
+    expect(res.created).toBe(0);
+    expect(res.updated).toBe(1);
+
+    const rows = entriesForProject(P).filter((r) =>
+      r.title.startsWith("Upgrade binary lock re-entry"),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe("revised description of the lock bug");
+  });
+});

--- a/packages/core/test/ltm-tombstone-by-title.test.ts
+++ b/packages/core/test/ltm-tombstone-by-title.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+
+const P = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "__tmp_tombstone_by_title__",
+);
+
+describe("ltm.findTombstonedByTitle", () => {
+  beforeEach(() => {
+    ensureProject(P);
+  });
+
+  test("false when no entry with the title exists", () => {
+    expect(
+      ltm.findTombstonedByTitle({ title: "Never existed", projectId: null }),
+    ).toBe(false);
+  });
+
+  test("true when the only same-title entry in scope is tombstoned", () => {
+    const id = ltm.create({
+      projectPath: P,
+      category: "pattern",
+      title: "Deleted concept",
+      content: "body",
+      scope: "project",
+    });
+    ltm.remove(id);
+    const pid = ensureProject(P);
+    expect(
+      ltm.findTombstonedByTitle({ title: "Deleted concept", projectId: pid }),
+    ).toBe(true);
+  });
+
+  test("false when a LIVE same-title entry exists (live takes precedence)", () => {
+    // Guard under test: a live current row with this title is an UPDATE target,
+    // not a resurrection. Even if a same-title death-cert also exists in scope,
+    // the live row must win → findTombstonedByTitle returns false. Removing the
+    // `if (live) return false` short-circuit flips this to true.
+    const pid = ensureProject(P);
+
+    ltm.create({
+      projectPath: P,
+      category: "pattern",
+      title: "Contested title",
+      content: "live body",
+      scope: "project",
+    });
+
+    const crossId = ltm.create({
+      category: "pattern",
+      title: "Contested title",
+      content: "cross body",
+      scope: "global",
+      crossProject: true,
+    });
+    ltm.remove(crossId);
+
+    expect(
+      ltm.findTombstonedByTitle({ title: "Contested title", projectId: pid }),
+    ).toBe(false);
+  });
+});

--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -728,6 +728,82 @@ async function handleImportRecord(req: Request): Promise<Response> {
   return jsonResponse({ recorded: true });
 }
 
+/**
+ * POST /api/v1/import/structured — write already-structured memory (Engram /
+ * mem0) directly to the knowledge store. The client produces + validates the
+ * `LoreImportDoc` (it has filesystem access; the gateway does not), but the
+ * gateway re-validates defensively before touching the DB — never trust the
+ * client. After writing, embeddings are backfilled so entries are searchable.
+ */
+async function handleImportStructured(req: Request): Promise<Response> {
+  // Blocked in hosted mode. This writes attacker-supplied content verbatim into
+  // the knowledge store and triggers a DB-wide embeddings backfill — it must
+  // only run on the operator's own gateway, never from an untrusted network
+  // caller (mirrors handleEntityRebuild). Migration is a local, one-time CLI
+  // action; the CLI always produces the doc locally and posts it to *its own*
+  // gateway, so a legitimate `lore import` never needs the hosted path.
+  if (isHostedMode()) {
+    return errorResponse(
+      403,
+      "forbidden",
+      "Structured import is not available in hosted mode (writes knowledge and triggers embedding cost).",
+    );
+  }
+
+  const body = await parseBody<{
+    git_remote?: string;
+    path?: string;
+    global?: boolean;
+    dry_run?: boolean;
+    doc: unknown;
+  }>(req);
+
+  // Resolve the target project. Hosted mode is already refused above, so this
+  // only ever runs on the operator's own single-tenant gateway — there is no
+  // cross-tenant boundary to cross here, so a first-time import may register a
+  // new project from `path` (mirrors handleImportExtract). The hosted guard,
+  // not project-resolution, is what prevents cross-tenant writes.
+  const projectId = resolveProjectByRemoteOrPath(body.git_remote, body.path);
+  const projectPath = projectId ? getProjectPathById(projectId) : body.path;
+  if (!projectPath) {
+    return errorResponse(
+      404,
+      "not_found",
+      "Project not found. Provide git_remote or path.",
+    );
+  }
+
+  // Re-validate the document server-side — the trust boundary.
+  const parsed = conversationImport.safeParseImportDoc(body.doc);
+  if (!parsed.success) {
+    return errorResponse(
+      400,
+      "invalid_request",
+      `Invalid import document: ${parsed.error.message}`,
+    );
+  }
+
+  const dryRun = body.dry_run === true;
+  const result = conversationImport.importStructuredEntries(parsed.data, {
+    defaultProjectPath: projectPath,
+    global: body.global === true,
+    dryRun,
+  });
+
+  // A dry run computes counts against this (the target) DB without writing —
+  // skip the embeddings backfill too.
+  if (!dryRun) {
+    // Make imported entries searchable (best-effort; retried on next boot).
+    try {
+      await embedding.backfillEmbeddings();
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  return jsonResponse(result);
+}
+
 // ---------------------------------------------------------------------------
 // Main request dispatcher
 // ---------------------------------------------------------------------------
@@ -871,6 +947,11 @@ export async function handleAPIRequest(
     // POST /api/v1/import/record
     if (pathname === "/api/v1/import/record") {
       return await handleImportRecord(req);
+    }
+
+    // POST /api/v1/import/structured
+    if (pathname === "/api/v1/import/structured") {
+      return await handleImportStructured(req);
     }
 
     // POST /api/v1/sessions/move — move sessions between projects

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -37,7 +37,13 @@ const {
   isImported,
   recordImport,
   computeHash,
+  getStructuredSource,
+  getStructuredSources,
+  detectStructuredSources,
+  importStructuredEntries,
+  safeParseImportDoc,
 } = conversationImport;
+type StructuredSourceName = conversationImport.StructuredSourceName;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -232,6 +238,204 @@ export function filterAlreadyImported(
 // Command entry point
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Structured-memory import (Engram / mem0)
+// ---------------------------------------------------------------------------
+
+const STRUCTURED_SOURCE_NAMES: readonly StructuredSourceName[] = [
+  "engram",
+  "mem0",
+];
+
+function isStructuredName(name: string): name is StructuredSourceName {
+  return (STRUCTURED_SOURCE_NAMES as readonly string[]).includes(name);
+}
+
+/**
+ * Decide whether this `lore import` invocation targets a structured-memory
+ * source, and which one. Precedence:
+ *   1. explicit `--source <name>`,
+ *   2. `--agent <name>` naming a structured source,
+ *   3. `--file` with no source, when exactly one structured source is detected.
+ *
+ * A bare `lore import` (no flags) does NOT auto-route to a structured source
+ * even if one is installed — it stays on the conversation-import lane so a user
+ * who merely has the `engram` binary on PATH isn't surprised. Structured import
+ * requires an explicit signal (`--source`, `--agent <structured>`, or `--file`).
+ *
+ * Returns null to fall through to the conversation-import lane.
+ */
+export function resolveStructuredSourceName(opts: {
+  sourceFlag: string | null;
+  agentFilter: string | null;
+  fileFlag: string | null;
+}): StructuredSourceName | null {
+  const { sourceFlag, agentFilter, fileFlag } = opts;
+  if (sourceFlag && isStructuredName(sourceFlag)) return sourceFlag;
+  if (agentFilter && isStructuredName(agentFilter)) return agentFilter;
+  // A --file with no source: auto-route to a detected structured source when
+  // exactly one is present (a file is an explicit migration intent).
+  if (fileFlag && !sourceFlag && !agentFilter) {
+    const detected = detectStructuredSources();
+    if (detected.length === 1) return detected[0].name;
+  }
+  return null;
+}
+
+async function importStructured(opts: {
+  remote: string | undefined;
+  projectPath: string;
+  sourceName: StructuredSourceName;
+  filePath: string | null;
+  dryRun: boolean;
+  yes: boolean;
+  global: boolean;
+}): Promise<void> {
+  const { projectPath, sourceName, filePath, dryRun, global } = opts;
+
+  const source = getStructuredSource(sourceName);
+  if (!source) {
+    const supported = getStructuredSources()
+      .map((s) => s.name)
+      .join(", ");
+    console.error(
+      `[lore] Import source "${sourceName}" is not available yet. Supported: ${supported}.`,
+    );
+    return;
+  }
+
+  console.log(
+    `[lore] Importing structured memory from ${source.displayName}...`,
+  );
+
+  // Produce the normalized document (runs the source's export CLI / reads
+  // --file). This always happens client-side — the remote gateway has no shared
+  // filesystem with the client.
+  let doc: conversationImport.LoreImportDoc;
+  try {
+    doc = source.produceDoc({ filePath: filePath ?? undefined });
+  } catch (err) {
+    console.error(
+      `[lore] Could not read ${source.displayName} memory: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  if (doc.entries.length === 0) {
+    console.log(`[lore] No entries found in ${source.displayName} memory.`);
+    return;
+  }
+
+  console.log(`[lore] Found ${doc.entries.length} entries.`);
+
+  if (dryRun) {
+    const preview = importStructuredEntries(doc, {
+      defaultProjectPath: projectPath,
+      global,
+      dryRun: true,
+    });
+    console.log(
+      `[lore] Dry run — would create ${preview.created}, update ${preview.updated}, skip ${preview.skipped}.`,
+    );
+    return;
+  }
+
+  if (!opts.yes) {
+    const ok = await confirm(
+      `[lore] Import ${doc.entries.length} entries from ${source.displayName}?`,
+    );
+    if (!ok) {
+      console.log("[lore] Import cancelled.");
+      return;
+    }
+  }
+
+  // Remote mode: send the validated doc to the gateway for the actual write.
+  if (opts.remote) {
+    await importStructuredRemote(opts.remote, projectPath, doc, global);
+    return;
+  }
+
+  // Local mode: write directly.
+  const result = importStructuredEntries(doc, {
+    defaultProjectPath: projectPath,
+    global,
+  });
+
+  setLastImportAt(projectPath, Date.now());
+  try {
+    // Ensure imported entries become searchable even in a short-lived CLI.
+    const { embedding } = await import("@loreai/core");
+    await embedding.backfillEmbeddings();
+  } catch {
+    // Non-fatal — embeddings backfill on next gateway boot.
+  }
+  try {
+    exportLoreFile(projectPath);
+  } catch {
+    // Non-fatal
+  }
+
+  console.log(
+    `[lore] Import complete: ${result.created} created, ${result.updated} updated, ${result.skipped} skipped.`,
+  );
+  console.log("[lore] Run `lore data list knowledge` to review.");
+}
+
+async function importStructuredRemote(
+  remote: string,
+  projectPath: string,
+  doc: conversationImport.LoreImportDoc,
+  global: boolean,
+): Promise<void> {
+  const { getGitRemote, normalizeRemoteUrl } = await import("@loreai/core");
+  const raw = getGitRemote(projectPath);
+  const normalized = raw ? normalizeRemoteUrl(raw) : undefined;
+
+  console.log(`\n[lore] Using remote gateway at ${remote}`);
+
+  // Re-validate before sending (defensive; the server re-validates too).
+  const check = safeParseImportDoc(doc);
+  if (!check.success) {
+    console.error(
+      "[lore] Internal error: produced an invalid import document.",
+    );
+    return;
+  }
+
+  let result: { created: number; updated: number; skipped: number };
+  try {
+    result = await remotePost(
+      remote,
+      "/api/v1/import/structured",
+      {
+        git_remote: normalized,
+        path: projectPath,
+        global,
+        doc,
+      },
+      { compress: true },
+    );
+  } catch (err) {
+    console.error(
+      `[lore] Structured import failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  setLastImportAt(projectPath, Date.now());
+  try {
+    exportLoreFile(projectPath);
+  } catch {
+    // Non-fatal
+  }
+
+  console.log(
+    `[lore] Import complete: ${result.created} created, ${result.updated} updated, ${result.skipped} skipped.`,
+  );
+  console.log("[lore] Run `lore data list knowledge` to review.");
+}
+
 export async function commandImport(
   _args: string[],
   flags: Record<string, unknown>,
@@ -240,6 +444,9 @@ export async function commandImport(
   const dryRun = flags["dry-run"] === true || flags.dryRun === true;
   const yes = flags.yes === true || flags.y === true;
   const agentFilter = (flags.agent as string) ?? null;
+  const sourceFlag = (flags.source as string) ?? null;
+  const fileFlag = (flags.file as string) ?? null;
+  const global = flags.global === true;
   const noWorktrees =
     flags["no-worktrees"] === true || flags.noWorktrees === true;
   const projectFlag = flags.project as string | undefined;
@@ -255,6 +462,37 @@ export async function commandImport(
   await load(projectPath);
   if (!remote) {
     ensureProject(projectPath);
+  }
+
+  // Structured-memory import lane (Engram / mem0). Routed by --source/--file
+  // (or --agent naming a structured source). This reads ALREADY structured
+  // memory and writes it directly to the knowledge store (no curator LLM).
+  // Conversation-history import (below) is the other lane.
+  if (sourceFlag && !getStructuredSource(sourceFlag)) {
+    const supported = getStructuredSources()
+      .map((s) => s.name)
+      .join(", ");
+    console.error(
+      `[lore] Import source "${sourceFlag}" is not available. Supported: ${supported}.`,
+    );
+    return;
+  }
+  const structuredName = resolveStructuredSourceName({
+    sourceFlag,
+    agentFilter,
+    fileFlag,
+  });
+  if (structuredName) {
+    await importStructured({
+      remote,
+      projectPath,
+      sourceName: structuredName,
+      filePath: fileFlag,
+      dryRun,
+      yes,
+      global,
+    });
+    return;
   }
 
   // Detect conversation history (local filesystem scan — always local)

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -120,6 +120,14 @@ const OPTIONS = {
   // `lore import` flag — restrict detection to the current directory only
   // (skip sibling git worktrees / clone paths of the same repo).
   "no-worktrees": { type: "boolean" as const },
+  // `lore import` — filter to a single source/agent (e.g. --agent engram).
+  agent: { type: "string" as const },
+  // `lore import` — structured-memory flags (Engram / mem0 migration).
+  // `--file` points at an explicit export dump; `--source` forces the source
+  // type; `--global` imports every entry as cross-project.
+  file: { type: "string" as const },
+  source: { type: "string" as const },
+  global: { type: "boolean" as const },
   "min-confidence": { type: "string" as const },
   "no-backup": { type: "boolean" as const },
   // `lore data clear` flags

--- a/packages/gateway/test/api.test.ts
+++ b/packages/gateway/test/api.test.ts
@@ -482,3 +482,106 @@ describe("POST /api/v1/import/record", () => {
     expect(res.status).toBe(400);
   });
 });
+
+describe("POST /api/v1/import/structured", () => {
+  const doc = (entries: unknown[]) => ({
+    lore_import_version: 1,
+    source: "generic",
+    entries,
+  });
+
+  async function knowledgeCount(path: string): Promise<number> {
+    const { ltm } = await import("@loreai/core");
+    return ltm.forProject(path, false).length;
+  }
+
+  it("writes entries and reports counts", async () => {
+    const { projectPath } = await seedProject();
+    const before = await knowledgeCount(projectPath);
+    const res = await api("/api/v1/import/structured", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: projectPath,
+        doc: doc([
+          { title: "Struct import A", content: "body a", category: "pattern" },
+        ]),
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      created: number;
+      updated: number;
+      skipped: number;
+    };
+    expect(body.created).toBe(1);
+    expect(await knowledgeCount(projectPath)).toBe(before + 1);
+  });
+
+  it("dry_run reports counts without writing", async () => {
+    const { projectPath } = await seedProject();
+    const before = await knowledgeCount(projectPath);
+    const res = await api("/api/v1/import/structured", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: projectPath,
+        dry_run: true,
+        doc: doc([
+          {
+            title: "Dry struct entry",
+            content: "must not persist",
+            category: "pattern",
+          },
+        ]),
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { created: number };
+    expect(body.created).toBe(1);
+    expect(await knowledgeCount(projectPath)).toBe(before);
+  });
+
+  it("returns 400 for an invalid document", async () => {
+    const { projectPath } = await seedProject();
+    const res = await api("/api/v1/import/structured", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: projectPath,
+        doc: { lore_import_version: 1, source: "generic", entries: [{}] },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the project cannot be resolved", async () => {
+    const res = await api("/api/v1/import/structured", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        doc: doc([{ title: "x", content: "y", category: "pattern" }]),
+      }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 in hosted mode", async () => {
+    const { projectPath } = await seedProject();
+    const core = await import("@loreai/core");
+    core.enableHostedMode();
+    try {
+      const res = await api("/api/v1/import/structured", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          path: projectPath,
+          doc: doc([{ title: "Blocked", content: "no", category: "pattern" }]),
+        }),
+      });
+      expect(res.status).toBe(403);
+    } finally {
+      core._resetHostedModeForTest();
+    }
+  });
+});

--- a/packages/gateway/test/import-structured-routing.test.ts
+++ b/packages/gateway/test/import-structured-routing.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "vitest";
+import { resolveStructuredSourceName } from "../src/cli/import";
+
+describe("resolveStructuredSourceName", () => {
+  test("routes on explicit --source engram", () => {
+    expect(
+      resolveStructuredSourceName({
+        sourceFlag: "engram",
+        agentFilter: null,
+        fileFlag: null,
+      }),
+    ).toBe("engram");
+  });
+
+  test("routes on --source mem0", () => {
+    expect(
+      resolveStructuredSourceName({
+        sourceFlag: "mem0",
+        agentFilter: null,
+        fileFlag: null,
+      }),
+    ).toBe("mem0");
+  });
+
+  test("routes on --agent naming a structured source", () => {
+    expect(
+      resolveStructuredSourceName({
+        sourceFlag: null,
+        agentFilter: "engram",
+        fileFlag: null,
+      }),
+    ).toBe("engram");
+  });
+
+  test("falls through for a conversation agent name", () => {
+    expect(
+      resolveStructuredSourceName({
+        sourceFlag: null,
+        agentFilter: "claude-code",
+        fileFlag: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("falls through for an unknown --source", () => {
+    expect(
+      resolveStructuredSourceName({
+        sourceFlag: "notasource",
+        agentFilter: null,
+        fileFlag: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("bare import (no flags) does NOT auto-route to a structured source", () => {
+    expect(
+      resolveStructuredSourceName({
+        sourceFlag: null,
+        agentFilter: null,
+        fileFlag: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/website/src/content/docs/docs/import.md
+++ b/packages/website/src/content/docs/docs/import.md
@@ -28,6 +28,8 @@ lore import --project <path>     # Import for a specific project (default: cwd)
 lore import --yes                # Skip prompts and import everything
 ```
 
+To migrate from a dedicated memory tool (Engram, mem0) instead of conversation history, use `--source` — see [Migrating from another memory system](#migrating-from-another-memory-system).
+
 ## Supported agents
 
 | Agent | Where history is read from |
@@ -67,6 +69,39 @@ Each agent records conversations under the **directory it ran in**. Since git wo
 `lore import` resolves the full set of paths that belong to the same repository — using `git worktree list` plus the paths Lore already associates with the project — and finds sessions recorded under **any** of them. So running `lore import` from the main checkout also picks up conversations you had in a worktree, and vice-versa.
 
 Pass `--no-worktrees` to restrict detection to the current directory only.
+
+## Migrating from another memory system
+
+`lore import` also migrates **already-curated** memory from dedicated memory tools directly into Lore's knowledge store. Unlike conversation import, this does **not** run the curator LLM — the entries are already structured, so they are mapped and written directly (fast and free).
+
+### Engram
+
+```bash
+lore import --source engram                       # runs `engram export` for you
+lore import --source engram --file engram.json    # or import an explicit export
+lore import --source engram --global              # import as cross-project knowledge
+lore import --source engram --dry-run             # preview counts without writing
+```
+
+Produce an export file manually with `engram export engram.json` if the `engram` binary isn't on your `PATH`.
+
+**Mapping.** Engram observation `type` values map onto Lore categories:
+
+| Engram `type` | Lore category |
+| --- | --- |
+| `decision` | `decision` |
+| `architecture` | `architecture` |
+| `config` | `architecture` |
+| `pattern` | `pattern` |
+| `preference` | `preference` |
+| `bugfix`, `discovery` | `gotcha` |
+| (anything else) | `pattern` |
+
+Each observation's project is recovered from its Engram session `directory`; observations scoped `personal`/`global` are imported as cross-project knowledge. Soft-deleted observations are skipped. The import is **idempotent** — re-running dedups by title and updates only entries whose content changed.
+
+### mem0
+
+mem0 migration is coming in a follow-up release. It will read mem0's local store natively (server, OpenMemory, and embedded-default deployments) with no Python required.
 
 ## Next steps
 


### PR DESCRIPTION
## What & why

Closes the ask in #1398 (migrating existing memory-tool memories into Lore). Adds a **second `lore import` lane** that maps **already-curated** memory directly into the knowledge store, bypassing the curator LLM (the entries are already structured, so mapping is fast and free). Ships **Engram**; **mem0** is a documented follow-up.

```bash
lore import --source engram                    # runs `engram export` for you
lore import --source engram --file dump.json   # or an explicit export
lore import --source engram --global           # as cross-project knowledge
lore import --source engram --dry-run          # preview counts
```

## Design

- **Single trust boundary** (`import/schema.ts`): `LoreImportDoc`/`LoreImportEntry` zod, `.strict()`, version-literal gate, `content` bounded at 64K (defense-in-depth; importer truncates to 1200). Adapter output **and** `--file` input are validated here.
- **Importer** (`import/structured.ts`): exact-title → fuzzy dedup (update-on-content-change, else skip), by-title **tombstone-resurrection guard**, 1200-char truncation, confidence clamp, `--global`, `dryRun`. No worker attribution (user-authored).
- **Engram adapter** (`import/sources/engram.ts`): `type`→category map (`bugfix`/`discovery`→`gotcha`, `config`→`architecture`, …), project from session `directory`, truthy `deleted_at` skip, generic pass-through.
- **Registry** (`import/structured-sources.ts`): `execFileSync` (no shell) to run `engram export` or read `--file`.
- **Endpoint** `POST /api/v1/import/structured`: re-validates server-side; **403 in hosted mode** (writes knowledge + triggers a DB-wide embedding backfill → operator-gateway only, mirrors `entities/rebuild`); supports `dry_run`.
- **CLI routing**: `--source`/`--file`/`--global`/`--agent`. A bare `lore import` **never** auto-routes to a structured source, so a user who merely has the `engram` binary on PATH isn't surprised.

## Review rigor

Two independent review passes per `quality/REVIEW.md §6`:

- **Adversarial correctness** → MERGE. Two surviving mutants from the first pass are now closed with regression tests (fuzzy-update branch; `findTombstonedByTitle` live-precedence). Four guards (truncation, fuzzy, `deleted_at`, live-precedence) each **mutation-verified** — reverting the guard turns exactly one test red.
- **Security/pentest** → DO-NOT-MERGE originally; both MUST-FIX resolved: hosted-mode 403 guard (eliminates the cross-tenant / `global`-over-the-wire and cost/DoS vectors), and `content` bounded at the schema. `execFileSync` (no shell) confirmed injection-safe.

## Tests / gate

- New tests: schema, structured (fuzzy + tombstone + intra-batch + confidence-only + truncated-reimport), engram edge cases, structured-sources, CLI routing, `ltm-tombstone-by-title`, api endpoint.
- Full suite green in the main colocated repo (6323 passed / 0 failures); typecheck, lint, format:check all clean.

## Follow-ups (not blocking)

- mem0 import connector (native local-store read, no Python).
- Consider scoping/rate-limiting the endpoint's embedding backfill; cap decompressed request-body size globally (pre-existing).

Refs #1398