### PR TITLE
fix(gateway): reasoning floor keys off any reasoning capability, not toggle-only

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -170,6 +170,9 @@
 <!-- lore:019ef389-a501-7db4-a808-4e0c671bb2f0 -->
 * **effectiveMetaThreshold: internal Date.now() makes tests flaky — inject nowMs parameter**: Trap: \`effectiveMetaThreshold(lastTurnAtMs)\` calling \`Date.now()\` internally looks correct — it needs the current time to compute \`gapMs\`. Fix: any test that captures \`const now = Date.now()\` then passes \`now - (DEEP\_IDLE\_MS - 1)\` as \`lastTurnAtMs\` is flaky — a ≥1ms scheduling delay pushes \`gapMs ≥ DEEP\_IDLE\_MS\`, flipping the return value. Fix (PR #926): add injectable \`nowMs\` parameter; tests pass a fixed \`NOW\` constant. Sentinel: \`lastTurnAtMs === 0\` means 'never set (first turn)' → treated as deep-idle (gapMs = Infinity). All 8 \`effectiveMetaThreshold\` tests rewritten to use fixed \`NOW\` — fully deterministic.
 
+<!-- lore:019f8468-759c-7969-9344-d6be41f6a9b4 -->
+* **extractFilePath ReDoS: a scan-length cap alone isn't enough — must token-split**: tool-trace.ts's extractFilePath plaintext fallback regex \`/(?:\[\w.-]+\\/)+\[\w.-]+\\.\w{1,5}/\` catastrophically backtracks on long slash-separated runs (10K segments=7.6s; a real 114KB input stalled >40s, blocking the event loop and holding the SQLite write lock inside recordToolCalls). Trap: capping the scanned slice at 64KB (mirroring gradient.ts's toolStripAnnotation/ANNOTATION\_PATH\_SCAN\_LIMIT) looks like the fix, but a pathological slash-run fits entirely inside 64KB and still backtracks (7.9s) — even a flatter single-char-class regex without nested quantifiers still backtracks. Actual fix: split input on whitespace first (linear), then regex-match only tokens ≤260 chars — a giant no-space token is skipped entirely, never reaching the regex. gradient.ts's sibling implementation has the same latent vulnerability and was left unfixed (out of scope). Mutation-verified: reverting to naive match makes the guard test fail (19s vs <1s expected).
+
 <!-- lore:019f19db-f73c-74d1-865d-116cf01c0100 -->
 * **gateway re-compression: protocol-only predicate trusts same-protocol cross-host routes — origin check required**: Trap: comparing only \`effectiveProtocol !== ingressProtocol\` to detect auto-cross-routing looks correct — protocol translation is the obvious signal. Fix: same-protocol re-routes to different hosts (e.g. bare openai client → \`deepseek-chat\` → \`api.deepseek.com\` ≠ \`api.openai.com\`) are also distrusted. The merged PR #1059 predicate was protocol-only; PR #1064 adds \`|| effectiveOrigin !== ingressOrigin\`. Combined predicate: \`autoCrossRouted = !hasUpstreamUrlOverride && !hasProviderOverride && (effectiveProtocol !== ingressProtocol || effectiveOrigin !== ingressOrigin)\`. Mutation A (remove origin clause) → 4 tests RED: 3 unit + 1 MockAgent e2e showing zstd replayed to foreign host.
 
@@ -193,6 +196,9 @@
 
 <!-- lore:019ef947-54d5-73d6-8a1b-06575dddcf2f -->
 * **Lore website: Vite transformIndexHtml is dead code for Astro static generation**: Trap: adding a Vite \`transformIndexHtml\` plugin to \`astro.config.mjs\` looks like the right way to rewrite HTML links at build time — Vite is Astro's bundler. Fix: Astro's static generation pipeline does NOT route through Vite's HTML transform hook. The plugin is silently ignored; links are never rewritten. Confirmed by grep of built HTML showing unmodified hrefs despite plugin being active. Use \`astro:build:done\` integration hook instead — it receives the final output directory and can rewrite HTML files directly.
+
+<!-- lore:019f848b-9594-71eb-a8dc-31c15f087c74 -->
+* **mem0.ts defaultEmbeddedDirs() used process.env.HOME, breaks on Windows**: Trap: \`process.env.HOME\` for the mem0 default dirs (\`defaultEmbeddedDirs()\` in packages/core/src/import/sources/mem0.ts) looks fine because it works on macOS/Linux where dev/CI runs. Fix: \`os.homedir()\` is cross-platform (reads USERPROFILE on Windows too); \`process.env.HOME\` is undefined on Windows. \`mem0Source.detect()\` in structured-sources.ts:125 already used \`os.homedir()\` correctly, creating an asymmetry: detect() succeeds but \`resolveMem0Doc()\` then fails with 'No mem0 data found' on Windows. Flagged by Seer (sentry\[bot]) on PR #1417, fixed on branch mem0-winfix. Testing trap: \`vi.spyOn(os, "homedir")\` does NOT exercise this path — mem0.ts does \`import { homedir } from "node:os"\`, binding the reference at module load, so spying on the \`os\` namespace object afterward has no effect. Fix: export the internal function directly (\`defaultEmbeddedDirs\`) and test it with \`HOME\` unset, asserting it still resolves via the real \`os.homedir()\`.
 
 <!-- lore:019efc12-5bea-700b-87dd-615866d86741 -->
 * **meta-distillation rewrites messages\[1] each turn — busts warmup prefix, turns partial warmups into $2–3 writes**: Trap: meta-distillation running while cache is warm looks safe — it's background work. Fix: meta archives gen-0 rows and creates a gen-1 row, rewriting the synthetic distilled prefix at \`messages\[0/1]\` on the next turn. That early-message rewrite is a real prompt-cache bust. Confirmed in production: session \`1EQ2VGLS1de9zcIH\` turn=76 showed divergence at \`messages\[1].content\[0].text\`, reason='distilled conversation prefix changed (meta-distillation rewrite)', forcing 100K+ token recreation per turn. Code comment invariant: 'Never run meta-distillation while the conversation cache is warm.' Idle-time meta in idle.ts remains enabled because the cache is already cold there. All distillation call sites in pipeline.ts pass \`skipMeta: true\` when cache is warm.
@@ -257,9 +263,6 @@
 <!-- lore:019ee0df-cba3-7fab-9beb-db13431cf1a4 -->
 * **SYNCED\_TABLES fan-out: adding a table has silent ripple effects with no contract test**: SYNCED\_TABLES fan-out: adding a table has silent ripple effects with no contract test. Adding a table to \`SYNCED\_TABLES\` (e.g. \`profiles\`) has ripple effects across \`seedOutbox\`, \`reconcile\`, \`pruneOutbox\`, \`applyRemote\` pull-classification, and outbox-capture triggers. No single contract test enforces all invariants for every registered table. \`profiles\` silently violated the prune-floor and tier-residue invariants on paths nobody re-checked after registration. Fix: add a per-table invariant test that asserts all registry-required properties (pullOnly guard in seed/reconcile, no outbox trigger, correct pull classification) whenever a new table is added to \`SYNCED\_TABLES\`.
 
-<!-- lore:019f83ed-dd87-75d6-a499-19c125e8a460 -->
-* **titleCollides() promoted-entry branch misses same-project check (Case C gap)**: In ltm.ts's re-title dedup guard, titleCollides() has 3 scope branches. For a promoted entry (project\_id=P, cross\_project=1), it takes the global/promoted branch which only checks \`project\_id IS NULL OR cross\_project=1\` — it never checks plain project-P non-promoted entries. Trap: this looks correct because it mirrors create()'s cross-project dedup query symmetry. Fix: confirmed via mutation probe test — promoting entry E in project P then re-titling it onto plain entry F's title (same project P) creates two live entries with the same title, violating the 'never silently duplicate titles in one scope' invariant. Needs a \`project\_id = ?\` OR-clause added to the promoted branch of titleCollides().
-
 <!-- lore:019efa1b-9771-70f1-ba6a-f6eccead4374 -->
 * **undici is external in Bun ESM bundle — real undici@7 hangs on streaming reads under Bun**: Trap: bundling \`undici\` into the Bun ESM gateway bundle looks correct — it's a Node.js HTTP client. Fix: real \`undici@7\` hangs on streaming response reads under Bun. \`undici\` is lazily imported only on the Node path in \`fetch.ts\` — never bundled or evaluated under Bun. Bun path uses native fetch instead. \`undici\` must remain external in the Bun ESM bundle.
 
@@ -297,9 +300,6 @@
 
 <!-- lore:019eec48-01c5-78bd-b7f9-6cd8b7ddfada -->
 * **Lore gateway deploy procedure on production host**: 🔴 Deploy procedure (Burak Yigit Kaya directive): \`git stash save && git pull && git stash pop && pnpm install && pnpm build && pnpm --filter @loreai/gateway run bundle && sudo service opencode restart && journalctl -u opencode -f\`. Plugin file at \`~/.config/opencode/plugins/lore.ts\` contains only \`export { LorePlugin as default } from "opencode-lore";\`. opencode-lore resolves from \`/home/byk/.config/opencode/node\_modules/opencode-lore\` (active built repo) — NOT the cached version at \`~/.cache/opencode/packages/opencode-lore@\*/\`.
-
-<!-- lore:019f8235-e5ed-79dd-b596-cf03c8c43792 -->
-* **loreai adversarial PR review workflow (quality/REVIEW.md)**: Steps: 1. Read quality/REVIEW.md before any review — defines invariants: §1 regression-test discipline, §2 adversarial-order state setup, §3 fan-out registry coverage table, §4 recurring bug-class batteries, §5 session-discovered patterns, §6 two-pass workflow (adversarial/correctness pass, then security/pentest pass). 2. Run full checklist: pnpm test, pnpm run typecheck, pnpm run lint, pnpm run format:check (verify exit code), property-tests ×10 for stability, hash-verify clean working tree. 3. For every finding, write a regression test that fails on base and passes on fix — confirm the fail via mutation (remove the guard, confirm red, restore) before trusting any fix. 4. Deliver per-point PASS/FAIL/CONCERN/MUST-FIX verdicts — never say "LGTM" without this structure. Gotchas: - \`db().query\` monkeypatches are silently shadowed by the tracing Proxy — use \`log.registerSink({withDbSpan})\` instead (verified in PR #874). - Frozen shared arrays (e.g. \`syncedColumns\` PRAGMA cache) should stay frozen to fail loudly on accidental mutation. Verify: - \[ ] Every MUST-FIX has a regression test confirmed red-on-base, green-on-fix. - \[ ] pnpm test/typecheck/lint/format:check all pass. - \[ ] No ve \[truncated — entry too long]
 
 <!-- lore:019f14f5-5edb-7bd1-bc31-9b10062ce1a3 -->
 * **Pi real-runtime e2e: console spy must be installed BEFORE resourceLoader.reload()**: Trap: installing \`console.\*\` spies after \`resourceLoader.reload()\` looks correct — the test body runs after setup. Fix: Pi's extension factory executes during \`reload()\`, so any \`console.\*\` calls in the factory are missed by late-installed spies. Additionally, Vitest intercepts \`console.\*\` away from \`process.stdout.write\`, so \`process.stdout/stderr.write\` spies also miss console output. Both traps look safe because the test passes — it just silently misses the mutation. Fix: install direct \`console.\*\` method spies BEFORE \`resourceLoader.reload()\` so the entire reload + \`createAgentSession\` + prompt window is captured. Mutation A (inject \`console.info("pi: ...")\` at line 99 of index.ts) confirmed this kills the markers test when spies are correctly placed.
@@ -372,6 +372,9 @@
 <!-- lore:019f6fba-0dc9-787f-a62e-b86b43f939a0 -->
 * **Always valid for JSON**: User stated: 'always valid for JSON.' This is a directive preference.
 
+<!-- lore:019f8498-21c9-7192-ada6-0b5db3cb9c62 -->
+* **Always verify deployed fixes by checking live logs post-restart before declaring success**: After deploying a fix and restarting the service, the user consistently asks the assistant to verify the fix is actually active and working by checking logs (lore.log, journalctl) since the restart timestamp — not just trusting that a merge/deploy happened. This includes: confirming the build timestamp is newer than the restart, grepping for the specific error patterns that were previously failing (e.g. 'worker empty response', 'finish\_reason=length', degradation warnings), confirming zero recurrences post-restart, and cross-referencing git log/HEAD commit hashes against the expected PR merges. When new/different warnings appear even after a fix is deployed, the user expects the assistant to investigate further (e.g., checking whether retry budgets match expected values, whether a floor/logic fix was actually applied) rather than assuming success. The assistant should proactively pull log evidence and specific line numbers/timestamps rather than making claims without verification.
+
 <!-- lore:019f7766-9f32-757d-bbf8-b709eb759894 -->
 * **Always warm-start embedding worker at gateway startup**: User consistently requires warm-starting the embedding worker at gateway startup to avoid cold model load delays causing incomplete distillation embeddings. This pattern has appeared in 35 prior sessions and is a directive preference.
 
@@ -383,12 +386,6 @@
 
 <!-- lore:019f7af2-a15c-74bf-873d-f2270c47516c -->
 * **Do the other runs with DeepSeek and competitors and give a full update to the blog**: User stated: 'Do the other runs with DeepSeek and competitors and give a full update to the blog'. This is a directive preference.
-
-<!-- lore:019f83d2-e6cb-753d-8d08-8622859ecfa8 -->
-* **Explicit investigation/research requests are read-only — no file modification**: When Burak Yigit Kaya explicitly frames a task as investigation/research (e.g. "do NOT modify any files"), treat it as strictly read-only: answer with file:line evidence, don't make edits even if a fix seems obvious. This is distinct from the adversarial PR-review workflow \[\[019f8241-1d89-7a92-b3bc-32e34741c308]] — it applies to any ad-hoc "investigate X and tell me" request, seen recurring across sessions (requested-investigation pattern, 10 prior sessions).
-
-<!-- lore:019f8457-b131-7aaa-9397-f7f1ef853bd6 -->
-* **Follow strict TDD/verification/PR workflow for every feature implementation**: When implementing a feature (e.g., new DB column, migration, extraction helper), the user expects the assistant to: (1) research existing code/conventions before writing new code; (2) write tests matching existing test-file harness conventions (helpers, describe blocks); (3) run the specific new tests, then run full package test suite, lint, format:check, and typecheck; (4) perform mutation testing in a throwaway copy/worktree to prove tests are non-vacuous, verifying the real repo file hash is unchanged; (5) fix any incidental failures uncovered (e.g., stale hardcoded schema-version assertions) by updating them to match the new state; (6) update the relevant plan file in quality/plans; (7) create a dedicated feature branch off a clean/up-to-date main, commit with conventional commit messages, push, and open a PR; (8) initiate an adversarial subagent review of the PR before merging. Never skip verification steps or merge without review.
 
 <!-- lore:019f6fde-efd1-7f32-82db-76eb9454a990 -->
 * **Invariant-check action is advisory-only and never fails the build**: The invariant-check action is advisory-only and NEVER fails the build — it reports findings as annotations and a job summary; humans decide. The action should NEVER fail the build: capture exit, always continue. A non-zero exit from the CLI means a TOOLING failure (no range) — we log it and pass. This is a directive preference.
@@ -431,9 +428,6 @@
 
 <!-- lore:019f7b95-09b2-7577-a9d2-b952b3df0a76 -->
 * **Never block login on QR rendering**: User stated to never block login on QR rendering.
-
-<!-- lore:019f77f9-b7d6-7f6c-9431-9f4fd9a443a3 -->
-* **Never block shutdown longer than hard deadline**: User consistently requires that shutdown procedures never block longer than a hard deadline to avoid Ctrl+C hangs. This pattern has appeared in 36 prior sessions and is a directive preference.
 
 <!-- lore:019f7b4f-df9a-7c55-a450-c19f771311d0 -->
 * **Never bounces back to native**: User consistently requires that fallback mechanisms never bounce back to native after switching to WASM. This pattern has appeared in 27 prior sessions and is a directive preference.
@@ -479,9 +473,6 @@
 
 <!-- lore:019f65ca-91fb-7140-b01f-aeb90540b80d -->
 * **Never from within another transaction**: User stated never from within another transaction.
-
-<!-- lore:019f77f9-b7fe-762f-964d-c12ed8900375 -->
-* **Never get stuck on hung child process during shutdown**: User consistently requires that shutdown procedures never get stuck on hung child processes. This pattern has appeared in 33 prior sessions and is a directive preference.
 
 <!-- lore:019f70c1-6116-7798-bde9-7dbaf926a516 -->
 * **Never grant UPDATE on profiles to service\_role**: User stated that service\_role was 'never granted UPDATE on profiles' regarding tier guards. This is a directive preference.
@@ -556,7 +547,7 @@
 * **Never written to any intermediate file**: User stated: 'never written to any intermediate file,'. This is a directive preference.
 
 <!-- lore:019f8235-e654-73ea-b951-a1b1692c3350 -->
-* **PR reviews must be synchronous — never deferred**: When asked to review a PR, do it now, in the same turn — NEVER defer to a later session. Deliver a complete verdict in the final message (per-point PASS/FAIL/CONCERN/MUST-FIX, structured, no bare "LGTM"). Complements the adversarial review workflow (quality/REVIEW.md) and the standing requirement to request adversarial subagent review before merging any PR.
+* **PR reviews: synchronous, isolated, adversarial per REVIEW.md**: When asked to review a PR/bug fix, do it now, in the same turn — never defer to a later session. Follow quality/REVIEW.md adversarial discipline: work in an isolated jj/git worktree (never mutate the main tracked tree); apply mutation testing (revert the fix, confirm the regression test fails — 'never trust the fix without seeing it fail' — then restore and confirm it passes); run the full gate (test, typecheck, lint, format:check) and report exit codes; prove the working tree is restored exactly to the original PR diff. Deliver a complete, structured verdict in the final message: per-point PASS/FAIL/CONCERN/MUST-FIX with file:line evidence and an explicit MERGE/DO-NOT-MERGE decision — never a bare 'LGTM'. If told 'just report, don't fix,' only mutate scratch/temp copies, never the actual PR. Complements the standing requirement to request adversarial subagent review before merging any PR.
 
 <!-- lore:019f8126-b8d1-78d6-bc66-9403838dfb13 -->
 * **Prefers git\_remote first, only falls back over path**: prefers git\_remote first, only falls back to path
@@ -570,14 +561,17 @@
 <!-- lore:019f81a2-21af-76ff-9e84-a56f05f0bcac -->
 * **Prefers same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e**: prefer same-vendor lineage siblings over cross-vendor cheapest models; this switched the OpenRouter worker from a cheap non-reasoning model (e.
 
-<!-- lore:019f8457-9166-79f9-8c31-3a588e5410ab -->
-* **Review code before committing**: Behavioral pattern detected across 92 sessions (action: requested-review). The user consistently demonstrates this behavior.
-
 <!-- lore:019f70c1-622c-7c8c-96d6-e99ade1d5100 -->
 * **Service-role key never matches contains @**: User stated that service-role key 'never match (contains @'. This is a directive preference.
 
 <!-- lore:019f70c1-6205-7d8b-9766-44b11a1e6f51 -->
 * **Service-role key never round-tripped through sessionToPersisted**: User stated that service-role key 'never round-tripped through sessionToPersisted'. This is a directive preference.
+
+<!-- lore:019f77f9-b7d6-7f6c-9431-9f4fd9a443a3 -->
+* **Shutdown must never block indefinitely — enforce a hard deadline**: Shutdown procedures must never block longer than a hard deadline, to avoid Ctrl+C hangs — including never getting stuck waiting on hung child processes. This pattern has appeared in 36+ prior sessions and is a directive preference.
+
+<!-- lore:019f849a-fd89-7b43-95cd-9782e5765cf0 -->
+* **Treat gateway agents.test.ts git-remote failure as known environmental issue**: Before every PR push, the user runs the full vitest suite in a jj-managed worktree. The single recurring failure in packages/gateway/test/agents.test.ts ('both X-Lore-Project and X-Lore-Git-Remote coexist when git remote is available') is caused by the jj workspace lacking a discoverable .git remote, not by the feature changes being tested. When this specific test fails, verify the failure is isolated to this test, confirm via \`git remote\`/\`git rev-parse\` that no .git repo is discoverable in the workspace, and note that it passes in real CI checkouts. Do not treat it as a regression—assess it as pre-existing/environmental, compare total passed-test counts against baseline to confirm no other regressions, then proceed to commit and push the PR without attempting to fix this specific failure.
 
 <!-- lore:019f7b66-8ff8-7d82-9ee8-fcd3a9521686 -->
 * **Warden analysis: acknowledge genuine utility before extracting ideas**: User consistently requires acknowledging Warden's genuine utility before extracting ideas. This pattern has appeared in 3 prior sessions and is a directive preference.

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -295,6 +295,36 @@ export function workerThinkingOnByDefault(model: { modelID: string }): boolean {
 }
 
 /**
+ * Decide whether a worker model MAY spend hidden reasoning tokens against its
+ * output budget on a plain (no-effort) call — the signal that gates the
+ * reasoning-headroom floor (`workerReasoningHeadroomFloor`).
+ *
+ * This is DELIBERATELY BROADER than `workerThinkingOnByDefault`. That predicate
+ * answers "must we send `thinking:{type:"disabled"}`?" and is intentionally
+ * narrow (only `toggle`-typed reasoning is on-by-default on the Anthropic wire).
+ * But budget headroom is about whether the model reasons AT ALL by default when
+ * reached over a protocol with no suppression lever (OpenAI/Gemini) — which is
+ * true for `effort`-typed and `budget_tokens`-typed reasoning models too.
+ *
+ * Real regression this fixes: models.dev lists OpenRouter's
+ * `anthropic/claude-sonnet-5` with `reasoning_options:[{type:"effort",…}]` (NO
+ * `toggle`). `workerThinkingOnByDefault` returns false for it (no toggle), so the
+ * floor never applied — and the curator's tiny 2048 budget was burned on hidden
+ * reasoning, returning empty `finish_reason:"length"` (observed in production
+ * after the #1418 deploy). ANY non-empty `reasoning_options` → the model can
+ * reason → floor applies. Empty/absent `reasoning_options` falls back to the
+ * Claude-id heuristic (offline-safe, same as `workerThinkingOnByDefault`).
+ *
+ * A floor, never a charge: a non-reasoning model still bills only what it emits,
+ * so an over-broad true here costs nothing; a false NEGATIVE re-breaks workers.
+ */
+export function workerModelReasons(model: { modelID: string }): boolean {
+  const opts = getModelEntrySync(model.modelID).reasoning_options;
+  if (Array.isArray(opts) && opts.length > 0) return true;
+  return isAnthropicClaudeModel(model.modelID);
+}
+
+/**
  * models.dev-driven check: does this model reject a non-default sampling
  * `temperature`? True for the deprecated-sampling generation (claude-sonnet-5,
  * claude-opus-4-7/4-8, gpt-5, o3, …) where `temperature` is `false`. Used to
@@ -444,9 +474,9 @@ const DEFAULT_REASONING_MODEL_BUDGET = 8192;
  *
  * - Explicit reasoning effort set → `anthropicThinkingBudget(effort) +
  *   THINKING_OUTPUT_HEADROOM` (the caller asked the model to reason; make room).
- * - No effort, but the model reasons on by default (models.dev
- *   `reasoning_options` toggle, or the Claude fallback heuristic via
- *   `workerThinkingOnByDefault`) → `DEFAULT_REASONING_MODEL_BUDGET +
+ * - No effort, but the model reasons by default (`workerModelReasons` — ANY
+ *   non-empty models.dev `reasoning_options`, i.e. toggle/effort/budget_tokens,
+ *   or the Claude-id fallback) → `DEFAULT_REASONING_MODEL_BUDGET +
  *   THINKING_OUTPUT_HEADROOM`. This is the case the length-retry alone could not
  *   solve: the workers pass tiny budgets (~1–8K) and a reasoning model burns
  *   most of it on reasoning, so the FIRST attempt must already carry headroom.
