### PR TITLE
fix(import): plumb dedicatedWorkerKey and workerUpstream to LLM client

### DIFF
--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -668,8 +668,9 @@ export async function commandImport(
   // built-in default. Track whether the provider was *explicitly* configured so
   // the no-credential message below doesn't tell a Copilot/OpenRouter user to
   // set an "anthropic key" they don't have.
-  const modelExplicit = cfg.model != null;
-  const defaultModel = cfg.model ?? {
+  // Prefer `workerModel` over `model` since imports are background work.
+  const modelExplicit = cfg.model != null || cfg.workerModel != null;
+  const defaultModel = cfg.workerModel ?? cfg.model ?? {
     providerID: "anthropic",
     modelID: "claude-sonnet-4-6",
   };
@@ -721,10 +722,15 @@ export async function commandImport(
     return;
   }
 
+  const workerUpstreams = config.workerUpstream
+    ? { anthropic: config.workerUpstream, openai: config.workerUpstream }
+    : { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI };
+
   const llm = createGatewayLLMClient(
-    { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI },
+    workerUpstreams,
     getImportAuth,
     defaultModel,
+    { dedicatedWorkerKey: !!workerApiKey },
   );
 
   try {

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -670,10 +670,11 @@ export async function commandImport(
   // set an "anthropic key" they don't have.
   // Prefer `workerModel` over `model` since imports are background work.
   const modelExplicit = cfg.model != null || cfg.workerModel != null;
-  const defaultModel = cfg.workerModel ?? cfg.model ?? {
-    providerID: "anthropic",
-    modelID: "claude-sonnet-4-6",
-  };
+  const defaultModel = cfg.workerModel ??
+    cfg.model ?? {
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+    };
 
   // Extraction needs a usable credential. `lore import` is a standalone CLI
   // process: it never proxies a conversation turn, so no client credential is
@@ -725,6 +726,39 @@ export async function commandImport(
   const workerUpstreams = config.workerUpstream
     ? { anthropic: config.workerUpstream, openai: config.workerUpstream }
     : { anthropic: config.upstreamAnthropic, openai: config.upstreamOpenAI };
+
+  // `dedicatedWorkerKey` disables the in-adapter protocol-mismatch pre-flight
+  // (llm-adapter.ts) so a deliberately cross-provider key/model combo isn't
+  // rejected. But that guard also caught the common misconfiguration where a
+  // worker key is set with NO routing hint: it defaults to the anthropic
+  // upstream, and a non-`sk-ant-` key there is doomed. Without the guard that
+  // would fire one failed request + one Sentry capture PER CHUNK. Re-assert the
+  // check once here, pre-flight, and fail loudly with actionable guidance
+  // instead. Only applies when we'd hit the DEFAULT anthropic upstream (no
+  // explicit LORE_WORKER_UPSTREAM) with an anthropic-protocol model.
+  if (
+    workerApiKey &&
+    !config.workerUpstream &&
+    defaultModel.providerID === "anthropic" &&
+    !workerApiKey.startsWith("sk-ant-")
+  ) {
+    console.error(
+      `\n[lore] Can't import: LORE_WORKER_API_KEY is set but doesn't look like an\n` +
+        `[lore] Anthropic key (no \`sk-ant-\` prefix), and no target was configured,\n` +
+        `[lore] so it would be sent to Anthropic and rejected. Point it at the right\n` +
+        `[lore] provider, e.g.:\n` +
+        `[lore]\n` +
+        `[lore]   export LORE_WORKER_API_KEY=<a raw key for a provider Lore proxies>\n` +
+        `[lore]   export LORE_WORKER_UPSTREAM=https://api.openai.com/v1   # match your key\n` +
+        `[lore]   lore import\n` +
+        `[lore]\n` +
+        `[lore] Note: a GitHub Copilot / ChatGPT subscription token is NOT a usable\n` +
+        `[lore] raw key. If that's all you have, run \`lore run\` and send one message —\n` +
+        `[lore] Lore captures the live credential and imports automatically.`,
+    );
+    if (owned) await shutdown();
+    return;
+  }
 
   const llm = createGatewayLLMClient(
     workerUpstreams,

--- a/packages/gateway/test/import-command-local.test.ts
+++ b/packages/gateway/test/import-command-local.test.ts
@@ -21,15 +21,21 @@ vi.mock("../src/cli/start", () => ({
 }));
 
 // Stub the LLM client so the positive (guard-passed) paths never make a real
-// network call — the curator returns [] (answered, nothing to create).
+// network call — the curator returns [] (answered, nothing to create). Capture
+// the constructor args so we can assert the upstreams map, defaultModel, and
+// the dedicatedWorkerKey option that #1454 plumbs through.
+const llmClientCalls: unknown[][] = [];
 vi.mock("../src/llm-adapter", () => ({
-  createGatewayLLMClient: () => ({
-    prompt: vi.fn(async () => "[]"),
-  }),
+  createGatewayLLMClient: (...args: unknown[]) => {
+    llmClientCalls.push(args);
+    return { prompt: vi.fn(async () => "[]") };
+  },
 }));
 
 import { commandImport } from "../src/cli/import";
 import { setLastSeenAuth, _resetAuthForTest } from "../src/auth";
+import { load as loadConfig } from "@loreai/core";
+import { writeFileSync } from "node:fs";
 
 const AIDER_FIXTURE = join(
   fileURLToPath(new URL(".", import.meta.url)),
@@ -61,6 +67,7 @@ describe("commandImport (local mode) — auth pre-flight", () => {
     copyFileSync(AIDER_FIXTURE, join(project, ".aider.chat.history.md"));
     logs.length = 0;
     errs.length = 0;
+    llmClientCalls.length = 0;
     logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
       logs.push(a.join(" "));
     });
@@ -70,12 +77,15 @@ describe("commandImport (local mode) — auth pre-flight", () => {
     shutdownMock.mockClear();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     logSpy.mockRestore();
     errSpy.mockRestore();
     vi.restoreAllMocks();
     rmSync(project, { recursive: true, force: true });
     _resetAuthForTest();
+    // Reset process-global config to a clean empty dir so a test that wrote a
+    // `.lore.json` (e.g. the workerModel case) can't leak into later tests.
+    await loadConfig(tmpdir());
     if (prevRemote === undefined) delete process.env.LORE_REMOTE_URL;
     else process.env.LORE_REMOTE_URL = prevRemote;
   });
@@ -108,7 +118,9 @@ describe("commandImport (local mode) — auth pre-flight", () => {
   });
 
   test("worker key set → passes the guard and proceeds to read/extract", async () => {
-    startConfig.workerApiKey = "sk-worker-test";
+    // An Anthropic-prefixed key with the default (anthropic) upstream passes
+    // the pre-flight guard cleanly.
+    startConfig.workerApiKey = "sk-ant-worker-test";
 
     await commandImport([], { project, agent: "aider", yes: true });
 
@@ -117,6 +129,96 @@ describe("commandImport (local mode) — auth pre-flight", () => {
     // against the real curator; no assertion on its result here).
     expect(logs.join("\n")).toContain("Reading");
     expect(shutdownMock).toHaveBeenCalled();
+  });
+
+  test("worker key set → LLM client gets dedicatedWorkerKey + upstreams + model (#1454)", async () => {
+    startConfig.workerApiKey = "sk-ant-worker-test";
+
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    // The client must be constructed with the four-arg form: an upstreams map,
+    // the resolver, the default model, and the dedicatedWorkerKey option. The
+    // flag is what disables the in-adapter protocol-mismatch pre-flight for a
+    // deliberately-chosen worker key.
+    expect(llmClientCalls.length).toBeGreaterThan(0);
+    const [upstreams, , defaultModel, opts] = llmClientCalls[0] as [
+      Record<string, string>,
+      unknown,
+      { providerID: string; modelID: string },
+      { dedicatedWorkerKey?: boolean } | undefined,
+    ];
+    expect(opts?.dedicatedWorkerKey).toBe(true);
+    expect(upstreams.anthropic).toBe("https://api.anthropic.com");
+    // No cfg.model / workerModel here → built-in anthropic default.
+    expect(defaultModel.providerID).toBe("anthropic");
+  });
+
+  test("LORE_WORKER_UPSTREAM redirects the worker upstreams map (#1454)", async () => {
+    startConfig.workerApiKey = "sk-ant-worker-test";
+    startConfig.workerUpstream = "https://proxy.example/v1";
+
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    expect(llmClientCalls.length).toBeGreaterThan(0);
+    const [upstreams] = llmClientCalls[0] as [Record<string, string>];
+    expect(upstreams.anthropic).toBe("https://proxy.example/v1");
+    expect(upstreams.openai).toBe("https://proxy.example/v1");
+  });
+
+  test("cfg.workerModel is preferred over cfg.model for extraction (#1454)", async () => {
+    writeFileSync(
+      join(project, ".lore.json"),
+      JSON.stringify({
+        model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+        workerModel: { providerID: "openai", modelID: "gpt-5.6-luna" },
+      }),
+    );
+    await loadConfig(project);
+    startConfig.workerApiKey = "sk-worker-test";
+    startConfig.workerUpstream = "https://api.openai.com/v1";
+
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    expect(llmClientCalls.length).toBeGreaterThan(0);
+    const [, , defaultModel] = llmClientCalls[0] as [
+      unknown,
+      unknown,
+      { providerID: string; modelID: string },
+    ];
+    // workerModel (openai) wins over model (anthropic).
+    expect(defaultModel.providerID).toBe("openai");
+    expect(defaultModel.modelID).toBe("gpt-5.6-luna");
+  });
+
+  test("non-Anthropic worker key with no upstream → fails loudly pre-flight (no doomed calls)", async () => {
+    // Regression guard: with dedicatedWorkerKey disabling the in-adapter
+    // mismatch check, a non-`sk-ant-` key defaulting to the anthropic upstream
+    // would otherwise fire N doomed requests + N Sentry captures. We must catch
+    // it once, pre-flight, before ever building the client.
+    startConfig.workerApiKey = "sk-openai-not-anthropic";
+    // No workerUpstream, no cfg.model → defaults to anthropic upstream.
+
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    const out = errs.join("\n");
+    expect(out).toContain("Can't import");
+    expect(out).toContain("sk-ant-");
+    // Never built the client / read anything.
+    expect(llmClientCalls.length).toBe(0);
+    expect(logs.join("\n")).not.toContain("Reading");
+    expect(shutdownMock).toHaveBeenCalled();
+  });
+
+  test("non-Anthropic worker key WITH upstream → passes the guard (#1454)", async () => {
+    // The escape hatch: a raw OpenAI/OpenRouter/etc. key + explicit upstream is
+    // exactly the supported cross-provider worker path and must NOT be blocked.
+    startConfig.workerApiKey = "sk-openai-not-anthropic";
+    startConfig.workerUpstream = "https://api.openai.com/v1";
+
+    await commandImport([], { project, agent: "aider", yes: true });
+
+    expect(errs.join("\n")).not.toContain("Can't import");
+    expect(logs.join("\n")).toContain("Reading");
   });
 
   test("session credential present → passes the guard and proceeds to read/extract", async () => {


### PR DESCRIPTION
## Problem

Standalone `lore import` had three bugs blocking extraction when a dedicated worker key is configured:

1. **Missing `dedicatedWorkerKey` flag** — the LLM client was created without `{ dedicatedWorkerKey: true }`, so the protocol-mismatch check in `llm-adapter.ts:1862-1863` always fired even when `LORE_WORKER_API_KEY` was set. `pipeline.ts` passes this correctly (line 2502).

2. **`LORE_WORKER_UPSTREAM` ignored** — the import always used `config.upstreamAnthropic` instead of `config.workerUpstream`. `pipeline.ts` handles this at lines 2485-2487.

3. **`workerModel` config ignored** — the hardcoded `claude-sonnet-4-6` default (Anthropic protocol) always applied even when the user configured a `workerModel` with a different provider in `.lore.json`.

## Fix

1. Pass `{ dedicatedWorkerKey: !!workerApiKey }` to `createGatewayLLMClient` so the mismatch check is skipped when a dedicated worker key is configured.
2. Use `config.workerUpstream` when set, falling back to the default upstreams.
3. Honor `cfg.workerModel` before falling back to `cfg.model` or the hardcoded claude-sonnet-4-6 default.

## Testing

With an OpenAI key and upstream:
```bash
export LORE_WORKER_API_KEY=sk-...
export LORE_WORKER_UPSTREAM=https://api.openai.com/v1
lore import --project ~/dev/my-project --agent opencode -y
```

Or configure `.lore.json`:
```json
{
  "workerModel": { "providerID": "openai", "modelID": "gpt-4o-mini" }
}
```

Previously: all chunks fail with `protocol-mismatch`, 0 entries created.
With fix: extraction proceeds normally.