### PR TITLE
fix(import): read engram export from a file, not stdout (#1398)

### DIFF
--- a/packages/core/src/import/structured-sources.ts
+++ b/packages/core/src/import/structured-sources.ts
@@ -8,8 +8,8 @@
  * written directly to the knowledge store via `importStructuredEntries`.
  */
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseEngramExport } from "./sources/engram";
 import {
@@ -93,12 +93,24 @@ export const engramSource: StructuredSource = {
     if (opts?.filePath) {
       raw = readJson(opts.filePath);
     } else if (hasBinary("engram")) {
-      // `engram export` writes the ExportData JSON to stdout.
-      const out = execFileSync("engram", ["export"], {
-        encoding: "utf8",
-        maxBuffer: 256 * 1024 * 1024,
-      });
-      raw = JSON.parse(out);
+      // `engram export [file]` writes the ExportData JSON to a FILE (default
+      // `engram-export.json`) and prints a human-readable summary ("Exported to
+      // …", possibly preceded by an "Update available" banner) to stdout — it
+      // does NOT emit JSON on stdout. So we hand it an explicit temp file, then
+      // read and parse that file. Parsing stdout fails with e.g.
+      // `Unexpected token 'E', "Exported t"... is not valid JSON` — or, when the
+      // update banner precedes the summary, `"Update ava"...` (issue #1398).
+      const dir = mkdtempSync(join(tmpdir(), "lore-engram-"));
+      const exportFile = join(dir, "engram-export.json");
+      try {
+        execFileSync("engram", ["export", exportFile], {
+          stdio: "ignore",
+          maxBuffer: 256 * 1024 * 1024,
+        });
+        raw = readJson(exportFile);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     } else {
       throw new Error(
         "Engram not found. Install the `engram` binary or pass --file <export.json> " +

--- a/packages/core/test/import/engram-binary-export.test.ts
+++ b/packages/core/test/import/engram-binary-export.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression test for issue #1398: `lore import --source engram` failed with
+ * `Unexpected token 'E', "Exported t"... is not valid JSON`.
+ *
+ * Root cause: `engram export [file]` writes the JSON to a FILE (default
+ * `engram-export.json`) and prints a human-readable summary ("Exported to …",
+ * possibly preceded by an "Update available" banner) to stdout. The old code
+ * ran `engram export` with no file arg and `JSON.parse`d stdout — which is the
+ * summary text, not JSON. The fix passes an explicit temp file and reads it.
+ *
+ * We mock `node:child_process.execFileSync` to reproduce the real binary's
+ * behavior: the `which`/`where` probe succeeds, and `engram export <file>`
+ * writes JSON to the file path it was given while emitting summary text to
+ * stdout. A correct implementation must read the FILE, not parse stdout.
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { writeFileSync } from "node:fs";
+
+const EXPORT_JSON = {
+  version: "1.0",
+  exported_at: "2026-07-21 18:37:34",
+  sessions: [{ id: "s1", directory: "/repo" }],
+  observations: [
+    {
+      session_id: "s1",
+      type: "architecture",
+      title: "Auth uses JWT",
+      content: "The auth layer validates JWT in middleware",
+      scope: "project",
+    },
+  ],
+  prompts: [],
+};
+
+const SUMMARY_STDOUT =
+  "Update available: 0.0.0 -> 1.20.0\nTo update:\n  brew upgrade engram\n\n" +
+  "Exported to engram-export.json\n  Sessions:     1\n  Observations: 1\n  Prompts:      0\n";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn((cmd: string, args: readonly string[]) => {
+    // `which engram` / `where engram` probe → succeed (binary present).
+    if (cmd === "which" || cmd === "where") return "";
+    // `engram export <file>` → write JSON to the file arg, "print" summary.
+    if (cmd === "engram" && args[0] === "export") {
+      const outFile = args[1];
+      if (typeof outFile === "string") {
+        writeFileSync(outFile, JSON.stringify(EXPORT_JSON), "utf8");
+      }
+      return SUMMARY_STDOUT;
+    }
+    throw new Error(`unexpected execFileSync call: ${cmd} ${args?.join(" ")}`);
+  }),
+}));
+
+describe("engramSource.produceDoc (binary path, #1398 regression)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("reads the export FILE, never parses stdout summary text", async () => {
+    // Imported after the mock is registered.
+    const { engramSource } =
+      await import("../../src/import/structured-sources");
+    const doc = await engramSource.produceDoc();
+    expect(doc.source).toBe("engram");
+    expect(doc.entries).toHaveLength(1);
+    expect(doc.entries[0].title).toBe("Auth uses JWT");
+    expect(doc.entries[0].category).toBe("architecture");
+    expect(doc.entries[0].project).toBe("/repo");
+  });
+
+  test("passes an explicit output file to `engram export`", async () => {
+    const cp = await import("node:child_process");
+    const { engramSource } =
+      await import("../../src/import/structured-sources");
+    await engramSource.produceDoc();
+    const exportCall = (
+      cp.execFileSync as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls.find((c) => c[0] === "engram");
+    expect(exportCall).toBeDefined();
+    // args = ["export", "<tmpfile>"] — the file arg is required for the fix.
+    const args = exportCall?.[1] as string[];
+    expect(args[0]).toBe("export");
+    expect(typeof args[1]).toBe("string");
+    expect(args[1].length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Report

@Kjaer hit this on `0.38.0-dev.1784647061` ([#1398 comment](https://github.com/BYK/loreai/issues/1398#issuecomment-5037159805)):

```
$ lore import --source engram --global
[lore] Importing structured memory from Engram...
[lore] Could not read Engram memory: Unexpected token 'E', "Exported t"... is not valid JSON
```

## Root cause

`engram export [file]` **writes the JSON to a FILE** (default `engram-export.json`) and prints a human-readable summary to stdout:

```
Exported to engram-export.json
  Sessions:     2
  Observations: 2
  Prompts:      0
```

(and, in some builds, an `Update available: …` banner before it). The connector ran `engram export` with **no file arg** and did `JSON.parse(stdout)` — parsing the summary text ("**Exported t**o…"), not JSON. The `// engram export writes the ExportData JSON to stdout` comment was simply wrong. Confirmed by reading Engram's source (`cmdExport` in `cmd/engram/main.go`: `os.WriteFile(outFile, …)` + `fmt.Printf("Exported to %s\n", …)`).

Note: this never reached Sentry — the CLI catches it in `importStructured` and prints `Could not read … memory`, so there's no captured event to find.

## Fix

Run `engram export <tmpfile>` (explicit output path under a `mkdtemp` dir), read + parse that file, and remove the temp dir in a `finally`. This also sidesteps the stdout update-banner entirely.

**Verified end-to-end against the real `engram` binary** (built from `github.com/Gentleman-Programming/engram`): a store with 2 observations now imports as `2 created` (correct category/scope mapping) instead of crashing.

## Test

New `packages/core/test/import/engram-binary-export.test.ts` mocks `node:child_process` to reproduce the real binary's behavior (probe succeeds; `engram export <file>` writes JSON to the file arg, prints summary to stdout). The binary export path previously had **zero coverage** — only `--file` and not-found were tested, which is exactly why this shipped. **Mutation-verified:** reverting to `JSON.parse(stdout)` fails both new tests.

## Gate

- Full suite **6459 passed** (+2). Only failure is the environmental jj-workspace `agents.test.ts` git-remote check — passes in CI. typecheck / lint / format:check clean.

Fixes the Engram import failure reported in #1398.