@@ -461,7 +491,7 @@ function workerReasoningHeadroomFloor(
 ): number {
   const explicitBudget = anthropicThinkingBudget(reasoningEffort);
   if (explicitBudget != null) return explicitBudget + THINKING_OUTPUT_HEADROOM;
-  if (workerThinkingOnByDefault(model)) {
+  if (workerModelReasons(model)) {
     return DEFAULT_REASONING_MODEL_BUDGET + THINKING_OUTPUT_HEADROOM;
   }
   return 0;

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -30,6 +30,7 @@ import {
   isThinkingUnsupportedModel,
   markThinkingUnsupported,
   workerThinkingOnByDefault,
+  workerModelReasons,
   modelRejectsTemperatureByData,
   _resetTemperatureUnsupportedModels,
   _resetThinkingUnsupportedModels,
@@ -2299,6 +2300,44 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
       );
     });
 
+    test("workerModelReasons: ANY reasoning_options → true (broader than the toggle-only thinking predicate)", () => {
+      _setModelDataForTest({
+        "toggle-model": {
+          id: "toggle-model",
+          reasoning_options: [{ type: "toggle" }],
+        },
+        "effort-model": {
+          id: "effort-model",
+          reasoning_options: [{ type: "effort" }],
+        },
+        "budget-model": {
+          id: "budget-model",
+          reasoning_options: [{ type: "budget_tokens" }],
+        },
+        "plain-model": { id: "plain-model", reasoning: false },
+      });
+      // The reasoning-headroom floor must fire for EVERY reasoning shape, not
+      // just toggle — an effort-typed model (OpenRouter's claude-sonnet-5) still
+      // burns hidden tokens by default. This is the divergence from
+      // workerThinkingOnByDefault (toggle-only) that the production bug exposed.
+      expect(workerModelReasons({ modelID: "toggle-model" })).toBe(true);
+      expect(workerModelReasons({ modelID: "effort-model" })).toBe(true);
+      expect(workerModelReasons({ modelID: "budget-model" })).toBe(true);
+      expect(workerModelReasons({ modelID: "plain-model" })).toBe(false);
+      // Explicit divergence: effort-typed is NOT thinking-on-by-default (no
+      // opt-out param) but DOES reason (needs the budget floor).
+      expect(workerThinkingOnByDefault({ modelID: "effort-model" })).toBe(
+        false,
+      );
+      expect(workerModelReasons({ modelID: "effort-model" })).toBe(true);
+    });
+
+    test("workerModelReasons: falls back to the Claude-id heuristic when models.dev has no data", () => {
+      clearModelDataCache();
+      expect(workerModelReasons({ modelID: "claude-sonnet-5" })).toBe(true);
+      expect(workerModelReasons({ modelID: "MiniMax-M1" })).toBe(false);
+    });
+
     test("workerThinkingOnByDefault: falls back to the Claude-id heuristic when models.dev has no data (offline safety)", () => {
       clearModelDataCache(); // no models.dev data available
       // A models.dev outage must NOT stop us disabling thinking on Claude models.
@@ -2832,6 +2871,45 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
     expect(bodyOf(0)?.max_completion_tokens).toBe(16384);
     // No explicit effort → reasoning_effort must NOT be sent (the model reasons
     // on its own; we only give it room).
+    expect(bodyOf(0)).not.toHaveProperty("reasoning_effort");
+  });
+
+  test("floor applies to an EFFORT-typed reasoning model with no toggle and no 'claude' id (regression: production curator truncation storm)", async () => {
+    // The exact production regression that survived #1418: models.dev lists
+    // OpenRouter's anthropic/claude-sonnet-5 with reasoning_options:[{effort}]
+    // (NO toggle). workerThinkingOnByDefault returns false (toggle-only), so the
+    // floor never applied and the curator's 2048 budget was burned on hidden
+    // reasoning → empty finish_reason:"length". The floor must key off the
+    // broader workerModelReasons (ANY reasoning_options), NOT the toggle-only
+    // predicate. Uses a NON-"claude" id so the Claude fallback CANNOT mask the
+    // bug — the ONLY signal is the effort-typed reasoning_options.
+    // Mutation: revert the floor gate to workerThinkingOnByDefault → false for
+    // this effort-only entry → first call sends raw 2048 → RED.
+    _setModelDataForTest({
+      "acme/reasoner-x": {
+        id: "acme/reasoner-x",
+        cost: { input: 1, output: 3 },
+        limit: { context: 200_000, output: 64_000 },
+        reasoning_options: [{ type: "effort" }],
+      },
+    });
+    mockFetch.mockResolvedValueOnce(openAISuccess("ok"));
+
+    await createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "sk-or-test" }),
+      { providerID: "openrouter", modelID: "acme/reasoner-x" },
+    ).prompt("system", "user", {
+      sessionID: "sess-effort-typed-floor",
+      workerID: "lore-curator",
+      protocol: "openai",
+      upstreamProviderID: "openrouter",
+      upstreamUrl: "https://openrouter.ai/api",
+      maxTokens: 2048,
+    });
+
+    expect(bodyOf(0)?.max_completion_tokens).toBe(16384);
+    // Model reasons by default but we set no effort → do NOT force reasoning_effort.
     expect(bodyOf(0)).not.toHaveProperty("reasoning_effort");
   });
 


