### PR TITLE
feat(import): use github-copilot on-disk token directly for extraction

### DIFF
--- a/packages/core/src/import/auth/opencode.ts
+++ b/packages/core/src/import/auth/opencode.ts
@@ -5,7 +5,13 @@
  * (`$XDG_DATA_HOME/opencode/auth.json`, default `~/.local/share/opencode`).
  * Each entry is keyed by the models.dev provider ID and is one of:
  *   - `{ type: "api", key }`                       → api-key credential
- *   - `{ type: "oauth", access, refresh, expires }` → bearer credential (access token)
+ *   - `{ type: "oauth", access, refresh, expires }` → bearer credential
+ *
+ * For most oauth providers the short-lived `access` token is the bearer. For
+ * `github-copilot`, OpenCode uses the long-lived GitHub OAuth `refresh` token
+ * (`gho_...`) directly as the bearer against api.githubcopilot.com (no
+ * `copilot_internal/v2/token` exchange), and stores `expires: 0` as a
+ * "no known expiry" sentinel — handled below.
  *
  * We map each entry to an AgentResolvedAuth. OpenCode uses models.dev provider
  * IDs, which line up with Lore's canonical provider IDs for the common cases;
@@ -53,18 +59,34 @@ const opencodeAuth: AgentAuthProvider = {
 
       if (entry.type === "api" && typeof entry.key === "string" && entry.key) {
         out.push({ scheme: "api-key", value: entry.key, providerID });
-      } else if (
-        entry.type === "oauth" &&
-        typeof entry.access === "string" &&
-        entry.access
-      ) {
-        out.push({
-          scheme: "bearer",
-          value: entry.access,
-          providerID,
-          expiresAt:
-            typeof entry.expires === "number" ? entry.expires : undefined,
-        });
+      } else if (entry.type === "oauth") {
+        // OpenCode's github-copilot integration uses the `refresh` field (the
+        // long-lived GitHub OAuth `gho_` token) directly as an
+        // `Authorization: Bearer` against api.githubcopilot.com — it does NOT
+        // perform the `copilot_internal/v2/token` exchange. For other oauth
+        // providers the short-lived `access` token is the bearer. Prefer the
+        // provider-correct field: refresh for copilot, access otherwise.
+        const token =
+          providerID === "github-copilot"
+            ? (entry.refresh ?? entry.access)
+            : entry.access;
+        if (typeof token === "string" && token) {
+          // github-copilot stores the long-lived GitHub OAuth token with
+          // `expires: 0` (a sentinel meaning "no known expiry", NOT "expired at
+          // epoch 0"). Treat a non-positive expiry as unset so the routability
+          // filter's `isUnexpired` check doesn't discard a perfectly valid
+          // token. Real short-lived oauth access tokens carry a positive epoch.
+          const expiresAt =
+            typeof entry.expires === "number" && entry.expires > 0
+              ? entry.expires
+              : undefined;
+          out.push({
+            scheme: "bearer",
+            value: token,
+            providerID,
+            expiresAt,
+          });
+        }
       }
     }
     return out;

--- a/packages/core/test/import/auth.test.ts
+++ b/packages/core/test/import/auth.test.ts
@@ -112,6 +112,46 @@ describe("OpenCode auth reader", () => {
     expect(readUsableAuth("opencode")).toEqual([]);
   });
 
+  test("github-copilot oauth uses refresh token as bearer", () => {
+    // OpenCode uses the long-lived GitHub OAuth `refresh` token directly as a
+    // Bearer against api.githubcopilot.com (no copilot_internal/v2/token
+    // exchange). Prefer refresh over access for this provider specifically.
+    writeJson(authFile(), {
+      "github-copilot": {
+        type: "oauth",
+        access: "gho_access_should_not_win",
+        refresh: "gho_refresh_wins",
+        expires: 0,
+      },
+    });
+    const creds = readUsableAuth("opencode");
+    expect(creds).toEqual([
+      {
+        scheme: "bearer",
+        value: "gho_refresh_wins",
+        providerID: "github-copilot",
+        // expires:0 is a "no known expiry" sentinel → expiresAt undefined, so
+        // the credential is NOT filtered out as epoch-0-expired.
+        expiresAt: undefined,
+      },
+    ]);
+  });
+
+  test("expires:0 sentinel is treated as unexpired (not epoch-0-expired)", () => {
+    writeJson(authFile(), {
+      openai: { type: "oauth", access: "tok-live", expires: 0 },
+    });
+    const creds = readUsableAuth("opencode");
+    expect(creds).toEqual([
+      {
+        scheme: "bearer",
+        value: "tok-live",
+        providerID: "openai",
+        expiresAt: undefined,
+      },
+    ]);
+  });
+
   test("garbage file yields [] (no throw)", () => {
     mkdirSync(join(authFile(), ".."), { recursive: true });
     writeFileSync(authFile(), "not json{{{", "utf8");

--- a/packages/core/test/import/auth.test.ts
+++ b/packages/core/test/import/auth.test.ts
@@ -137,6 +137,33 @@ describe("OpenCode auth reader", () => {
     ]);
   });
 
