### PR TITLE
fix(embedding): bump onnxruntime-node 1.21.0 → 1.27.0 to fix Node 24 HandleScope crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "ip-address": "10.2.0",
       "fast-xml-parser": "5.7.3",
       "@huggingface/hub": "2.11.0",
+      "onnxruntime-node": "1.27.0",
       "yaml": ">=2.8.3",
       "esbuild": ">=0.28.1",
       "@opentelemetry/core": ">=2.8.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
   },
   "optionalDependencies": {
     "@huggingface/transformers": "^3.7.1",
-    "onnxruntime-node": "1.21.0",
+    "onnxruntime-node": "1.27.0",
     "sharp": "^0.34.1"
   },
   "devDependencies": {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -74,7 +74,7 @@
     "@types/qrcode-terminal": "^0.12.2",
     "@types/semver": "^7.7.1",
     "fossilize": "^0.10.1",
-    "onnxruntime-node": "1.21.0",
+    "onnxruntime-node": "1.27.0",
     "tar": "^7.5.19",
     "undici": "^7.28.0"
   }

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -712,7 +712,7 @@ async function buildBinary() {
     }
   }
   // Runtime manifest of the ORT native file set per target. native-loader.cjs
-  // reads it to learn the (version-specific, e.g. libonnxruntime.1.21.0.dylib)
+  // reads it to learn the (version-specific, e.g. libonnxruntime.<version>.dylib)
   // filenames to extract for the running platform — so filenames live in ONE
   // place (vendor-ort-native.ts) instead of being duplicated in the loader.
   const ortFileManifest: Record<string, string[]> = {};

--- a/packages/gateway/script/ort-native-plugin.ts
+++ b/packages/gateway/script/ort-native-plugin.ts
@@ -18,7 +18,7 @@
  *      in the unreachable browser branch — so stubbing it avoids bundling the
  *      ~MBs of WASM glue (and shipping the `.wasm`) with zero behavioral change.
  *   3. Rewrite `onnxruntime-node`'s `binding.js` native-addon `require(...)` —
- *      which resolves `../bin/napi-v3/<platform>/<arch>/onnxruntime_binding.node`
+ *      which resolves `../bin/napi-v<N>/<platform>/<arch>/onnxruntime_binding.node`
  *      relative to node_modules (absent in a SEA) — to require the path
  *      `native-loader.cjs` exposes on `globalThis.__LORE_ORT_BINDING_PATH__`
  *      after extracting the addon from a SEA asset.
