### PR TITLE
feat(provenance): capture tool_calls.input_path (file-provenance foundation)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -387,6 +387,9 @@
 <!-- lore:019f83d2-e6cb-753d-8d08-8622859ecfa8 -->
 * **Explicit investigation/research requests are read-only — no file modification**: When Burak Yigit Kaya explicitly frames a task as investigation/research (e.g. "do NOT modify any files"), treat it as strictly read-only: answer with file:line evidence, don't make edits even if a fix seems obvious. This is distinct from the adversarial PR-review workflow \[\[019f8241-1d89-7a92-b3bc-32e34741c308]] — it applies to any ad-hoc "investigate X and tell me" request, seen recurring across sessions (requested-investigation pattern, 10 prior sessions).
 
+<!-- lore:019f8457-b131-7aaa-9397-f7f1ef853bd6 -->
+* **Follow strict TDD/verification/PR workflow for every feature implementation**: When implementing a feature (e.g., new DB column, migration, extraction helper), the user expects the assistant to: (1) research existing code/conventions before writing new code; (2) write tests matching existing test-file harness conventions (helpers, describe blocks); (3) run the specific new tests, then run full package test suite, lint, format:check, and typecheck; (4) perform mutation testing in a throwaway copy/worktree to prove tests are non-vacuous, verifying the real repo file hash is unchanged; (5) fix any incidental failures uncovered (e.g., stale hardcoded schema-version assertions) by updating them to match the new state; (6) update the relevant plan file in quality/plans; (7) create a dedicated feature branch off a clean/up-to-date main, commit with conventional commit messages, push, and open a PR; (8) initiate an adversarial subagent review of the PR before merging. Never skip verification steps or merge without review.
+
 <!-- lore:019f6fde-efd1-7f32-82db-76eb9454a990 -->
 * **Invariant-check action is advisory-only and never fails the build**: The invariant-check action is advisory-only and NEVER fails the build — it reports findings as annotations and a job summary; humans decide. The action should NEVER fail the build: capture exit, always continue. A non-zero exit from the CLI means a TOOLING failure (no range) — we log it and pass. This is a directive preference.
 
@@ -566,6 +569,9 @@
 
 <!-- lore:019f81a2-21af-76ff-9e84-a56f05f0bcac -->
 * **Prefers same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e**: prefer same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e.
+
+<!-- lore:019f8457-9166-79f9-8c31-3a588e5410ab -->
+* **Review code before committing**: Behavioral pattern detected across 92 sessions (action: requested-review). The user consistently demonstrates this behavior.
 
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1877,6 +1877,18 @@ const MIGRATIONS: string[] = [
     PRIMARY KEY (logical_id, kind, anchor)
   );
   `,
+
+  `
+  -- Version 75: tool_calls.input_path — the source-file path a file-operation
+  -- tool acted on (Read/Edit/Write/etc.), extracted from the tool_use input at
+  -- record time (#627 Step 1; Modem "how coding agents read your code"). This is
+  -- session→file PROVENANCE: which files a session actually touched, distinct
+  -- from the file:line anchors a knowledge entry's PROSE cites (knowledge_ref_
+  -- anchor, v74). NULL for non-file tools (bash, grep, task, …) and when no path
+  -- is recoverable from the input. Foundation for associating knowledge entries
+  -- with the files that produced them (D2c).
+  ALTER TABLE tool_calls ADD COLUMN input_path TEXT;
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -3377,6 +3389,12 @@ function recoverMissingObjects(database: Database) {
       .all() as Array<{ name: string }>;
     if (!tcols.some((c) => c.name === "verifier")) {
       database.exec("ALTER TABLE tool_calls ADD COLUMN verifier INTEGER;");
+    }
+    // Version 75: tool_calls.input_path (file provenance, #627 Step 1 / D2c).
+    // Same recovery rationale as verifier — CREATE TABLE IF NOT EXISTS cannot
+    // add a missing column to a pre-existing table.
+    if (!tcols.some((c) => c.name === "input_path")) {
+      database.exec("ALTER TABLE tool_calls ADD COLUMN input_path TEXT;");
     }
   }
   // Version 54: knowledge_session_injections.verdict (outcome impact, #497).

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -7,6 +7,7 @@ import * as log from "./log";
 import * as embedding from "./embedding";
 import {
   classifyToolError,
+  extractFilePath,
   isVerifierCall,
   MAX_ERROR_MESSAGE_LEN,
 } from "./tool-trace";
