### PR TITLE
feat(upgrade): TTY progress bars for delta-patch apply and full download

### DIFF
--- a/packages/gateway/src/cli/lib/bspatch.ts
+++ b/packages/gateway/src/cli/lib/bspatch.ts
@@ -616,6 +616,7 @@ async function applyReaderToFile(
   oldReader: OldReader,
   patchData: Uint8Array,
   destPath: string,
+  onBytes?: (bytes: number) => void,
 ): Promise<string> {
   const writer = createWriteStream(destPath, {
     highWaterMark: WRITE_HIGH_WATER_MARK,
@@ -639,6 +640,7 @@ async function applyReaderToFile(
       }
       writer.write(chunk);
       hasher.update(chunk);
+      onBytes?.(chunk.byteLength);
     });
   } finally {
     await new Promise<void>((resolve, reject) => {
@@ -667,6 +669,7 @@ async function applyReaderToFile(
 async function applyReaderToMemory(
   oldReader: OldReader,
   patchData: Uint8Array,
+  onBytes?: (bytes: number) => void,
 ): Promise<Uint8Array> {
   // Preallocate the exact output size from the header so chunks can be copied
   // in place — avoids a final concat pass over ~310 MB of output.
@@ -677,6 +680,7 @@ async function applyReaderToMemory(
   await transformPatch(oldReader, patchData, (chunk) => {
     output.set(chunk, offset);
     offset += chunk.byteLength;
+    onBytes?.(chunk.byteLength);
   });
 
   return output;
@@ -715,6 +719,7 @@ export async function applyPatchChainInMemory(
   oldPath: string,
   patches: Uint8Array[],
   destPath: string,
+  onBytes?: (bytes: number) => void,
 ): Promise<string> {
   if (patches.length === 0) {
     throw new Error("Cannot apply an empty patch chain");
@@ -732,7 +737,7 @@ export async function applyPatchChainInMemory(
       if (!patch) {
         throw new Error(`Missing patch at index ${i}`);
       }
-      const next = await applyReaderToMemory(reader, patch);
+      const next = await applyReaderToMemory(reader, patch, onBytes);
       await reader.close();
       reader = new MemoryOldReader(next);
     }
@@ -742,7 +747,7 @@ export async function applyPatchChainInMemory(
     if (!finalPatch) {
       throw new Error("Missing final patch");
     }
-    return await applyReaderToFile(reader, finalPatch, destPath);
+    return await applyReaderToFile(reader, finalPatch, destPath, onBytes);
   } finally {
     await reader.close();
   }

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -28,7 +28,8 @@ import {
   isDowngrade,
   isNightlyVersion,
 } from "./binary";
-import { applyPatchChainInMemory } from "./bspatch";
+import { applyPatchChainInMemory, parsePatchHeader } from "./bspatch";
+import { makeByteProgress } from "./progress";
 import { VERSION } from "../version";
 import {
   downloadLayerBlob,
@@ -632,12 +633,38 @@ async function applyChainAndReturn(
   oldBinaryPath: string,
   destPath: string,
 ): Promise<DeltaResult> {
-  const sha256 = await applyPatchChain(chain, oldBinaryPath, destPath);
-  return {
-    sha256,
-    patchBytes: chain.totalSize,
-    chainLength: chain.patches.length,
-  };
+  // Progress bar for the apply phase: total is the final binary size (the last
+  // patch's declared `newSize`), so the number shown is the real output the
+  // user gets — not the sum of intermediate hop writes. The bar advances per
+  // byte written across all hops, so it stays smooth through the chain.
+  let finalSize: number | null = null;
+  try {
+    const last = chain.patches.at(-1);
+    if (last) {
+      finalSize = parsePatchHeader(last.data).newSize;
+    }
+  } catch {
+    // Header parse is best-effort for the bar; a corrupt header is rejected
+    // properly downstream. Leave the bar indeterminate in that case.
+    finalSize = null;
+  }
+  const label = `Applying ${chain.patches.length} patch(es)`;
+  const progress = makeByteProgress(label, finalSize);
+  try {
+    const sha256 = await applyPatchChain(
+      chain,
+      oldBinaryPath,
+      destPath,
+      progress.onProgress,
+    );
+    return {
+      sha256,
+      patchBytes: chain.totalSize,
+      chainLength: chain.patches.length,
+    };
+  } finally {
+    progress.done();
+  }
 }
 
 /**
@@ -690,11 +717,13 @@ export async function applyPatchChain(
   chain: PatchChain,
   oldBinaryPath: string,
   destPath: string,
+  onBytes?: (bytes: number) => void,
 ): Promise<string> {
   const sha256 = await applyPatchChainInMemory(
     oldBinaryPath,
     chain.patches.map((p) => p.data),
     destPath,
+    onBytes,
   );
 
   if (sha256 !== chain.expectedSha256) {

--- a/packages/gateway/src/cli/lib/progress.ts
+++ b/packages/gateway/src/cli/lib/progress.ts
@@ -1,0 +1,104 @@
+/**
+ * Byte-driven TTY progress bar for long-running CLI operations.
+ *
+ * Design contract (shared with the sync progress reporter):
+ * - Renders only on a TTY; a no-op otherwise (header may still print once).
+ * - Cosmetic ONLY — rendering must never throw or abort the underlying work.
+ * - Determinate: caller supplies a byte `total`; progress advances by reported
+ *   bytes written/downloaded. When `total` is unknown, an indeterminate form
+ *   (byte counter, no bar) is used.
+ *
+ * One line, redrawn in place via carriage return; `done()` clears the line so
+ * the next message prints cleanly.
+ */
+
+export type ByteProgressOut = {
+  isTTY?: boolean;
+  write: (s: string) => unknown;
+};
+
+export type ByteProgress = {
+  /** Report `bytes` additional bytes processed since the last call. */
+  onProgress: (bytes: number) => void;
+  /** Clear the progress line (call before printing the next message). */
+  done: () => void;
+};
+
+const BAR_WIDTH = 16;
+
+function renderBar(frac: number, width = BAR_WIDTH): string {
+  const filled = Math.max(0, Math.min(width, Math.round(width * frac)));
+  return "█".repeat(filled) + "░".repeat(width - filled);
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let v = n / 1024;
+  let u = 0;
+  while (v >= 1024 && u < units.length - 1) {
+    v /= 1024;
+    u++;
+  }
+  return `${v.toFixed(v >= 100 ? 0 : v >= 10 ? 1 : 2)} ${units[u]}`;
+}
+
+/**
+ * Create a byte-progress bar.
+ *
+ * @param label - Short label shown before the bar (e.g. "Applying 3 patches").
+ * @param totalBytes - Expected total bytes; `null` renders an indeterminate
+ *   byte counter instead of a bar.
+ * @param out - Output stream (defaults to stderr, the CLI's progress channel).
+ */
+export function makeByteProgress(
+  label: string,
+  totalBytes: number | null,
+  out: ByteProgressOut = process.stderr,
+): ByteProgress {
+  const tty = !!out.isTTY;
+  let written = 0;
+  let lastLen = 0;
+  let headerShown = false;
+
+  const line = (): string => {
+    if (totalBytes === null || totalBytes <= 0) {
+      return `${label}  ${formatBytes(written)}`;
+    }
+    const frac = Math.min(written / totalBytes, 1);
+    return (
+      `${label} [${renderBar(frac)}] ` +
+      `${formatBytes(written)} / ${formatBytes(totalBytes)}`
+    );
+  };
+
+  const onProgress = (bytes: number): void => {
+    // Cosmetic only — a rendering failure must never abort the operation.
+    try {
+      written += bytes;
+      if (!tty) {
+        if (!headerShown) {
+          out.write(`${label}\n`);
+          headerShown = true;
+        }
+        return;
+      }
+      const l = line();
+      lastLen = l.length;
+      out.write(`\r${l}`);
+    } catch {
+      // ignore — progress is cosmetic
+    }
+  };
+
+  const done = (): void => {
+    // Cosmetic only — must never throw, matching onProgress's contract.
+    try {
+      if (tty && lastLen > 0) out.write(`\r${" ".repeat(lastLen)}\r`);
+    } catch {
+      // ignore — progress is cosmetic
+    }
+  };
+
+  return { onProgress, done };
+}

--- a/packages/gateway/src/cli/lib/upgrade.ts
+++ b/packages/gateway/src/cli/lib/upgrade.ts
@@ -42,6 +42,7 @@ import {
 } from "./binary";
 import { attemptDeltaUpgrade } from "./delta-upgrade";
 import { UpgradeError } from "./errors";
+import { makeByteProgress } from "./progress";
 import {
   downloadNightlyBlob,
   fetchManifest,
@@ -287,6 +288,11 @@ export type DownloadResult = {
 
 /**
  * Stream a response body through gzip decompression to disk.
+ *
+ * Shows a byte-counter progress line on a TTY. The decompressed size is not
+ * known ahead of time (Content-Length covers only the compressed stream), so
+ * the bar is indeterminate — a live byte count, not a fraction, to avoid a
+ * misleading total.
  */
 async function streamDecompressToFile(
   body: ReadableStream<Uint8Array>,
@@ -298,10 +304,24 @@ async function streamDecompressToFile(
       Uint8Array
     >,
   );
-  await pipeline(
-    Readable.fromWeb(stream as never),
-    createWriteStream(destPath),
-  );
+
+  const progress = makeByteProgress("Downloading", null);
+  try {
+    // Tap the stream to count decompressed bytes without buffering them.
+    const counting = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        progress.onProgress(chunk.byteLength);
+        controller.enqueue(chunk);
+      },
+    });
+    const counted = stream.pipeThrough(counting);
+    await pipeline(
+      Readable.fromWeb(counted as never),
+      createWriteStream(destPath),
+    );
+  } finally {
+    progress.done();
+  }
 }
 
 function getNightlyGzFilename(): string {

--- a/packages/gateway/test/progress.test.ts
+++ b/packages/gateway/test/progress.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the byte-driven CLI progress bar.
+ *
+ * The bar is cosmetic-only and must never abort the operation it decorates.
+ * These cover: determinate fraction rendering, indeterminate byte counter,
+ * non-TTY header-only behavior, byte accumulation across calls, and the
+ * never-throws contract (a failing output stream must not propagate).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { makeByteProgress } from "../src/cli/lib/progress";
+
+type FakeOut = {
+  isTTY: boolean;
+  writes: string[];
+  write: (s: string) => boolean;
+};
+
+function fakeOut(isTTY: boolean): FakeOut {
+  const writes: string[] = [];
+  return {
+    isTTY,
+    writes,
+    write(s: string) {
+      writes.push(s);
+      return true;
+    },
+  };
+}
+
+describe("makeByteProgress", () => {
+  it("renders a determinate bar advancing with reported bytes on a TTY", () => {
+    const out = fakeOut(true);
+    const p = makeByteProgress("Applying 3 patches", 1000, out);
+    p.onProgress(500);
+    p.onProgress(500);
+    p.done();
+
+    const last = out.writes.at(-2); // last real line before the clear
+    expect(last).toContain("Applying 3 patches");
+    expect(last).toContain("█");
+    // 1000/1000 -> full bar; 1000 B is below the 1024 threshold, shown as bytes
+    expect(last).toContain("█".repeat(16));
+    expect(last).toContain("1000 B");
+  });
+
+  it("renders an indeterminate byte counter when total is null", () => {
+    const out = fakeOut(true);
+    const p = makeByteProgress("Downloading", null, out);
+    p.onProgress(2048);
+    p.done();
+
+    const last = out.writes.at(-2);
+    expect(last).toContain("Downloading");
+    expect(last).toContain("2.00 KB");
+    expect(last).not.toContain("░"); // no bar in indeterminate mode
+  });
+
+  it("accumulates bytes across multiple onProgress calls", () => {
+    const out = fakeOut(true);
+    const p = makeByteProgress("Applying", 100, out);
+    p.onProgress(10);
+    p.onProgress(40);
+    p.onProgress(50); // total 100 -> full
+    p.done();
+    const last = out.writes.at(-2);
+    expect(last).toContain("█".repeat(16));
+    expect(last).toContain("100 B");
+  });
+
+  it("clamps the bar at full even if bytes exceed the total", () => {
+    const out = fakeOut(true);
+    const p = makeByteProgress("Applying", 100, out);
+    p.onProgress(5000);
+    p.done();
+    const last = out.writes.at(-2);
+    expect(last).toContain("█".repeat(16));
+    expect(last).not.toContain("░");
+  });
+
+  it("prints the header once (no bar) off a TTY", () => {
+    const out = fakeOut(false);
+    const p = makeByteProgress("Applying 3 patches", 1000, out);
+    p.onProgress(500);
+    p.onProgress(500);
+    p.done();
+    expect(out.writes).toEqual(["Applying 3 patches\n"]);
+  });
+
+  it("never throws even if the output stream throws", () => {
+    const throwing = {
+      isTTY: true,
+      write(): boolean {
+        throw new Error("boom");
+      },
+    };
+    const p = makeByteProgress("Applying", 100, throwing);
+    expect(() => {
+      p.onProgress(50);
+      p.done();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Adds live progress bars to `lore upgrade` so the slow phases aren't a silent wait.

- **Apply phase** (the slow part of a delta upgrade): a determinate bar — `Applying 3 patches [███████░░░░░░░░░] 152 MB / 310 MB`. Total is the **final binary size** (the last patch's declared `newSize`), i.e. the real output the user gets — not the sum of intermediate hop writes. Progress is byte-driven across the whole chain, so it advances smoothly rather than stalling per-hop.
- **Full-binary download**: an indeterminate byte counter — `Downloading  87.0 MB`. The decompressed size isn't knowable ahead (`Content-Length` only covers the compressed stream), so it shows an honest live byte count, not a fake fraction.

The tiny parallel patch downloads (KBs) intentionally get **no** bar.

## How

- New `packages/gateway/src/cli/lib/progress.ts`: `makeByteProgress(label, totalBytes)` — reusable, modeled on the existing `makeSyncProgress`. TTY-only; cosmetic (rendering must never abort the operation); clears its line on `done()`.
- Progress callback (`onBytes`) threaded through `transformPatch` → `applyReaderToMemory`/`applyReaderToFile` → `applyPatchChainInMemory` → `applyPatchChain`, reporting bytes-written per output chunk.
- Apply bar created in `applyChainAndReturn`; download bar in `streamDecompressToFile`.

## Tests

`packages/gateway/test/progress.test.ts` (6 tests): determinate/indeterminate rendering, non-TTY header-only behavior, full-bar clamping, byte accumulation, and the **never-throws** contract — which caught an unguarded `done()` (a throwing output stream could propagate); fixed.

## Verification

- 23/23 tests pass (6 progress + 17 bspatch), `typecheck` clean, `lint` 0 errors, `format:check` clean.
- No behavior change to the apply/download logic — purely additive progress reporting.