### PR TITLE
feat(upgrade): Sentry tracing + metrics for the delta-upgrade path

### DIFF
--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -30,6 +30,7 @@ import {
 } from "./binary";
 import { applyPatchChainInMemory, parsePatchHeader } from "./bspatch";
 import { makeByteProgress } from "./progress";
+import { spanDeltaUpgrade, type DeltaUpgradeTelemetry } from "../../sentry";
 import { VERSION } from "../version";
 import {
   downloadLayerBlob,
@@ -540,36 +541,61 @@ export async function attemptDeltaUpgrade(
 
   const channel = isNightlyVersion(targetVersion) ? "nightly" : "stable";
 
-  try {
-    const result =
-      channel === "nightly"
-        ? await resolveAndApplyDelta({
-            targetVersion,
-            oldBinaryPath,
-            destPath,
-            resolveFromNetwork: () =>
-              resolveNightlyChainWithContext(targetVersion),
-            channel: "nightly",
-            offline,
-          })
-        : await resolveAndApplyDelta({
-            targetVersion,
-            oldBinaryPath,
-            destPath,
-            resolveFromNetwork: () =>
-              resolveStableChain(VERSION, targetVersion),
-            channel: "stable",
-            offline,
-          });
+  // Wrap the attempt in a `lore.upgrade.delta` span recording the same decision
+  // points Sentry CLI captures (result/source/patch_bytes/chain_length). The
+  // report callback is filled in by resolveAndApplyDelta as facts become known.
+  return spanDeltaUpgrade(
+    { channel, fromVersion: VERSION, toVersion: targetVersion },
+    async (report) => {
+      try {
+        const result =
+          channel === "nightly"
+            ? await resolveAndApplyDelta({
+                targetVersion,
+                oldBinaryPath,
+                destPath,
+                resolveFromNetwork: () =>
+                  resolveNightlyChainWithContext(targetVersion),
+                channel: "nightly",
+                offline,
+                report,
+              })
+            : await resolveAndApplyDelta({
+                targetVersion,
+                oldBinaryPath,
+                destPath,
+                resolveFromNetwork: () =>
+                  resolveStableChain(VERSION, targetVersion),
+                channel: "stable",
+                offline,
+                report,
+              });
 
-    return result;
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error(
-      `[lore] Delta upgrade failed (${msg}), falling back to full download`,
-    );
-    return null;
-  }
+        if (result === null) {
+          report({
+            channel,
+            fromVersion: VERSION,
+            toVersion: targetVersion,
+            result: "unavailable",
+          });
+        }
+        return result;
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        report({
+          channel,
+          fromVersion: VERSION,
+          toVersion: targetVersion,
+          result: "error",
+          errorMessage: msg,
+        });
+        console.error(
+          `[lore] Delta upgrade failed (${msg}), falling back to full download`,
+        );
+        return null;
+      }
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -583,6 +609,7 @@ type ResolveAndApplyOpts = {
   resolveFromNetwork: () => Promise<PatchChain | null>;
   channel: string;
   offline?: boolean;
+  report?: (t: DeltaUpgradeTelemetry) => void;
 };
 
 async function resolveAndApplyDelta(
@@ -593,16 +620,43 @@ async function resolveAndApplyDelta(
     oldBinaryPath,
     destPath,
     resolveFromNetwork,
+    channel,
     offline,
+    report,
   } = opts;
+
+  const reportOk = (
+    source: string,
+    r: { sha256: string; patchBytes: number; chainLength: number },
+  ): void => {
+    report?.({
+      channel,
+      fromVersion: VERSION,
+      toVersion: targetVersion,
+      source,
+      result: "ok",
+      patchBytes: r.patchBytes,
+      chainLength: r.chainLength,
+      sha256: r.sha256,
+    });
+  };
 
   // Check patch cache first — enables fully offline upgrades
   const cached = await tryLoadCachedChain(VERSION, targetVersion);
   if (cached) {
-    return await applyChainAndReturn(cached, oldBinaryPath, destPath);
+    const r = await applyChainAndReturn(cached, oldBinaryPath, destPath);
+    reportOk("cache", r);
+    return r;
   }
 
   if (offline) {
+    report?.({
+      channel,
+      fromVersion: VERSION,
+      toVersion: targetVersion,
+      source: "offline_miss",
+      result: "unavailable",
+    });
     return null;
   }
 
@@ -614,7 +668,9 @@ async function resolveAndApplyDelta(
     savePatchesToCache(chain, chain.steps).catch(() => {});
   }
 
-  return await applyChainAndReturn(chain, oldBinaryPath, destPath);
+  const r = await applyChainAndReturn(chain, oldBinaryPath, destPath);
+  reportOk("network", r);
+  return r;
 }
 
 async function tryLoadCachedChain(

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -886,6 +886,103 @@ export async function spanStartupBackfill(
 }
 
 // ---------------------------------------------------------------------------
+// Delta-upgrade (CLI self-update) tracing + metrics
+// ---------------------------------------------------------------------------
+
+/**
+ * Outcome of a delta-upgrade attempt, for span attributes and metrics.
+ * Mirrors the points Sentry CLI records on its `upgrade.delta` span so the two
+ * CLIs can be compared in the same dashboards.
+ */
+export type DeltaUpgradeTelemetry = {
+  channel: string; // "stable" | "nightly"
+  fromVersion: string;
+  toVersion: string;
+  /** cache | network | offline_miss — where the patch chain came from. */
+  source?: string;
+  /** ok (patches applied) | unavailable (no usable chain) | error. */
+  result: "ok" | "unavailable" | "error";
+  patchBytes?: number;
+  chainLength?: number;
+  sha256?: string;
+  errorMessage?: string;
+};
+
+/**
+ * Wrap a delta-upgrade attempt in a `lore.upgrade.delta` span, recording the
+ * decision attributes Sentry CLI captures (from/to version, channel, result,
+ * patch bytes, chain length, source) and emitting patch-size + chain-length
+ * distributions on success. The span is best-effort: telemetry must never
+ * change upgrade behavior, and a Sentry failure must not break the update.
+ *
+ * `run` performs the actual resolve+apply and reports its outcome via the
+ * `report` callback (called with the telemetry fields that only become known
+ * during the attempt). Returns whatever `run` returns.
+ */
+export async function spanDeltaUpgrade<T>(
+  base: { channel: string; fromVersion: string; toVersion: string },
+  run: (report: (t: DeltaUpgradeTelemetry) => void) => Promise<T>,
+): Promise<T> {
+  if (!Sentry.isInitialized()) {
+    return run(() => {});
+  }
+
+  return Sentry.startSpan(
+    {
+      name: "lore.upgrade.delta",
+      op: "upgrade.delta",
+      attributes: {
+        "delta.from_version": base.fromVersion,
+        "delta.to_version": base.toVersion,
+        "delta.channel": base.channel,
+      },
+    },
+    async (span) => {
+      let outcome: DeltaUpgradeTelemetry | null = null;
+      const report = (t: DeltaUpgradeTelemetry): void => {
+        outcome = t;
+        span.setAttribute("delta.result", t.result);
+        if (t.source) span.setAttribute("delta.source", t.source);
+        if (t.patchBytes !== undefined)
+          span.setAttribute("delta.patch_bytes", t.patchBytes);
+        if (t.chainLength !== undefined)
+          span.setAttribute("delta.chain_length", t.chainLength);
+        if (t.sha256) span.setAttribute("delta.sha256", t.sha256.slice(0, 12));
+        if (t.errorMessage) span.setAttribute("delta.error", t.errorMessage);
+      };
+
+      try {
+        return await run(report);
+      } finally {
+        // Emit distributions only for a successful patch application — the
+        // "how much did delta save us" signal. Fire-and-forget. Read via a
+        // function so TS's closure narrowing (outcome only assigned in the
+        // callback) doesn't collapse the type to never.
+        const finalOutcome = (): DeltaUpgradeTelemetry | null => outcome;
+        const done = finalOutcome();
+        if (done && done.result === "ok") {
+          const attrs = { channel: base.channel };
+          if (done.patchBytes !== undefined) {
+            Sentry.metrics.distribution(
+              "lore.upgrade.delta.patch_bytes",
+              done.patchBytes,
+              { attributes: attrs, unit: "byte" },
+            );
+          }
+          if (done.chainLength !== undefined) {
+            Sentry.metrics.distribution(
+              "lore.upgrade.delta.chain_length",
+              done.chainLength,
+              { attributes: attrs },
+            );
+          }
+        }
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Client-abort-under-pressure capture
 // ---------------------------------------------------------------------------
 

--- a/packages/gateway/test/delta-upgrade-telemetry.test.ts
+++ b/packages/gateway/test/delta-upgrade-telemetry.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @sentry/bun BEFORE importing the module under test (mirrors
+// cache-bust-metric.test.ts). We drive isInitialized() and capture startSpan +
+// metrics.distribution calls.
+vi.mock("@sentry/bun", () => ({
+  isInitialized: vi.fn(() => false),
+  metrics: {
+    distribution: vi.fn(),
+    count: vi.fn(),
+  },
+  startSpan: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/bun";
+import { spanDeltaUpgrade } from "../src/sentry";
+
+type Attrs = Record<string, unknown>;
+
+// Run startSpan by invoking the callback with a recording fake span.
+function setupStartSpan(): { attrs: Attrs } {
+  const attrs: Attrs = {};
+  vi.mocked(Sentry.startSpan).mockImplementation(async (_opts, cb) =>
+    cb({
+      setAttribute: (k: string, v: unknown) => {
+        attrs[k] = v;
+      },
+    } as unknown as Sentry.Span),
+  );
+  return { attrs };
+}
+
+const BASE = { channel: "stable", fromVersion: "1.0.0", toVersion: "1.1.0" };
+
+function distCall(name: string): { value: number; attrs?: Attrs } | undefined {
+  const call = vi
+    .mocked(Sentry.metrics.distribution)
+    .mock.calls.find((c) => c[0] === name);
+  if (!call) return undefined;
+  return {
+    value: call[1],
+    attrs: (call[2] as { attributes?: Attrs })?.attributes,
+  };
+}
+
+describe("spanDeltaUpgrade", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Sentry.isInitialized).mockReturnValue(true);
+  });
+
+  it("emits patch_bytes + chain_length distributions and span attributes on ok", async () => {
+    const { attrs } = setupStartSpan();
+    const out = await spanDeltaUpgrade(BASE, async (report) => {
+      report({
+        channel: "stable",
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        source: "network",
+        result: "ok",
+        patchBytes: 12_400_000,
+        chainLength: 3,
+        sha256: "abcdef1234567890deadbeef",
+      });
+      return "done";
+    });
+
+    expect(out).toBe("done");
+    expect(attrs["delta.result"]).toBe("ok");
+    expect(attrs["delta.source"]).toBe("network");
+    expect(attrs["delta.patch_bytes"]).toBe(12_400_000);
+    expect(attrs["delta.chain_length"]).toBe(3);
+    // sha256 is truncated to 12 chars on the span
+    expect(attrs["delta.sha256"]).toBe("abcdef123456");
+
+    const pb = distCall("lore.upgrade.delta.patch_bytes");
+    expect(pb?.value).toBe(12_400_000);
+    expect(pb?.attrs).toEqual({ channel: "stable" });
+    const cl = distCall("lore.upgrade.delta.chain_length");
+    expect(cl?.value).toBe(3);
+  });
+
+  it("emits NO distributions on unavailable (graceful fallback)", async () => {
+    setupStartSpan();
+    await spanDeltaUpgrade(BASE, async (report) => {
+      report({
+        channel: "stable",
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        result: "unavailable",
+      });
+      return null;
+    });
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+  });
+
+  it("emits NO distributions when a non-ok report carries patch metrics (ok-gate is load-bearing)", async () => {
+    // Drives the real invariant the `result === "ok"` guard protects: a report
+    // that carries patchBytes/chainLength but is NOT ok must not emit
+    // distributions. Without this, the guard mutation ships GREEN (vacuous).
+    setupStartSpan();
+    await spanDeltaUpgrade(BASE, async (report) => {
+      report({
+        channel: "stable",
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        result: "error",
+        patchBytes: 9_999,
+        chainLength: 5,
+        errorMessage: "apply failed mid-chain",
+      });
+      return null;
+    });
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+  });
+
+  it("emits NO distributions on error and records the error attribute", async () => {
+    const { attrs } = setupStartSpan();
+    await spanDeltaUpgrade(BASE, async (report) => {
+      report({
+        channel: "stable",
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        result: "error",
+        errorMessage: "SHA-256 mismatch",
+      });
+      return null;
+    });
+    expect(attrs["delta.result"]).toBe("error");
+    expect(attrs["delta.error"]).toBe("SHA-256 mismatch");
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op pass-through when Sentry is not initialized", async () => {
+    vi.mocked(Sentry.isInitialized).mockReturnValue(false);
+    const out = await spanDeltaUpgrade(BASE, async (report) => {
+      report({
+        channel: "stable",
+        fromVersion: "1.0.0",
+        toVersion: "1.1.0",
+        result: "ok",
+        patchBytes: 1,
+      });
+      return "ran";
+    });
+    expect(out).toBe("ran");
+    expect(Sentry.startSpan).not.toHaveBeenCalled();
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Ports the telemetry points Sentry CLI records on its `upgrade.delta` span into our gateway. The original port of `delta-upgrade.ts` stripped all Sentry SDK telemetry ("uses plain logging") — this re-adds it for our own CLI.

The upgrade path is already covered by the same Sentry init as the rest of the CLI (`instrument.ts`, `tracesSampleRate: 1.0`), so spans and distributions record in production builds.

## How

- New `spanDeltaUpgrade()` helper in `sentry.ts` (no-op when Sentry uninitialized), following the existing `spanStartupBackfill` / `emitWarmupMetric` pattern.
- Wraps `attemptDeltaUpgrade` in a `lore.upgrade.delta` span (`op: upgrade.delta`) recording: `delta.from_version`, `delta.to_version`, `delta.channel`, `delta.result` (ok / unavailable / error), `delta.source` (cache / network / offline_miss), `delta.patch_bytes`, `delta.chain_length`, `delta.sha256` (12-char), `delta.error`.
- On success emits `lore.upgrade.delta.patch_bytes` and `lore.upgrade.delta.chain_length` distributions tagged by channel — the "how much did delta save us" signal, comparable with sentry-cli's `upgrade.delta.*` metrics.
- A `report` callback threads into `resolveAndApplyDelta` so source/bytes/length are captured as they become known. Telemetry is best-effort and never changes upgrade behavior (graceful full-download fallback preserved).

## Tests

`test/delta-upgrade-telemetry.test.ts` (5 tests): metrics + span attributes on ok, no metrics on unavailable / error, the ok-gate is load-bearing (a non-ok report carrying patch metrics emits nothing — **mutation-verified RED** when the gate is dropped), and no-op pass-through when uninitialized.

## Verification

- 5/5 telemetry tests + 17 bspatch + 6 progress pass (28/28), typecheck clean, lint 0 errors, format clean.
- No behavior change to the apply/fallback logic — purely additive telemetry.