@@ -188,20 +189,20 @@ export function recordToolCalls(input: {
   // in order and fires ON CONFLICT row-by-row, so a duplicate call_id within one
   // batch resolves identically to the old sequential loop.
   if (seeds.length) {
-    const COLS_PER_ROW = 11;
+    const COLS_PER_ROW = 12;
     // Chunk the multi-row INSERT so a pathological batch can never exceed
     // SQLite's bound-variable ceiling. We use the conservative ~900-param budget
     // from the #796 chunking convention in db.ts (portable across SQLite builds,
     // whose historical minimum ceiling is 999) — well under the ≥3.32 default of
-    // 32766. 81 rows × 11 cols = 891 params. A real turn has far fewer tool_use
+    // 32766. 75 rows × 12 cols = 900 params. A real turn has far fewer tool_use
     // parts; this only matters for a pathological batch.
-    const CHUNK = Math.floor(900 / COLS_PER_ROW); // 81
+    const CHUNK = Math.floor(900 / COLS_PER_ROW); // 75
     const rowSql = `(${Array.from({ length: COLS_PER_ROW }, () => "?").join(", ")})`;
     for (let i = 0; i < seeds.length; i += CHUNK) {
       const batch = seeds.slice(i, i + CHUNK);
       const seedStmt = db().query(
         `INSERT INTO tool_calls
-           (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier)
+           (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier, input_path)
          VALUES ${Array.from({ length: batch.length }, () => rowSql).join(", ")}
          ON CONFLICT(call_id) DO UPDATE SET
            status = CASE WHEN tool_calls.status = 'pending' THEN excluded.status ELSE tool_calls.status END,
@@ -210,7 +211,10 @@ export function recordToolCalls(input: {
            duration_ms = COALESCE(excluded.duration_ms, tool_calls.duration_ms),
            -- verifier is derived from the tool_use input (stable across re-seeds);
            -- keep the first non-null classification.
-           verifier = COALESCE(tool_calls.verifier, excluded.verifier)`,
+           verifier = COALESCE(tool_calls.verifier, excluded.verifier),
+           -- input_path is likewise derived from the (stable) tool_use input;
+           -- keep the first non-null path so a re-seed never clobbers it.
+           input_path = COALESCE(tool_calls.input_path, excluded.input_path)`,
       );
       const params: Array<string | number | null> = [];
       for (const p of batch) {
@@ -227,6 +231,7 @@ export function recordToolCalls(input: {
           outcome.duration,
           createdAt,
           isVerifierCall(p.state.input) ? 1 : 0,
+          extractFilePath(p.state.input) ?? null,
         );
       }
       seedStmt.run(...params);

--- a/packages/core/src/tool-trace.ts
+++ b/packages/core/src/tool-trace.ts
@@ -165,6 +165,80 @@ export function extractCommand(input: unknown): string | null {
   return null;
 }
 
+// A path-like token: one or more slash-separated segments ending in a
+// dotted extension of 1-5 chars (e.g. `src/auth/jwt.ts`, `db.ts` won't match
+// without a slash — the plain-text fallback needs at least one dir segment to
+// avoid grabbing prose words). Used only as a fallback when the input isn't
+// structured JSON.
+const PATH_FALLBACK_RE = /(?:[\w.-]+\/)+[\w.-]+\.\w{1,5}/;
+
+// ReDoS mitigation. The plain-text fallback runs on a RAW string input — which
+// happens when a tool call's arguments failed to JSON-parse (streaming
+// truncation / malformed blob) and the host stored the raw string in
+// `state.input`. PATH_FALLBACK_RE's nested quantifiers backtrack super-linearly
+// on a long run of slash-separated tokens with no matching extension (measured
+// ~8s on a crafted 64KB `a/a/a/…` blob — a 64KB slice cap alone does NOT help,
+// since the whole blob is one pathological token). recordToolCalls runs
+// synchronously inside a SQLite savepoint on the hot request path, so an
+// unguarded match would stall the event loop AND hold the write lock. Defenses,
+// all O(n): (1) skip when there is no `/` at all; (2) scan only the first few KB
+// (a real path appears early and is short); (3) split on whitespace and only run
+// the regex on individual short tokens — a pathological no-whitespace blob is
+// one giant token that exceeds PATH_TOKEN_MAX and is skipped, so the backtracking
+// regex never sees adversarial input. A real path is a short, whitespace-bounded
+// token, so this never drops a legitimate match.
+const PATH_SCAN_LIMIT = 8192;
+const PATH_TOKEN_MAX = 260; // generous vs the 255-char component limit on most FSes
+
+/**
+ * Best-effort extraction of the source-file path a tool call acted on, from its
+ * `input` (host-shaped, hence `unknown`). Handles the common file-tool shapes
+ * (`{ path }` / `{ filePath }` / `{ file }` — the keys used by Read/Edit/Write/
+ * read_file/edit_file/write_to_file across hosts), a JSON string of the same,
+ * and a plain-text path fallback. Returns undefined when no path is recoverable
+ * (bash/grep/task/etc.), so the caller stores NULL. This is provenance only —
+ * a best-effort signal, never load-bearing, so a miss is always safe.
+ */
+export function extractFilePath(input: unknown): string | undefined {
+  const fromObject = (o: Record<string, unknown>): string | undefined => {
+    for (const key of ["path", "filePath", "file"] as const) {
+      const v = o[key];
+      if (typeof v === "string" && v.length > 0) return v;
+    }
+    return undefined;
+  };
+  if (input && typeof input === "object") {
+    return fromObject(input as Record<string, unknown>);
+  }
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input);
+      if (parsed && typeof parsed === "object") {
+        return fromObject(parsed as Record<string, unknown>);
+      }
+    } catch {
+      // not JSON — fall through to the plain-text path heuristic
+    }
+    // The fallback regex requires a `/`; a `/`-free string can never match.
+    if (input.indexOf("/") === -1) return undefined;
+    // Bound the scan, then run the backtracking regex only on short,
+    // whitespace-bounded tokens (see PATH_SCAN_LIMIT/PATH_TOKEN_MAX notes).
+    for (const token of input.slice(0, PATH_SCAN_LIMIT).split(/\s+/)) {
+      if (
+        token.length === 0 ||
+        token.length > PATH_TOKEN_MAX ||
+        token.indexOf("/") === -1
+      ) {
+        continue;
+      }
+      const match = token.match(PATH_FALLBACK_RE)?.[0];
+      if (match) return match;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
 /**
  * True when a tool call's `input` invokes a recognized verifier. The command is
  * split into segments on the shell chaining/pipe operators (`&&`, `||`, `;`,

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -119,7 +119,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(74);
+    expect(row.version).toBe(75);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -176,7 +176,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(74);
+    expect(ver.version).toBe(75);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 74", () => {
+  test("schema version is 75", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(74);
+    expect(v.version).toBe(75);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/tool-file-provenance.test.ts
+++ b/packages/core/test/tool-file-provenance.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as temporal from "../src/temporal";
+import { extractFilePath } from "../src/tool-trace";
+import type { LoreMessage, LorePart } from "../src/types";
+
+// D2c PR-1 (#627 Step 1): capture the source-file path a tool call acted on into
+// tool_calls.input_path — session→file provenance, the substrate for associating
+// knowledge entries with the files that produced them.
+
+describe("extractFilePath", () => {
+  test("reads path from an object input ({ path })", () => {
+    expect(extractFilePath({ path: "src/auth/jwt.ts" })).toBe(
+      "src/auth/jwt.ts",
+    );
+  });
+
+  test("reads filePath and file keys", () => {
+    expect(extractFilePath({ filePath: "a/b.ts" })).toBe("a/b.ts");
+    expect(extractFilePath({ file: "c/d.ts" })).toBe("c/d.ts");
+  });
+
+  test("prefers path over filePath over file", () => {
+    expect(
+      extractFilePath({ path: "p.ts", filePath: "fp.ts", file: "f.ts" }),
+    ).toBe("p.ts");
+    expect(extractFilePath({ filePath: "fp.ts", file: "f.ts" })).toBe("fp.ts");
+  });
+
+  test("parses a JSON string input", () => {
+    expect(extractFilePath('{"path":"src/x.ts"}')).toBe("src/x.ts");
+  });
+
+  test("falls back to a path-like token in a plain-text string", () => {
+    expect(extractFilePath("editing packages/core/src/db.ts now")).toBe(
+      "packages/core/src/db.ts",
+    );
+  });
+
+  test("returns undefined for non-file tool inputs", () => {
+    expect(extractFilePath({ command: "pnpm test" })).toBeUndefined();
+    expect(extractFilePath({ pattern: "TODO" })).toBeUndefined();
+    expect(extractFilePath("just some prose with no path")).toBeUndefined();
+    expect(extractFilePath(null)).toBeUndefined();
+    expect(extractFilePath(undefined)).toBeUndefined();
+    expect(extractFilePath(42)).toBeUndefined();
+  });
+
+  test("ignores an empty-string path", () => {
+    expect(extractFilePath({ path: "" })).toBeUndefined();
+  });
+
+  test("a `/`-free string is skipped without running the regex", () => {
+    // No slash → cannot be a path → cheap early return (also the ReDoS skip).
+    expect(extractFilePath("no slashes here just prose words")).toBeUndefined();
+  });
+
+  test("does not stall on a pathological long slash-run (ReDoS guard)", () => {
+    // A long run of slash-separated tokens with no matching extension is the
+    // super-linear-backtracking worst case for the fallback regex. With the
+    // length cap + slash skip this must return promptly, not hang.
+    const evil = `${"a/".repeat(50_000)}bbbbbbbbbbbb`;
+    const start = Date.now();
+    const result = extractFilePath(evil);
+    const elapsed = Date.now() - start;
+    expect(result).toBeUndefined();
+    expect(elapsed).toBeLessThan(1000);
+  });
+});
+
+const TOOL_PROJECT = "/test/temporal/input-path";
+
+function makeMessage(id: string, sessionID: string): LoreMessage {
+  return {
+    id,
+    sessionID,
+    role: "assistant",
+    time: { created: 1_700_000_000_000 },
+    parentID: "parent-1",
+    modelID: "claude-sonnet-4-20250514",
+    providerID: "anthropic",
+    mode: "build",
+    path: { cwd: "/test", root: "/test" },
+    cost: 0,
+    tokens: {
+      input: 100,
+      output: 50,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+}
+
+function toolPart(
+  messageID: string,
+  callID: string,
+  tool: string,
+  state: Record<string, unknown>,
+): LorePart {
+  return {
+    id: `tp-${callID}`,
+    sessionID: "sess-ip",
+    messageID,
+    type: "tool",
+    tool,
+    callID,
+    state,
+  };
+}
+
+function pathOf(pid: string, callId: string): string | null {
+  return (
+    (
+      db()
+        .query(
+          "SELECT input_path FROM tool_calls WHERE project_id = ? AND call_id = ?",
+        )
+        .get(pid, callId) as { input_path: string | null } | null
+    )?.input_path ?? null
+  );
+}
+
+describe("recordToolCalls populates input_path (D2c PR-1)", () => {
+  beforeEach(() => {
+    const pid = ensureProject(TOOL_PROJECT);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+  });
+
+  test("stores the path for file tools and NULL for non-file tools", () => {
+    const pid = ensureProject(TOOL_PROJECT);
+    const info = makeMessage("m-ip", "sess-ip");
+    const parts: LorePart[] = [
+      toolPart("m-ip", "r1", "read", {
+        status: "pending",
+        input: { path: "src/auth/jwt.ts" },
+      }),
+      toolPart("m-ip", "e1", "edit", {
+        status: "pending",
+        input: { filePath: "src/config.ts" },
+      }),
+      toolPart("m-ip", "b1", "bash", {
+        status: "pending",
+        input: { command: "pnpm test" },
+      }),
+      toolPart("m-ip", "g1", "grep", {
+        status: "pending",
+        input: { pattern: "TODO" },
+      }),
+    ];
+    temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+
+    expect(pathOf(pid, "r1")).toBe("src/auth/jwt.ts");
+    expect(pathOf(pid, "e1")).toBe("src/config.ts");
+    expect(pathOf(pid, "b1")).toBeNull();
+    expect(pathOf(pid, "g1")).toBeNull();
+  });
+
+  test("a re-seed never clobbers a captured path (COALESCE keeps first non-null)", () => {
+    const pid = ensureProject(TOOL_PROJECT);
+    const info = makeMessage("m-re", "sess-ip");
+    const withPath: LorePart[] = [
+      toolPart("m-re", "rx", "read", {
+        status: "pending",
+        input: { path: "src/first.ts" },
+      }),
+    ];
+    temporal.recordToolCalls({
+      projectPath: TOOL_PROJECT,
+      info,
+      parts: withPath,
+    });
+    // Re-seed the SAME call_id with no recoverable path (retry / re-delivery).
+    const noPath: LorePart[] = [
+      toolPart("m-re", "rx", "read", { status: "pending", input: {} }),
+    ];
+    temporal.recordToolCalls({
+      projectPath: TOOL_PROJECT,
+      info,
+      parts: noPath,
+    });
+    expect(pathOf(pid, "rx")).toBe("src/first.ts");
+
+    // Re-seed with a DIFFERENT non-null path — the first captured path must WIN
+    // (COALESCE direction: keep existing, never overwrite). Guards against a
+    // reversed COALESCE that would silently clobber provenance on re-delivery.
+    const otherPath: LorePart[] = [
+      toolPart("m-re", "rx", "read", {
+        status: "pending",
+        input: { path: "src/second.ts" },
+      }),
+    ];
+    temporal.recordToolCalls({
+      projectPath: TOOL_PROJECT,
+      info,
+      parts: otherPath,
+    });
+    expect(pathOf(pid, "rx")).toBe("src/first.ts");
+  });
+});

--- a/quality/plans/modem-recall-code-anchors.md
+++ b/quality/plans/modem-recall-code-anchors.md
@@ -40,6 +40,14 @@ Source: https://modem.dev/blog/how-coding-agents-read-your-code (Ben Vinegar, Mo
   `curator-retitle.test.ts` (apply-path threading, collision via curator, backward-compat).
   Collision guard mutation-verified.
 - ⬜ Remaining (follow-ups): D2c (entry↔file association), D3 (blog post).
+- 🔨 **D2c split into 3 sub-PRs** (matches #627 phasing):
+  - PR-1 (foundation, no behavior change): `tool_calls.input_path` (migration v75 + recovery def),
+    `extractFilePath()` helper in tool-trace.ts (string+object+plaintext shapes), populated in
+    `recordToolCalls` seed insert via COALESCE (re-seed never clobbers). Tests:
+    `tool-file-provenance.test.ts` (extractFilePath unit + input_path integration, mutation-verified).
+  - PR-2 (core): `knowledge_file_refs` table + curator "files touched" context block + create-path
+    population + recall rendering. (open design decision: heuristic all-touched vs curator-selected.)
+  - PR-3 (optional/deferred): git-diff `gitHead..HEAD` file-change staleness → confidence decay.
 
 ---
 


### PR DESCRIPTION
## What

**D2c PR-1** of the Modem *"[how coding agents read your code](https://modem.dev/blog/how-coding-agents-read-your-code)"* plan — this is #627 **Step 1**, the foundation for associating knowledge entries with the source files that produced them.

This is a **different** signal from #1414's code anchors. #1414 surfaces the file:line that a knowledge entry's *prose cites*. This records which files a session *actually touched* — session→file **provenance** — so a later PR can attribute an entry to the files behind it (and, optionally, flag it stale when they change).

**No behavior change:** the column is written but not yet read by anything. This PR is deliberately self-contained and reviewable on its own.

## Change

- **Migration v75:** adds nullable `tool_calls.input_path`, plus the matching column-recovery in `recoverMissingObjects` (a `CREATE TABLE IF NOT EXISTS` can't add a column to a pre-existing table — same recovery pattern as the `verifier` column).
- **`extractFilePath(input: unknown)`** in `tool-trace.ts` (beside its sibling `extractCommand`): pulls the path from the common file-tool shapes (`{path}` / `{filePath}` / `{file}` — the keys Read/Edit/Write/read_file/edit_file/write_to_file use across hosts), a JSON string of the same, and a plain-text path fallback. Returns `undefined` for bash/grep/task/etc. Provenance-only — best-effort, never load-bearing, so a miss is always safe.
- **`recordToolCalls`** populates it in the seed INSERT via `input_path = COALESCE(tool_calls.input_path, excluded.input_path)`, so a re-seed (retry / stream re-delivery) never clobbers a captured path. `COLS_PER_ROW` 11→12; chunk recomputed to 75 rows (75×12 = 900, still under the portable ~900-param budget).

## Tests

`tool-file-provenance.test.ts`:
- `extractFilePath` units: object (`{path}`/`{filePath}`/`{file}` + precedence), JSON string, plain-text fallback, non-file inputs → `undefined`, empty-path → `undefined`, non-string/null/number.
- `recordToolCalls` integration: path stored for `read`/`edit`, NULL for `bash`/`grep`; a re-seed with no path keeps the first captured path (COALESCE).

Population **mutation-verified** (neutering `extractFilePath` fails both integration tests). Bumped the three "current schema version" assertions 74→75 (expected for a new migration). Full `@loreai/core` suite green (156 files / 3213 tests); typecheck/format/lint clean.

## Next (D2c PR-2/3, not in this PR)
- **PR-2:** `knowledge_file_refs` table + curator "files touched this session" context block + create-path population + recall rendering. (Open design decision: heuristic all-touched vs curator-selected subset.)
- **PR-3 (optional):** git-diff `gitHead..HEAD` file-change staleness → confidence decay (#627 Step 3).