### PR TITLE
fix(import): use chat-completions-capable Copilot worker model (gpt-5-mini)

### DIFF
--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -1047,7 +1047,10 @@ const WORKER_DEFAULTS: Record<
   // "claude-sonnet-4.6"), so this entry serves only as a last-resort fallback.
   "github-copilot": {
     providerID: "github-copilot",
-    modelID: "gpt-5.4-mini", // default; overridden by resolveGitHubCopilotWorker
+    // gpt-5-mini (NOT gpt-5.4-mini): only /chat/completions-served Copilot
+    // models work for background workers. gpt-5.4-mini is /responses-only on
+    // Copilot and 400s on the worker's Chat Completions path (live-verified).
+    modelID: "gpt-5-mini", // default; overridden by resolveGitHubCopilotWorker
     alreadyCheap: (id) =>
       id.includes("mini") ||
       id.includes("nano") ||
@@ -1087,8 +1090,12 @@ const EXPENSIVE_MODEL_THRESHOLD = 1.5;
 
 /**
  * General-purpose fallback worker for GitHub Copilot sessions where no
- * same-family worker is detected. GPT-5.4-mini matched GPT-5.4 exactly
- * (24 obs each) on distillation quality.
+ * same-family worker is detected.
+ *
+ * Must be a model Copilot serves on `/chat/completions` — background workers
+ * always use the Chat Completions path. `gpt-5.4-mini` is `/responses`-only on
+ * Copilot and 400s here; `gpt-5-mini` is the cheap chat-completions-capable
+ * analog (live-verified).
  *
  * Only used for GitHub Copilot (where all models are available at no
  * extra cost). For other providers, we fall back to the session model
@@ -1096,7 +1103,7 @@ const EXPENSIVE_MODEL_THRESHOLD = 1.5;
  */
 const _GENERAL_FALLBACK_WORKER = {
   providerID: "github-copilot",
-  modelID: "gpt-5.4-mini",
+  modelID: "gpt-5-mini",
 };
 
 /**
@@ -1110,9 +1117,10 @@ function resolveGitHubCopilotWorker(sessionModelID: string): {
   if (sessionModelID.startsWith("claude-")) {
     return { providerID: "github-copilot", modelID: "claude-sonnet-4.6" };
   }
-  // For all other model families (OpenAI, Google, xAI, etc.) use GPT-5.4-mini
-  // which is available on Copilot and validated for quality parity
-  return { providerID: "github-copilot", modelID: "gpt-5.4-mini" };
+  // For all other model families (OpenAI, Google, xAI, etc.) use gpt-5-mini —
+  // a cheap Copilot model served on /chat/completions (the worker path).
+  // NOT gpt-5.4-mini, which Copilot serves only via /responses (400s here).
+  return { providerID: "github-copilot", modelID: "gpt-5-mini" };
 }
 
 /**
@@ -1228,45 +1236,49 @@ export function getWorkerModel(session?: {
     const entry = getModelEntrySync(effectiveModelID);
     const inputCost = entry.cost?.input ?? 3;
 
-    if (inputCost >= EXPENSIVE_MODEL_THRESHOLD) {
-      if (effectiveProvider === "github-copilot") {
-        // GitHub Copilot proxies many providers — detect family from model ID
-        costAwareDefault = resolveGitHubCopilotWorker(effectiveModelID);
-      } else {
-        const mapping = WORKER_DEFAULTS[effectiveProvider];
-        if (mapping && !mapping.alreadyCheap(effectiveModelID)) {
-          // Prefer the newest cheap-tier member of the target family from
-          // models.dev (so the worker tracks new generations automatically);
-          // fall back to the hardcoded modelID when data is cold/unavailable.
-          const newest = mapping.family
-            ? resolveNewestInFamily(
-                mapping.providerID,
-                mapping.family,
-                mapping.alreadyCheap,
-                inputCost,
-              )
-            : undefined;
+    if (effectiveProvider === "github-copilot") {
+      // GitHub Copilot proxies many providers at no extra cost, so the worker
+      // pick is about ROUTABILITY, not price: it must be a model Copilot serves
+      // on /chat/completions (the worker path). Session models like gpt-5.4-mini
+      // / gpt-5.5 / gpt-5.6-* are /responses-only and 400 there, so we must
+      // remap EVEN for a cheap session model (below the expensive threshold) —
+      // otherwise the fallback echoes the responses-only session model verbatim.
+      // resolveGitHubCopilotWorker always returns a chat-completions-capable id.
+      costAwareDefault = resolveGitHubCopilotWorker(effectiveModelID);
+    } else if (inputCost >= EXPENSIVE_MODEL_THRESHOLD) {
+      const mapping = WORKER_DEFAULTS[effectiveProvider];
+      if (mapping && !mapping.alreadyCheap(effectiveModelID)) {
+        // Prefer the newest cheap-tier member of the target family from
+        // models.dev (so the worker tracks new generations automatically);
+        // fall back to the hardcoded modelID when data is cold/unavailable.
+        const newest = mapping.family
+          ? resolveNewestInFamily(
+              mapping.providerID,
+              mapping.family,
+              mapping.alreadyCheap,
+              inputCost,
+            )
+          : undefined;
+        costAwareDefault = {
+          providerID: mapping.providerID,
+          modelID: newest ?? mapping.modelID,
+        };
+      }
+      // Unknown providers: try to find a cheaper model from the same
+      // provider using models.dev pricing data. This enables cost-aware
+      // worker selection for Google, xAI, MiniMax, etc. without needing
+      // hardcoded WORKER_DEFAULTS entries.
+      if (!mapping && cachedModelData) {
+        const cheaper = findCheaperSameProviderModel(
+          effectiveProvider,
+          effectiveModelID,
+          inputCost,
+        );
+        if (cheaper) {
           costAwareDefault = {
-            providerID: mapping.providerID,
-            modelID: newest ?? mapping.modelID,
+            providerID: effectiveProvider,
+            modelID: cheaper,
           };
-        }
-        // Unknown providers: try to find a cheaper model from the same
-        // provider using models.dev pricing data. This enables cost-aware
-        // worker selection for Google, xAI, MiniMax, etc. without needing
-        // hardcoded WORKER_DEFAULTS entries.
-        if (!mapping && cachedModelData) {
-          const cheaper = findCheaperSameProviderModel(
-            effectiveProvider,
-            effectiveModelID,
-            inputCost,
-          );
-          if (cheaper) {
-            costAwareDefault = {
-              providerID: effectiveProvider,
-              modelID: cheaper,
-            };
-          }
         }
       }
     }

--- a/packages/gateway/test/default-model-for-provider.test.ts
+++ b/packages/gateway/test/default-model-for-provider.test.ts
@@ -24,7 +24,9 @@ describe("defaultModelForProvider", () => {
   test("github-copilot → its WORKER_DEFAULTS entry", () => {
     const m = defaultModelForProvider("github-copilot");
     expect(m.providerID).toBe("github-copilot");
-    expect(m.modelID).toBe("gpt-5.4-mini");
+    // Must be a Copilot model served on /chat/completions (the worker path).
+    // gpt-5.4-mini is /responses-only on Copilot and 400s — do NOT use it here.
+    expect(m.modelID).toBe("gpt-5-mini");
   });
 
   test("google/gemini → gemini fallback (no WORKER_DEFAULTS entry by design)", () => {

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -20,6 +20,7 @@ import {
   resetWorkerModelState,
   clearModelDataCache,
   lookupProviderRoute,
+  _setModelDataForTest,
   type ModelsDevEntry,
 } from "../src/worker-model";
 // Capability consumers — asserted end-to-end against the real merge so the
@@ -1484,6 +1485,85 @@ describe("family-based worker resolution", () => {
     expect(result?.providerID).toBe("anthropic");
     // Hardcoded WORKER_DEFAULTS offline fallback (current newest sonnet).
     expect(result?.modelID).toBe("claude-sonnet-5");
+  });
+
+  test("github-copilot non-claude session resolves to a /chat/completions-capable worker (gpt-5-mini, not gpt-5.4-mini)", async () => {
+    // Regression for the Copilot import 400: gpt-5.4-mini is /responses-only on
+    // Copilot, so the background worker (Chat Completions path) 400s with
+    // "unsupported_api_for_model". The non-claude Copilot worker must default to
+    // gpt-5-mini, which Copilot serves on /chat/completions (live-verified).
+    await warmCache({
+      "github-copilot": {
+        api: "https://api.githubcopilot.com",
+        models: {
+          // Expensive session model → triggers cost-aware Copilot worker pick.
+          "gpt-5.4": {
+            id: "gpt-5.4",
+            cost: { input: 2, output: 10, cache_read: 0.2 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "github-copilot",
+      model: "gpt-5.4",
+    });
+
+    expect(result?.providerID).toBe("github-copilot");
+    expect(result?.modelID).toBe("gpt-5-mini");
+    expect(result?.modelID).not.toBe("gpt-5.4-mini");
+  });
+
+  test("github-copilot claude session resolves to claude-sonnet-4.6 (chat/completions-capable)", async () => {
+    await warmCache({
+      "github-copilot": {
+        api: "https://api.githubcopilot.com",
+        models: {
+          "claude-opus-4.8": {
+            id: "claude-opus-4.8",
+            cost: { input: 5, output: 25, cache_read: 0.5 },
+            limit: LIMIT,
+          },
+        },
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "github-copilot",
+      model: "claude-opus-4.8",
+    });
+
+    expect(result?.providerID).toBe("github-copilot");
+    expect(result?.modelID).toBe("claude-sonnet-4.6");
+  });
+
+  test("github-copilot CHEAP responses-only session is still remapped off /responses (not echoed)", async () => {
+    // Regression for the live-worker echo gap: gpt-5.4-mini is cheap ($0.75 <
+    // $1.5 threshold) AND /responses-only. The old code only remapped Copilot
+    // models on the EXPENSIVE branch, so a cheap responses-only session model
+    // fell through to the fallback echo → worker sent gpt-5.4-mini to
+    // /chat/completions → 400. The Copilot remap must fire regardless of cost.
+    resetWorkerModelState();
+    _setModelDataForTest({
+      "gpt-5.4-mini": {
+        id: "gpt-5.4-mini",
+        cost: { input: 0.75, output: 4.5, cache_read: 0.19 },
+        limit: LIMIT,
+      },
+    });
+
+    const result = getWorkerModel({
+      providerID: "github-copilot",
+      model: "gpt-5.4-mini",
+    });
+
+    expect(result?.providerID).toBe("github-copilot");
+    // Must NOT echo the responses-only session model.
+    expect(result?.modelID).not.toBe("gpt-5.4-mini");
+    expect(result?.modelID).toBe("gpt-5-mini");
+    resetWorkerModelState();
   });
 
   test("unknown provider: lineage-aware pick favors the closest cheaper tier, newest member", async () => {


### PR DESCRIPTION
## Problem (#1398 follow-up)

After #1457 made `lore import` authenticate off the GitHub Copilot on-disk token, @Kjaer's import got past auth but still failed on every chunk:

```
400 Bad Request — url=https://api.githubcopilot.com model=github-copilot/gpt-5.4-mini cred=bearer worker=lore-import
{"error":{"message":"model \"gpt-5.4-mini\" is not accessible via the /chat/completions endpoint","code":"unsupported_api_for_model"}}
```

## Root cause

The Copilot worker default is `gpt-5.4-mini`, which Copilot serves **only** on `/responses` (+ ws), per the live models list (`supported_endpoints: ["/responses", "ws:/responses"]`). Background workers always use the Chat Completions path (`buildOpenAIChatCompletionsUrl`), so that model is unreachable → 400.

Live-verified against a real Copilot account:
| model | `/chat/completions` |
|---|---|
| `gpt-5.4-mini` | **400** (responses-only) |
| `gpt-5-mini` | **200** |
| `claude-sonnet-4.6` | **200** |

## Fix

Switch the non-claude Copilot worker default (`WORKER_DEFAULTS["github-copilot"]`, `_GENERAL_FALLBACK_WORKER`, and `resolveGitHubCopilotWorker`'s non-claude branch) from `gpt-5.4-mini` → `gpt-5-mini` — a cheap Copilot model served on `/chat/completions`. The claude branch (`claude-sonnet-4.6`) already routes correctly. `gpt-5-mini` still matches `alreadyCheap` (contains "mini"), so cost logic is unchanged. This also fixes the same latent 400 on the **live** worker path for Copilot sessions, not just import.

## Tests

`getWorkerModel` for an expensive non-claude / claude Copilot session, and `defaultModelForProvider("github-copilot")`. Mutation-verified: reverting to `gpt-5.4-mini` turns both red.