### PR TITLE
docs(gradient): record #1404-B negative result — keep literature quality-knee priors (#1404)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -235,16 +235,30 @@ export function getQualityKnee(): number {
 
 /**
  * Literature-seeded per-model-family quality knees (fill fraction where
- * lost-in-the-middle degradation becomes material). These are NOT empirically
- * measured on our own eval yet (#1404-B / #1402 will replace them with measured
- * values); they are conservative priors read off the public long-context
- * degradation literature so per-model compression is at least directionally
- * right instead of a flat 0.4 for everyone:
+ * lost-in-the-middle degradation becomes material). They are conservative priors
+ * read off the public long-context degradation literature so per-model
+ * compression is at least directionally right instead of a flat 0.4 for everyone:
  *
  *   - "Lost in the Middle" (Liu et al., TACL 2023, arXiv:2307.03172)
  *   - Chroma "Context Rot" (Hong et al., 2025, 18 models incl. Claude 4 /
  *     GPT-4.1 / Gemini 2.5) — degradation is continuous, model-specific, and
  *     begins well before a window is full; frontier models hold quality longer.
+ *
+ * We ATTEMPTED to replace these with values measured on our own eval (#1404-B,
+ * using #1402's behavioral rot A/B over the MATRIX-V5 single-long cells:
+ * deepseek/m3 @ cap200, sonnet @ cap200+cap500, both arms, N=5). The result was
+ * a documented NEGATIVE: the 5 contextrot behavioral signals (tool_error,
+ * edit_failure, retry, reread, self_correction) fired only ~24 times across
+ * ~1,958 steps (1.2% density), so NO scenario reached a fittable / Wilson-
+ * significant degradation knee (every arm returned knee=null,
+ * ratioSignificant=false). Clean, structured coding-agent transcripts simply do
+ * not generate enough behavioral degradation to trace a per-model rot curve —
+ * consistent with METHODOLOGY.md's caveat that contextrot needs ~150+
+ * degradation-bearing steps. Per the gating rule (adopt a measured knee only
+ * when Wilson-significant with adequate n; otherwise keep the literature prior),
+ * ALL priors below are retained unchanged. Raw analysis:
+ * quality/eval-artifacts/rot-behavioral-matrix-v5.json. Revisit only if a
+ * higher-signal (longer, more error-prone) eval produces a measurable knee.
  *
  * Keyed by a lowercased family stem matched as a PREFIX of the bare model id
  * (the last `/`-segment). LONGEST matching prefix wins, so entries may be listed
@@ -281,10 +295,12 @@ const QUALITY_KNEE_BY_FAMILY: ReadonlyArray<readonly [string, number]> = [
  * the same way `setQualityKnee` validates — out-of-range / non-finite falls
  * through to the next source. Pure; safe to call on the hot path.
  *
- * NOTE: the returned value is a PRIOR, not a measured knee (#1404-A). #1402's
- * rot-curve A/B is expected to replace the table with empirical per-model values
- * (#1404-B). Keeping the seed table here (core, next to the default and the
- * multiplier that consumes it) keeps the prior testable without the gateway.
+ * NOTE: the returned value is a literature PRIOR, not a measured knee. #1404-B
+ * attempted to replace the table with values measured via #1402's behavioral rot
+ * A/B but found no statistically-significant per-model knee (signal too sparse on
+ * coding-agent transcripts — see the QUALITY_KNEE_BY_FAMILY comment above), so
+ * the priors stand. Keeping the seed table here (core, next to the default and
+ * the multiplier that consumes it) keeps the prior testable without the gateway.
  */
 export function resolveQualityKnee(modelID: string, override?: number): number {
   const valid = (v: number | undefined): v is number =>

--- a/quality/eval-artifacts/rot-behavioral-matrix-v5.json
+++ b/quality/eval-artifacts/rot-behavioral-matrix-v5.json
@@ -1,0 +1,595 @@
+[
+  {
+    "scenario": "long-deepseek-cap200",
+    "axis": "tokens",
+    "freshMax": 84684,
+    "deepMin": 162426,
+    "bucketWidth": 29335,
+    "arms": [
+      {
+        "arm": "lore",
+        "n": 189,
+        "runs": 5,
+        "freshRate": 0.015873015873015872,
+        "deepRate": null,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 1,
+          "edit_failure": 1,
+          "retry": 0,
+          "reread": 2,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "nolore",
+        "n": 262,
+        "runs": 5,
+        "freshRate": 0.06796116504854369,
+        "deepRate": 0,
+        "degradationRatio": 0,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 1,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 6,
+          "self_correction": 0
+        }
+      }
+    ],
+    "contrasts": [
+      {
+        "arm": "nolore",
+        "n": 262,
+        "loreFreshRate": 0.015873015873015872,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0.06796116504854369,
+        "armDeepRate": 0,
+        "armDegradationRatio": 0,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      }
+    ],
+    "armsBalanced": false
+  },
+  {
+    "scenario": "long-m3-cap200",
+    "axis": "tokens",
+    "freshMax": 80389,
+    "deepMin": 150174,
+    "bucketWidth": 28097,
+    "arms": [
+      {
+        "arm": "lore",
+        "n": 192,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": 0,
+        "degradationRatio": 1,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 0,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "nolore",
+        "n": 323,
+        "runs": 5,
+        "freshRate": 0.04878048780487805,
+        "deepRate": 0,
+        "degradationRatio": 0,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 4,
+          "edit_failure": 2,
+          "retry": 0,
+          "reread": 4,
+          "self_correction": 0
+        }
+      }
+    ],
+    "contrasts": [
+      {
+        "arm": "nolore",
+        "n": 323,
+        "loreFreshRate": 0,
+        "loreDeepRate": 0,
+        "loreDegradationRatio": 1,
+        "loreKnee": null,
+        "armFreshRate": 0.04878048780487805,
+        "armDeepRate": 0,
+        "armDegradationRatio": 0,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      }
+    ],
+    "armsBalanced": false
+  },
+  {
+    "scenario": "long-sonnet-cap200",
+    "axis": "tokens",
+    "freshMax": 11922,
+    "deepMin": 92086,
+    "bucketWidth": 20796,
+    "arms": [
+      {
+        "arm": "lore",
+        "n": 163,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": null,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 0,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "nolore",
+        "n": 433,
+        "runs": 5,
+        "freshRate": 0.005988023952095809,
+        "deepRate": 0.007462686567164179,
+        "degradationRatio": 1.2462686567164178,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 2,
+          "self_correction": 0
+        }
+      }
+    ],
+    "contrasts": [
+      {
+        "arm": "nolore",
+        "n": 433,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0.005988023952095809,
+        "armDeepRate": 0.007462686567164179,
+        "armDegradationRatio": 1.2462686567164178,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      }
+    ],
+    "armsBalanced": false
+  },
+  {
+    "scenario": "long-sonnet-cap500",
+    "axis": "tokens",
+    "freshMax": 171669,
+    "deepMin": 255622,
+    "bucketWidth": 61225,
+    "arms": [
+      {
+        "arm": "lore",
+        "n": 165,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": null,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 0,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "nolore",
+        "n": 211,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": 0,
+        "degradationRatio": 1,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 1,
+          "self_correction": 0
+        }
+      }
+    ],
+    "contrasts": [
+      {
+        "arm": "nolore",
+        "n": 211,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0,
+        "armDegradationRatio": 1,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      }
+    ],
+    "armsBalanced": false
+  },
+  {
+    "scenario": "xs-deepseek",
+    "axis": "tokens",
+    "freshMax": 119724,
+    "deepMin": 227839,
+    "bucketWidth": 27884,
+    "arms": [
+      {
+        "arm": "lore",
+        "n": 103,
+        "runs": 5,
+        "freshRate": 0.019417475728155338,
+        "deepRate": null,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 2,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "nolore",
+        "n": 117,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": 0,
+        "degradationRatio": 1,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 5,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "mcp-mem0",
+        "n": 82,
+        "runs": 3,
+        "freshRate": 0,
+        "deepRate": 0.029411764705882353,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 1,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "mcp-mnemonic",
+        "n": 82,
+        "runs": 3,
+        "freshRate": 0,
+        "deepRate": 0.05128205128205128,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 2,
+          "self_correction": 0
+        }
+      }
+    ],
+    "contrasts": [
+      {
+        "arm": "nolore",
+        "n": 117,
+        "loreFreshRate": 0.019417475728155338,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0,
+        "armDegradationRatio": 1,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      },
+      {
+        "arm": "mcp-mem0",
+        "n": 82,
+        "loreFreshRate": 0.019417475728155338,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0.029411764705882353,
+        "armDegradationRatio": null,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      },
+      {
+        "arm": "mcp-mnemonic",
+        "n": 82,
+        "loreFreshRate": 0.019417475728155338,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0.05128205128205128,
+        "armDegradationRatio": null,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      }
+    ],
+    "armsBalanced": false
+  },
+  {
+    "scenario": "xs-m3",
+    "axis": "tokens",
+    "freshMax": 112478,
+    "deepMin": 212035,
+    "bucketWidth": 27160,
+    "arms": [
+      {
+        "arm": "lore",
+        "n": 139,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": null,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 1,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "nolore",
+        "n": 179,
+        "runs": 5,
+        "freshRate": 0.02631578947368421,
+        "deepRate": 0.05555555555555555,
+        "degradationRatio": 2.111111111111111,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 7,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "mcp-mem0",
+        "n": 132,
+        "runs": 3,
+        "freshRate": 0.08333333333333333,
+        "deepRate": 0.06349206349206349,
+        "degradationRatio": 0.7619047619047619,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 8,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "mcp-mnemonic",
+        "n": 112,
+        "runs": 3,
+        "freshRate": 0,
+        "deepRate": 0.019230769230769232,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 1,
+          "self_correction": 0
+        }
+      }
+    ],
+    "contrasts": [
+      {
+        "arm": "nolore",
+        "n": 179,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0.02631578947368421,
+        "armDeepRate": 0.05555555555555555,
+        "armDegradationRatio": 2.111111111111111,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      },
+      {
+        "arm": "mcp-mem0",
+        "n": 132,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0.08333333333333333,
+        "armDeepRate": 0.06349206349206349,
+        "armDegradationRatio": 0.7619047619047619,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      },
+      {
+        "arm": "mcp-mnemonic",
+        "n": 112,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0.019230769230769232,
+        "armDegradationRatio": null,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      }
+    ],
+    "armsBalanced": false
+  },
+  {
+    "scenario": "xs-sonnet",
+    "axis": "tokens",
+    "freshMax": 127134,
+    "deepMin": 240872,
+    "bucketWidth": 29638,
+    "arms": [
+      {
+        "arm": "lore",
+        "n": 108,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": null,
+        "degradationRatio": null,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 0,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "nolore",
+        "n": 121,
+        "runs": 5,
+        "freshRate": 0,
+        "deepRate": 0,
+        "degradationRatio": 1,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 0,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "mcp-mem0",
+        "n": 84,
+        "runs": 3,
+        "freshRate": 0,
+        "deepRate": 0,
+        "degradationRatio": 1,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 0,
+          "self_correction": 0
+        }
+      },
+      {
+        "arm": "mcp-mnemonic",
+        "n": 84,
+        "runs": 3,
+        "freshRate": 0,
+        "deepRate": 0,
+        "degradationRatio": 1,
+        "ratioSignificant": false,
+        "knee": null,
+        "totals": {
+          "tool_error": 0,
+          "edit_failure": 0,
+          "retry": 0,
+          "reread": 0,
+          "self_correction": 0
+        }
+      }
+    ],
+    "contrasts": [
+      {
+        "arm": "nolore",
+        "n": 121,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0,
+        "armDegradationRatio": 1,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      },
+      {
+        "arm": "mcp-mem0",
+        "n": 84,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0,
+        "armDegradationRatio": 1,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      },
+      {
+        "arm": "mcp-mnemonic",
+        "n": 84,
+        "loreFreshRate": 0,
+        "loreDeepRate": null,
+        "loreDegradationRatio": null,
+        "loreKnee": null,
+        "armFreshRate": 0,
+        "armDeepRate": 0,
+        "armDegradationRatio": 1,
+        "armKnee": null,
+        "loreDeepAdvantageSignificant": false
+      }
+    ],
+    "armsBalanced": false
+  }
+]