@@ -31,12 +31,13 @@ import { readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type * as esbuild from "esbuild";
 
-/** The exact native-addon `require` in onnxruntime-node@1.21's `dist/binding.js`
- *  (a tagged-template path). Matching it precisely lets us fail loudly if a
- *  future bump changes the shape, rather than silently shipping a broken addon
- *  loader. */
+/** The native-addon `require` in onnxruntime-node's `dist/binding.js` (a
+ *  tagged-template path). The N-API ABI segment (napi-v3, napi-v6, …) changes
+ *  across releases, so match `napi-v<N>` generically. Matching the rest of the
+ *  shape precisely lets us fail loudly if a future bump changes it, rather than
+ *  silently shipping a broken addon loader. */
 const ORT_BINDING_REQUIRE =
-  /require\(`\.\.\/bin\/napi-v3\/\$\{process\.platform\}\/\$\{process\.arch\}\/onnxruntime_binding\.node`\)/;
+  /require\(`\.\.\/bin\/napi-v\d+\/\$\{process\.platform\}\/\$\{process\.arch\}\/onnxruntime_binding\.node`\)/;
 
 /** Replacement: require the runtime-extracted addon path, throwing a clear error
  *  if the loader shim didn't run (so a broken SEA fails loudly, not with a

--- a/packages/gateway/script/ort-npm-plugin.ts
+++ b/packages/gateway/script/ort-npm-plugin.ts
@@ -34,11 +34,13 @@ import { dirname, join } from "node:path";
 import type * as esbuild from "esbuild";
 import { findOrtWebDir } from "./ort-web-plugin";
 
-/** onnxruntime-node@1.21's `dist/binding.js` native-addon require (tagged
- *  template). Kept in sync with `ort-native-plugin.ts`; a bump that changes it
- *  fails the build loudly rather than silently shipping a broken loader. */
+/** onnxruntime-node's `dist/binding.js` native-addon require (tagged template).
+ *  The N-API ABI segment (napi-v3, napi-v6, …) changes across releases, so match
+ *  `napi-v<N>` generically. Kept in sync with `ort-native-plugin.ts`; a bump that
+ *  changes the surrounding shape fails the build loudly (see the guard below)
+ *  rather than silently shipping a broken loader. */
 const ORT_BINDING_REQUIRE =
-  /require\(`\.\.\/bin\/napi-v3\/\$\{process\.platform\}\/\$\{process\.arch\}\/onnxruntime_binding\.node`\)/;
+  /require\(`\.\.\/bin\/napi-v\d+\/\$\{process\.platform\}\/\$\{process\.arch\}\/onnxruntime_binding\.node`\)/;
 
 /** Graceful replacement: native addon when the worker set the path, else a
  *  dormant stub (index.js calls `binding.listSupportedBackends()` at load).

--- a/packages/gateway/script/ort-platform-package.ts
+++ b/packages/gateway/script/ort-platform-package.ts
@@ -48,7 +48,7 @@ import {
 export interface OrtNpmPlatform {
   /** `${process.platform}-${process.arch}`, e.g. "linux-x64", "win32-arm64". */
   target: string;
-  /** onnxruntime-node `bin/napi-v3` subdir, e.g. "linux/x64". */
+  /** onnxruntime-node `bin/napi-v<N>` subdir, e.g. "linux/x64". */
   subdir: string;
   /** npm `os` field value (== process.platform). */
   os: string;
@@ -56,11 +56,12 @@ export interface OrtNpmPlatform {
   cpu: string;
 }
 
-/** The platforms onnxruntime-node@1.21 ships prebuilt binaries for. */
+/** The platforms onnxruntime-node ships prebuilt binaries for. Note: 1.27.0
+ *  dropped the Intel macOS (`darwin-x64`) prebuilt, so it's absent here — Intel
+ *  Macs fall back to WASM via the null binding-path resolution. */
 export const ORT_NPM_PLATFORMS: readonly OrtNpmPlatform[] = [
   { target: "linux-x64", subdir: "linux/x64", os: "linux", cpu: "x64" },
   { target: "linux-arm64", subdir: "linux/arm64", os: "linux", cpu: "arm64" },
-  { target: "darwin-x64", subdir: "darwin/x64", os: "darwin", cpu: "x64" },
   {
     target: "darwin-arm64",
     subdir: "darwin/arm64",

--- a/packages/gateway/script/pack-ort-npm.ts
+++ b/packages/gateway/script/pack-ort-npm.ts
@@ -10,8 +10,8 @@
  *   1. Generate the 6 platform packages and `npm pack` each into the tarball dir
  *      → `loreai-onnxruntime-<target>-<version>.tgz` (Craft publishes them via a
  *      dedicated npm target keyed on that name).
- *   2. Inject `optionalDependencies` (the 6 packages, pinned EXACTLY to the
- *      release version) into the already-packed `loreai-gateway-<version>.tgz`
+ *   2. Inject `optionalDependencies` (one per platform package, pinned EXACTLY
+ *      to the release version) into the already-packed `loreai-gateway-<version>.tgz`
  *      by extract → edit package.json → repack. Done on the tarball — NOT the
  *      workspace package.json — so the repo + lockfile stay clean and
  *      release-branch `pnpm install --frozen-lockfile` keeps working. npm's
@@ -54,7 +54,7 @@ function packPlatformPackages(tarballsDir: string, version: string): void {
   }
 }
 
-/** Add optionalDependencies (the 6 platform packages, pinned to `version`) to
+/** Add optionalDependencies (the platform packages, pinned to `version`) to
  *  the packed gateway tarball's package.json, in place. */
 function injectGatewayOptionalDeps(tarballsDir: string, version: string): void {
   const gatewayTarball = join(tarballsDir, `loreai-gateway-${version}.tgz`);

--- a/packages/gateway/script/pack-ort-npm.ts
+++ b/packages/gateway/script/pack-ort-npm.ts
@@ -7,7 +7,7 @@
  * prefers them over WASM).
  *
  * Steps, all at the release version (CRAFT_NEW_VERSION):
- *   1. Generate the 6 platform packages and `npm pack` each into the tarball dir
+ *   1. Generate the per-platform packages and `npm pack` each into the tarball dir
  *      → `loreai-onnxruntime-<target>-<version>.tgz` (Craft publishes them via a
  *      dedicated npm target keyed on that name).
  *   2. Inject `optionalDependencies` (one per platform package, pinned EXACTLY

--- a/packages/gateway/script/vendor-ort-native.ts
+++ b/packages/gateway/script/vendor-ort-native.ts
@@ -2,7 +2,7 @@
  * Vendor the native `onnxruntime-node` runtime for every build target.
  *
  * The SEA (fossilize) binary has no `node_modules`, so `onnxruntime-node`'s
- * `binding.js` — which does `require("../bin/napi-v3/<platform>/<arch>/
+ * `binding.js` — which does `require("../bin/napi-v<N>/<platform>/<arch>/
  * onnxruntime_binding.node")` — can't find its native addon inside the binary.
  * Instead we embed the addon + its shared libraries as SEA assets (one set per
  * target) and extract them at runtime (see `native-loader.cjs`, which sets
@@ -11,7 +11,7 @@
  *
  * Unlike `sqlite-vec` (whose per-platform binaries live in separate npm
  * packages), `onnxruntime-node` ships EVERY platform's binaries in one package
- * under `bin/napi-v3/<platform>/<arch>/`. So there is no download step: we copy
+ * under `bin/napi-v<N>/<platform>/<arch>/`. So there is no download step: we copy
  * straight from the installed package. Lore's SEA builds are cross-platform (a
  * single Linux host stages linux/windows and prepares darwin for the macOS
  * `--from-staging` job), and every target's files are present in `node_modules`,
@@ -39,7 +39,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
 const repoRoot = dirname(dirname(packageDir));
 
-/** Map a build target to onnxruntime-node's `bin/napi-v3/<platform>/<arch>`
+/** Map a build target to onnxruntime-node's `bin/napi-v<N>/<platform>/<arch>`
  *  subdirectory (Node's `process.platform`/`process.arch` naming). */
 const ORT_TARGET_SUBDIR: Record<VendorTarget, string> = {
   "darwin-arm64": "darwin/arm64",
@@ -84,10 +84,23 @@ export function ortNodeVersion(): string {
   return v;
 }
 
-/** onnxruntime-node's `bin/napi-v3` root, under which each platform's files
- *  live in `<process.platform>/<process.arch>/` subdirs. */
+/** onnxruntime-node's `bin/napi-v<N>` root, under which each platform's files
+ *  live in `<process.platform>/<process.arch>/` subdirs. The N-API ABI dir name
+ *  (napi-v3, napi-v6, …) changes across onnxruntime-node releases, so discover
+ *  it from the installed package instead of hard-coding it — a version bump that
+ *  moves the dir would otherwise silently break every SEA/npm native build. */
 export function ortNodeBinRoot(): string {
-  return join(ortNodeDir(), "bin", "napi-v3");
+  const binDir = join(ortNodeDir(), "bin");
+  const napiDirs = existsSync(binDir)
+    ? readdirSync(binDir).filter((d) => /^napi-v\d+$/.test(d))
+    : [];
+  if (napiDirs.length !== 1) {
+    throw new Error(
+      `vendor-ort-native: expected exactly one bin/napi-v<N> dir in ` +
+        `onnxruntime-node, found [${napiDirs.join(", ")}]`,
+    );
+  }
+  return join(binDir, napiDirs[0]);
 }
 
 /**
@@ -95,9 +108,10 @@ export function ortNodeBinRoot(): string {
  * subdir (e.g. `"linux/x64"`, `"win32/arm64"`). Returns every file in the dir
  * MINUS longer-versioned aliases of another file: linux ships both
  * `libonnxruntime.so.1` (the SONAME the addon's NEEDED entry references) and
- * `libonnxruntime.so.1.21.0` (identical bytes) — we keep the SONAME and drop the
- * duplicate to avoid shipping ~21 MB twice. darwin's `libonnxruntime.1.21.0.
- * dylib` has no shorter alias so it's kept; windows' `onnxruntime.dll` /
+ * `libonnxruntime.so.1.<version>` (identical bytes) — we keep the SONAME and drop
+ * the duplicate to avoid shipping ~21 MB twice. darwin's
+ * `libonnxruntime.<version>.dylib` has no shorter alias so it's kept; windows'
+ * `onnxruntime.dll` /
  * `DirectML.dll` are kept. Version-robust: no hard-coded library filenames.
  * Throws if the dir is missing or lacks the addon.
  */
@@ -112,7 +126,7 @@ export function collectOrtFiles(
   }
   const all = readdirSync(dir).filter((f) => !f.startsWith("."));
   // Drop F when some other G is a strict prefix of F followed by "." — i.e. F is
-  // a longer-versioned alias (libX.so.1.21.0 vs the SONAME libX.so.1).
+  // a longer-versioned alias (libX.so.1.27.0 vs the SONAME libX.so.1).
   const kept = all.filter(
     (f) => !all.some((g) => g !== f && f.startsWith(`${g}.`)),
   );

--- a/packages/gateway/script/vendor-ort-native.ts
+++ b/packages/gateway/script/vendor-ort-native.ts
@@ -104,16 +104,68 @@ export function ortNodeBinRoot(): string {
 }
 
 /**
- * The native files for one onnxruntime-node platform, given its `bin/napi-v3`
+ * A shared library filename split into (stem, version, ext) if it carries an
+ * embedded numeric version, else `null`. Handles both linker conventions:
+ *   linux : `libonnxruntime.so.1`      → { stem:"libonnxruntime", ver:"1",      ext:".so" }
+ *           `libonnxruntime.so.1.27.0` → { stem:"libonnxruntime", ver:"1.27.0", ext:".so" }
+ *   darwin: `libonnxruntime.1.dylib`   → { stem:"libonnxruntime", ver:"1",      ext:".dylib" }
+ *           `libonnxruntime.1.27.0.dylib` → { stem:"libonnxruntime", ver:"1.27.0", ext:".dylib" }
+ * Files without an embedded numeric version (the addon, distinct `.dll`s) → null.
+ */
+function parseVersionedLib(
+  file: string,
+): { stem: string; version: string; ext: string } | null {
+  // darwin: <stem>.<numeric-version>.dylib
+  let m = /^(.+?)\.(\d+(?:\.\d+)*)\.dylib$/.exec(file);
+  if (m) return { stem: m[1], version: m[2], ext: ".dylib" };
+  // linux/elf: <stem>.so.<numeric-version>
+  m = /^(.+?\.so)\.(\d+(?:\.\d+)*)$/.exec(file);
+  if (m) return { stem: m[1], version: m[2], ext: "" };
+  return null;
+}
+
+/**
+ * Given a flat list of a platform's native files, drop longer-versioned
+ * duplicates of a shared library, keeping only the canonical (shortest-version)
+ * member of each (stem, ext) group. Pure/deterministic — the filesystem-reading
+ * `collectOrtFiles` delegates its dedup here so the rule is unit-testable with
+ * synthetic file sets. See `collectOrtFiles` for the rationale/examples.
+ */
+export function dropVersionedLibAliases(all: readonly string[]): string[] {
+  const versionComponents = (v: string): number => v.split(".").length;
+  return all.filter((f) => {
+    const info = parseVersionedLib(f);
+    if (!info) return true; // no embedded version → always keep
+    // Drop F if a sibling shares its (stem, ext) but has a shorter version.
+    return !all.some((g) => {
+      if (g === f) return false;
+      const gi = parseVersionedLib(g);
+      return (
+        gi !== null &&
+        gi.stem === info.stem &&
+        gi.ext === info.ext &&
+        versionComponents(gi.version) < versionComponents(info.version)
+      );
+    });
+  });
+}
+
+/**
+ * The native files for one onnxruntime-node platform, given its `bin/napi-v<N>`
  * subdir (e.g. `"linux/x64"`, `"win32/arm64"`). Returns every file in the dir
- * MINUS longer-versioned aliases of another file: linux ships both
- * `libonnxruntime.so.1` (the SONAME the addon's NEEDED entry references) and
- * `libonnxruntime.so.1.<version>` (identical bytes) — we keep the SONAME and drop
- * the duplicate to avoid shipping ~21 MB twice. darwin's
- * `libonnxruntime.<version>.dylib` has no shorter alias so it's kept; windows'
- * `onnxruntime.dll` /
- * `DirectML.dll` are kept. Version-robust: no hard-coded library filenames.
- * Throws if the dir is missing or lacks the addon.
+ * MINUS longer-versioned aliases of another shared library. A library can ship
+ * multiple version-named copies of identical bytes that a single linker
+ * install-name/SONAME resolves to:
+ *   linux : `libonnxruntime.so.1` (the SONAME the addon NEEDs) alongside a
+ *           historical `libonnxruntime.so.1.<version>`;
+ *   darwin (onnxruntime-node ≥ 1.27): `libonnxruntime.1.dylib` (the addon's
+ *           `@rpath` install-name) alongside `libonnxruntime.1.27.0.dylib`.
+ * For each (stem, ext) group we keep ONLY the shortest-versioned member (fewest
+ * dotted components — the alias the addon actually references) and drop the
+ * longer duplicates, saving ~21 MB (linux) / ~38 MB (darwin) per platform.
+ * Files with no embedded numeric version (the addon, distinct windows DLLs like
+ * `onnxruntime.dll` / `DirectML.dll`) are always kept. Version-robust: no
+ * hard-coded library filenames. Throws if the dir is missing or lacks the addon.
  */
 export function collectOrtFiles(
   binSubdir: string,
@@ -125,11 +177,7 @@ export function collectOrtFiles(
     );
   }
   const all = readdirSync(dir).filter((f) => !f.startsWith("."));
-  // Drop F when some other G is a strict prefix of F followed by "." — i.e. F is
-  // a longer-versioned alias (libX.so.1.27.0 vs the SONAME libX.so.1).
-  const kept = all.filter(
-    (f) => !all.some((g) => g !== f && f.startsWith(`${g}.`)),
-  );
+  const kept = dropVersionedLibAliases(all);
   if (!kept.includes(ORT_BINDING_FILE)) {
     throw new Error(
       `vendor-ort-native: ${ORT_BINDING_FILE} not found in ${dir}`,

--- a/packages/gateway/test/ort-platform-package.test.ts
+++ b/packages/gateway/test/ort-platform-package.test.ts
@@ -17,10 +17,9 @@ import {
 // embeddings (resolve throws → WASM fallback). This binds both sides.
 
 describe("ORT_NPM_PLATFORMS ⇄ runtime resolution key", () => {
-  test("covers the 6 onnxruntime-node platforms, no dupes", () => {
+  test("covers the 5 onnxruntime-node platforms, no dupes", () => {
     expect(ORT_NPM_PLATFORMS.map((p) => p.target).sort()).toEqual([
       "darwin-arm64",
-      "darwin-x64",
       "linux-arm64",
       "linux-x64",
       "win32-arm64",
@@ -87,7 +86,7 @@ describe("buildOrtPlatformPackages (real onnxruntime-node)", () => {
   test("alias-drop keeps the linux SONAME, drops the versioned duplicate", () => {
     const linux = built.find((b) => b.target === "linux-x64")!;
     expect(linux.files).toContain("libonnxruntime.so.1");
-    expect(linux.files).not.toContain("libonnxruntime.so.1.21.0");
+    expect(linux.files).not.toContain("libonnxruntime.so.1.27.0");
   });
 
   test("darwin keeps its versioned dylib; win32 ships both DLLs", () => {

--- a/packages/gateway/test/ort-platform-package.test.ts
+++ b/packages/gateway/test/ort-platform-package.test.ts
@@ -89,11 +89,11 @@ describe("buildOrtPlatformPackages (real onnxruntime-node)", () => {
     expect(linux.files).not.toContain("libonnxruntime.so.1.27.0");
   });
 
-  test("darwin keeps its versioned dylib; win32 ships both DLLs", () => {
+  test("darwin keeps the install-name dylib and drops the versioned duplicate; win32 ships both DLLs", () => {
     const darwin = built.find((b) => b.target === "darwin-arm64")!;
-    expect(
-      darwin.files.some((f) => /^libonnxruntime\..*\.dylib$/.test(f)),
-    ).toBe(true);
+    // Keep the addon's `@rpath` install-name; drop the identical longer-versioned copy.
+    expect(darwin.files).toContain("libonnxruntime.1.dylib");
+    expect(darwin.files).not.toContain("libonnxruntime.1.27.0.dylib");
     const win = built.find((b) => b.target === "win32-x64")!;
     expect(win.files).toContain("onnxruntime.dll");
     expect(win.files).toContain("DirectML.dll");

--- a/packages/gateway/test/vendor-ort-native.test.ts
+++ b/packages/gateway/test/vendor-ort-native.test.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import {
+  dropVersionedLibAliases,
   ORT_BINDING_FILE,
   ortAssetKey,
   ortNativeAssets,
@@ -100,10 +101,55 @@ describe("vendor-ort-native asset selection (real package)", () => {
     expect(linux).not.toContain("libonnxruntime.so.1.27.0");
   });
 
-  test("darwin keeps its version-named dylib (no shorter alias to drop)", () => {
+  test("darwin keeps the addon's install-name dylib, drops the versioned duplicate", () => {
     const darwin = assets.get("darwin-arm64")!.map((f) => f.file);
-    expect(darwin.some((f) => /^libonnxruntime\..*\.dylib$/.test(f))).toBe(
-      true,
-    );
+    // The addon's `@rpath` install-name is `libonnxruntime.1.dylib`; keep it.
+    expect(darwin).toContain("libonnxruntime.1.dylib");
+    // onnxruntime-node ≥ 1.27 also ships an identical `libonnxruntime.1.27.0.dylib`
+    // (~38 MB) — the longer-versioned duplicate must be dropped, not embedded.
+    expect(darwin).not.toContain("libonnxruntime.1.27.0.dylib");
+    expect(darwin).toContain(ORT_BINDING_FILE);
+  });
+});
+
+describe("dropVersionedLibAliases (pure)", () => {
+  test("darwin: keeps the shorter install-name dylib, drops the longer version", () => {
+    expect(
+      dropVersionedLibAliases([
+        "libonnxruntime.1.27.0.dylib",
+        "libonnxruntime.1.dylib",
+        "onnxruntime_binding.node",
+      ]).sort(),
+    ).toEqual(["libonnxruntime.1.dylib", "onnxruntime_binding.node"]);
+  });
+
+  test("linux: keeps the SONAME, drops the longer versioned .so alias", () => {
+    expect(
+      dropVersionedLibAliases([
+        "libonnxruntime.so.1",
+        "libonnxruntime.so.1.27.0",
+        "onnxruntime_binding.node",
+      ]).sort(),
+    ).toEqual(["libonnxruntime.so.1", "onnxruntime_binding.node"]);
+  });
+
+  test("linux without a duplicate: keeps the sole SONAME unchanged", () => {
+    expect(
+      dropVersionedLibAliases([
+        "libonnxruntime.so.1",
+        "onnxruntime_binding.node",
+      ]).sort(),
+    ).toEqual(["libonnxruntime.so.1", "onnxruntime_binding.node"]);
+  });
+
+  test("windows: distinct DLLs are all kept (no false alias-drop)", () => {
+    const win = [
+      "DirectML.dll",
+      "dxcompiler.dll",
+      "dxil.dll",
+      "onnxruntime.dll",
+      "onnxruntime_binding.node",
+    ];
+    expect(dropVersionedLibAliases(win).sort()).toEqual([...win].sort());
   });
 });

--- a/packages/gateway/test/vendor-ort-native.test.ts
+++ b/packages/gateway/test/vendor-ort-native.test.ts
@@ -97,7 +97,7 @@ describe("vendor-ort-native asset selection (real package)", () => {
     const linux = assets.get("linux-x64")!.map((f) => f.file);
     expect(linux).toContain("libonnxruntime.so.1");
     // The identical, longer-versioned alias must NOT be embedded twice.
-    expect(linux).not.toContain("libonnxruntime.so.1.21.0");
+    expect(linux).not.toContain("libonnxruntime.so.1.27.0");
   });
 
   test("darwin keeps its version-named dylib (no shorter alias to drop)", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   ip-address: 10.2.0
   fast-xml-parser: 5.7.3
   '@huggingface/hub': 2.11.0
+  onnxruntime-node: 1.27.0
   yaml: '>=2.8.3'
   esbuild: '>=0.28.1'
   '@opentelemetry/core': '>=2.8.0'
@@ -123,8 +124,8 @@ importers:
         specifier: ^3.7.1
         version: 3.8.1
       onnxruntime-node:
-        specifier: 1.21.0
-        version: 1.21.0
+        specifier: 1.27.0
+        version: 1.27.0
       sharp:
         specifier: ^0.34.1
         version: 0.34.5
@@ -169,8 +170,8 @@ importers:
         specifier: ^0.10.1
         version: 0.10.1
       onnxruntime-node:
-        specifier: 1.21.0
-        version: 1.21.0
+        specifier: 1.27.0
+        version: 1.27.0
       tar:
         specifier: '>=7.5.19'
         version: 7.5.20
@@ -2251,6 +2252,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2412,10 +2417,6 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  boolean@3.2.0:
-    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -2629,9 +2630,6 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
-
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
@@ -2711,9 +2709,6 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
-
-  es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -2905,8 +2900,8 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  global-agent@3.0.0:
-    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+  global-agent@4.1.3:
+    resolution: {integrity: sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==}
     engines: {node: '>=10.0'}
 
   globalthis@1.0.4:
@@ -3166,9 +3161,6 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
-  json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -3321,8 +3313,8 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
-  matcher@3.0.0:
-    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+  matcher@4.0.0:
+    resolution: {integrity: sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==}
     engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
@@ -3629,14 +3621,14 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
-  onnxruntime-common@1.21.0:
-    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
-
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
     resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
 
-  onnxruntime-node@1.21.0:
-    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+  onnxruntime-common@1.27.0:
+    resolution: {integrity: sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==}
+
+  onnxruntime-node@1.27.0:
+    resolution: {integrity: sha512-QEzGwrvNBgv4uPVdnbHsOGG4G6T96mdlcFI8aAKPjMU8wOPpVocPXb6k3QGkaZagVTv2G9Bnnbo6Z3JdXr1fQw==}
     os: [win32, darwin, linux]
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
@@ -4017,10 +4009,6 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
-  roarr@2.15.4:
-    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
-    engines: {node: '>=8.0'}
-
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4047,9 +4035,6 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
-  semver-compare@1.0.0:
-    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4074,8 +4059,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  serialize-error@7.0.1:
-    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+  serialize-error@8.1.0:
+    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
     engines: {node: '>=10'}
 
   sharp@0.34.5:
@@ -4146,9 +4131,6 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   sqlite-vec-darwin-arm64@0.1.9:
     resolution: {integrity: sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==}
@@ -4296,8 +4278,8 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  type-fest@0.13.1:
-    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
   typebox@1.1.38:
@@ -5765,7 +5747,7 @@ snapshots:
   '@huggingface/transformers@3.8.1':
     dependencies:
       '@huggingface/jinja': 0.5.9
-      onnxruntime-node: 1.21.0
+      onnxruntime-node: 1.27.0
       onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
       sharp: 0.34.5
     optional: true
@@ -6895,6 +6877,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.18: {}
+
   agent-base@7.1.4: {}
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
@@ -7107,8 +7091,6 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  boolean@3.2.0: {}
-
   bowser@2.14.1: {}
 
   brace-expansion@5.0.7:
@@ -7290,8 +7272,6 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node@2.1.0: {}
-
   devalue@5.8.1: {}
 
   devlop@1.1.0:
@@ -7360,8 +7340,6 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
-
-  es6-error@4.1.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -7625,14 +7603,12 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  global-agent@3.0.0:
+  global-agent@4.1.3:
     dependencies:
-      boolean: 3.2.0
-      es6-error: 4.1.1
-      matcher: 3.0.0
-      roarr: 2.15.4
+      globalthis: 1.0.4
+      matcher: 4.0.0
       semver: 7.8.4
-      serialize-error: 7.0.1
+      serialize-error: 8.1.0
 
   globalthis@1.0.4:
     dependencies:
@@ -8010,8 +7986,6 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-stringify-safe@5.0.1: {}
-
   json5@2.2.3: {}
 
   jsonc-parser@2.3.1: {}
@@ -8136,7 +8110,7 @@ snapshots:
 
   marked@18.0.5: {}
 
-  matcher@3.0.0:
+  matcher@4.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
 
@@ -8702,16 +8676,16 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  onnxruntime-common@1.21.0: {}
-
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
     optional: true
 
-  onnxruntime-node@1.21.0:
+  onnxruntime-common@1.27.0: {}
+
+  onnxruntime-node@1.27.0:
     dependencies:
-      global-agent: 3.0.0
-      onnxruntime-common: 1.21.0
-      tar: 7.5.20
+      adm-zip: 0.5.18
+      global-agent: 4.1.3
+      onnxruntime-common: 1.27.0
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
     dependencies:
@@ -9180,15 +9154,6 @@ snapshots:
 
   retry@0.13.1: {}
 
-  roarr@2.15.4:
-    dependencies:
-      boolean: 3.2.0
-      detect-node: 2.1.0
-      globalthis: 1.0.4
-      json-stringify-safe: 5.0.1
-      semver-compare: 1.0.0
-      sprintf-js: 1.1.3
-
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -9269,8 +9234,6 @@ snapshots:
 
   sax@1.6.0: {}
 
-  semver-compare@1.0.0: {}
-
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -9281,9 +9244,9 @@ snapshots:
 
   semver@7.8.4: {}
 
-  serialize-error@7.0.1:
+  serialize-error@8.1.0:
     dependencies:
-      type-fest: 0.13.1
+      type-fest: 0.20.2
 
   sharp@0.34.5:
     dependencies:
@@ -9385,8 +9348,6 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   split2@4.2.0: {}
-
-  sprintf-js@1.1.3: {}
 
   sqlite-vec-darwin-arm64@0.1.9:
     optional: true
@@ -9546,7 +9507,7 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  type-fest@0.13.1: {}
+  type-fest@0.20.2: {}
 
   typebox@1.1.38: {}
 


### PR DESCRIPTION
## Problem

A user on macOS arm64 / Node 24.13.1 reported the latest build randomly crashing with a hard native abort:

```
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
```

Native stack: `InferenceSessionWrap::Run` → `OrtValueToNapiValue` → `Napi::FunctionReference::New`, inside `@loreai/onnxruntime-darwin-arm64/onnxruntime_binding.node`, fired from the embedding worker via a `processImmediate` callback.

## Root cause

`onnxruntime-node` **1.21.0** uses a process-global `static Napi::FunctionReference` for the Tensor constructor (`InferenceSessionWrap::GetTensorConstructor()`). The embedding worker runs inference in a **worker thread**, and onnxruntime-node's `backend.js` wraps the synchronous native `Run` in a `setImmediate`, so output conversion happens in libuv's **check phase**. Calling that process-global static reference there triggers `Napi::FunctionReference::New` → `napi_open_escapable_handle_scope` with **no active HandleScope** → hard abort. This matches frame 6 of the reported stack exactly. It's timing-sensitive, which is why it presented as random.

Previously this user would have run the WASM backend; PRs #1149/#1150 (npm bundle prefers native ONNX + per-platform `@loreai/onnxruntime-*` packages) routed macOS arm64 onto the native addon for the first time, exposing the bug.

## Fix

Upstream fixed this in **1.22.0** by moving the Tensor constructor to per-`env` instance data (`OrtInstanceData::TensorConstructor(env)`), which correctly scopes handle allocation to the NAPI environment. Verified against the upstream C++ source across 1.22.0 / 1.23.0 / 1.27.0. This bumps to the latest stable **1.27.0**.

## Follow-on changes required by the bump

- **`napi-v3` → `napi-v6`**: 1.27.0 moved native binaries to a new N-API ABI dir. `ortNodeBinRoot()` now discovers the `napi-v<N>` dir dynamically, and both esbuild plugins' `binding.js` require regexes match `napi-v\d+` generically — so future bumps don't silently break the SEA/npm native builds. (Both plugins already fail the build loudly if the shape stops matching.)
- **`darwin-x64` dropped**: 1.27.0 no longer ships an Intel-macOS prebuilt. Removed from `ORT_NPM_PLATFORMS` (now 5 platform packages); Intel Macs fall back to WASM via the existing null binding-path resolution. The SEA build path was already Apple-Silicon-only.
- **pnpm override**: forces `onnxruntime-node` to 1.27.0 tree-wide so `@huggingface/transformers`' pinned 1.21.0 transitive copy is eliminated entirely, not merely bypassed by esbuild interception order.
- Updated stale version/count literals in two tests and several comments.

## Verification

- ORT-specific tests (vendor / platform-package / worker-types): **82 passed**.
- Full suite: **6479 passed / 226 skipped**, with only the two known-flaky `cache-stability.e2e` tests failing under load — both pass on isolated re-run (16/16). A prior run on the same changes was **6481/0**.
- typecheck + lint + `oxfmt --check` all clean.
- Empirically confirmed the 1.27.0 native addon loads and runs inference inside `setImmediate` on Node 24 without aborting.

**Honesty caveat:** I could not synthesize the reporter's exact crash locally — it needs the specific macOS arm64 / Node 24.13.1 / transformers.js timing conditions. The fix rests on the primary upstream C++ evidence (static → per-env constructor) rather than a reproduced-then-fixed crash.