### PR TITLE
fix(import): resolve mem0 embedded home dir cross-platform (os.homedir, not $HOME)

### DIFF
--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -67,6 +67,7 @@ export {
   fetchMem0ServerMemories,
   readEmbeddedStorage,
   embeddedStorageCandidates,
+  defaultEmbeddedDirs,
   type Mem0Record,
   type Mem0ResolveOptions,
 } from "./sources/mem0";

--- a/packages/core/src/import/sources/mem0.ts
+++ b/packages/core/src/import/sources/mem0.ts
@@ -16,6 +16,7 @@
  * the mem0 point id kept as `external_id` for idempotency.
  */
 import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import {
   parseImportDoc,
@@ -349,9 +350,12 @@ async function defaultProbe(
 }
 
 /** Default embedded-store base dir (`~/.mem0` sibling `/tmp/qdrant`, or cwd). */
-function defaultEmbeddedDirs(): string[] {
+export function defaultEmbeddedDirs(): string[] {
   const dirs = ["/tmp/qdrant"];
-  const home = process.env.HOME;
+  // Use os.homedir() (cross-platform) — process.env.HOME is undefined on
+  // Windows, which would make this resolver miss the ~/.mem0 store that
+  // mem0Source.detect() (also os.homedir()) successfully found.
+  const home = homedir();
   if (home) dirs.push(join(home, ".mem0"));
   return dirs;
 }

--- a/packages/core/src/import/structured-sources.ts
+++ b/packages/core/src/import/structured-sources.ts
@@ -12,7 +12,11 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseEngramExport } from "./sources/engram";
-import { resolveMem0Doc } from "./sources/mem0";
+import {
+  defaultEmbeddedDirs,
+  embeddedStorageCandidates,
+  resolveMem0Doc,
+} from "./sources/mem0";
 import { safeParseImportDoc, type LoreImportDoc } from "./schema";
 
 export type StructuredSourceName = "engram" | "mem0";
@@ -121,15 +125,11 @@ export const mem0Source: StructuredSource = {
     // Embedded-default store artifacts (cheap, synchronous existence checks).
     // A running Qdrant/mem0 server is detected at produceDoc time (async probe);
     // detection here just surfaces the source when a local store is present.
-    const dirs = ["/tmp/qdrant"];
-    const home = homedir();
-    if (home) dirs.push(join(home, ".mem0"));
-    for (const dir of dirs) {
-      if (
-        existsSync(join(dir, "collection", "mem0", "storage.sqlite")) ||
-        existsSync(join(dir, "collection", "openmemory", "storage.sqlite"))
-      ) {
-        return true;
+    // Reuse the resolver's dir list + candidate paths so detect() and
+    // resolveMem0Doc can never drift on where the embedded store lives.
+    for (const dir of defaultEmbeddedDirs()) {
+      for (const storagePath of embeddedStorageCandidates(dir)) {
+        if (existsSync(storagePath)) return true;
       }
     }
     return false;

--- a/packages/core/test/import/mem0.test.ts
+++ b/packages/core/test/import/mem0.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, afterAll } from "vitest";
 import { fileURLToPath } from "node:url";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import {
@@ -10,6 +11,7 @@ import {
   fetchMem0ServerMemories,
   readEmbeddedStorage,
   embeddedStorageCandidates,
+  defaultEmbeddedDirs,
   parseMem0File,
   resolveMem0Doc,
 } from "../../src/import/sources/mem0";
@@ -287,6 +289,21 @@ describe("readEmbeddedStorage (native pickle reader)", () => {
     const cands = embeddedStorageCandidates("/base");
     expect(cands).toContain("/base/collection/mem0/storage.sqlite");
     expect(cands).toContain("/base/collection/openmemory/storage.sqlite");
+  });
+
+  test("defaultEmbeddedDirs resolves ~/.mem0 via os.homedir even when $HOME is unset (Windows)", () => {
+    // Regression (Seer): the resolver used process.env.HOME (undefined on
+    // Windows) while detect() used os.homedir(), so a detected ~/.mem0 store
+    // was then missed → false "No mem0 data found". defaultEmbeddedDirs must
+    // use os.homedir() and not depend on $HOME.
+    const prev = process.env.HOME;
+    try {
+      delete process.env.HOME;
+      const dirs = defaultEmbeddedDirs();
+      expect(dirs).toContain(join(homedir(), ".mem0"));
+    } finally {
+      if (prev !== undefined) process.env.HOME = prev;
+    }
   });
 
   test("uses the point's decoded UUID, NOT the base64-pickled id column (real mem0 2.0.12)", async () => {


### PR DESCRIPTION
## What

Follow-up to #1417. Seer flagged a **HIGH-severity Windows bug** in the mem0 connector: [`packages/core/src/import/sources/mem0.ts#L355`](https://github.com/BYK/loreai/pull/1417#discussion_r3618813785).

`resolveMem0Doc`'s `defaultEmbeddedDirs()` used `process.env.HOME` (undefined on Windows), while `mem0Source.detect()` used `os.homedir()`. On Windows this means:

1. `detect()` finds `~/.mem0` (via `os.homedir()`) → source is surfaced/selected.
2. The import then resolves the store dir via `process.env.HOME` → `undefined` → the `~/.mem0` path is never added → **"No mem0 data found"**.

## Fix

- `defaultEmbeddedDirs()` now uses `os.homedir()` so the detect and resolve paths agree on every platform.
- **Root-cause hardening:** exported `defaultEmbeddedDirs` + `embeddedStorageCandidates` as the single source of truth and made `mem0Source.detect()` reuse them, instead of duplicating the `/tmp/qdrant` + `~/.mem0` dir list. detect() and `resolveMem0Doc` can no longer drift on where the embedded store lives — the duplication was what let this divergence happen in the first place (per adversarial-review CONCERN).
- Added a **mutation-verified** regression test that unsets `$HOME` and asserts `~/.mem0` still resolves via `os.homedir()` (reverting to `process.env.HOME` fails the test).

## Gate

- Full suite: **6424 passed** (+1 new test). Only failure is the environmental jj-workspace `agents.test.ts` git-remote check — passes in CI. typecheck / lint / format:check clean.
- Adversarial review: **MERGE** (regression test mutation-killed; detect/resolve consolidation verified).

Addresses PR #1417 review comment (Seer, HIGH).