### PR TITLE
fix(eval): decision-recall negative-control baseline must be "raw", not "no-memory"

### DIFF
--- a/packages/core/eval/decision-recall.test.ts
+++ b/packages/core/eval/decision-recall.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, test } from "vitest";
 import { scoreRetrieval } from "./recall-score";
 import { scenarios } from "./scenarios/decision-recall";
+import { ALL_BASELINES } from "./types";
 
 const scenario = scenarios[0];
 const byId = new Map(scenario.questions.map((q) => [q.id, q]));
 
 describe("DEC-1 decision-recall scenario (#1403)", () => {
-  test("registers one scenario with 3 evolving sessions and the no-memory control arm", () => {
+  test("registers one scenario with 3 evolving sessions and the raw no-memory control arm", () => {
     expect(scenario.id).toBe("dec-1-decision-evolution");
     expect(scenario.sessions).toHaveLength(3);
-    expect(scenario.applicableBaselines).toContain("no-memory");
+    // The negative-control arm must be `raw` (full history, no memory layer):
+    // "no-memory" is NOT a valid BaselineMode, so the harness would silently
+    // filter it out and the control would never run (regression guard for the
+    // Seer-flagged bug in #1431).
+    expect(scenario.applicableBaselines).toContain("raw");
     expect(scenario.applicableBaselines).toContain("lore");
+    // Every listed baseline must be a REAL BaselineMode — else harness.ts's
+    // `.includes(b)` intersection silently drops it and the arm never executes.
+    for (const b of scenario.applicableBaselines) {
+      expect(ALL_BASELINES).toContain(b);
+    }
   });
 
   test("every question carries deterministic anchors (expected or forbidden facts)", () => {

--- a/packages/core/eval/scenarios/decision-recall.ts
+++ b/packages/core/eval/scenarios/decision-recall.ts
@@ -16,8 +16,9 @@
  *
  * Scored two ways, kept separate (no justifier): deterministic retrieval via
  * expectedFacts/forbiddenFacts, and the currency-weighted `preferenceEvolution`
- * rubric for end-task quality. Runs on the lore arms AND the `no-memory`
- * negative-control baseline so a "memory does nothing" arm is measured too.
+ * rubric for end-task quality. Runs on the lore arms AND the `raw` (full history,
+ * no memory layer) negative-control baseline so a "memory does nothing" arm is
+ * measured too.
  */
 
 import type {
@@ -35,7 +36,7 @@ const APPLICABLE_BASELINES: BaselineMode[] = [
   "lore-memory-only",
   "tail-window",
   "compaction",
-  "no-memory",
+  "raw",
 ];
 
 let toolId = 0;


### PR DESCRIPTION
## What

Fixes the Seer bug prediction on #1431 ([review r3622842287](https://github.com/BYK/loreai/pull/1431#discussion_r3622842287)) — **verified real**.

`decision-recall.ts` (the DEC-1 decision-evolution scenario, #1403) listed `"no-memory"` in `APPLICABLE_BASELINES`, but `"no-memory"` is **not** a member of the `BaselineMode` union (`types.ts:31`). The no-memory control is `"raw"` — *"full conversation, no memory layer"* (`baselines.ts:264`). The harness intersects a scenario's `applicableBaselines` against the configured baselines via `.includes(b)` (`harness.ts:886`), so `"no-memory"` was silently filtered out and the negative-control arm — the scenario's entire reason for existing (measure a *"memory does nothing"* baseline) — **never ran**.

## Why it wasn't caught

`packages/core/eval` is not in the core `tsconfig.json` `include` (`["src","test","script"]`), so `BaselineMode[]` type-checking never covered the eval scenarios — a `"no-memory"` literal in a `BaselineMode[]` array compiles clean. Widening eval typecheck coverage surfaces ~60 pre-existing errors (ImportMeta, `bun:sqlite`, etc.), so that's tracked separately and out of scope here.

The existing test was also **vacuous** on this: `expect(scenario.applicableBaselines).toContain("no-memory")` only checked the string was *present*, so it passed while the arm silently didn't execute.

## Change

- `decision-recall.ts`: `"no-memory"` → `"raw"` in `APPLICABLE_BASELINES`; doc comment clarified (`` `raw` (full history, no memory layer) ``).
- `decision-recall.test.ts`: now asserts `"raw"` is present **and** that *every* listed baseline is a real `BaselineMode` (`ALL_BASELINES` membership) — a regression guard against any future invalid baseline the harness would silently drop.

**Mutation-verified:** forcing `"no-memory"` back (`as BaselineMode`) fails the new membership assertion. Full `@loreai/core` eval suite green (3 files / 32 tests); format clean.