### PR TITLE
fix(gateway): reasoning-headroom floor for OpenAI-protocol workers (no explicit effort)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -37,6 +37,9 @@
 <!-- lore:019ef387-4ae0-7676-b7b5-140c85ad2627 -->
 * **knowledge\_meta table: confidence/last\_reinforced\_at moved off knowledge table (v55)**: Migration v55 moves \`confidence\` and \`last\_reinforced\_at\` off the \`knowledge\` table into a new convergent register table: \`knowledge\_meta (logical\_id TEXT PRIMARY KEY, confidence REAL NOT NULL DEFAULT 1.0, last\_reinforced\_at INTEGER, updated\_at INTEGER NOT NULL DEFAULT 0)\`. \`knowledge\_current\` view exposes both via LEFT JOIN: \`SELECT k.\*, COALESCE(m.confidence, 1.0) AS confidence, m.last\_reinforced\_at FROM knowledge k LEFT JOIN knowledge\_meta m ON m.logical\_id = k.logical\_id WHERE k.is\_current=1 AND k.is\_deleted=0\`. Reading/writing confidence on the base \`knowledge\` table now errors with 'no such column'. For v1 rows: logical\_id == id. \`ltm.create()\` creates matching knowledge\_meta row automatically. Schema version bumped 54→55. \`markInjected()\` updates \`knowledge\_meta.last\_reinforced\_at\` but does NOT bump \`updated\_at\` — injection stays sync-silent. Content-only \`update()\` also must NOT bump \`meta.updated\_at\`.
 
+<!-- lore:019f824a-3efd-70ae-ae6f-bcb7bc5704fd -->
+* **llm-adapter.ts: reasoning-headroom floor for OpenAI-protocol workers**: In packages/gateway/src/llm-adapter.ts, worker max\_completion\_tokens gets a reasoning floor: if reasoningEffort is explicit, floor = anthropicThinkingBudget(effort) + THINKING\_OUTPUT\_HEADROOM(8192). Else if workerThinkingOnByDefault(model) is true (e.g. claude-sonnet-5, models.dev reasoning\_options='toggle'), floor = DEFAULT\_REASONING\_MODEL\_BUDGET(8192) + THINKING\_OUTPUT\_HEADROOM(8192) = 16384. Else floor = 0 — non-reasoning models with no effort get NO floor, avoiding wasted budget (confirmed via test 'does NOT floor a NON-reasoning model with no effort'). Length-retry (finish\_reason:'length') always multiplies from this FLOORED effective budget, never the tiny raw one — a floor is 'never a charge': models that don't reason still bill only the raw budget since no reasoning\_effort/thinking param is sent when floor path isn't taken.
+
 <!-- lore:019edfbc-edd5-780d-ac81-07a35390121b -->
 * **ltm.ts: confidence lifecycle — decay, reinforcement, eviction, and cross-project protection**: ltm.ts: confidence lifecycle — decay, reinforcement, eviction, cross-project protection. \`decayProject(path)\` decrements confidence, never bumps \`updated\_at\`. \`markInjected(ids)\` writes only \`last\_reinforced\_at\`. \`evictLowestValue\`/\`pruneDeadEntries\`/\`pruneDeadEntriesAllProjects\` MUST skip \`cross\_project=1\` entries. \`DEAD\_CONFIDENCE\_FLOOR=0.2\`. \`enforceEntryCap\` counts promoted rows but eviction excludes them. Global sweep in \`idle.ts\`: \`pruneDeadEntriesAllProjects()\` on first tick then hourly (\`GLOBAL\_DEAD\_SWEEP\_INTERVAL\_MS=3600000\`), gated on \`loreConfig().knowledge.enabled\`. \`lastGlobalDeadSweepAt\` starts at 0, set BEFORE try block (prevents retry storm). Sweep wrapped in try/catch. Queries \`WHERE cross\_project=0 AND confidence<=0.2 LIMIT ?\` — \`cross\_project=0\` implicitly guarantees non-null \`project\_id\` (enforced at \`create()\`: null pid forces \`cross\_project=1\`).
 
@@ -564,9 +567,6 @@
 <!-- lore:019f81a2-21af-76ff-9e84-a56f05f0bcac -->
 * **Prefers same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e**: prefer same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e.
 
-<!-- lore:019f8239-6b29-7835-9c70-02185e8c2496 -->
-* **Respect explicitly rejected approaches**: Behavioral pattern detected across 46 sessions (action: rejected-approach). The user consistently demonstrates this behavior.
-
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
 
@@ -611,6 +611,3 @@
 
 <!-- lore:019f77f9-b825-7350-a219-87bda1045e2e -->
 * **Warmup embedding never hits network or burns quota**: User consistently requires that embedding warmup never hits the network or burns quota. This pattern has appeared in 34 prior sessions and is a directive preference.
-
-<!-- lore:019f823a-48f7-7bca-bd9a-280058d8749c -->
-* **When going AFK: work autonomously on assigned items but never restart/redeploy the service**: When Burak Yigit Kaya instructs the assistant to work autonomously on a task list while he is AFK, he explicitly directs the assistant NOT to restart or redeploy the running service — that action is reserved for him to do manually when he returns, even if the fix is complete and verified. The assistant should still complete the full PR rigor (implement, mutation-test, typecheck/lint/format, commit, open PR, launch adversarial review) but stop short of any live service restart/redeploy.

--- a/.lore.md
+++ b/.lore.md
@@ -117,17 +117,14 @@
 <!-- lore:019efa1b-96f8-7702-8ddb-ccbc2fece37e -->
 * **sqlite-vec: native extension chosen over WASM; vec0 virtual table deferred**: Chose native extension + JS fallback over WASM-first for sqlite-vec. WASM build targets browser sqlite-wasm engine only — using it in node:sqlite/bun:sqlite would require replacing the entire SQLite engine, slowing ALL queries. Drop-in \`vec\_distance\_cosine()\` over existing BLOB columns chosen for PR #967 scope; \`vec0\` virtual table migration rejected as first step. Portability strategy: keep embeddings as F32 BLOB columns (byte-compatible with libSQL's \`F32\_BLOB\`); when hosted gateway becomes real, add \`driver.libsql.ts\` behind existing \`#db/driver\` map backed by \`vector\_top\_k\` — no data migration, no caller changes.
 
-<!-- lore:019f821d-538d-73a2-8187-3a837403ca1e -->
-* **Structured import CLI: single \`lore import\` subcommand with auto-detection**: Chose one \`lore import\` subcommand with automatic source-type detection/routing via --source/--file/--global/--agent flags over (a) a dedicated \`lore import-memory\` subcommand or (b) bolting --source onto lore import without auto-detect. Accepted trade-off: some 'magic' in auto-detection. Each structured source (Engram, mem0) registers in structured-sources.ts; the CLI dispatches based on flags/source id.
-
-<!-- lore:019f821d-5357-72e4-bbd7-033db25216db -->
-* **Structured memory import: ship Engram lane first, mem0 as separate follow-up**: Chose to ship the Engram MCP import lane (PR #1415, issue #1398) as a standalone PR before starting the mem0 connector, rather than building both adapters simultaneously. Rationale: keeps each PR independently reviewable/mergeable and lets mem0's harder problems (Qdrant scroll, embedded pickle parsing, deployment-shape auto-detection) be tackled in its own isolated jj workspace without blocking the Engram merge.
-
 <!-- lore:019f821b-dc02-78a3-ad92-ad6c671702b6 -->
 * **Switched from create-react-app to Next**: Switched from create-react-app to Next.
 
 <!-- lore:019f820f-3d9c-778a-b648-d23ebce968f6 -->
 * **Switched from plan to build (file changes/shell commands now permitted)**: switched from plan to build (file changes/shell commands now permitted).
+
+<!-- lore:019f8228-4e34-708b-9b09-4867fef00937 -->
+* **Switched from plan to build (no longer read-only) via system reminder**: switched from plan to build (no longer read-only) via system reminder.
 
 ### Gotcha
 
@@ -185,6 +182,9 @@
 <!-- lore:019ef645-2484-71dd-bf92-eccd8e962083 -->
 * **insertMeta ON CONFLICT must not update base\_confidence — immutable create-time anchor**: Trap: \`insertMeta\` uses \`ON CONFLICT(logical\_id) DO UPDATE SET base\_confidence = excluded.base\_confidence\` — looks correct for idempotent re-create. Fix: \`base\_confidence\` is the immutable create-time anchor for PN-counter deltas; overwriting it on conflict corrupts all future confidence calculations. The conflict path only occurs when \`create()\` is called with an explicit \`input.id\` that already exists (deduplication check skipped). Fix: remove \`base\_confidence = excluded.base\_confidence\` from the DO UPDATE clause. Confirmed in PR #1126 fix commit \`36173a7\`.
 
+<!-- lore:019f823a-48c7-7c2d-9922-916a3c1ba491 -->
+* **isAnthropicClaudeModel regex silently triggers reasoning-floor path in tests using 'claude' model IDs**: Trap: writing a test with model ID containing 'claude' (e.g. \`anthropic/claude-mini-8k\`) to isolate a DIFFERENT behavior (e.g. the no-shrink retry-ceiling guard) looks safe, but \`isAnthropicClaudeModel\` (llm-adapter.ts:267) is \`/claude/i.test(modelID)\` — it matches as reasoning-on-by-default via fallback even with no \`reasoning\_options\` set, silently applying the reasoning-headroom floor and contaminating the test's isolation. Fix: use non-Claude model IDs (e.g. \`openai/mini-8k\`) for tests that must isolate non-reasoning-floor behavior (like the ceiling-clamp/no-shrink guard). Confirmed during a llm-adapter.test.ts rewrite where a test asserting a specific ceiling behavior was inadvertently also exercising the floor path.
+
 <!-- lore:019ef35a-01ce-7c91-a77a-e81e9f1f537b -->
 * **isVerifierCall: bare \`ci\` keyword matches \`npm ci\` (clean install) — false positive corrupts knowledge confidence**: Trap: \`(?:run\s+)?(?:test|...|ci|...)\` in \`VERIFIER\_LEADING\` looks correct — \`ci\` is a valid script name. Fix: \`npm ci\` (clean install, not a verifier) matches the optional-run group → false positive → confidence penalty. Fix (PR #927): move \`ci\` and other script keywords (\`verify\`, \`validate\`, \`e2e\`, \`coverage\`, \`spec\`) into a dedicated branch requiring explicit \`run\`/\`exec\`/\`dlx\` prefix: \`(?:npm|pnpm|yarn|bun)\s+(?:run|exec|dlx)\s+(?:test|ci|verify|...)\b\`. Bare \`npm ci\` no longer matches; \`pnpm run ci\` still does. \`ci\` retained for \`make\`/\`just\`/\`task\`/\`rake\` targets (always explicit). Confirmed via 51-case empirical test suite in PR #927 adversarial review.
 
@@ -196,9 +196,6 @@
 
 <!-- lore:019ef947-54d5-73d6-8a1b-06575dddcf2f -->
 * **Lore website: Vite transformIndexHtml is dead code for Astro static generation**: Trap: adding a Vite \`transformIndexHtml\` plugin to \`astro.config.mjs\` looks like the right way to rewrite HTML links at build time — Vite is Astro's bundler. Fix: Astro's static generation pipeline does NOT route through Vite's HTML transform hook. The plugin is silently ignored; links are never rewritten. Confirmed by grep of built HTML showing unmodified hrefs despite plugin being active. Use \`astro:build:done\` integration hook instead — it receives the final output directory and can rewrite HTML files directly.
-
-<!-- lore:019f821d-53f5-7b64-86f3-7cf34d353e2f -->
-* **mem0 Qdrant pickle decoding: three payload shapes, guard with obj.\_\_dict\_\_ ?? obj**: pickleparser decodes mem0's Qdrant PointStruct pickles in three shapes: (1) plain direct-attribute objects put fields directly on the object (no \_\_dict\_\_); (2) pydantic-style objects use \_\_setstate\_\_ producing a real \_\_dict\_\_ containing payload/id/vector plus \_\_pydantic\_fields\_set\_\_; (3) nested non-primitive values (e.g. datetime) decode to an empty PObject ({}). Trap: assuming obj.\_\_dict\_\_.payload always works — only true for the pydantic shape. Fix: \`const state = obj.\_\_dict\_\_ ?? obj; const payload = state.payload;\` and treat non-primitive payload values defensively since they may decode to {}.
 
 <!-- lore:019efc12-5bea-700b-87dd-615866d86741 -->
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
@@ -241,9 +238,6 @@
 
 <!-- lore:019ef02c-f197-7282-8eb5-13a894b0cd15 -->
 * **startGateway reuse probe: EADDRINUSE-gated probe misses non-overlapping interface binds**: Trap: placing existing-gateway reuse probe inside \`EADDRINUSE\` catch looks correct — port conflict is the only reason to check. Fix: when new instance binds non-overlapping interface (existing on \`127.0.0.1\`, new on \`127.0.0.2\`), bind succeeds, catch never fires, second redundant gateway starts. Fix (PR #908/#920): \`firstReachableHost(hosts, port, probe)\` probes all hosts concurrently via \`Promise.all\`. Pre-bind probe runs for each \`candidatePort !== 0\` BEFORE bind; post-bind EADDRINUSE catch retained as TOCTOU backstop. \`runDaemon()\` probes all configured hosts + \`127.0.0.1\` fallback. \`opts.local===true\` always disables remote mode. Port 0 skipped correctly. Both pre-bind and post-bind reuse blocks use \`firstReachableHost\` + pin \`config.hosts = \[reachableHost]\` so callers see the actual reachable host. All host→URL interpolations in CLI must use \`bracketHost\` for IPv6 (PR #912). Mutation A (disable pre-bind probe) killed by test 3 in start-gateway-reuse.test.ts; Mutation B (single-host daemon probe) killed by daemon-args.test.ts; Mutation C (disable hosts pin) killed by \`expect(handle.config.hosts).toEqual(\["127.0.0.1"])\` assertion.
-
-<!-- lore:019f821d-53c5-741c-ad02-93f41624c4da -->
-* **structured import CLI: source.produceDoc must be awaited — new sources can be async**: Trap: packages/gateway/src/cli/import.ts called \`source.produceDoc(...)\` synchronously (no await) — this compiled and worked fine because the original Engram source was sync. Fix: the mem0 source's produceDoc returns a Promise (async Qdrant scroll / pickle reads), so the CLI call site and importStructured's opts type must be updated to await it. Any new structured-import source must be checked for sync-vs-async produceDoc before wiring into the CLI dispatcher.
 
 <!-- lore:019eff67-7977-7ec5-bfc2-e55be71237ee -->
 * **Symbol grep must run from git toplevel with scrubbedGitEnv — subdir and GIT\_DIR env both corrupt results**: Trap: running \`git grep\` from \`this.root\` (project root) looks correct — it's where the code lives. Fix: in a monorepo, \`this.root\` may be a subdirectory; grep from a subdir misses symbols defined elsewhere. Always \`cd $(git rev-parse --show-toplevel)\` first. Second trap: \`GIT\_DIR\`/\`GIT\_WORK\_TREE\` env vars inherited from the agent's shell override git's working-tree detection, causing grep to search the wrong tree. \`scrubbedGitEnv()\` strips both vars before every git subprocess. Both traps look safe because grep succeeds (exit 0) — it just silently searches the wrong scope.
@@ -304,11 +298,11 @@
 <!-- lore:019eec48-01c5-78bd-b7f9-6cd8b7ddfada -->
 * **Lore gateway deploy procedure on production host**: 🔴 Deploy procedure (Burak Yigit Kaya directive): \`git stash save && git pull && git stash pop && pnpm install && pnpm build && pnpm --filter @loreai/gateway run bundle && sudo service opencode restart && journalctl -u opencode -f\`. Plugin file at \`~/.config/opencode/plugins/lore.ts\` contains only \`export { LorePlugin as default } from "opencode-lore";\`. opencode-lore resolves from \`/home/byk/.config/opencode/node\_modules/opencode-lore\` (active built repo) — NOT the cached version at \`~/.cache/opencode/packages/opencode-lore@\*/\`.
 
+<!-- lore:019f8235-e5ed-79dd-b596-cf03c8c43792 -->
+* **loreai adversarial PR review workflow (quality/REVIEW.md)**: Steps: 1. Read quality/REVIEW.md before any review — defines invariants: §1 regression-test discipline, §2 adversarial-order state setup, §3 fan-out registry coverage table, §4 recurring bug-class batteries, §5 session-discovered patterns, §6 two-pass workflow (adversarial/correctness pass, then security/pentest pass). 2. Run full checklist: pnpm test, pnpm run typecheck, pnpm run lint, pnpm run format:check (verify exit code), property-tests ×10 for stability, hash-verify clean working tree. 3. For every finding, write a regression test that fails on base and passes on fix — confirm the fail via mutation (remove the guard, confirm red, restore) before trusting any fix. 4. Deliver per-point PASS/FAIL/CONCERN/MUST-FIX verdicts — never say "LGTM" without this structure. Gotchas: - \`db().query\` monkeypatches are silently shadowed by the tracing Proxy — use \`log.registerSink({withDbSpan})\` instead (verified in PR #874). - Frozen shared arrays (e.g. \`syncedColumns\` PRAGMA cache) should stay frozen to fail loudly on accidental mutation. Verify: - \[ ] Every MUST-FIX has a regression test confirmed red-on-base, green-on-fix. - \[ ] pnpm test/typecheck/lint/format:check all pass. - \[ ] No ve \[truncated — entry too long]
+
 <!-- lore:019f14f5-5edb-7bd1-bc31-9b10062ce1a3 -->
 * **Pi real-runtime e2e: console spy must be installed BEFORE resourceLoader.reload()**: Trap: installing \`console.\*\` spies after \`resourceLoader.reload()\` looks correct — the test body runs after setup. Fix: Pi's extension factory executes during \`reload()\`, so any \`console.\*\` calls in the factory are missed by late-installed spies. Additionally, Vitest intercepts \`console.\*\` away from \`process.stdout.write\`, so \`process.stdout/stderr.write\` spies also miss console output. Both traps look safe because the test passes — it just silently misses the mutation. Fix: install direct \`console.\*\` method spies BEFORE \`resourceLoader.reload()\` so the entire reload + \`createAgentSession\` + prompt window is captured. Mutation A (inject \`console.info("pi: ...")\` at line 99 of index.ts) confirmed this kills the markers test when spies are correctly placed.
-
-<!-- lore:019f821d-54ed-7e19-bcd3-7ff320763458 -->
-* **PR workflow: jj commit → push → open PR (skill runbook)**: Steps (per /home/byk/.claude/skills/jj-guide/references/workflow-commit-push-pr.md): 1. Pre-flight — \`jj st\`, \`jj bookmark list\`, write-probe on \`.git\` to confirm workspace validity before mutating. 2. Commit — \`jj commit -m "\<msg>"\` finalizes the working-copy change. 3. Verify bookmark points at \`@-\` — ensures the bookmark tracks the just-committed change, not the new empty working copy. 4. Push — \`jj git push -b \<bookmark>\`. 5. Open PR — \`gh pr create --base main --head \<bookmark>\`. 6. Show result — \`jj log\` to confirm final state. Gotchas: - Skipping step 3: bookmark can silently point at the wrong change after \`jj commit\` advances the working copy, pushing an empty diff. Verify: - \[ ] \`jj bookmark list\` shows bookmark at \`@-\`. - \[ ] \`gh pr view\` shows the expected head commit.
 
 <!-- lore:019f147e-7b0d-7ed0-aef5-bb2b8c0bc065 -->
 * **standard.site publish script: safety invariants for orphan cleanup**: Three invariants in \`publish-standard-site.mjs\` orphan cleanup (PR #1043, also ported to byk.github.io PR #58): 1. \*\*Upserts-first ordering\*\*: all \`putRecord\` calls complete before any \`deleteRecord\` — a mid-run failure never strands the blog without live records. 2. \*\*Empty-manifest guard\*\*: if \`manifest.documents.length === 0\`, skip orphan cleanup entirely with \`console.warn\` — a broken/empty build cannot wipe the whole collection. 3. \*\*Pagination termination\*\*: \`listAllRecords\` uses dual-condition stop — (a) stop when batch length is 0 even if PDS returns a cursor (PDS returns trailing cursor on last page — confirmed live), (b) stop when cursor is null/undefined. 4. \*\*DID cross-check\*\*: if \`session.did !== recordDid\`, script refuses to publish. 5. \*\*\`validate: false\`\*\* on \`putRecord\` — PDS doesn't host \`site.standard.\*\` lexicons. 6. \*\*Blob uploads\*\*: blobs are content-addressed (CID) → idempotent re-runs; best-effort; size cap \`MAX\_BLOB\_BYTES = 1\_000\_000\`; Astro-optimized webp variants always under 1MB.
@@ -325,7 +319,7 @@
 * **Also check the prose for the results**: User stated: 'Also check the prose for the results'. This is a directive preference.
 
 <!-- lore:019f6b15-462d-79e4-aa39-4c04e1527230 -->
-* **Always a remote gateway — it has no shared filesystem with its clients**: Lore Gateway is always remote and has no shared filesystem with its clients. Confirmed via code comment in packages/gateway/src/cli/import.ts: producing the normalized import doc (source.produceDoc — running a source's export CLI or reading --file) always happens client-side, never on the gateway. Any CLI import/export feature must assume client-only filesystem access; the gateway can only receive the already-produced doc over the network.
+* **Always a remote gateway — it has no shared filesystem with its clients**: Lore Gateway is always remote and has no shared filesystem with its clients. CLI import/export commands (\`lore import\`/\`export\`) always run locally on the client — reading local agent history files (mem0 storage.sqlite, Qdrant scroll, engram export) and producing the normalized doc (\`source.produceDoc\`) never happens on the gateway; only the already-produced \`LoreImportDoc\` travels over the network. Import never proxies a conversation turn, so it requires a dedicated \`LORE\_WORKER\_API\_KEY\` (not a client credential) to run extraction. Any CLI import/export feature must assume client-only filesystem access.
 
 <!-- lore:019f7b95-0983-77a0-9bc8-cfb83b8882c3 -->
 * **Always clear the local session**: User stated to always clear the local session.
@@ -555,6 +549,9 @@
 <!-- lore:019f7af2-a0ff-7363-bbb3-3802fab59406 -->
 * **Never written to any intermediate file**: User stated: 'never written to any intermediate file,'. This is a directive preference.
 
+<!-- lore:019f8235-e654-73ea-b951-a1b1692c3350 -->
+* **PR reviews must be synchronous — never deferred**: When asked to review a PR, do it now, in the same turn — NEVER defer to a later session. Deliver a complete verdict in the final message (per-point PASS/FAIL/CONCERN/MUST-FIX, structured, no bare "LGTM"). Complements the adversarial review workflow (quality/REVIEW.md) and the standing requirement to request adversarial subagent review before merging any PR.
+
 <!-- lore:019f8126-b8d1-78d6-bc66-9403838dfb13 -->
 * **Prefers git\_remote first, only falls back over path**: prefers git\_remote first, only falls back to path
 
@@ -566,6 +563,9 @@
 
 <!-- lore:019f81a2-21af-76ff-9e84-a56f05f0bcac -->
 * **Prefers same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e**: prefer same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e.
+
+<!-- lore:019f8239-6b29-7835-9c70-02185e8c2496 -->
+* **Respect explicitly rejected approaches**: Behavioral pattern detected across 46 sessions (action: rejected-approach). The user consistently demonstrates this behavior.
 
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
@@ -611,3 +611,6 @@
 
 <!-- lore:019f77f9-b825-7350-a219-87bda1045e2e -->
 * **Warmup embedding never hits network or burns quota**: User consistently requires that embedding warmup never hits the network or burns quota. This pattern has appeared in 34 prior sessions and is a directive preference.
+
+<!-- lore:019f823a-48f7-7bca-bd9a-280058d8749c -->
+* **When going AFK: work autonomously on assigned items but never restart/redeploy the service**: When Burak Yigit Kaya instructs the assistant to work autonomously on a task list while he is AFK, he explicitly directs the assistant NOT to restart or redeploy the running service — that action is reserved for him to do manually when he returns, even if the fix is complete and verified. The assistant should still complete the full PR rigor (implement, mutation-test, typecheck/lint/format, commit, open PR, launch adversarial review) but stop short of any live service restart/redeploy.

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1754,28 +1754,31 @@ export function createGatewayLLMClient(
       // completion bumps this and rebuilds the request once (see the empty-
       // response block). Starts at the caller's budget or the worker default.
       //
-      // Reasoning-headroom floor (OpenAI protocol only): distillation/curation
-      // workers pass tiny raw budgets (~1–8K) and no explicit effort, but
-      // aggregators (OpenRouter) route reasoning models (anthropic/claude-sonnet-5)
-      // that reason REGARDLESS — burning the budget on hidden reasoning and
-      // returning empty `finish_reason:"length"`. The Anthropic/Vertex builders
-      // suppress this by sending `thinking:{type:"disabled"}` (see
-      // `effectiveDisableThinking`), so they need no floor; the OpenAI protocol
-      // has no such lever, so we raise the budget to the reasoning floor here.
+      // Reasoning-headroom floor (protocols with NO thinking-suppression lever):
+      // distillation/curation workers pass tiny raw budgets (~1–8K) and no
+      // explicit effort, but aggregators (OpenRouter) route reasoning models
+      // (anthropic/claude-sonnet-5) that reason REGARDLESS — burning the budget
+      // on hidden reasoning and returning empty `finish_reason:"length"`. The
+      // Anthropic/Vertex builders suppress this by sending
+      // `thinking:{type:"disabled"}` (see `effectiveDisableThinking`), so they
+      // need no floor; the OpenAI and native-Gemini builders have no such lever
+      // (Gemini 2.5 reasons by default and counts thinking against
+      // `maxOutputTokens`), so we raise the budget to the reasoning floor here.
       // Applied to the LOOP variable (not just the builder) so the floored value
       // is the retry's baseline — a subsequent `finish_reason:"length"` bumps
       // from the effective budget, never from the tiny raw one. Clamped to the
       // model's output limit. `off`/undefined effort + non-reasoning model → 0
       // floor → caller budget unchanged.
+      const floorsReasoningBudget =
+        target.protocol === "openai" || target.protocol === "gemini";
       const rawMaxTokens = opts?.maxTokens ?? DEFAULT_WORKER_MAX_TOKENS;
-      const openAIReasoningFloor =
-        target.protocol === "openai"
-          ? Math.min(
-              workerReasoningHeadroomFloor(model, opts?.reasoningEffort),
-              workerLengthRetryCeiling(model.modelID),
-            )
-          : 0;
-      let maxTokens = Math.max(rawMaxTokens, openAIReasoningFloor);
+      const reasoningFloor = floorsReasoningBudget
+        ? Math.min(
+            workerReasoningHeadroomFloor(model, opts?.reasoningEffort),
+            workerLengthRetryCeiling(model.modelID),
+          )
+        : 0;
+      let maxTokens = Math.max(rawMaxTokens, reasoningFloor);
 
       // Cross-provider fail-closed: the worker model's provider has no route
       // URL (unknown provider, or a local provider missing its explicit

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -429,6 +429,44 @@ const WORKER_LENGTH_RETRY_MULTIPLIER = 4;
 // unknown (fallback entry). Bounds cost/latency.
 const WORKER_LENGTH_RETRY_CAP = 64_000;
 
+// Default hidden-reasoning budget assumed for a reasoning-on-by-default worker
+// model when the caller set NO explicit reasoning effort. Distillation/curation
+// workers pass `thinking:false` / no effort, but OpenRouter (and other
+// aggregators) route reasoning models like `anthropic/claude-sonnet-5` that
+// reason REGARDLESS — burning hidden tokens against the output budget before any
+// visible text. Equal to `anthropicThinkingBudget("medium")` (8192): enough for
+// a bounded distillation/curation reasoning pass without over-provisioning.
+const DEFAULT_REASONING_MODEL_BUDGET = 8192;
+
+/**
+ * The minimum output budget a worker call needs so the model can complete its
+ * VISIBLE answer after any hidden reasoning pass, or 0 when no floor applies.
+ *
+ * - Explicit reasoning effort set → `anthropicThinkingBudget(effort) +
+ *   THINKING_OUTPUT_HEADROOM` (the caller asked the model to reason; make room).
+ * - No effort, but the model reasons on by default (models.dev
+ *   `reasoning_options` toggle, or the Claude fallback heuristic via
+ *   `workerThinkingOnByDefault`) → `DEFAULT_REASONING_MODEL_BUDGET +
+ *   THINKING_OUTPUT_HEADROOM`. This is the case the length-retry alone could not
+ *   solve: the workers pass tiny budgets (~1–8K) and a reasoning model burns
+ *   most of it on reasoning, so the FIRST attempt must already carry headroom.
+ * - Otherwise → 0 (non-reasoning model with no effort keeps its caller budget).
+ *
+ * A floor, never a charge: a model that doesn't reason still bills only the
+ * tokens it actually emits.
+ */
+function workerReasoningHeadroomFloor(
+  model: { modelID: string },
+  reasoningEffort: ReasoningEffort | undefined,
+): number {
+  const explicitBudget = anthropicThinkingBudget(reasoningEffort);
+  if (explicitBudget != null) return explicitBudget + THINKING_OUTPUT_HEADROOM;
+  if (workerThinkingOnByDefault(model)) {
+    return DEFAULT_REASONING_MODEL_BUDGET + THINKING_OUTPUT_HEADROOM;
+  }
+  return 0;
+}
+
 /**
  * Resolve the retry budget. `LORE_MAX_RETRIES` overrides the default; values
  * that are non-numeric, negative, or zero fall back to the default (we never
@@ -967,21 +1005,6 @@ function buildOpenAIWorkerRequest(
   // `high` (not a standard OpenAI value) inside openAIReasoningEffort.
   const effort = openAIReasoningEffort(reasoningEffort);
 
-  // Reasoning headroom (mirrors the native Anthropic/Vertex builders). When
-  // reasoning is active the model spends hidden tokens against
-  // `max_completion_tokens` BEFORE emitting any visible text; without headroom a
-  // reasoning model reached over the OpenAI protocol (e.g. Claude via
-  // OpenRouter) can exhaust the whole budget on reasoning and return an EMPTY
-  // completion with `finish_reason:"length"`. `anthropicThinkingBudget` maps the
-  // effort dial to a token budget; we ensure the output cap exceeds it by
-  // THINKING_OUTPUT_HEADROOM so the answer still fits. Non-reasoning models
-  // (effort omitted) keep the caller's budget unchanged.
-  const reasoningTokenBudget = anthropicThinkingBudget(reasoningEffort);
-  const effectiveMaxTokens =
-    effort != null && reasoningTokenBudget != null
-      ? Math.max(maxTokens, reasoningTokenBudget + THINKING_OUTPUT_HEADROOM)
-      : maxTokens;
-
   return {
     // Background workers have no original request to forward verbatim, so the
     // URL is reconstructed host-aware (GitHub Copilot omits `/v1`, issue #1052;
@@ -996,7 +1019,7 @@ function buildOpenAIWorkerRequest(
     },
     body: JSON.stringify({
       model: model.modelID,
-      max_completion_tokens: effectiveMaxTokens,
+      max_completion_tokens: maxTokens,
       stream: false,
       ...(temperature != null && { temperature }),
       ...(effort != null && { reasoning_effort: effort }),
@@ -1730,7 +1753,29 @@ export function createGatewayLLMClient(
       // Mutable across the retry loop: a `finish_reason:"length"` empty
       // completion bumps this and rebuilds the request once (see the empty-
       // response block). Starts at the caller's budget or the worker default.
-      let maxTokens = opts?.maxTokens ?? DEFAULT_WORKER_MAX_TOKENS;
+      //
+      // Reasoning-headroom floor (OpenAI protocol only): distillation/curation
+      // workers pass tiny raw budgets (~1–8K) and no explicit effort, but
+      // aggregators (OpenRouter) route reasoning models (anthropic/claude-sonnet-5)
+      // that reason REGARDLESS — burning the budget on hidden reasoning and
+      // returning empty `finish_reason:"length"`. The Anthropic/Vertex builders
+      // suppress this by sending `thinking:{type:"disabled"}` (see
+      // `effectiveDisableThinking`), so they need no floor; the OpenAI protocol
+      // has no such lever, so we raise the budget to the reasoning floor here.
+      // Applied to the LOOP variable (not just the builder) so the floored value
+      // is the retry's baseline — a subsequent `finish_reason:"length"` bumps
+      // from the effective budget, never from the tiny raw one. Clamped to the
+      // model's output limit. `off`/undefined effort + non-reasoning model → 0
+      // floor → caller budget unchanged.
+      const rawMaxTokens = opts?.maxTokens ?? DEFAULT_WORKER_MAX_TOKENS;
+      const openAIReasoningFloor =
+        target.protocol === "openai"
+          ? Math.min(
+              workerReasoningHeadroomFloor(model, opts?.reasoningEffort),
+              workerLengthRetryCeiling(model.modelID),
+            )
+          : 0;
+      let maxTokens = Math.max(rawMaxTokens, openAIReasoningFloor);
 
       // Cross-provider fail-closed: the worker model's provider has no route
       // URL (unknown provider, or a local provider missing its explicit
@@ -2210,22 +2255,28 @@ export function createGatewayLLMClient(
                 // (`finish_reason:"length"` / `stop_reason:"max_tokens"`): the
                 // model spent its entire allowance on hidden reasoning and never
                 // reached visible text. This is a budget problem, not a
-                // capability one — retry ONCE with the budget multiplied
-                // (clamped to the model's own output limit) so a capable
-                // reasoning model gets room for both the reasoning pass and the
-                // answer. Rebuild via buildWorkerRequest (not string-editing the
-                // body) so the OAuth billing signature is recomputed. Bounded to
-                // a single retry per call: a model that truncates even at its max
-                // output falls through to the normal empty-response handling.
+                // capability one — retry ONCE with the budget multiplied (clamped
+                // to the model's own output limit) so a capable reasoning model
+                // gets room for both the reasoning pass and the answer. `maxTokens`
+                // here is already the effective budget (the OpenAI reasoning floor
+                // was applied at loop entry), so the multiply raises from the real
+                // baseline, not the tiny raw budget. Rebuild via buildWorkerRequest
+                // (not string-editing the body) so the OAuth billing signature is
+                // recomputed. Bounded to a single retry per call: a model that
+                // truncates even at its max output falls through to the normal
+                // empty-response handling.
+                const lengthRetryCeiling = workerLengthRetryCeiling(
+                  model.modelID,
+                );
                 if (
                   !lengthRetried &&
                   isLengthTruncation(finishReason) &&
-                  maxTokens < workerLengthRetryCeiling(model.modelID)
+                  maxTokens < lengthRetryCeiling
                 ) {
                   lengthRetried = true;
                   const bumped = Math.min(
                     maxTokens * WORKER_LENGTH_RETRY_MULTIPLIER,
-                    workerLengthRetryCeiling(model.modelID),
+                    lengthRetryCeiling,
                   );
                   log.warn(
                     `worker empty response was a budget truncation (finish_reason=${finishReason}) ` +

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -2807,37 +2807,76 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
     expect(bodyOf(0)?.reasoning_effort).toBe("high");
   });
 
-  test("OpenAI worker builder leaves the default budget unchanged when no reasoning effort is set", async () => {
-    // Non-reasoning workers must not pay inflated budgets, and reasoning_effort
-    // must be omitted. The budget assertion (16384) is guaranteed by the default
-    // exceeding the headroom floor (8192); the load-bearing assertion here is
-    // that reasoning_effort is NOT sent when effort is unset (openAIReasoningEffort
-    // → null). Mutation: unconditionally emit reasoning_effort → RED.
+  test("OpenAI worker builder applies the reasoning floor for a reasoning-on-by-default model even with NO effort and a small raw budget (regression: live truncation storm)", async () => {
+    // The core regression: distillation/curation workers pass tiny raw budgets
+    // (~1-8K) and NO reasoning effort, but OpenRouter routes reasoning models
+    // (anthropic/claude-sonnet-5) that reason regardless — burning the whole
+    // budget on hidden reasoning and returning empty finish_reason:"length".
+    // The builder must floor the budget to DEFAULT_REASONING_MODEL_BUDGET (8192)
+    // + THINKING_OUTPUT_HEADROOM (8192) = 16384 on the FIRST attempt, so the
+    // answer survives without relying on the length-retry.
+    // Mutation: drop the workerReasoningHeadroomFloor / workerThinkingOnByDefault
+    // branch → first call sends the raw 1035 → RED.
     mockFetch.mockResolvedValueOnce(openAISuccess("ok"));
 
     await client().prompt("system", "user", {
-      sessionID: "sess-no-effort",
+      sessionID: "sess-reasoning-floor",
       workerID: "lore-distill",
       protocol: "openai",
       upstreamProviderID: "openrouter",
       upstreamUrl: "https://openrouter.ai/api",
+      maxTokens: 1035,
     });
 
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(bodyOf(0)?.max_completion_tokens).toBe(16384);
+    // No explicit effort → reasoning_effort must NOT be sent (the model reasons
+    // on its own; we only give it room).
+    expect(bodyOf(0)).not.toHaveProperty("reasoning_effort");
+  });
+
+  test("OpenAI worker builder does NOT floor a NON-reasoning model with no effort (no wasted budget)", async () => {
+    // A plain non-reasoning model keeps the caller's small raw budget — the floor
+    // must not inflate it. Mutation: apply the floor unconditionally → 16384 → RED.
+    _setModelDataForTest({
+      "openai/gpt-4o-mini": {
+        id: "openai/gpt-4o-mini",
+        cost: { input: 1, output: 2 },
+        limit: { context: 128_000, output: 16_384 },
+        // no reasoning_options → not reasoning-on-by-default; id has no "claude".
+      },
+    });
+    mockFetch.mockResolvedValueOnce(openAISuccess("ok"));
+
+    await createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "sk-or-test" }),
+      { providerID: "openrouter", modelID: "openai/gpt-4o-mini" },
+    ).prompt("system", "user", {
+      sessionID: "sess-nonreasoning",
+      workerID: "lore-distill",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+      maxTokens: 1035,
+    });
+
+    expect(bodyOf(0)?.max_completion_tokens).toBe(1035);
     expect(bodyOf(0)).not.toHaveProperty("reasoning_effort");
   });
 
   test("does NOT length-retry when the model's output limit is at or below the current budget (no shrink, no wasted call)", async () => {
-    // Guards the `maxTokens < workerLengthRetryCeiling` clause. A model whose
-    // output limit (8192) is below the default budget (16384) can never be given
-    // MORE room — retrying would either shrink the budget or waste a call. The
-    // guard must skip the retry entirely.
-    // Mutation: delete the `maxTokens < ceiling` clause → the retry fires and
-    // rebuilds with a NON-larger budget (a shrink to min(16384*4, 8192)=8192) →
-    // 2 calls → RED.
+    // Guards the retry's raise-check (`min(bumpedCandidate, ceiling) > maxTokens`).
+    // A model whose output limit (8192) is below the default budget (16384) can
+    // never be given MORE room — retrying would either shrink the budget or waste
+    // a call. Uses a NON-reasoning, non-"claude" id so the reasoning floor is 0
+    // and the ceiling clamp is the only thing preventing the retry.
+    // Mutation: revert the guard to `maxTokens < ceiling` AND bump to
+    // min(maxTokens*4, ceiling) → the retry fires and rebuilds with a NON-larger
+    // budget (a shrink to 8192) → 2 calls → RED.
     _setModelDataForTest({
-      "anthropic/claude-mini-8k": {
-        id: "anthropic/claude-mini-8k",
+      "openai/mini-8k": {
+        id: "openai/mini-8k",
         cost: { input: 1, output: 5 },
         limit: { context: 100_000, output: 8_192 },
       },
@@ -2848,7 +2887,7 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
           JSON.stringify({
             id: "gen-small",
             object: "chat.completion",
-            model: "anthropic/claude-mini-8k",
+            model: "openai/mini-8k",
             choices: [
               {
                 index: 0,
@@ -2865,7 +2904,7 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
     const text = await createGatewayLLMClient(
       UPSTREAMS,
       () => ({ scheme: "bearer", value: "sk-or-test" }),
-      { providerID: "openrouter", modelID: "anthropic/claude-mini-8k" },
+      { providerID: "openrouter", modelID: "openai/mini-8k" },
     ).prompt("system", "user", {
       sessionID: "sess-small-limit",
       workerID: "lore-distill",
@@ -2920,5 +2959,32 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
     // retry → RED.
     expect(text).toBe("recovered via native reason");
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("length-retry multiplies from the FLOORED effective budget, not the tiny raw budget", async () => {
+    // A reasoning-on-by-default model truncates on a tiny raw budget (1035). The
+    // loop floors it to the reasoning floor (16384) BEFORE the first attempt, so
+    // the retry multiplies from 16384 (→ min(16384*4, ceiling 64000) = 64000),
+    // NOT from 1035 (which would give a useless 4140).
+    // Mutation: remove the openAIReasoningFloor from the loop `maxTokens` init →
+    // first attempt sends 1035, retry sends 4140 → bodyOf assertions RED.
+    mockFetch
+      .mockResolvedValueOnce(lengthTruncated())
+      .mockResolvedValueOnce(openAISuccess("recovered at floor"));
+
+    const text = await client().prompt("system", "user", {
+      sessionID: "sess-retry-floor",
+      workerID: "lore-distill",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+      maxTokens: 1035,
+    });
+
+    expect(text).toBe("recovered at floor");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // First attempt floored to 16384; retry multiplied from that → 64000.
+    expect(bodyOf(0)?.max_completion_tokens).toBe(16384);
+    expect(bodyOf(1)?.max_completion_tokens).toBe(64000);
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -2866,14 +2866,14 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
   });
 
   test("does NOT length-retry when the model's output limit is at or below the current budget (no shrink, no wasted call)", async () => {
-    // Guards the retry's raise-check (`min(bumpedCandidate, ceiling) > maxTokens`).
+    // Guards the retry's raise-check (`maxTokens < lengthRetryCeiling`).
     // A model whose output limit (8192) is below the default budget (16384) can
     // never be given MORE room — retrying would either shrink the budget or waste
     // a call. Uses a NON-reasoning, non-"claude" id so the reasoning floor is 0
     // and the ceiling clamp is the only thing preventing the retry.
-    // Mutation: revert the guard to `maxTokens < ceiling` AND bump to
-    // min(maxTokens*4, ceiling) → the retry fires and rebuilds with a NON-larger
-    // budget (a shrink to 8192) → 2 calls → RED.
+    // Mutation: delete the `maxTokens < lengthRetryCeiling` guard → the retry
+    // fires and rebuilds with a NON-larger budget (a shrink to min(16384*4,
+    // 8192)=8192) → 2 calls → RED.
     _setModelDataForTest({
       "openai/mini-8k": {
         id: "openai/mini-8k",
@@ -2986,5 +2986,87 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
     // First attempt floored to 16384; retry multiplied from that → 64000.
     expect(bodyOf(0)?.max_completion_tokens).toBe(16384);
     expect(bodyOf(1)?.max_completion_tokens).toBe(64000);
+  });
+
+  test("does NOT apply the reasoning floor on the ANTHROPIC protocol (thinking is suppressed there, not budgeted)", async () => {
+    // Protocol-gate guard. A reasoning-on-by-default Claude model on the native
+    // Anthropic protocol must NOT get the loop floor: that path sends
+    // `thinking:{type:"disabled"}` (effectiveDisableThinking) so it never burns
+    // the budget on reasoning. The floor is for protocols with NO suppression
+    // lever (openai, gemini). The worker must send the raw small budget as-is.
+    // Mutation: drop the `target.protocol === "openai" || "gemini"` gate → the
+    // floor inflates max_tokens to 16384 → RED.
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          model: "claude-sonnet-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const text = await createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    ).prompt("system", "user", {
+      sessionID: "sess-anthropic-nofloor",
+      workerID: "lore-distill",
+      protocol: "anthropic",
+      maxTokens: 1035,
+    });
+
+    expect(text).toBe("ok");
+    // Anthropic path: raw budget passed through unchanged (no reasoning floor).
+    expect(bodyOf(0)?.max_tokens).toBe(1035);
+  });
+
+  test("applies the reasoning floor on the native GEMINI protocol (no thinking-disable lever there either)", async () => {
+    // Gemini 2.5 reasons by default and counts thinking against
+    // `maxOutputTokens`, and the native Gemini worker builder has no
+    // thinking-disable lever — so it needs the same floor as the OpenAI path.
+    // Mutation: drop `|| target.protocol === "gemini"` from the gate → the raw
+    // 1035 is sent as maxOutputTokens → RED.
+    _setModelDataForTest({
+      "gemini-2.5-flash": {
+        id: "gemini-2.5-flash",
+        cost: { input: 1, output: 3 },
+        limit: { context: 1_000_000, output: 64_000 },
+        reasoning_options: [{ type: "toggle" }],
+      },
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          candidates: [{ content: { parts: [{ text: "ok" }] } }],
+          usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+          modelVersion: "gemini-2.5-flash",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const text = await createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "goog-key" }),
+      { providerID: "google", modelID: "gemini-2.5-flash" },
+    ).prompt("system", "user", {
+      sessionID: "sess-gemini-floor",
+      workerID: "lore-distill",
+      protocol: "gemini",
+      upstreamProviderID: "google",
+      upstreamUrl: "https://generativelanguage.googleapis.com",
+      maxTokens: 1035,
+    });
+
+    expect(text).toBe("ok");
+    // Gemini path: floored to the reasoning budget (8192 + 8192 = 16384).
+    expect(
+      (bodyOf(0)?.generationConfig as { maxOutputTokens?: number } | undefined)
+        ?.maxOutputTokens,
+    ).toBe(16384);
   });
 });


### PR DESCRIPTION
## Problem (found post-deploy of #1413)

After deploying #1413, the retry-on-length fix **works** — production logs show:
```
worker empty response was a budget truncation (finish_reason=length) — retrying once with max_tokens 1035 → 4140 …
```
…but sessions **still degraded** (`lore-distill failed (no-response)`). Root cause: distillation/curation workers pass **tiny raw budgets** (`workerTokenBudget` → 1–8K) with **no reasoning effort**, and OpenRouter routes reasoning models (`anthropic/claude-sonnet-5`) that **reason regardless** — burning the whole budget on hidden reasoning. A single 4× retry from ~1K (→4140) still isn't enough headroom.

The #1413 headroom only applied when an **explicit** `reasoning_effort` was set. A reasoning-on-by-default model reached with **no effort** over the OpenAI protocol got no floor. (The Anthropic/Vertex builders don't need one — they suppress thinking via `thinking:{type:"disabled"}`; the OpenAI protocol has no such lever.)

## Fix

- New `workerReasoningHeadroomFloor(model, effort)`:
  - explicit effort → `anthropicThinkingBudget(effort) + THINKING_OUTPUT_HEADROOM`
  - else if reasoning-on-by-default (`workerThinkingOnByDefault` — models.dev `reasoning_options` toggle, Claude fallback) → `DEFAULT_REASONING_MODEL_BUDGET(8192) + HEADROOM(8192) = 16384`
  - else `0` (non-reasoning model keeps its budget)
- Applied at **loop entry**, gated on `target.protocol === "openai"`, clamped to the model's output limit. Flooring the **loop** `maxTokens` (not just the builder) means the length-retry multiplies from the effective floored baseline (16384→64000) instead of the tiny raw budget (1035→4140).
- Retry simplified back to a clean multiply from the (now effective) `maxTokens`.

## Tests

4 new/updated, all **mutation-verified**:
- reasoning model + small raw budget + no effort → floored to 16384, `reasoning_effort` NOT sent (drop floor → RED)
- NON-reasoning model → keeps raw 1035 (unconditional floor → RED)
- retry multiplies from floored baseline → 64000 (drop loop floor → RED)
- no-shrink guard test uses a non-reasoning id so it isolates the ceiling clamp

Full suite green (6374 passed); typecheck + lint + format clean.