### PR TITLE
fix(build): serialize SEA binary injects to avoid postject WASM race

### DIFF
--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -343,15 +343,17 @@ async function runFossilize(
         assetManifest: manifestPath,
         sign: false,
         // Serialize the per-platform builds. fossilize injects the SEA blob
-        // via postject@1.0.0-alpha.6, whose WASM module is a process-global
-        // singleton with a shared heap. Running `inject()` on several
-        // platforms at once (as `Promise.all` with concurrency > 1 does)
-        // races on that heap and intermittently aborts with a bare
-        // `Aborted()` (RuntimeError from the postject WASM). The abort is
-        // non-deterministic — it surfaced on the linux-x64 code-cache inject
-        // in the 0.38.0 release build but passed on identical local runs.
-        // Serializing removes the race; the release build is a few minutes
-        // slower, which is an acceptable trade for a deterministic build.
+        // via postject@1.0.0-alpha.6, which spins up a fresh WASM instance for
+        // each inject() call. Each instance loads the whole ~350 MB binary into
+        // its own heap plus the rebuilt output and the resource blob, peaking
+        // near ~1 GB. Running several platforms at once (as `Promise.all` with
+        // concurrency > 1 does) stacks those heaps until the runner runs out of
+        // memory and postject aborts with a bare `Aborted()` (a C-side abort()
+        // from the WASM, not a JS error we can catch here). The abort is
+        // non-deterministic — it hit the linux-x64 code-cache inject in the
+        // 0.38.0 release build but passed on identical local runs. Serializing
+        // keeps only one ~1 GB heap live at a time; the release build is a few
+        // minutes slower, which is an acceptable trade for a deterministic build.
         concurrencyLimit: 1,
       },
       bundlePath,

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -342,7 +342,17 @@ async function runFossilize(
         cacheDir: join(packageDir, ".node-cache"),
         assetManifest: manifestPath,
         sign: false,
-        concurrencyLimit: 3,
+        // Serialize the per-platform builds. fossilize injects the SEA blob
+        // via postject@1.0.0-alpha.6, whose WASM module is a process-global
+        // singleton with a shared heap. Running `inject()` on several
+        // platforms at once (as `Promise.all` with concurrency > 1 does)
+        // races on that heap and intermittently aborts with a bare
+        // `Aborted()` (RuntimeError from the postject WASM). The abort is
+        // non-deterministic — it surfaced on the linux-x64 code-cache inject
+        // in the 0.38.0 release build but passed on identical local runs.
+        // Serializing removes the race; the release build is a few minutes
+        // slower, which is an acceptable trade for a deterministic build.
+        concurrencyLimit: 1,
       },
       bundlePath,
     );


### PR DESCRIPTION
## Problem

Cutting the 0.38.0 release failed CI on the release branch ([run 29940630021](https://github.com/BYK/loreai/actions/runs/29940630021)). The `test` job passed every test/lint/typecheck step and failed only at **Build release binaries (all platforms)**:

```
Generating code-cache blob for host platform (linux-x64)...
Injecting blob into node executable: ...lore-linux-x64 (with code cache)
Aborted()
✗ fossilize failed: RuntimeError: Aborted(). Build with -sASSERTIONS for more info.
    at abort (.../postject/dist/api.js:399:19)
```

## Root cause

The release build runs `fossilize` with `concurrencyLimit: 3`, so up to three per-platform builds call postject's `inject()` concurrently via `Promise.all`.

postject@1.0.0-alpha.6 spins up a **fresh WASM instance per `inject()` call**. Each instance loads the whole ~350 MB binary into its own heap, plus the rebuilt output and the resource blob, peaking near ~1 GB. Running three platforms at once stacks those heaps (~3 GB) until the runner runs out of memory and postject aborts with a bare `Aborted()` — a C-side `abort()` from inside the WASM, raised outside the code-cache try/catch so it is fatal.

The failure is **non-deterministic** — it hit the linux-x64 code-cache inject (the largest blob) in the release build but passed on identical local runs. The single-platform nightly build on `main` never trips it because there is only one inject in flight. The larger embedded payload from the recent onnxruntime-node 1.21→1.27 bump (#1444) widened the window.

## Fix

Set `concurrencyLimit: 1` so the per-platform injects run serially, keeping only one ~1 GB WASM heap live at a time. A single inject stays far under postject's ~4 GiB per-instance cap, so the fix is durable as binaries grow. The release build is a few minutes slower in exchange for a deterministic build.

## Verification

Reproduced locally: the failing build shows three `Injecting blob` lines interleaved before any `Created executable`. With the fix, each `Injecting blob` is immediately followed by its `Created executable` before the next inject starts — fully serialized, all four platforms built and gzipped. `typecheck`, `lint`, and `format:check` all pass.

An adversarial review confirmed the remedy is correct and the only fossilize/postject call site in the repo; it corrected the mechanism from an earlier 'shared-heap race' wording to the per-instance RAM-exhaustion described above (the code comment is updated to match).