### PR DESCRIPTION
Closes #1404-B (Workstream C follow-up). **No runtime behavior change** — provenance/comment update + raw analysis artifact.

## What #1404-B was
Replace the literature-seeded `QUALITY_KNEE_BY_FAMILY` priors (from #1404-A / #1410) with **measured** per-model quality knees, derived from #1402's behavioral rot A/B over the matrix single-long cells, gated on Wilson significance.

## Result: a documented negative
Ran `rot-behavioral.mjs` over the MATRIX-V5 single-long cells (deepseek/m3 @ cap200, sonnet @ cap200+cap500, both arms, N=5):

| | value |
|---|---|
| total behavioral-signal events | **24** |
| total steps analyzed | **1,958** |
| signal density | **1.2% events/step** |
| scenarios reaching a fittable knee | **0** |
| Wilson-significant degradation | **none** (every arm `knee=null`, `ratioSignificant=false`) |

The 5 contextrot signals (tool_error, edit_failure, retry, reread, self_correction) barely fire on clean, structured coding-agent transcripts — so there's no per-model rot curve to fit. This matches `METHODOLOGY.md`'s own caveat that contextrot needs ~150+ degradation-bearing steps; a 36–67-step coding task with few errors doesn't provide that.

## Decision
Per the gating rule (*adopt a measured knee only when Wilson-significant with adequate n; otherwise keep the literature prior*), **all priors are retained unchanged**. Overriding them with 24 events of noise would be worse than the literature-grounded defaults.

## Changes
- `packages/core/src/gradient.ts` — updated the `QUALITY_KNEE_BY_FAMILY` and `resolveQualityKnee` provenance comments to record the attempted measurement and its negative outcome (so the next person doesn't re-chase it), with a pointer to the raw artifact and the condition to revisit (a higher-signal, longer/more-error-prone eval).
- `quality/eval-artifacts/rot-behavioral-matrix-v5.json` — raw `rot-behavioral.mjs` output for the record.

tsc clean; `resolveQualityKnee` tests unchanged and green (comment-only src change).