### PR TITLE
fix(upgrade): harden SWAR alignment + fix multi-hop apply progress total

### DIFF
--- a/packages/gateway/src/cli/lib/bspatch.ts
+++ b/packages/gateway/src/cli/lib/bspatch.ts
@@ -485,25 +485,43 @@ async function loadOldBinary(oldPath: string): Promise<OldReader> {
  * The old bytes are read as raw bytes (no `?? 0` per element) because the
  * OldReader already zero-fills out-of-range positions.
  */
-function addDiffChunk(
+export function addDiffChunk(
   output: Uint8Array,
   oldChunk: Uint8Array,
   diffChunk: Uint8Array,
   n: number,
 ): void {
-  const words = n >> 2; // floor(n / 4)
-  const oldWords = new Uint32Array(oldChunk.buffer, oldChunk.byteOffset, words);
-  const diffWords = new Uint32Array(
-    diffChunk.buffer,
-    diffChunk.byteOffset,
-    words,
-  );
-  const outWords = new Uint32Array(output.buffer, output.byteOffset, words);
-  for (let i = 0; i < words; i++) {
-    const a = oldWords[i] ?? 0;
-    const b = diffWords[i] ?? 0;
-    outWords[i] =
-      (((a & 0x7f7f7f7f) + (b & 0x7f7f7f7f)) ^ ((a ^ b) & 0x80808080)) >>> 0;
+  // The SWAR fast path reinterprets each buffer as a Uint32Array, which
+  // requires a 4-byte-aligned byteOffset — `new Uint32Array(buf.buffer,
+  // byteOffset)` throws RangeError otherwise. Today all callers pass fresh,
+  // offset-0 buffers (`new Uint8Array(len)` / `Buffer.alloc(len)`), but a
+  // future caller could hand us a pooled or subarray view. Rather than throw
+  // (this is a perf detail that must never break patch application), fall back
+  // to the byte loop when any buffer is misaligned. Correct for all inputs;
+  // the vectorized path stays a pure optimization.
+  const aligned =
+    output.byteOffset % 4 === 0 &&
+    oldChunk.byteOffset % 4 === 0 &&
+    diffChunk.byteOffset % 4 === 0;
+  const words = aligned ? n >> 2 : 0; // floor(n / 4), or 0 to skip SWAR
+  if (words > 0) {
+    const oldWords = new Uint32Array(
+      oldChunk.buffer,
+      oldChunk.byteOffset,
+      words,
+    );
+    const diffWords = new Uint32Array(
+      diffChunk.buffer,
+      diffChunk.byteOffset,
+      words,
+    );
+    const outWords = new Uint32Array(output.buffer, output.byteOffset, words);
+    for (let i = 0; i < words; i++) {
+      const a = oldWords[i] ?? 0;
+      const b = diffWords[i] ?? 0;
+      outWords[i] =
+        (((a & 0x7f7f7f7f) + (b & 0x7f7f7f7f)) ^ ((a ^ b) & 0x80808080)) >>> 0;
+    }
   }
   for (let i = words << 2; i < n; i++) {
     output[i] = ((oldChunk[i] ?? 0) + (diffChunk[i] ?? 0)) % 256;

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -689,23 +689,25 @@ async function applyChainAndReturn(
   oldBinaryPath: string,
   destPath: string,
 ): Promise<DeltaResult> {
-  // Progress bar for the apply phase: total is the final binary size (the last
-  // patch's declared `newSize`), so the number shown is the real output the
-  // user gets — not the sum of intermediate hop writes. The bar advances per
-  // byte written across all hops, so it stays smooth through the chain.
-  let finalSize: number | null = null;
+  // Progress bar for the apply phase. `onBytes` fires for the output bytes of
+  // EVERY hop — the in-memory intermediates AND the final disk write — so the
+  // bar's total must be the SUM of all hops' output sizes (each patch's
+  // declared `newSize`), not just the final binary size. Using only the last
+  // patch's `newSize` makes a multi-hop bar reach 100% before the final hop and
+  // then clamp (freeze). The bar advances per byte written across all hops, so
+  // it stays smooth through the chain.
+  let totalBytes: number | null = 0;
   try {
-    const last = chain.patches.at(-1);
-    if (last) {
-      finalSize = parsePatchHeader(last.data).newSize;
+    for (const patch of chain.patches) {
+      totalBytes += parsePatchHeader(patch.data).newSize;
     }
   } catch {
     // Header parse is best-effort for the bar; a corrupt header is rejected
     // properly downstream. Leave the bar indeterminate in that case.
-    finalSize = null;
+    totalBytes = null;
   }
   const label = `Applying ${chain.patches.length} patch(es)`;
-  const progress = makeByteProgress(label, finalSize);
+  const progress = makeByteProgress(label, totalBytes);
   try {
     const sha256 = await applyPatchChain(
       chain,

--- a/packages/gateway/test/bspatch.test.ts
+++ b/packages/gateway/test/bspatch.test.ts
@@ -27,6 +27,7 @@ import { zstdCompressSync } from "node:zlib";
 import { afterAll, describe, expect, it } from "vitest";
 
 import {
+  addDiffChunk,
   applyPatch,
   applyPatchChainInMemory,
   applyPatchToMemory,
@@ -289,6 +290,35 @@ describe("applyPatchToMemory", () => {
     });
   });
 
+  it("produces correct output when a buffer view is misaligned (SWAR fallback)", () => {
+    // The SWAR fast path needs a 4-byte-aligned byteOffset; addDiffChunk falls
+    // back to the byte loop otherwise. No current caller passes a misaligned
+    // view (the readers and the output chunk are all fresh, offset-0
+    // allocations), so this directly unit-tests the guard against a future
+    // caller that might hand in a pooled/subarray view. Every offset combo
+    // (0-3 on each of old/diff/output) must match the per-byte reference.
+    const n = 4096 + 3; // exercises a 3-byte tail too
+    for (const oldOff of [0, 1, 2, 3]) {
+      for (const diffOff of [0, 3]) {
+        for (const outOff of [0, 2]) {
+          const oldBuf = new Uint8Array(n + oldOff).subarray(oldOff);
+          const diffBuf = new Uint8Array(n + diffOff).subarray(diffOff);
+          const outBuf = new Uint8Array(n + outOff).subarray(outOff);
+          for (let i = 0; i < n; i++) {
+            oldBuf[i] = (i * 37) % 256;
+            diffBuf[i] = (i * 53 + 3) % 256;
+          }
+          const expected = new Uint8Array(n);
+          for (let i = 0; i < n; i++) {
+            expected[i] = ((oldBuf[i] ?? 0) + (diffBuf[i] ?? 0)) % 256;
+          }
+          addDiffChunk(outBuf, oldBuf, diffBuf, n);
+          expect(outBuf).toEqual(expected);
+        }
+      }
+    }
+  });
+
   it("throws on output size mismatch", () => {
     const patch = buildPatch({
       control: ctrl(2, 0, 0),
@@ -465,6 +495,36 @@ describe("applyPatchChainInMemory", () => {
     const written = await readFile(destPath);
     expect(written).toEqual(expected);
     expect(hash).toBe(sha256(expected));
+  });
+
+  it("onBytes reports every hop's output — total = sum of all newSizes", async () => {
+    // The progress callback fires for the output bytes of EVERY hop (the
+    // in-memory intermediate AND the final disk write), so a multi-hop total
+    // is the sum of all hops' newSize, not just the final binary's. This is
+    // the invariant the apply progress-bar total relies on; a last-hop-only
+    // total would make the bar reach 100% before the final hop and freeze.
+    const old = Buffer.from([1, 2, 3, 4]);
+    const patch1 = buildPatch({
+      control: ctrl(4, 0, 0),
+      diff: Buffer.from([10, 10, 10, 10]),
+      extra: Buffer.alloc(0),
+      newSize: 4,
+    });
+    const patch2 = buildPatch({
+      control: ctrl(4, 1, 0),
+      diff: Buffer.from([1, 1, 1, 1]),
+      extra: Buffer.from([42]),
+      newSize: 5,
+    });
+
+    const oldPath = writeTemp("chain-onbytes-old.bin", old);
+    const destPath = join(WORK_DIR, "chain-onbytes-new.bin");
+    let reported = 0;
+    await applyPatchChainInMemory(oldPath, [patch1, patch2], destPath, (n) => {
+      reported += n;
+    });
+    // hop1 emits 4 bytes (newSize 4), hop2 emits 5 bytes (newSize 5).
+    expect(reported).toBe(9);
   });
 
   it("rejects an empty chain", async () => {


### PR DESCRIPTION
Back-ports two hardening fixes surfaced by the adversarial + bot reviews of the *same* delta-upgrade code when I ported it to `getsentry/cli` (their PRs #1280 and #1281). Both are latent in Lore today.

## 1. SWAR misalignment guard — `bspatch.ts`

`addDiffChunk` reinterprets the old/diff/output buffers as `Uint32Array` for the vectorized wrapping-add. `new Uint32Array(buf.buffer, buf.byteOffset, words)` throws `RangeError: start offset ... multiple of 4` if `byteOffset` isn't 4-aligned. Every current caller passes fresh offset-0 buffers (`new Uint8Array(len)` / `Buffer.alloc(len)`), so it's safe today — but it's an **undocumented, untested runtime invariant**. A future caller passing a pooled/`subarray` view would crash the apply.

Fix: fall back to the byte loop when any buffer is misaligned, rather than throw — a perf detail must never break patch application. `addDiffChunk` is now exported so the guard is directly unit-testable.

## 2. Multi-hop apply progress total — `delta-upgrade.ts`

`applyChainAndReturn` set the progress-bar total to only the **last** patch's `newSize`. But `onBytes` fires for the output bytes of **every** hop (the in-memory intermediates *and* the final disk write). On a ≥2-patch chain the accumulated bytes exceed the total, so the determinate bar reaches 100% before the final hop and clamps — it visibly freezes. (The old comment even claimed the last-hop total was correct; it wasn't.)

Fix: sum every hop's `newSize` for the total. Single-patch chains are unaffected.

> These are the exact two findings the getsentry/cli reviews caught (their Seer multi-hop-total finding + the SWAR alignment concern). The other two findings from those reviews (`writer.end()` error masking; progress-vs-spinner clash) **don't apply to Lore** — Lore's `streamDecompressToFile` uses `node:stream/promises` `pipeline()` (no manual `writer.end()` in a finally), and Lore has no spinner.

## Tests (`bspatch.test.ts`)

- **Misaligned SWAR fallback**: drives `addDiffChunk` with every byteOffset combo (0–3 on each of old/diff/output) against a per-byte reference. Mutation-verified: removing the guard → `RangeError` → RED.
- **Multi-hop onBytes total**: asserts a 2-hop chain reports `sum(newSize)` across both hops. Mutation-verified: dropping `onBytes` on in-memory hops → RED.

## Verification
- bspatch + progress + delta-upgrade-telemetry suites: 30/30 pass.
- `typecheck` clean, `lint` exit 0 (only pre-existing warnings elsewhere), `format:check` clean.