### PR TITLE
feat(import): native mem0 connector for the structured-import lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ lore import --source engram --global
 
 Engram observation types map onto Lore categories (`bugfix`/`discovery` → `gotcha`, `config` → `architecture`, etc.), and each observation's project is recovered from its session directory. Idempotent — re-running dedups by title and only updates entries whose content changed.
 
-> mem0 migration is coming in a follow-up release.
+**mem0** is imported natively too — `lore import --source mem0` auto-detects your deployment (Qdrant/OpenMemory server, mem0 self-hosted server, or the embedded default store) and reads it with no Python required. Imported memories default to the `pattern` category. Use `--file <dump.json>` or the `--mem0-*` flags to point at a specific store.
 
 ### Web dashboard
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
     "@noble/hashes": "^2.2.0",
     "micromark": "^4.0.0",
     "p-limit": "7",
+    "pickleparser": "0.2.1",
     "remark": "^15.0.1",
     "sqlite-vec": "0.1.9",
     "uuidv7": "^1.1.0",

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -59,12 +59,26 @@ export {
 } from "./structured";
 export { parseEngramExport } from "./sources/engram";
 export {
+  resolveMem0Doc,
+  parseMem0File,
+  mem0RecordsToDoc,
+  mem0RecordToEntry,
+  scrollQdrantCollection,
+  fetchMem0ServerMemories,
+  readEmbeddedStorage,
+  embeddedStorageCandidates,
+  type Mem0Record,
+  type Mem0ResolveOptions,
+} from "./sources/mem0";
+export {
   engramSource,
+  mem0Source,
   getStructuredSources,
   getStructuredSource,
   detectStructuredSources,
   type StructuredSource,
   type StructuredSourceName,
+  type ProduceDocOptions,
 } from "./structured-sources";
 
 // Register built-in providers on first import.