+  test("github-copilot falls back to access when refresh is absent", () => {
+    // Older OpenCode auth.json may lack `refresh`; `access` still works.
+    writeJson(authFile(), {
+      "github-copilot": {
+        type: "oauth",
+        access: "gho_access_only",
+        expires: 0,
+      },
+    });
+    const creds = readUsableAuth("opencode");
+    expect(creds).toEqual([
+      {
+        scheme: "bearer",
+        value: "gho_access_only",
+        providerID: "github-copilot",
+        expiresAt: undefined,
+      },
+    ]);
+  });
+
+  test("github-copilot with neither refresh nor access is omitted (no throw)", () => {
+    writeJson(authFile(), {
+      "github-copilot": { type: "oauth", expires: 0 },
+    });
+    expect(readUsableAuth("opencode")).toEqual([]);
+  });
+
   test("expires:0 sentinel is treated as unexpired (not epoch-0-expired)", () => {
     writeJson(authFile(), {
       openai: { type: "oauth", access: "tok-live", expires: 0 },

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -92,16 +92,16 @@ export function resolveAgentImportAuth(
   // 2. Harness on-disk auth — pick the first credential whose provider Lore
   //    can DIRECTLY authenticate for extraction. A provider is usable only if
   //    it has a concrete upstream URL (some routes carry url:null — local
-  //    runtimes like ollama/vllm/lmstudio) AND does not require a runtime token
-  //    exchange we can't do from a stored key (github-copilot mints a Copilot
-  //    token from a GitHub token — a stored bearer isn't usable as-is). Anything
+  //    runtimes like ollama/vllm/lmstudio, not reachable for extraction).
+  //    github-copilot IS usable: OpenCode stores the GitHub OAuth token that
+  //    api.githubcopilot.com accepts directly as a Bearer (no runtime token
+  //    exchange needed), and its route carries a concrete url. Anything
   //    filtered here falls through to the accurate "no usable credential"
   //    guidance rather than a confusing downstream "no response from the model".
   const creds: AgentResolvedAuth[] = readUsableAuth(agentName);
-  const usable = creds.find((c) => {
-    if (c.providerID === "github-copilot") return false;
-    return resolveProviderRoute(c.providerID)?.url != null;
-  });
+  const usable = creds.find(
+    (c) => resolveProviderRoute(c.providerID)?.url != null,
+  );
   if (usable) {
     const model = usable.modelID
       ? { providerID: usable.providerID, modelID: usable.modelID }

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -50,6 +50,7 @@ import {
 import {
   buildOpenAIChatCompletionsUrl,
   gitHubModelsHeaders,
+  copilotHeaders,
 } from "./translate/openai";
 import { accumulateOpenAISSEStream } from "./stream/openai";
 import { accumulateResponsesSSEStream } from "./stream/openai-responses";
@@ -1052,6 +1053,9 @@ function buildOpenAIWorkerRequest(
       ...authHeaders(cred),
       // GitHub Models requires Accept + X-GitHub-Api-Version; no-op for others.
       ...gitHubModelsHeaders(target.url),
+      // GitHub Copilot wants Copilot-Integration-Id + X-GitHub-Api-Version;
+      // no-op for others.
+      ...copilotHeaders(target.url),
     },
     body: JSON.stringify({
       model: model.modelID,

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -524,6 +524,9 @@ export function isGitHubModelsHost(hostname: string): boolean {
 /** The API version pinned for GitHub Models requests. */
 export const GITHUB_MODELS_API_VERSION = "2026-03-10";
 
+/** The API version pinned for GitHub Copilot requests (matches Copilot CLI). */
+export const GITHUB_COPILOT_API_VERSION = "2026-06-01";
+
 /** Static headers GitHub Models requires beyond auth. Empty for every other
  *  host, so callers can spread the result unconditionally. */
 export function gitHubModelsHeaders(url: string): Record<string, string> {
@@ -532,6 +535,27 @@ export function gitHubModelsHeaders(url: string): Record<string, string> {
       return {
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": GITHUB_MODELS_API_VERSION,
+      };
+    }
+  } catch {
+    // Unparseable URL — add nothing.
+  }
+  return {};
+}
+
+/**
+ * Extra headers GitHub Copilot expects on Chat Completions calls. The stored
+ * GitHub OAuth token authenticates on its own (verified), but Copilot's API
+ * canonically wants a `Copilot-Integration-Id` identifying the integration and
+ * an `X-GitHub-Api-Version`. Sending them matches what real Copilot clients do
+ * and hardens against the API tightening later. No-op for non-Copilot hosts.
+ */
+export function copilotHeaders(url: string): Record<string, string> {
+  try {
+    if (isGitHubCopilotHost(new URL(url).hostname)) {
+      return {
+        "Copilot-Integration-Id": "vscode-chat",
+        "X-GitHub-Api-Version": GITHUB_COPILOT_API_VERSION,
       };
     }
   } catch {

--- a/packages/gateway/test/import-auth-chain.test.ts
+++ b/packages/gateway/test/import-auth-chain.test.ts
@@ -87,13 +87,25 @@ describe("resolveAgentImportAuth", () => {
     expect(res).toBeNull();
   });
 
-  test("skips a github-copilot credential (token exchange required, not a raw key)", () => {
-    const future = Date.now() + 3600_000;
+  test("resolves a github-copilot credential (bearer, no token exchange)", () => {
+    // OpenCode's github-copilot GitHub OAuth token works directly as a Bearer
+    // against api.githubcopilot.com (route has a concrete url) — it must NOT be
+    // skipped. The refresh field is preferred and expires:0 is not "expired".
     writeOpenCodeAuth({
-      "github-copilot": { type: "oauth", access: "gh-tok", expires: future },
+      "github-copilot": {
+        type: "oauth",
+        access: "gho_access",
+        refresh: "gho_refresh",
+        expires: 0,
+      },
     });
     const res = resolveAgentImportAuth("opencode", undefined, undefined);
-    expect(res).toBeNull();
+    expect(res).not.toBeNull();
+    expect(res?.model.providerID).toBe("github-copilot");
+    expect(res?.getAuth()).toEqual({
+      scheme: "bearer",
+      value: "gho_refresh",
+    });
   });
 
   test("prefers a routable credential over an unroutable earlier one", () => {

--- a/packages/gateway/test/worker-github-copilot.test.ts
+++ b/packages/gateway/test/worker-github-copilot.test.ts
@@ -65,4 +65,54 @@ describe("worker github-copilot URL (#1052)", () => {
     expect(url).toBe("https://api.githubcopilot.com/chat/completions");
     expect(url).not.toContain("/v1/chat/completions");
   });
+
+  test("sends Bearer auth + Copilot-Integration-Id + X-GitHub-Api-Version", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "github-copilot"
+          ? { scheme: "bearer", value: "gho_worker" }
+          : null,
+      { providerID: "github-copilot", modelID: "gpt-4.1" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-copilot",
+      workerID: "lore-distill",
+      model: { providerID: "github-copilot", modelID: "gpt-4.1" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const init = mockFetch.mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    const headers = init.headers;
+    // The stored GitHub OAuth token goes as a Bearer (not x-api-key) — the
+    // Copilot API rejects x-api-key with 400.
+    expect(headers.Authorization).toBe("Bearer gho_worker");
+    expect(headers["x-api-key"]).toBeUndefined();
+    // Copilot-canonical headers (belt-and-suspenders; token alone also works).
+    expect(headers["Copilot-Integration-Id"]).toBe("vscode-chat");
+    expect(headers["X-GitHub-Api-Version"]).toBe("2026-06-01");
+  });
+
+  test("non-copilot openai worker gets no Copilot headers", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-openai" }),
+      { providerID: "openai", modelID: "gpt-4o-mini" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-openai",
+      workerID: "lore-distill",
+      model: { providerID: "openai", modelID: "gpt-4o-mini" },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const init = mockFetch.mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(init.headers["Copilot-Integration-Id"]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem (#1398)

`lore import` skipped OpenCode's `github-copilot` credential, on the assumption it needed a `copilot_internal/v2/token` exchange we can't do from a stored key. That's why Kjaer's Copilot-only setup couldn't import.

## What's actually true (verified live against a real Copilot account)

OpenCode stores the long-lived GitHub OAuth token (`gho_...`) and uses it **directly** as `Authorization: Bearer` against `api.githubcopilot.com` — there is **no token exchange** (the `copilot_internal/v2/token` endpoint 404s with this token; OpenCode never calls it). A `chat/completions` request with just the stored token returns `200`.

## Fix

- **`opencode.ts` reader**: for `github-copilot`, emit the bearer from `refresh` (the field OpenCode itself uses), and treat `expires: 0` as a "no known expiry" sentinel rather than epoch-0-expired (so a valid token isn't filtered out). The sentinel handling is safe for all oauth providers — a genuinely-expired token carries a positive past epoch.
- **`import.ts`**: drop the `github-copilot` exclusion from the routability filter — it IS routable (concrete `api.githubcopilot.com` url + usable stored bearer).
- **`copilotHeaders()`**: add `Copilot-Integration-Id` + `X-GitHub-Api-Version` on worker requests to githubcopilot hosts (matches real Copilot clients; the token alone also authenticates). No-op for other hosts.

## Tests

Reader (refresh preferred, `expires:0` sentinel), routability filter (github-copilot now resolves), and worker-request headers (Bearer not x-api-key, integration headers present / absent for non-copilot). Mutation-verified: reverting each of the four changes turns its regression test red. A live end-to-end check (real creds → 200) was run locally and removed before commit (it hits the network / needs creds).