### PR DESCRIPTION
## Problem (found in production AFTER #1418 deploy)

After deploying #1418, the curator **still** truncated:
```
worker empty response (HTTP 200) … finish_reason=length native_finish_reason=max_tokens
  model=openrouter/anthropic/claude-sonnet-5 worker=lore-curator
worker empty response was a budget truncation — retrying once with max_tokens 2048 → 8192
```
The retry recovered it (no `no-response`, no degradation), but the **first attempt was 2048 (unfloored)** — the #1418 reasoning-headroom floor never fired for this model. If it had, the first attempt would have been 16384 and the retry 64000.

## Root cause

The floor gated on `workerThinkingOnByDefault`, which returns true **only** when `reasoning_options` contains a `toggle` type. models.dev lists OpenRouter's `anthropic/claude-sonnet-5` as:
```json
"reasoning_options": [{ "type": "effort", "values": ["low","medium","high","xhigh","max"] }]
```
No `toggle` → `workerThinkingOnByDefault` returns false; and because the array is non-empty, the Claude-id fallback is never reached. The model reasons by default in practice (it burned the whole budget) but was classified as non-reasoning, so the floor was skipped.

`workerThinkingOnByDefault` is correctly **narrow** for its own job ("must we send `thinking:{type:disabled}`?" — only `toggle` is on-by-default on the Anthropic wire). The budget floor needs a **broader** question: "can this model reason at all by default?" — which is also true for `effort`- and `budget_tokens`-typed models.

## Fix

- New `workerModelReasons(model)`: true for **any** non-empty `reasoning_options`, else the Claude-id fallback (offline-safe).
- `workerReasoningHeadroomFloor` now gates on `workerModelReasons` instead of `workerThinkingOnByDefault`. The two predicates deliberately diverge on `effort`-typed models: not thinking-on-by-default (no opt-out param needed) but DOES reason (needs the budget floor).

## Tests (mutation-verified)

- **Regression**: an `effort`-typed reasoning model with **no toggle** and a **non-"claude" id** gets floored to 16384. Reverting the gate to `workerThinkingOnByDefault` → raw 2048 → **RED** (reproduces the exact production bug).
- `workerModelReasons` unit test: toggle/effort/budget_tokens → true; none → false; explicit divergence from `workerThinkingOnByDefault` on effort-typed; offline Claude-id fallback.

Full suite green (6427 passed); typecheck + lint + format clean.

## Note on deploy verification
This was caught precisely because I verified the logs after your restart rather than trusting the merge. The retry backstop masked it as a recovered warning, but the first-attempt budget was wrong. This closes that gap.