--- a/packages/core/src/import/sources/mem0.ts
+++ b/packages/core/src/import/sources/mem0.ts
@@ -1,0 +1,438 @@
+/**
+ * mem0 source adapter — native, Python-free migration of mem0 memories into a
+ * `LoreImportDoc`.
+ *
+ * mem0 has several deployment shapes; this adapter reads every common one
+ * without invoking Python:
+ *   1. Qdrant server (OpenMemory / raw Qdrant)  → HTTP `points/scroll` (fetch)
+ *   2. mem0 self-hosted server (FastAPI)        → HTTP `GET /memories` (fetch)
+ *   3. Embedded default (`Memory()`)            → read `storage.sqlite` +
+ *                                                 decode pickled Qdrant points
+ *   4. Explicit `--file <dump.json>`            → generic LoreImportDoc / raw
+ *
+ * The vector is never used (we ignore embeddings). Only the payload text and a
+ * few metadata fields are imported. mem0 OSS has no category → default
+ * `pattern` (per plan decision); a fresh Lore UUIDv7 is minted per entry, with
+ * the mem0 point id kept as `external_id` for idempotency.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  parseImportDoc,
+  safeParseImportDoc,
+  MAX_IMPORT_CONTENT_LENGTH,
+  type LoreImportDoc,
+  type LoreImportEntry,
+} from "../schema";
+
+/** A single normalized mem0 memory record, source-shape-independent. */
+export type Mem0Record = {
+  id?: string | number;
+  /** Memory text — Qdrant/embedded payload key is `data`; server REST is `memory`. */
+  data?: unknown;
+  memory?: unknown;
+  user_id?: unknown;
+  hash?: unknown;
+  created_at?: unknown;
+  metadata?: Record<string, unknown> | null;
+};
+
+/** Coerce an unknown payload value to a plain string, or undefined. */
+function asString(v: unknown): string | undefined {
+  if (typeof v === "string") return v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return undefined;
+}
+
+/**
+ * Map one normalized mem0 record → a `LoreImportEntry` (or null to skip).
+ * `data` (embedded/Qdrant) and `memory` (server REST) both carry the text.
+ */
+export function mem0RecordToEntry(
+  rec: Mem0Record,
+  opts?: { project?: string },
+): LoreImportEntry | null {
+  const text = asString(rec.data) ?? asString(rec.memory);
+  if (!text || text.trim() === "") return null;
+
+  const entry: LoreImportEntry = {
+    // Clamp to the schema ceiling so an oversized memory is truncated here
+    // rather than failing validation and aborting the whole import.
+    content:
+      text.length > MAX_IMPORT_CONTENT_LENGTH
+        ? text.slice(0, MAX_IMPORT_CONTENT_LENGTH)
+        : text,
+    // mem0 OSS has no category taxonomy → default pattern (plan decision).
+    category: "pattern",
+  };
+
+  // Project: explicit --project wins; else metadata.repo if present.
+  const repo = asString(rec.metadata?.repo);
+  const project = opts?.project ?? repo;
+  if (project) entry.project = project;
+
+  const createdAt = asString(rec.created_at);
+  if (createdAt) entry.created_at = createdAt;
+
+  const externalId =
+    rec.id != null ? String(rec.id) : (asString(rec.hash) ?? undefined);
+  if (externalId) entry.external_id = externalId;
+
+  return entry;
+}
+
+/** Build a validated LoreImportDoc from normalized mem0 records. */
+export function mem0RecordsToDoc(
+  records: Mem0Record[],
+  opts?: { project?: string },
+): LoreImportDoc {
+  const entries: LoreImportEntry[] = [];
+  for (const rec of records) {
+    const entry = mem0RecordToEntry(rec, opts);
+    if (entry) entries.push(entry);
+  }
+  return parseImportDoc({
+    lore_import_version: 1,
+    source: "mem0",
+    entries,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Native path 1 — Qdrant scroll (OpenMemory / raw Qdrant server)
+// ---------------------------------------------------------------------------
+
+/** A Qdrant point as returned by the scroll API (only fields we read). */
+type QdrantPoint = {
+  id?: string | number;
+  payload?: Record<string, unknown> | null;
+};
+
+/**
+ * Scroll every point out of a Qdrant collection via the HTTP API (pure fetch,
+ * no @qdrant/js-client-rest — the official client has no embedded mode and its
+ * scroll() is a 1:1 wrapper over this same endpoint). Paginates on
+ * `next_page_offset` until null.
+ */
+export async function scrollQdrantCollection(opts: {
+  url: string;
+  collection: string;
+  apiKey?: string;
+  pageSize?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<Mem0Record[]> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const base = opts.url.replace(/\/+$/, "");
+  const limit = opts.pageSize ?? 256;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (opts.apiKey) headers["api-key"] = opts.apiKey;
+
+  const records: Mem0Record[] = [];
+  let offset: unknown = null;
+  // Bound iterations defensively so a misbehaving server can't spin forever.
+  for (let page = 0; page < 100_000; page++) {
+    const res = await doFetch(
+      `${base}/collections/${encodeURIComponent(opts.collection)}/points/scroll`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          limit,
+          with_payload: true,
+          with_vector: false,
+          offset,
+        }),
+      },
+    );
+    if (!res.ok) {
+      throw new Error(
+        `Qdrant scroll failed (${res.status} ${res.statusText}) for collection "${opts.collection}" at ${base}.`,
+      );
+    }
+    const body = (await res.json()) as {
+      result?: { points?: QdrantPoint[]; next_page_offset?: unknown };
+    };
+    const points = body.result?.points ?? [];
+    for (const p of points) {
+      // On-store payload text key is `data` (NOT `memory`).
+      const payload = p.payload ?? {};
+      records.push({ id: p.id, ...payload });
+    }
+    const next = body.result?.next_page_offset ?? null;
+    // Stop when the server signals no more pages OR returns an empty page.
+    if (next == null || points.length === 0) break;
+    offset = next;
+  }
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// Native path 2 — mem0 self-hosted server REST
+// ---------------------------------------------------------------------------
+
+/**
+ * Read memories from a mem0 self-hosted FastAPI server (`GET /memories`).
+ * Requires a user id (mem0 server scopes by user). Auth via X-API-Key/token.
+ */
+export async function fetchMem0ServerMemories(opts: {
+  url: string;
+  userId: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<Mem0Record[]> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  const base = opts.url.replace(/\/+$/, "");
+  const headers: Record<string, string> = {};
+  if (opts.apiKey) headers["X-API-Key"] = opts.apiKey;
+
+  const res = await doFetch(
+    `${base}/memories?user_id=${encodeURIComponent(opts.userId)}`,
+    { headers },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `mem0 server request failed (${res.status} ${res.statusText}) at ${base}. ` +
+        (res.status === 401 || res.status === 403
+          ? "Provide --mem0-token for an authenticated server."
+          : ""),
+    );
+  }
+  const body = (await res.json()) as
+    | {
+        results?: Mem0Record[];
+        memories?: Mem0Record[];
+      }
+    | Mem0Record[];
+  if (Array.isArray(body)) return body;
+  return body.results ?? body.memories ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Native path 3 — embedded default: read storage.sqlite + decode pickle
+// ---------------------------------------------------------------------------
+
+/** Candidate paths for the embedded Qdrant store's SQLite file. */
+export function embeddedStorageCandidates(baseDir: string): string[] {
+  // Layout: <baseDir>/collection/<name>/storage.sqlite. mem0's default
+  // collection is "mem0"; OpenMemory uses "openmemory".
+  return [
+    join(baseDir, "collection", "mem0", "storage.sqlite"),
+    join(baseDir, "collection", "openmemory", "storage.sqlite"),
+  ];
+}
+
+/**
+ * Read + pickle-decode an embedded Qdrant `storage.sqlite`. Pure Node — opens
+ * the file read-only via node:sqlite and decodes each `point` BLOB with
+ * `pickleparser` (both deps lazy-imported so detection-only paths stay light).
+ *
+ * pickleparser represents the decoded PointStruct with instance attributes
+ * either directly on the object OR under `__dict__` (pydantic __setstate__
+ * shape) — we guard with `obj.__dict__ ?? obj`. Non-primitive payload values
+ * (e.g. a pickled datetime) decode to an empty wrapper and are coerced/ignored.
+ */
+export async function readEmbeddedStorage(
+  storagePath: string,
+): Promise<Mem0Record[]> {
+  const { DatabaseSync } = await import("node:sqlite");
+  const { Parser } = await import("pickleparser");
+
+  const db = new DatabaseSync(storagePath, { readOnly: true });
+  try {
+    const rows = db.prepare("SELECT id, point FROM points").all() as {
+      id: unknown;
+      point: Uint8Array;
+    }[];
+    const parser = new Parser();
+    const records: Mem0Record[] = [];
+    for (const row of rows) {
+      if (!(row.point instanceof Uint8Array)) continue;
+      let obj: Record<string, unknown>;
+      try {
+        obj = parser.parse<Record<string, unknown>>(row.point);
+      } catch {
+        // A single undecodable blob must not abort the whole import.
+        continue;
+      }
+      const state =
+        (obj as { __dict__?: Record<string, unknown> }).__dict__ ?? obj;
+      const payload = (state.payload ?? {}) as Record<string, unknown>;
+      // Prefer the point id decoded from the pickled PointStruct (`state.id` is
+      // the real UUID). The `points.id` COLUMN is NOT the plain id — real mem0
+      // stores it as base64(pickle(uuid)), so using it verbatim yields a
+      // garbage external_id. Fall back to the raw column only if the decoded
+      // point carries no id.
+      const decodedId = state.id;
+      const id =
+        typeof decodedId === "string" || typeof decodedId === "number"
+          ? decodedId
+          : (row.id as string | number);
+      records.push({ id, ...payload });
+    }
+    return records;
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Native path 4 — explicit --file dump
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a `--file` dump. Accepts either an already-normalized `LoreImportDoc`
+ * (generic pass-through) or a raw mem0 export shape (`{ results: [...] }` or a
+ * bare array of records).
+ */
+export function parseMem0File(
+  filePath: string,
+  opts?: { project?: string },
+): LoreImportDoc {
+  const raw = JSON.parse(readFileSync(filePath, "utf8"));
+
+  // Already a LoreImportDoc?
+  const asGeneric = safeParseImportDoc(raw);
+  if (asGeneric.success) return asGeneric.data;
+
+  // Raw mem0 export: `{ results: [...] }`, `{ memories: [...] }`, or bare array.
+  const records: Mem0Record[] = Array.isArray(raw)
+    ? (raw as Mem0Record[])
+    : ((raw?.results ?? raw?.memories ?? []) as Mem0Record[]);
+  return mem0RecordsToDoc(records, opts);
+}
+
+// ---------------------------------------------------------------------------
+// Resolver — auto-detect deployment shape and produce the doc
+// ---------------------------------------------------------------------------
+
+export type Mem0ResolveOptions = {
+  /** Explicit dump file (skips all auto-detection). */
+  filePath?: string;
+  /** Default project for entries lacking metadata.repo. */
+  project?: string;
+  /** Overrides. */
+  qdrantUrl?: string;
+  collection?: string;
+  serverUrl?: string;
+  token?: string;
+  /** Embedded store base dir (contains collection/<name>/storage.sqlite). */
+  embeddedPath?: string;
+  userId?: string;
+  fetchImpl?: typeof fetch;
+  /** Probe function (injectable for tests). Returns true when URL is reachable. */
+  probe?: (url: string) => Promise<boolean>;
+};
+
+const DEFAULT_QDRANT_URL = "http://127.0.0.1:6333";
+const DEFAULT_SERVER_URL = "http://127.0.0.1:8888";
+
+/** Default TCP/HTTP reachability probe — a short HEAD/GET that never throws. */
+async function defaultProbe(
+  url: string,
+  fetchImpl?: typeof fetch,
+): Promise<boolean> {
+  const doFetch = fetchImpl ?? fetch;
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 800);
+    try {
+      const res = await doFetch(url, { signal: ctrl.signal });
+      return res.ok || res.status === 401 || res.status === 403;
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return false;
+  }
+}
+
+/** Default embedded-store base dir (`~/.mem0` sibling `/tmp/qdrant`, or cwd). */
+function defaultEmbeddedDirs(): string[] {
+  const dirs = ["/tmp/qdrant"];
+  const home = process.env.HOME;
+  if (home) dirs.push(join(home, ".mem0"));
+  return dirs;
+}
+
+/**
+ * Auto-detect the mem0 deployment shape and produce a validated LoreImportDoc.
+ * Order: explicit file → Qdrant server → mem0 server → embedded store. Throws
+ * an actionable error (with a manual `--file` one-liner) when nothing is found.
+ */
+export async function resolveMem0Doc(
+  opts: Mem0ResolveOptions = {},
+): Promise<LoreImportDoc> {
+  const project = opts.project;
+
+  // 0. Explicit file always wins.
+  if (opts.filePath) return parseMem0File(opts.filePath, { project });
+
+  const probe = opts.probe ?? ((u: string) => defaultProbe(u, opts.fetchImpl));
+
+  // 1. Qdrant server (OpenMemory / raw Qdrant).
+  const qdrantUrl = opts.qdrantUrl ?? DEFAULT_QDRANT_URL;
+  if (await probe(`${qdrantUrl.replace(/\/+$/, "")}/collections`)) {
+    const collection = opts.collection ?? "openmemory";
+    let records: Mem0Record[];
+    try {
+      records = await scrollQdrantCollection({
+        url: qdrantUrl,
+        collection,
+        apiKey: opts.token,
+        fetchImpl: opts.fetchImpl,
+      });
+    } catch {
+      // Try the other default collection name before giving up.
+      records = await scrollQdrantCollection({
+        url: qdrantUrl,
+        collection: opts.collection ?? "mem0",
+        apiKey: opts.token,
+        fetchImpl: opts.fetchImpl,
+      });
+    }
+    return mem0RecordsToDoc(records, { project });
+  }
+
+  // 2. mem0 self-hosted server (needs a user id).
+  const serverUrl = opts.serverUrl ?? DEFAULT_SERVER_URL;
+  if (opts.serverUrl || opts.userId) {
+    if (await probe(`${serverUrl.replace(/\/+$/, "")}/docs`)) {
+      if (!opts.userId) {
+        throw new Error(
+          "mem0 server detected but no user id given. Pass --mem0-user <id>.",
+        );
+      }
+      const records = await fetchMem0ServerMemories({
+        url: serverUrl,
+        userId: opts.userId,
+        apiKey: opts.token,
+        fetchImpl: opts.fetchImpl,
+      });
+      return mem0RecordsToDoc(records, { project });
+    }
+  }
+
+  // 3. Embedded default store.
+  const baseDirs = opts.embeddedPath
+    ? [opts.embeddedPath]
+    : defaultEmbeddedDirs();
+  for (const dir of baseDirs) {
+    for (const storagePath of embeddedStorageCandidates(dir)) {
+      if (existsSync(storagePath)) {
+        const records = await readEmbeddedStorage(storagePath);
+        return mem0RecordsToDoc(records, { project });
+      }
+    }
+  }
+
+  // 4. Nothing found — actionable last-resort guidance.
+  throw new Error(
+    "No mem0 data found. Start your mem0 server, or point Lore at it with " +
+      "--mem0-qdrant/--mem0-server/--mem0-path, or export manually and pass --file:\n" +
+      '  pip install mem0ai && python -c "import json;from mem0 import Memory;' +
+      'm=Memory();print(json.dumps(m.get_all(user_id=\\"YOUR_USER\\")))" > mem0.json\n' +
+      "  lore import --source mem0 --file mem0.json",
+  );
+}

--- a/packages/core/src/import/structured-sources.ts
+++ b/packages/core/src/import/structured-sources.ts
@@ -12,9 +12,25 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseEngramExport } from "./sources/engram";
+import { resolveMem0Doc } from "./sources/mem0";
 import { safeParseImportDoc, type LoreImportDoc } from "./schema";
 
 export type StructuredSourceName = "engram" | "mem0";
+
+/**
+ * Options passed to `produceDoc`. `filePath` and `project` are generic; the
+ * `mem0*` fields are mem0-specific deployment overrides (ignored by Engram).
+ */
+export type ProduceDocOptions = {
+  filePath?: string;
+  project?: string;
+  mem0QdrantUrl?: string;
+  mem0Collection?: string;
+  mem0ServerUrl?: string;
+  mem0Token?: string;
+  mem0Path?: string;
+  mem0User?: string;
+};
 
 export type StructuredSource = {
   /** Internal name (matches LoreImportDoc.source and --agent filter). */
@@ -29,9 +45,10 @@ export type StructuredSource = {
   /**
    * Produce a validated LoreImportDoc from this source. When `filePath` is
    * provided, read/convert that file; otherwise auto-discover (e.g. run the
-   * source's own export CLI). Throws with an actionable message on failure.
+   * source's own export CLI, or probe a running server). Throws with an
+   * actionable message on failure. May be async (network probes).
    */
-  produceDoc(opts?: { filePath?: string }): LoreImportDoc;
+  produceDoc(opts?: ProduceDocOptions): LoreImportDoc | Promise<LoreImportDoc>;
 };
 
 /** True when `bin` is resolvable on PATH (best-effort, never throws). */
@@ -67,7 +84,7 @@ export const engramSource: StructuredSource = {
     return existsSync(dbPath);
   },
 
-  produceDoc(opts?: { filePath?: string }): LoreImportDoc {
+  produceDoc(opts?: ProduceDocOptions): LoreImportDoc {
     let raw: unknown;
     if (opts?.filePath) {
       raw = readJson(opts.filePath);
@@ -93,10 +110,50 @@ export const engramSource: StructuredSource = {
 };
 
 // ---------------------------------------------------------------------------
+// mem0
+// ---------------------------------------------------------------------------
+
+export const mem0Source: StructuredSource = {
+  name: "mem0",
+  displayName: "mem0",
+
+  detect(): boolean {
+    // Embedded-default store artifacts (cheap, synchronous existence checks).
+    // A running Qdrant/mem0 server is detected at produceDoc time (async probe);
+    // detection here just surfaces the source when a local store is present.
+    const dirs = ["/tmp/qdrant"];
+    const home = homedir();
+    if (home) dirs.push(join(home, ".mem0"));
+    for (const dir of dirs) {
+      if (
+        existsSync(join(dir, "collection", "mem0", "storage.sqlite")) ||
+        existsSync(join(dir, "collection", "openmemory", "storage.sqlite"))
+      ) {
+        return true;
+      }
+    }
+    return false;
+  },
+
+  produceDoc(opts?: ProduceDocOptions): Promise<LoreImportDoc> {
+    return resolveMem0Doc({
+      filePath: opts?.filePath,
+      project: opts?.project,
+      qdrantUrl: opts?.mem0QdrantUrl,
+      collection: opts?.mem0Collection,
+      serverUrl: opts?.mem0ServerUrl,
+      token: opts?.mem0Token,
+      embeddedPath: opts?.mem0Path,
+      userId: opts?.mem0User,
+    });
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
-const sources: StructuredSource[] = [engramSource];
+const sources: StructuredSource[] = [engramSource, mem0Source];
 
 /** All registered structured sources. */
 export function getStructuredSources(): readonly StructuredSource[] {

--- a/packages/core/test/import/mem0.test.ts
+++ b/packages/core/test/import/mem0.test.ts
@@ -1,0 +1,485 @@
+import { describe, test, expect, afterAll } from "vitest";
+import { fileURLToPath } from "node:url";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import {
+  mem0RecordToEntry,
+  mem0RecordsToDoc,
+  scrollQdrantCollection,
+  fetchMem0ServerMemories,
+  readEmbeddedStorage,
+  embeddedStorageCandidates,
+  parseMem0File,
+  resolveMem0Doc,
+} from "../../src/import/sources/mem0";
+import { MAX_IMPORT_CONTENT_LENGTH } from "../../src/import/schema";
+
+const TMP = join(fileURLToPath(new URL(".", import.meta.url)), "__tmp_mem0__");
+mkdirSync(TMP, { recursive: true });
+afterAll(() => rmSync(TMP, { recursive: true, force: true }));
+
+// Pickle blobs captured from CPython pickle.dumps(..., protocol=4). No Python at
+// test time — we bake the bytes and only read them.
+const PICKLE = {
+  // Direct-attribute PointStruct: obj.payload.* on the object itself.
+  direct:
+    "gASV5gAAAAAAAACMCF9fbWFpbl9flIwBUJSTlCmBlH2UKIwCaWSUjARwdC0xlIwHcGF5bG9hZJR9lCiMBGRhdGGUjB9QcmVmZXJzIGRhcmsgbW9kZSBpbiB0aGUgZWRpdG9ylIwHdXNlcl9pZJSMBWFsaWNllIwEaGFzaJSMAmgxlIwKY3JlYXRlZF9hdJSMGTIwMjYtMDctMTlUMDk6MTI6MDAtMDA6MDCUjAhtZXRhZGF0YZR9lIwEcmVwb5SMCy9ob21lL3UvYXBwlHN1jAZ2ZWN0b3KUXZQoRz+5mZmZmZmaRz/JmZmZmZmaZXViLg==",
+  // __dict__/pydantic setstate PointStruct: obj.__dict__.payload.*.
+  dicted:
+    "gASVggAAAAAAAACMCF9fbWFpbl9flIwBUZSTlClSlH2UjAhfX2RpY3RfX5R9lCiMAmlklIwEcHQtMpSMB3BheWxvYWSUfZQojARkYXRhlIwRVXNlcyBwbnBtIG5vdCBucG2UjAd1c2VyX2lklIwDYm9ilHWMBnZlY3RvcpRdlEc/0zMzMzMzM2F1c2Iu",
+  // datetime in payload → decodes to a non-primitive; must be ignored.
+  dtime:
+    "gASViwAAAAAAAACMCF9fbWFpbl9flIwBUJSTlCmBlH2UKIwCaWSUjARwdC0zlIwHcGF5bG9hZJR9lCiMBGRhdGGUjAxIYXMgZGF0ZXRpbWWUjApjcmVhdGVkX2F0lIwIZGF0ZXRpbWWUjAhkYXRldGltZZSTlEMKB+oHEwkMAAAAAJSFlFKUdYwGdmVjdG9ylF2UdWIu",
+};
+
+// A REAL point captured from mem0 2.0.12's embedded Qdrant store
+// (qdrant_client.http.models.models.PointStruct, pydantic __dict__ shape). The
+// `points.id` COLUMN is base64(pickle(uuid)) — NOT the plain id — while the
+// real UUID lives inside the pickled point's __dict__.id. Regression fixture
+// for the id-column bug found by importing a real store.
+const REAL_MEM0 = {
+  // base64 of pickle.dumps("50000c04-da53-4fac-b10e-d699c84264dd")
+  idColumn:
+    "gASVKAAAAAAAAACMJDUwMDAwYzA0LWRhNTMtNGZhYy1iMTBlLWQ2OTljODQyNjRkZJQu",
+  uuid: "50000c04-da53-4fac-b10e-d699c84264dd",
+  point:
+    "gASVnAEAAAAAAACMIHFkcmFudF9jbGllbnQuaHR0cC5tb2RlbHMubW9kZWxzlIwLUG9pbnRTdHJ1Y3SUk5QpgZR9lCiMCF9fZGljdF9flH2UKIwCaWSUjCQ1MDAwMGMwNC1kYTUzLTRmYWMtYjEwZS1kNjk5Yzg0MjY0ZGSUjAZ2ZWN0b3KUfZSMAJRdlChHAAAAAAAAAABHP7mZmZmZmZpHP8mZmZmZmZpHP9MzMzMzMzRHP9mZmZmZmZpHP+AAAAAAAABHP+MzMzMzMzRHP+ZmZmZmZmdlc4wHcGF5bG9hZJR9lCiMBGRhdGGUjB9QcmVmZXJzIGRhcmsgbW9kZSBpbiB0aGUgZWRpdG9ylIwHdXNlcl9pZJSMBWFsaWNllIwEaGFzaJSMAmgwlIwIbWV0YWRhdGGUfZSMBHJlcG+UjAsvaG9tZS91L2FwcJRzdXWMEl9fcHlkYW50aWNfZXh0cmFfX5ROjBdfX3B5ZGFudGljX2ZpZWxkc19zZXRfX5SPlChoB2gJaA2QjBRfX3B5ZGFudGljX3ByaXZhdGVfX5ROdWIu",
+};
+
+function makeStorageSqlite(name: string, blobsB64: string[]): string {
+  const p = join(TMP, name);
+  const db = new DatabaseSync(p);
+  db.exec("CREATE TABLE points (id TEXT PRIMARY KEY, point BLOB)");
+  const stmt = db.prepare("INSERT INTO points VALUES (?, ?)");
+  blobsB64.forEach((b64, i) => {
+    stmt.run(`row-${i}`, Buffer.from(b64, "base64"));
+  });
+  db.close();
+  return p;
+}
+
+describe("mem0RecordToEntry", () => {
+  test("maps data/user/metadata; defaults category pattern", () => {
+    const entry = mem0RecordToEntry({
+      id: "m-1",
+      data: "Prefers dark mode",
+      user_id: "alice",
+      metadata: { repo: "/home/u/app" },
+    });
+    expect(entry).not.toBeNull();
+    expect(entry!.content).toBe("Prefers dark mode");
+    expect(entry!.category).toBe("pattern");
+    expect(entry!.project).toBe("/home/u/app");
+    expect(entry!.external_id).toBe("m-1");
+  });
+
+  test("falls back to `memory` key (server REST shape)", () => {
+    const entry = mem0RecordToEntry({ id: 7, memory: "Uses pnpm" });
+    expect(entry!.content).toBe("Uses pnpm");
+    expect(entry!.external_id).toBe("7");
+  });
+
+  test("explicit project overrides metadata.repo", () => {
+    const entry = mem0RecordToEntry(
+      { data: "x", metadata: { repo: "/from/meta" } },
+      { project: "/from/flag" },
+    );
+    expect(entry!.project).toBe("/from/flag");
+  });
+
+  test("skips empty/whitespace and non-string content", () => {
+    expect(mem0RecordToEntry({ data: "   " })).toBeNull();
+    expect(mem0RecordToEntry({ data: null })).toBeNull();
+    expect(mem0RecordToEntry({})).toBeNull();
+  });
+
+  test("truncates oversized content to the schema ceiling", () => {
+    const entry = mem0RecordToEntry({ data: "z".repeat(80_000) });
+    expect(entry!.content.length).toBeLessThanOrEqual(
+      MAX_IMPORT_CONTENT_LENGTH,
+    );
+  });
+
+  test("falls back to hash as external_id when id is absent", () => {
+    const entry = mem0RecordToEntry({ data: "x", hash: "deadbeef" });
+    expect(entry!.external_id).toBe("deadbeef");
+  });
+});
+
+describe("mem0RecordsToDoc", () => {
+  test("builds a validated mem0 doc, dropping skips", () => {
+    const doc = mem0RecordsToDoc([
+      { data: "keep 1", id: "1" },
+      { data: "  ", id: "2" },
+      { memory: "keep 2", id: "3" },
+    ]);
+    expect(doc.source).toBe("mem0");
+    expect(doc.entries).toHaveLength(2);
+    expect(doc.entries.every((e) => e.category === "pattern")).toBe(true);
+  });
+});
+
+describe("scrollQdrantCollection", () => {
+  test("paginates over next_page_offset and reads payload.data", async () => {
+    const pages = [
+      {
+        result: {
+          points: [
+            { id: "a", payload: { data: "first", user_id: "u1" } },
+            { id: "b", payload: { data: "second", user_id: "u1" } },
+          ],
+          next_page_offset: "cursor-1",
+        },
+      },
+      {
+        result: {
+          points: [{ id: "c", payload: { data: "third", user_id: "u1" } }],
+          next_page_offset: null,
+        },
+      },
+    ];
+    let call = 0;
+    const fetchImpl = (async (_url: string, _init: unknown) => {
+      const body = pages[call++];
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => body,
+      };
+    }) as unknown as typeof fetch;
+
+    const recs = await scrollQdrantCollection({
+      url: "http://127.0.0.1:6333",
+      collection: "mem0",
+      fetchImpl,
+      pageSize: 2,
+    });
+    expect(call).toBe(2);
+    expect(recs.map((r) => r.data)).toEqual(["first", "second", "third"]);
+    expect(recs[0].id).toBe("a");
+  });
+
+  test("throws on a non-ok response", async () => {
+    const fetchImpl = (async () => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    await expect(
+      scrollQdrantCollection({
+        url: "http://127.0.0.1:6333",
+        collection: "missing",
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/Qdrant scroll failed/);
+  });
+
+  test("stops on an empty page even if server returns a trailing cursor", async () => {
+    let call = 0;
+    const fetchImpl = (async () => {
+      call++;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          result: { points: [], next_page_offset: "still-here" },
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const recs = await scrollQdrantCollection({
+      url: "http://127.0.0.1:6333",
+      collection: "mem0",
+      fetchImpl,
+    });
+    expect(recs).toHaveLength(0);
+    expect(call).toBe(1);
+  });
+});
+
+describe("fetchMem0ServerMemories", () => {
+  test("reads results[] and sends the api key", async () => {
+    let sawHeader: string | undefined;
+    const fetchImpl = (async (
+      _url: string,
+      init: { headers?: Record<string, string> },
+    ) => {
+      sawHeader = init?.headers?.["X-API-Key"];
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ results: [{ id: "s1", memory: "server mem" }] }),
+      };
+    }) as unknown as typeof fetch;
+    const recs = await fetchMem0ServerMemories({
+      url: "http://127.0.0.1:8888",
+      userId: "alice",
+      apiKey: "secret",
+      fetchImpl,
+    });
+    expect(recs).toHaveLength(1);
+    expect(recs[0].memory).toBe("server mem");
+    expect(sawHeader).toBe("secret");
+  });
+
+  test("throws with auth hint on 401", async () => {
+    const fetchImpl = (async () => ({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    await expect(
+      fetchMem0ServerMemories({
+        url: "http://127.0.0.1:8888",
+        userId: "alice",
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/--mem0-token/);
+  });
+});
+
+describe("readEmbeddedStorage (native pickle reader)", () => {
+  test("decodes direct-attribute and __dict__ point shapes", async () => {
+    const path = makeStorageSqlite("s1.sqlite", [PICKLE.direct, PICKLE.dicted]);
+    const recs = await readEmbeddedStorage(path);
+    const byData = recs.map((r) => r.data);
+    expect(byData).toContain("Prefers dark mode in the editor");
+    expect(byData).toContain("Uses pnpm not npm");
+    const alice = recs.find(
+      (r) => r.data === "Prefers dark mode in the editor",
+    );
+    expect((alice!.metadata as { repo?: string })?.repo).toBe("/home/u/app");
+    expect(alice!.user_id).toBe("alice");
+  });
+
+  test("gracefully ignores a non-primitive payload value (datetime)", async () => {
+    const path = makeStorageSqlite("s2.sqlite", [PICKLE.dtime]);
+    const recs = await readEmbeddedStorage(path);
+    expect(recs).toHaveLength(1);
+    // Content still reads; created_at (a datetime object) is coerced away later.
+    const doc = mem0RecordsToDoc(recs);
+    expect(doc.entries[0].content).toBe("Has datetime");
+    expect(doc.entries[0].created_at).toBeUndefined();
+  });
+
+  test("skips an undecodable blob instead of aborting the whole read", async () => {
+    // A single corrupt/undecodable point must not throw — the reader continues
+    // and still returns the good rows.
+    const p = join(TMP, "corrupt.sqlite");
+    const db = new DatabaseSync(p);
+    db.exec("CREATE TABLE points (id TEXT PRIMARY KEY, point BLOB)");
+    const ins = db.prepare("INSERT INTO points VALUES (?, ?)");
+    ins.run("bad", Buffer.from([0x00, 0x01, 0x02, 0xff, 0xfe])); // not a pickle
+    ins.run("good", Buffer.from(PICKLE.direct, "base64"));
+    db.close();
+
+    const recs = await readEmbeddedStorage(p);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].data).toBe("Prefers dark mode in the editor");
+  });
+
+  test("embeddedStorageCandidates covers mem0 + openmemory collections", () => {
+    const cands = embeddedStorageCandidates("/base");
+    expect(cands).toContain("/base/collection/mem0/storage.sqlite");
+    expect(cands).toContain("/base/collection/openmemory/storage.sqlite");
+  });
+
+  test("uses the point's decoded UUID, NOT the base64-pickled id column (real mem0 2.0.12)", async () => {
+    // Regression: real mem0 stores points.id as base64(pickle(uuid)); the plain
+    // UUID lives in the pickled point's __dict__.id. The reader must read the
+    // decoded id, not the column, or external_id becomes a garbage blob.
+    const p = join(TMP, "real.sqlite");
+    const db = new DatabaseSync(p);
+    db.exec("CREATE TABLE points (id TEXT PRIMARY KEY, point BLOB)");
+    db.prepare("INSERT INTO points VALUES (?, ?)").run(
+      REAL_MEM0.idColumn,
+      Buffer.from(REAL_MEM0.point, "base64"),
+    );
+    db.close();
+
+    const recs = await readEmbeddedStorage(p);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].id).toBe(REAL_MEM0.uuid);
+    expect(recs[0].data).toBe("Prefers dark mode in the editor");
+
+    const doc = mem0RecordsToDoc(recs);
+    expect(doc.entries[0].external_id).toBe(REAL_MEM0.uuid);
+  });
+});
+
+describe("parseMem0File", () => {
+  test("passes through a generic LoreImportDoc", () => {
+    const p = join(TMP, "generic.json");
+    writeFileSync(
+      p,
+      JSON.stringify({
+        lore_import_version: 1,
+        source: "generic",
+        entries: [{ content: "already normalized", category: "pattern" }],
+      }),
+    );
+    const doc = parseMem0File(p);
+    expect(doc.source).toBe("generic");
+    expect(doc.entries[0].content).toBe("already normalized");
+  });
+
+  test("converts a raw mem0 export ({results:[...]}) ", () => {
+    const p = join(TMP, "raw.json");
+    writeFileSync(
+      p,
+      JSON.stringify({
+        results: [{ id: "1", memory: "raw mem", user_id: "u" }],
+      }),
+    );
+    const doc = parseMem0File(p);
+    expect(doc.source).toBe("mem0");
+    expect(doc.entries[0].content).toBe("raw mem");
+  });
+
+  test("converts a bare array export", () => {
+    const p = join(TMP, "arr.json");
+    writeFileSync(p, JSON.stringify([{ id: "1", data: "bare" }]));
+    const doc = parseMem0File(p);
+    expect(doc.entries[0].content).toBe("bare");
+  });
+});
+
+describe("resolveMem0Doc (auto-detect)", () => {
+  test("explicit file wins over all probes", async () => {
+    const p = join(TMP, "explicit.json");
+    writeFileSync(p, JSON.stringify([{ id: "1", data: "explicit" }]));
+    let probed = false;
+    const doc = await resolveMem0Doc({
+      filePath: p,
+      probe: async () => {
+        probed = true;
+        return true;
+      },
+    });
+    expect(doc.entries[0].content).toBe("explicit");
+    expect(probed).toBe(false);
+  });
+
+  test("routes to Qdrant scroll when :6333 is reachable", async () => {
+    const fetchImpl = (async (url: string) => {
+      if (String(url).includes("/points/scroll")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            result: {
+              points: [{ id: "q1", payload: { data: "from qdrant" } }],
+              next_page_offset: null,
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({}),
+      };
+    }) as unknown as typeof fetch;
+    const doc = await resolveMem0Doc({
+      probe: async (u) => u.includes("/collections"),
+      fetchImpl,
+    });
+    expect(doc.entries[0].content).toBe("from qdrant");
+  });
+
+  test("falls back to embedded store when no server is reachable", async () => {
+    const dir = join(TMP, "embedded");
+    const collDir = join(dir, "collection", "mem0");
+    mkdirSync(collDir, { recursive: true });
+    const dbPath = join(collDir, "storage.sqlite");
+    const db = new DatabaseSync(dbPath);
+    db.exec("CREATE TABLE points (id TEXT PRIMARY KEY, point BLOB)");
+    db.prepare("INSERT INTO points VALUES (?, ?)").run(
+      "row-0",
+      Buffer.from(PICKLE.direct, "base64"),
+    );
+    db.close();
+    const doc = await resolveMem0Doc({
+      embeddedPath: dir,
+      probe: async () => false,
+    });
+    expect(doc.entries[0].content).toBe("Prefers dark mode in the editor");
+  });
+
+  test("throws actionable guidance when nothing is found", async () => {
+    await expect(
+      resolveMem0Doc({
+        embeddedPath: join(TMP, "does-not-exist"),
+        probe: async () => false,
+      }),
+    ).rejects.toThrow(/No mem0 data found|--file/);
+  });
+
+  test("routes to the mem0 server when serverUrl+user given and Qdrant is down", async () => {
+    const fetchImpl = (async (url: string) => {
+      if (String(url).includes("/memories")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({ results: [{ id: "s1", memory: "srv mem" }] }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({}),
+      };
+    }) as unknown as typeof fetch;
+    const doc = await resolveMem0Doc({
+      serverUrl: "http://127.0.0.1:8888",
+      userId: "alice",
+      // Qdrant probe fails; server /docs probe passes.
+      probe: async (u) => u.includes("/docs"),
+      fetchImpl,
+    });
+    expect(doc.entries[0].content).toBe("srv mem");
+  });
+
+  test("errors with --mem0-user hint when server is reachable but no user id", async () => {
+    await expect(
+      resolveMem0Doc({
+        serverUrl: "http://127.0.0.1:8888",
+        probe: async (u) => u.includes("/docs"),
+      }),
+    ).rejects.toThrow(/--mem0-user/);
+  });
+
+  test("does NOT try the server branch when neither serverUrl nor userId is set", async () => {
+    // Guard: the server branch is gated on `serverUrl || userId`. With neither,
+    // a passing /docs probe must NOT trigger a server fetch — we fall through to
+    // embedded (absent here) and get the actionable not-found error. Only the
+    // /docs probe passes (Qdrant /collections fails) to isolate the server gate.
+    let serverFetched = false;
+    const fetchImpl = (async (url: string) => {
+      if (String(url).includes("/memories")) serverFetched = true;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({}),
+      };
+    }) as unknown as typeof fetch;
+    await expect(
+      resolveMem0Doc({
+        embeddedPath: join(TMP, "nope"),
+        probe: async (u) => u.includes("/docs"),
+        fetchImpl,
+      }),
+    ).rejects.toThrow(/No mem0 data found|--file/);
+    expect(serverFetched).toBe(false);
+  });
+});

--- a/packages/core/test/import/structured-sources.test.ts
+++ b/packages/core/test/import/structured-sources.test.ts
@@ -35,7 +35,7 @@ describe("structured sources registry", () => {
 });
 
 describe("engramSource.produceDoc", () => {
-  test("converts a native Engram export file", () => {
+  test("converts a native Engram export file", async () => {
     const file = writeFixture("engram.json", {
       version: "1.0",
       exported_at: "2026-07-20 14:05:00",
@@ -51,20 +51,20 @@ describe("engramSource.produceDoc", () => {
       ],
       prompts: [],
     });
-    const doc = engramSource.produceDoc({ filePath: file });
+    const doc = await engramSource.produceDoc({ filePath: file });
     expect(doc.source).toBe("engram");
     expect(doc.entries).toHaveLength(1);
     expect(doc.entries[0].category).toBe("gotcha");
     expect(doc.entries[0].project).toBe("/repo");
   });
 
-  test("passes through an already-generic LoreImportDoc file", () => {
+  test("passes through an already-generic LoreImportDoc file", async () => {
     const file = writeFixture("generic.json", {
       lore_import_version: LORE_IMPORT_VERSION,
       source: "generic",
       entries: [{ content: "already normalized", category: "pattern" }],
     });
-    const doc = engramSource.produceDoc({ filePath: file });
+    const doc = await engramSource.produceDoc({ filePath: file });
     expect(doc.source).toBe("generic");
     expect(doc.entries[0].content).toBe("already normalized");
   });

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -290,6 +290,14 @@ async function importStructured(opts: {
   dryRun: boolean;
   yes: boolean;
   global: boolean;
+  mem0?: {
+    qdrantUrl?: string;
+    collection?: string;
+    serverUrl?: string;
+    token?: string;
+    path?: string;
+    user?: string;
+  };
 }): Promise<void> {
   const { projectPath, sourceName, filePath, dryRun, global } = opts;
 
@@ -308,12 +316,21 @@ async function importStructured(opts: {
     `[lore] Importing structured memory from ${source.displayName}...`,
   );
 
-  // Produce the normalized document (runs the source's export CLI / reads
-  // --file). This always happens client-side — the remote gateway has no shared
-  // filesystem with the client.
+  // Produce the normalized document (runs the source's export CLI, reads
+  // --file, or probes a running server). This always happens client-side — the
+  // remote gateway has no shared filesystem with the client. May be async.
   let doc: conversationImport.LoreImportDoc;
   try {
-    doc = source.produceDoc({ filePath: filePath ?? undefined });
+    doc = await source.produceDoc({
+      filePath: filePath ?? undefined,
+      project: projectPath,
+      mem0QdrantUrl: opts.mem0?.qdrantUrl,
+      mem0Collection: opts.mem0?.collection,
+      mem0ServerUrl: opts.mem0?.serverUrl,
+      mem0Token: opts.mem0?.token,
+      mem0Path: opts.mem0?.path,
+      mem0User: opts.mem0?.user,
+    });
   } catch (err) {
     console.error(
       `[lore] Could not read ${source.displayName} memory: ${err instanceof Error ? err.message : String(err)}`,
@@ -447,6 +464,14 @@ export async function commandImport(
   const sourceFlag = (flags.source as string) ?? null;
   const fileFlag = (flags.file as string) ?? null;
   const global = flags.global === true;
+  const mem0Opts = {
+    qdrantUrl: (flags["mem0-qdrant"] as string) ?? undefined,
+    collection: (flags["mem0-collection"] as string) ?? undefined,
+    serverUrl: (flags["mem0-server"] as string) ?? undefined,
+    token: (flags["mem0-token"] as string) ?? undefined,
+    path: (flags["mem0-path"] as string) ?? undefined,
+    user: (flags["mem0-user"] as string) ?? undefined,
+  };
   const noWorktrees =
     flags["no-worktrees"] === true || flags.noWorktrees === true;
   const projectFlag = flags.project as string | undefined;
@@ -491,6 +516,7 @@ export async function commandImport(
       dryRun,
       yes,
       global,
+      mem0: mem0Opts,
     });
     return;
   }

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -128,6 +128,13 @@ const OPTIONS = {
   file: { type: "string" as const },
   source: { type: "string" as const },
   global: { type: "boolean" as const },
+  // `lore import --source mem0` deployment-shape overrides.
+  "mem0-qdrant": { type: "string" as const },
+  "mem0-collection": { type: "string" as const },
+  "mem0-server": { type: "string" as const },
+  "mem0-token": { type: "string" as const },
+  "mem0-path": { type: "string" as const },
+  "mem0-user": { type: "string" as const },
   "min-confidence": { type: "string" as const },
   "no-backup": { type: "boolean" as const },
   // `lore data clear` flags

--- a/packages/website/src/content/docs/docs/import.md
+++ b/packages/website/src/content/docs/docs/import.md
@@ -101,7 +101,34 @@ Each observation's project is recovered from its Engram session `directory`; obs
 
 ### mem0
 
-mem0 migration is coming in a follow-up release. It will read mem0's local store natively (server, OpenMemory, and embedded-default deployments) with no Python required.
+mem0 is imported **natively — no Python required** for any common deployment. `lore import --source mem0` auto-detects your deployment shape:
+
+```bash
+lore import --source mem0                       # auto-detect (Qdrant / server / embedded)
+lore import --source mem0 --file mem0.json      # explicit export dump
+lore import --source mem0 --global              # import as cross-project knowledge
+lore import --source mem0 --dry-run             # preview counts
+```
+
+**Deployment shapes** (detected in order):
+
+| Shape | How Lore reads it | Notes |
+| --- | --- | --- |
+| **Qdrant server** (OpenMemory / raw Qdrant) | HTTP `points/scroll` on `:6333` | Collections `openmemory` then `mem0`. `--mem0-token` if the server sets an api-key. |
+| **mem0 self-hosted server** (FastAPI) | HTTP `GET /memories` on `:8888` | Needs `--mem0-user <id>` and usually `--mem0-token`. |
+| **Embedded default** (`Memory()`) | Reads `storage.sqlite` + decodes pickled Qdrant points | Fully native (SQLite + a pure-TS pickle reader). No server, no Python. |
+
+**Overrides:** `--mem0-qdrant <url>`, `--mem0-collection <name>`, `--mem0-server <url>`, `--mem0-token <t>`, `--mem0-path <dir>` (embedded store base dir), `--mem0-user <id>`.
+
+mem0 OSS has no category taxonomy, so imported memories default to the `pattern` category. Each memory's `metadata.repo` (when present) sets its project; otherwise `--project`/cwd applies.
+
+**Fallback.** If native read ever fails (e.g. a future change to mem0's internal pickle format), export manually and pass `--file`:
+
+```bash
+pip install mem0ai
+python -c "import json;from mem0 import Memory;m=Memory();print(json.dumps(m.get_all(user_id='YOUR_USER')))" > mem0.json
+lore import --source mem0 --file mem0.json
+```
 
 ## Next steps
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       p-limit:
         specifier: '7'
         version: 7.3.0
+      pickleparser:
+        specifier: 0.2.1
+        version: 0.2.1
       remark:
         specifier: ^15.0.1
         version: 15.0.1
@@ -3491,6 +3494,10 @@ packages:
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
+
+  pickleparser@0.2.1:
+    resolution: {integrity: sha512-kMzY3uFYcR6OjOqr7nV2nkaXaBsUEOafu3zgPxeD6s/2ueMfVQH8lrymcDWBPGx0OkVxGMikxQit6jgByXjwBg==}
+    hasBin: true
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -8379,6 +8386,8 @@ snapshots:
       split2: 4.2.0
 
   piccolore@0.1.3: {}
+
+  pickleparser@0.2.1: {}
 
   picocolors@1.1.1: {}
 


### PR DESCRIPTION
## What & why

Completes #1398's migration story: adds a **native, Python-free mem0 connector** to the structured-import lane shipped in #1415. `lore import --source mem0` auto-detects the deployment shape and reads memories straight into the knowledge store (no curator LLM — mem0 memories are already curated).

```bash
lore import --source mem0                    # auto-detect (Qdrant / server / embedded)
lore import --source mem0 --file mem0.json   # explicit dump
lore import --source mem0 --global           # cross-project
lore import --source mem0 --dry-run          # preview
```

## Deployment shapes (`packages/core/src/import/sources/mem0.ts`)

| Shape | Read path |
| --- | --- |
| **Qdrant server** (OpenMemory / raw Qdrant) | HTTP `points/scroll` via `fetch`, `next_page_offset` pagination, reads `payload.data` |
| **mem0 self-hosted server** (FastAPI) | `GET /memories?user_id=…`, `X-API-Key` auth |
| **Embedded default** (`Memory()`) | `collection/<name>/storage.sqlite` opened read-only via `node:sqlite`; each pickled Qdrant `PointStruct` decoded with **`pickleparser`** (pure-TS, MIT, lazy-imported). No Python. |
| **`--file <dump.json>`** | generic `LoreImportDoc` pass-through, or raw mem0 export (`{results:[…]}` / `{memories:[…]}` / bare array) |

`resolveMem0Doc` probes in order (file → Qdrant → server → embedded) with an actionable last-resort message (manual `pip`/`python` one-liner + `--file`) when nothing is found. New `--mem0-qdrant/-collection/-server/-token/-path/-user` overrides.

## Key decisions / correctness notes

- **No `@qdrant/js-client-rest`** — it has no embedded mode and its `scroll()` is a 1:1 HTTP wrapper; a hand-rolled `fetch` loop is dependency-free and equivalent (consistent with Lore's no-dep HTTP style).
- **On-store payload text key is `data`, not `memory`** (`memory` is only the SDK's *returned* key). Reader handles both.
- **Pickle shapes**: `pickleparser` puts instance attributes either directly on the object OR under `__dict__` (pydantic `__setstate__`); guarded with `obj.__dict__ ?? obj`. Non-primitive payload values (e.g. a pickled `datetime`) decode to a wrapper and are coerced away.
- **produceDoc is now async** (`LoreImportDoc | Promise<LoreImportDoc>`) since mem0 probes the network; Engram stays synchronous (existing tests updated to `await`).
- mem0 OSS has no category taxonomy → default **`pattern`**; `metadata.repo` → project; point id (or `hash`) kept as `external_id`.
- New dep: **`pickleparser@0.2.1`** (pure-TS, zero-dep, MIT) on `@loreai/core`, lazy-imported so detection-only paths stay light.

## Tests / gate

- New `packages/core/test/import/mem0.test.ts`: record mapping, Qdrant scroll pagination (mock `fetch`), server REST + auth-hint, **embedded pickle reader against baked `storage.sqlite` fixtures (no Python in CI)**, `datetime`-value coercion, resolver auto-detect/override, `--file` shapes.
- Guards **mutation-verified**: empty-content skip, content truncation, Qdrant empty-page stop.
- Full suite green (6385 passed; the only failure is the environmental `agents.test.ts` git-remote check — no `.git` remote in a jj workspace, passes in CI's real checkout). typecheck / lint / format:check clean.

## Follow-ups (not blocking)

- Optional: LLM categorization pass for mem0 memories (deferred — default `pattern` per plan).
- Optional: mem0 hosted-cloud (`api.mem0.ai`) REST with `m0-…` key (out of scope for a local-migration tool).

Refs #1398