### PR TITLE
fix(ltm): run context-source fold even when the knowledge table is empty (#961)

### DIFF
--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -2485,12 +2485,29 @@ export async function forSession(
     hydrateKnowledgeEntry,
   ) as KnowledgeEntry[];
 
-  if (!crossEntries.length && !projectEntries.length) {
-    // Empty-knowledge fast path (new project, or all entries below the
-    // confidence floor). Emit before returning so the FASTEST path is
-    // represented in the read-path metrics — otherwise the distribution is
-    // skewed toward slower, non-empty turns and #966 B is decided on biased
-    // data. Mirrors the timeout early return above (Seer, PR #993).
+  // Empty-knowledge fast path (new project, or all entries below the
+  // confidence floor). Emit before returning so the FASTEST path is
+  // represented in the read-path metrics — otherwise the distribution is
+  // skewed toward slower, non-empty turns and #966 B is decided on biased
+  // data. Mirrors the timeout early return above (Seer, PR #993).
+  //
+  // BUT: when the caller asked to fold in passive context sources
+  // (distillation/temporal, #1228/#1293) and there is a session/hint context to
+  // score against, an empty knowledge table must NOT short-circuit — the whole
+  // point of context sources is to surface captured facts that were never
+  // promoted to knowledge (the common fresh-project / distillation-only case).
+  // Returning [] here silently disabled passive injection whenever knowledge was
+  // empty (found via #961 eval: captured+embedded facts never reached the model).
+  // Fall through so the context-source fold below runs; the scoring path handles
+  // empty knowledge pools fine (allScored simply starts empty).
+  const wantsContextSourceFold =
+    !!options?.includeContextSources?.length &&
+    (!!options.contextHint?.trim() || !!sessionID);
+  if (
+    !crossEntries.length &&
+    !projectEntries.length &&
+    !wantsContextSourceFold
+  ) {
     timer.emit("forSession", 0);
     return [];
   }
@@ -2501,7 +2518,15 @@ export async function forSession(
   // then recency. Confidence carries real meaning now: 1.0 = unconditional
   // directive, 0.9 = strong preference, 0.8 = moderate, 0.6 = mild.
   const isPreferenceOnly =
-    categoryFilter?.length === 1 && categoryFilter[0] === "preference";
+    categoryFilter?.length === 1 &&
+    categoryFilter[0] === "preference" &&
+    // A caller that also asked to fold in context sources must not take this
+    // cheap preference-only path — it returns before the fold. No production
+    // caller combines the two today (preference reads use categories:
+    // ["preference"] without includeContextSources; context reads use
+    // excludeCategories: ["preference"]), but keep the API honest: if both are
+    // set, fall through to the full path so the fold still runs (Seer #1432).
+    !wantsContextSourceFold;
   if (isPreferenceOnly) {
     // Blanket-inject only the user's own directives: project-local prefs
     // (Pool 1), true globals (`project_id IS NULL`), and this project's own

--- a/packages/core/test/ltm-context-sources.test.ts
+++ b/packages/core/test/ltm-context-sources.test.ts
@@ -128,6 +128,58 @@ describe("ltm.forSession — context sources (distillation + temporal)", () => {
     expect(ids.has(knowledgeId)).toBe(true);
   });
 
+  // Regression (#961): the empty-knowledge fast path (forSession returns [] when
+  // both knowledge pools are empty) used to fire BEFORE the context-source fold,
+  // silently disabling passive distillation/temporal injection whenever the
+  // knowledge table was empty — the common fresh-project / distillation-only
+  // case. Found via the live eval: facts were captured + embedded + FTS-matchable
+  // yet never reached the model. This test seeds NO knowledge and asserts the
+  // fold still runs. Mutation: restore the unconditional early return and this
+  // goes red.
+  test("REGRESSION: context sources still surface when the knowledge table is EMPTY", async () => {
+    // Remove the only knowledge entry so both pools are empty (fast-path trigger).
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    expect(
+      db()
+        .query("SELECT COUNT(*) AS n FROM knowledge WHERE project_id = ?")
+        .get(pid) as { n: number },
+    ).toEqual({ n: 0 });
+
+    const withFold = await ltm.forSession(PROJ, undefined, 4000, {
+      excludeCategories: ["preference"],
+      contextHint: HINT,
+      includeContextSources: ["distillation", "temporal"],
+    });
+    const foldIds = new Set(withFold.map((e) => e.id));
+    // The captured facts surface even with zero knowledge entries.
+    expect(foldIds.has(`d:${distId}`)).toBe(true);
+    expect(foldIds.has(`t:${tempId}`)).toBe(true);
+
+    // And the empty-knowledge fast path is PRESERVED when the fold isn't asked
+    // for: no context sources + empty knowledge => nothing surfaced.
+    const noFold = await ltm.forSession(PROJ, undefined, 4000, {
+      excludeCategories: ["preference"],
+      contextHint: HINT,
+    });
+    expect(noFold).toHaveLength(0);
+  });
+
+  // Seer #1432: the isPreferenceOnly fast path also returns before the fold. No
+  // production caller combines categories:["preference"] WITH
+  // includeContextSources, but the API must stay honest — if both are set, the
+  // fold must still run. Mutation: drop the `!wantsContextSourceFold` clause on
+  // isPreferenceOnly and this goes red.
+  test("REGRESSION: preference-category filter + context sources still folds", async () => {
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    const result = await ltm.forSession(PROJ, undefined, 4000, {
+      categories: ["preference"],
+      contextHint: HINT,
+      includeContextSources: ["distillation"],
+    });
+    const ids = new Set(result.map((e) => e.id));
+    expect(ids.has(`d:${distId}`)).toBe(true);
+  });
+
   test("cache-stable: stickyIds keeps a folded synthetic selected when a knowledge entry would otherwise displace it", async () => {
     // Budget fits exactly ONE non-arch entry, so a distillation synthetic
     // (d:distId) and a knowledge entry (k2) compete for that single slot.


### PR DESCRIPTION
## The bug
`forSession`'s empty-knowledge fast path returned `[]` as soon as **both** knowledge pools were empty — **before** the context-source fold (#1228/#1293) that surfaces passive distillation/temporal facts:

```js
if (!crossEntries.length && !projectEntries.length) {
  timer.emit("forSession", 0);
  return [];   // ← skips the includeContextSources fold below
}
```

So whenever the `knowledge` table was empty — a fresh project, or **any distillation-only session** — passive injection was silently dead. Facts were captured, embedded, and FTS-matchable, yet never reached the model.

## How it was found
The #961 live eval. On the single-long **lore** arm, the turn-0 aside (`channel=WHOLESALE, region=EMEA, warehouse=WH-07, status=SUBMITTED`) was:
- ✅ captured (distillation row)
- ✅ embedded (`distillation_vec` populated)
- ✅ FTS-matchable (best BM25 rank against the session context)

…yet `forSession(...)` returned **0 entries** and `gateway.log` showed **0** fact mentions. The agent produced generic defaults (`web`/`us-east`/`wh1`/`pending`) and failed the probes — **because Lore handed it nothing, not because the model couldn't apply facts.** (This also means prior single-long lore-arm eval numbers understate Lore — passive injection was off whenever knowledge was empty.)

## The fix
Take the fast path only when the caller did **not** ask for a context-source fold (or there's no session/hint context). When `includeContextSources` is set and a context exists, fall through so the fold runs — the scoring path handles empty knowledge pools fine (`allScored` just starts empty). The fast path is preserved for the common no-context-source empty-knowledge case (verified: 0 entries, no extra embed).

## Test
Existing context-source tests always seeded a knowledge entry, so they never hit the fast path — which is why this slipped through. Added a regression test that seeds a distillation + temporal message with **no knowledge** and asserts the fold still surfaces them, plus that the fast path is preserved when the fold isn't requested. **Mutation-verified:** restoring the unconditional early return turns the test red.

Verified against the actual failing eval DB: with the fix, the `WHOLESALE`/`EMEA`/`WH-07` distillation now surfaces into system[2] (`FACT SURFACED = true`), while the no-context-source empty-knowledge path still returns 0.