### PR TITLE
feat(binpatch): chain discovery behind a pluggable SourceStrategy

### DIFF
--- a/packages/binpatch/README.md
+++ b/packages/binpatch/README.md
@@ -23,10 +23,11 @@ The system splits into two halves joined by a single **wire contract**:
 2. **Generation + publishing** — CI-side patch creation and upload to
    GHCR / GitHub Releases. A reusable GitHub Action (separate, later).
 
-This package currently covers the **apply core** (PR1): patch parsing, chain
-application, an offline cache, and byte-progress reporting. Chain **discovery**
-(a pluggable `SourceStrategy` over GHCR tags and GitHub Release assets) lands in
-a follow-up.
+This package covers the **apply core** (patch parsing, chain application, an
+offline cache, byte-progress reporting) and **chain discovery** — a pluggable
+`SourceStrategy` over OCI/GHCR patch-manifest tags and GitHub Release assets,
+plus a cache-first `resolveAndApply` orchestrator. The CI-side patch
+*generation* half ships separately as a composite GitHub Action (later).
 
 ## API
 
@@ -52,14 +53,74 @@ await cache.cleanup(); // drop entries past the 7-day TTL
 await cache.clear();   // wipe everything (e.g. after a successful upgrade)
 ```
 
+### Discovery + resolve-and-apply
+
+Higher level: hand `resolveAndApply` a `SourceStrategy` and it does cache-first
+resolution, apply, SHA verification, and progress events. All product specifics
+are injected — the library has no GitHub/registry/version knowledge baked in.
+
+```ts
+import {
+  resolveAndApply,
+  ghcrSource,
+  githubReleaseSource,
+} from "binpatch";
+
+// Nightly channel — OCI patch-manifest tags on a registry (e.g. GHCR).
+const nightly = ghcrSource({
+  registry: "https://ghcr.io",
+  repo: "owner/project",
+  userAgent: "my-cli/1.2.3",
+  binaryName: "my-cli-linux-x64",
+  targetTag: (v) => `nightly-${v}`,   // where the target image manifest lives
+  compareVersions,                     // your semver comparator (-1|0|1)
+});
+
+// Stable channel — GitHub Release assets.
+const stable = githubReleaseSource({
+  releasesUrl: "https://api.github.com/repos/owner/project/releases",
+  binaryName: "my-cli-linux-x64",
+  userAgent: "my-cli/1.2.3",
+});
+
+const result = await resolveAndApply({
+  source: nightly,            // or stable
+  currentVersion, targetVersion,
+  oldPath, destPath,
+  cache,                       // optional — enables offline upgrades
+  offline,                     // optional — cache-only, never touch the network
+  onProgress: (e) => { /* {type:"phase"|"bytes"|"done", ...} */ },
+  telemetry: {                 // optional — the library is telemetry-agnostic
+    onResolved: ({ source }) => {/* "cache" | "network" */},
+    onOfflineMiss: () => {},
+  },
+});
+// result: { sha256, patchBytes, chainLength } | null (fall back to full download)
+```
+
+Implement your own `SourceStrategy` for any other layout — the contract is a
+single method: `resolveChain(current, target, signal?) => PatchChain | null`.
+
+### Progress is events, never rendering
+
+The library **never draws** progress. `resolveAndApply` emits
+`{ type: "phase" | "bytes" | "done"; phase; ... }` events via `onProgress`; a
+missing handler is silent, and a throwing handler can never abort the operation
+(`safeProgress`). Each consumer renders however it likes — a stderr bar
+(`makeByteProgress` ships as a convenience), a spinner message, or a log line.
+
 ### Exports
 
 - `parsePatchHeader`, `offtin`, `PatchHeader`, `MAX_OUTPUT_SIZE`, `addDiffChunk`
   — TRDIFF10 header parsing + the vectorized diff-add primitive.
 - `applyPatch`, `applyPatchToMemory`, `applyPatchChainInMemory` — patch apply.
-- `makeByteProgress`, `ByteProgress`, `ByteProgressOut` — a simple byte-progress
-  bar (a thin default; the eventual public API is pure event hooks so any
-  consumer can plug in any indicator, or none).
+- `resolveAndApply`, `SourceStrategy`, `ghcrSource`, `githubReleaseSource`,
+  `OciClient` — chain discovery + orchestration.
+- `ProgressEvent`, `ProgressHandler`, `safeProgress` — progress events.
+- `PatchChain`, `PatchLink`, `ChainStep`, `DeltaResult`, `BinpatchError`,
+  and the contract constants (`MAX_STABLE_CHAIN_DEPTH`,
+  `MAX_NIGHTLY_CHAIN_DEPTH`, `SIZE_THRESHOLD_RATIO`, `PATCH_TAG_PREFIX`).
+- `makeByteProgress` — a convenience stderr byte-progress bar (optional).
 - `makeCache`, `PatchCache`, `patchFileName`, `chainFileName`, `ChainMeta`,
   `PatchStepMeta` — the offline patch cache.
 

--- a/packages/binpatch/src/contract.ts
+++ b/packages/binpatch/src/contract.ts
@@ -1,0 +1,53 @@
+/**
+ * Wire-contract constants and shared types.
+ *
+ * These values are part of the binpatch wire contract — the generator (the
+ * publishing side) and this library MUST agree on them. See the package README
+ * for the full contract spec.
+ */
+
+/** Maximum stable patches to chain before falling back to a full download. */
+export const MAX_STABLE_CHAIN_DEPTH = 10;
+
+/** Maximum nightly patches to chain before falling back to a full download. */
+export const MAX_NIGHTLY_CHAIN_DEPTH = 30;
+
+/**
+ * Maximum ratio of total patch-chain size to the full (gzipped) download size.
+ * Above this, a full download is cheaper — abandon the chain.
+ */
+export const SIZE_THRESHOLD_RATIO = 0.6;
+
+/** GHCR tag prefix under which per-version patch manifests are published. */
+export const PATCH_TAG_PREFIX = "patch-";
+
+/** A single link in a patch chain: the raw patch bytes and their size. */
+export type PatchLink = {
+  data: Uint8Array;
+  size: number;
+};
+
+/** One from->to hop, used for cache keying. */
+export type ChainStep = {
+  fromVersion: string;
+  toVersion: string;
+};
+
+/**
+ * A resolved chain of patches from a current version to a target version,
+ * plus the expected SHA-256 of the final produced binary (the sole trust
+ * anchor) and the per-hop steps (for the offline cache).
+ */
+export type PatchChain = {
+  patches: PatchLink[];
+  totalSize: number;
+  expectedSha256: string;
+  steps?: ChainStep[];
+};
+
+/** Result of a successfully applied delta chain. */
+export type DeltaResult = {
+  sha256: string;
+  patchBytes: number;
+  chainLength: number;
+};

--- a/packages/binpatch/src/discover.ts
+++ b/packages/binpatch/src/discover.ts
@@ -1,0 +1,179 @@
+/**
+ * Chain discovery + resolve-and-apply orchestration.
+ *
+ * A {@link SourceStrategy} knows how to resolve a {@link PatchChain} from some
+ * backing store (an OCI registry, GitHub Release assets, ...). This module ties
+ * a strategy together with the offline cache, the apply core, integrity
+ * verification, and progress events — with every product-specific concern
+ * (version, telemetry, logging, cache location) injected.
+ */
+
+import { applyPatchChainInMemory, parsePatchHeader } from "./bspatch";
+import type { PatchCache } from "./patch-cache";
+import type { DeltaResult, PatchChain } from "./contract";
+import { type ProgressHandler, safeProgress } from "./events";
+
+/**
+ * A source of patch chains. Given the current and target versions, resolve the
+ * ordered chain of patches (oldest hop first) plus the expected final SHA-256,
+ * or `null` when no usable chain exists (caller falls back to a full download).
+ */
+export type SourceStrategy = {
+  resolveChain(
+    currentVersion: string,
+    targetVersion: string,
+    signal?: AbortSignal,
+  ): Promise<PatchChain | null>;
+};
+
+/** Where a resolved chain came from, for telemetry. */
+export type DeltaSource = "cache" | "network" | "offline_miss";
+
+/** Optional telemetry callback invoked as facts become known. */
+export type DeltaTelemetry = {
+  onResolved?: (info: { source: DeltaSource; chain: PatchChain }) => void;
+  onOfflineMiss?: () => void;
+};
+
+export type ResolveAndApplyOpts = {
+  source: SourceStrategy;
+  currentVersion: string;
+  targetVersion: string;
+  oldPath: string;
+  destPath: string;
+  /** Offline patch cache. When present, checked before hitting the network. */
+  cache?: PatchCache;
+  /** When true, never touch the network — cache hit or bust. */
+  offline?: boolean;
+  /** Progress events (phase/bytes/done). Never rendered by the library. */
+  onProgress?: ProgressHandler;
+  /** Telemetry hooks; the library stays telemetry-agnostic. */
+  telemetry?: DeltaTelemetry;
+  signal?: AbortSignal;
+};
+
+/**
+ * Resolve a patch chain (cache-first, then the source unless offline), apply
+ * it to `oldPath`, verify the SHA-256, and write the result to `destPath`.
+ * Returns the {@link DeltaResult}, or `null` when no chain is usable.
+ *
+ * Throws only on a genuine apply/verification failure (SHA mismatch, corrupt
+ * patch) — the caller treats a throw as "fall back to a full download".
+ */
+export async function resolveAndApply(
+  opts: ResolveAndApplyOpts,
+): Promise<DeltaResult | null> {
+  const {
+    source,
+    currentVersion,
+    targetVersion,
+    oldPath,
+    destPath,
+    cache,
+    offline,
+    onProgress,
+    telemetry,
+    signal,
+  } = opts;
+  const progress = safeProgress(onProgress);
+
+  // Cache first — enables fully offline upgrades.
+  if (cache) {
+    const cached = await tryLoadCachedChain(
+      cache,
+      currentVersion,
+      targetVersion,
+    );
+    if (cached) {
+      telemetry?.onResolved?.({ source: "cache", chain: cached });
+      return applyChain(cached, oldPath, destPath, progress);
+    }
+  }
+
+  if (offline) {
+    telemetry?.onOfflineMiss?.();
+    return null;
+  }
+
+  progress({ type: "phase", phase: "resolve" });
+  const chain = await source.resolveChain(
+    currentVersion,
+    targetVersion,
+    signal,
+  );
+  if (!chain) return null;
+
+  // Persist for future offline upgrades, then apply.
+  if (cache && chain.steps) {
+    cache.save(chain, chain.steps).catch(() => {});
+  }
+
+  telemetry?.onResolved?.({ source: "network", chain });
+  return applyChain(chain, oldPath, destPath, progress);
+}
+
+async function tryLoadCachedChain(
+  cache: PatchCache,
+  currentVersion: string,
+  targetVersion: string,
+): Promise<PatchChain | null> {
+  try {
+    return await cache.load(currentVersion, targetVersion);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Apply a resolved chain, emitting apply-phase byte progress, and verify the
+ * final SHA-256 against the chain's expected value.
+ */
+async function applyChain(
+  chain: PatchChain,
+  oldPath: string,
+  destPath: string,
+  progress: ProgressHandler,
+): Promise<DeltaResult> {
+  // Apply-phase progress total = SUM of every hop's declared output size
+  // (each patch header's `newSize`), because `onBytes` fires for the output
+  // bytes of EVERY hop — the in-memory intermediates AND the final disk write.
+  // Using only the last hop's size makes a multi-hop bar hit 100% after the
+  // first hop and then freeze.
+  let total: number | null = 0;
+  try {
+    for (const patch of chain.patches) {
+      total += parsePatchHeader(patch.data).newSize;
+    }
+  } catch {
+    // Header parse is best-effort for the bar; a corrupt header is rejected
+    // properly downstream. Leave the total indeterminate in that case.
+    total = null;
+  }
+
+  progress({ type: "phase", phase: "apply" });
+  let written = 0;
+  const sha256 = await applyPatchChainInMemory(
+    oldPath,
+    chain.patches.map((p) => p.data),
+    destPath,
+    (bytes) => {
+      written += bytes;
+      progress({ type: "bytes", phase: "apply", written, total });
+    },
+  );
+  progress({ type: "done", phase: "apply" });
+
+  progress({ type: "phase", phase: "verify" });
+  if (sha256 !== chain.expectedSha256) {
+    throw new Error(
+      `SHA-256 mismatch after patching: got ${sha256}, expected ${chain.expectedSha256}`,
+    );
+  }
+  progress({ type: "done", phase: "verify" });
+
+  return {
+    sha256,
+    patchBytes: chain.totalSize,
+    chainLength: chain.patches.length,
+  };
+}

--- a/packages/binpatch/src/errors.ts
+++ b/packages/binpatch/src/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * binpatch error types.
+ *
+ * A slim, product-neutral error hierarchy for the delta-update engine. No
+ * telemetry/SDK coupling — just typed reasons for programmatic handling.
+ * Generalized from Lore's `UpgradeError`.
+ */
+
+export type BinpatchErrorReason =
+  | "network_error"
+  | "execution_failed"
+  | "version_not_found"
+  | "offline_cache_miss";
+
+/** A binpatch error carrying a typed reason. */
+export class BinpatchError extends Error {
+  readonly reason: BinpatchErrorReason;
+
+  constructor(reason: BinpatchErrorReason, message?: string) {
+    const defaultMessages: Record<BinpatchErrorReason, string> = {
+      network_error: "Failed to fetch update information.",
+      execution_failed: "Applying the update failed.",
+      version_not_found: "The specified version was not found.",
+      offline_cache_miss:
+        "Cannot update offline — no pre-downloaded patch is available.",
+    };
+    super(message ?? defaultMessages[reason]);
+    this.name = "BinpatchError";
+    this.reason = reason;
+  }
+}

--- a/packages/binpatch/src/events.ts
+++ b/packages/binpatch/src/events.ts
@@ -1,0 +1,44 @@
+/**
+ * Progress events.
+ *
+ * The library never renders progress — it emits structured lifecycle events
+ * and the consumer plugs in any indicator (a stderr bar, a spinner message,
+ * a log line), or none. No handler → silent. This keeps rendering (and its
+ * per-consumer incompatibilities) entirely out of the library.
+ */
+
+/** The phases of a resolve-and-apply run, in order. */
+export type ProgressPhase = "resolve" | "download" | "apply" | "verify";
+
+/** A structured progress event emitted during {@link resolveAndApply}. */
+export type ProgressEvent =
+  | { type: "phase"; phase: ProgressPhase }
+  | {
+      type: "bytes";
+      phase: ProgressPhase;
+      /** Bytes produced so far in this phase. */
+      written: number;
+      /** Total bytes for this phase, or null when not known ahead of time. */
+      total: number | null;
+    }
+  | { type: "done"; phase: ProgressPhase };
+
+/** A progress-event sink. Implementations must never throw. */
+export type ProgressHandler = (event: ProgressEvent) => void;
+
+/**
+ * Wrap a possibly-throwing handler so a misbehaving consumer can never abort
+ * the underlying operation. Progress is always cosmetic.
+ */
+export function safeProgress(
+  handler: ProgressHandler | undefined,
+): ProgressHandler {
+  if (!handler) return () => {};
+  return (event) => {
+    try {
+      handler(event);
+    } catch {
+      // ignore — progress is cosmetic and must never abort the operation.
+    }
+  };
+}

--- a/packages/binpatch/src/index.ts
+++ b/packages/binpatch/src/index.ts
@@ -1,12 +1,14 @@
 /**
  * binpatch — reusable binary delta-update engine.
  *
- * Apply a TRDIFF10/bsdiff patch chain to a binary, with an offline patch
- * cache. Pure Node (only `node:*` builtins), zero product coupling — the
- * consumer injects the cache directory and (later) the download source.
+ * Two things, joined by one wire contract (see README):
+ * - **apply core** — parse + apply a TRDIFF10/bsdiff patch chain to a binary.
+ * - **discovery** — resolve a patch chain from a pluggable `SourceStrategy`
+ *   (OCI/GHCR tags or GitHub Release assets), then apply + verify it.
  *
- * PR1 scope: the apply core + progress + patch cache. Chain discovery
- * (a pluggable `SourceStrategy`) lands in a follow-up.
+ * Pure Node (`node:*` builtins only), zero product coupling — the consumer
+ * injects the cache directory, the download source, version comparison,
+ * progress handling, and telemetry.
  */
 
 export {
@@ -34,3 +36,63 @@ export {
   patchFileName,
   type PatchStepMeta,
 } from "./patch-cache";
+
+// Wire-contract constants + shared chain types.
+export {
+  type ChainStep,
+  type DeltaResult,
+  MAX_NIGHTLY_CHAIN_DEPTH,
+  MAX_STABLE_CHAIN_DEPTH,
+  PATCH_TAG_PREFIX,
+  type PatchChain,
+  type PatchLink,
+  SIZE_THRESHOLD_RATIO,
+} from "./contract";
+
+export { BinpatchError, type BinpatchErrorReason } from "./errors";
+
+// Progress events (the library never renders — it emits these).
+export {
+  type ProgressEvent,
+  type ProgressHandler,
+  type ProgressPhase,
+  safeProgress,
+} from "./events";
+
+// Discovery + orchestration.
+export {
+  type DeltaSource,
+  type DeltaTelemetry,
+  resolveAndApply,
+  type ResolveAndApplyOpts,
+  type SourceStrategy,
+} from "./discover";
+
+// Sources.
+export {
+  type GhcrSourceConfig,
+  ghcrSource,
+  getPatchFromVersion,
+  getPatchTargetSha256,
+  filterAndSortChainTags,
+  validateChainStep,
+} from "./sources/ghcr";
+
+export {
+  extractSha256,
+  extractStableChain,
+  type ExtractStableChainOpts,
+  type GitHubAsset,
+  type GitHubRelease,
+  type GitHubReleaseSourceConfig,
+  githubReleaseSource,
+  getStableTargetSha256,
+  type StableChainInfo,
+} from "./sources/github-release";
+
+export {
+  OciClient,
+  type OciClientConfig,
+  type OciLayer,
+  type OciManifest,
+} from "./sources/oci";

--- a/packages/binpatch/src/sources/ghcr.ts
+++ b/packages/binpatch/src/sources/ghcr.ts
@@ -22,6 +22,7 @@ import {
   SIZE_THRESHOLD_RATIO,
 } from "../contract";
 import type { SourceStrategy } from "../discover";
+import { BinpatchError } from "../errors";
 import { OciClient, type OciClientConfig, type OciManifest } from "./oci";
 
 export function getPatchFromVersion(manifest: OciManifest): string | null {
@@ -255,28 +256,39 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
 
   return {
     async resolveChain(currentVersion, targetVersion, signal) {
-      const token = await client.getAnonymousToken(signal);
+      // A network failure anywhere in resolution (token exchange, manifest /
+      // tag listing, or blob download) means "no usable chain" per the
+      // SourceStrategy contract — return null so the caller falls back to a
+      // full download and it is reported as `unavailable`, not a system
+      // `error`. Only BinpatchError (network) is swallowed; a programming bug
+      // still propagates.
+      try {
+        const token = await client.getAnonymousToken(signal);
 
-      const [targetManifest, patchTags] = await Promise.all([
-        client.fetchManifest(token, targetTag(targetVersion), signal),
-        client.listTags(token, PATCH_TAG_PREFIX, signal),
-      ]);
+        const [targetManifest, patchTags] = await Promise.all([
+          client.fetchManifest(token, targetTag(targetVersion), signal),
+          client.listTags(token, PATCH_TAG_PREFIX, signal),
+        ]);
 
-      const gzLayer = targetManifest.layers.find(
-        (l) =>
-          l.annotations?.["org.opencontainers.image.title"] ===
-          `${binaryName}.gz`,
-      );
-      if (!gzLayer) return null;
+        const gzLayer = targetManifest.layers.find(
+          (l) =>
+            l.annotations?.["org.opencontainers.image.title"] ===
+            `${binaryName}.gz`,
+        );
+        if (!gzLayer) return null;
 
-      return resolveNightlyChain({
-        token,
-        currentVersion,
-        targetVersion,
-        fullGzSize: gzLayer.size,
-        preloadedTags: patchTags,
-        signal,
-      });
+        return await resolveNightlyChain({
+          token,
+          currentVersion,
+          targetVersion,
+          fullGzSize: gzLayer.size,
+          preloadedTags: patchTags,
+          signal,
+        });
+      } catch (error) {
+        if (error instanceof BinpatchError) return null;
+        throw error;
+      }
     },
   };
 }

--- a/packages/binpatch/src/sources/ghcr.ts
+++ b/packages/binpatch/src/sources/ghcr.ts
@@ -1,0 +1,282 @@
+/**
+ * GHCR / OCI patch source (the "nightly" channel).
+ *
+ * Resolves a patch chain from OCI patch-manifest tags. Patches are published
+ * under `<patchTagPrefix><version>` tags whose manifests carry:
+ * - annotation `from-version=<prev>` — the chain back-pointer
+ * - annotation `sha256-<binaryName>=<hex>` — the target's uncompressed SHA-256
+ * - a patch layer whose title is `<binaryName>.patch`
+ *
+ * The target binary's gzipped size (for the ratio gate) is read from the
+ * target's own image manifest (its `<binaryName>.gz` layer). All product
+ * specifics — registry, repo, user-agent, binary name, the version→target-tag
+ * scheme, and version comparison — are injected. Generalized from Lore's
+ * nightly-channel resolver.
+ */
+
+import {
+  MAX_NIGHTLY_CHAIN_DEPTH,
+  PATCH_TAG_PREFIX,
+  type PatchChain,
+  type PatchLink,
+  SIZE_THRESHOLD_RATIO,
+} from "../contract";
+import type { SourceStrategy } from "../discover";
+import { OciClient, type OciClientConfig, type OciManifest } from "./oci";
+
+export function getPatchFromVersion(manifest: OciManifest): string | null {
+  return manifest.annotations?.["from-version"] ?? null;
+}
+
+export function getPatchTargetSha256(
+  manifest: OciManifest,
+  binaryName: string,
+): string | null {
+  return manifest.annotations?.[`sha256-${binaryName}`] ?? null;
+}
+
+/**
+ * Filter patch tags to those in the upgrade chain (current, target], sorted in
+ * apply order by `compareVersions`.
+ */
+export function filterAndSortChainTags(
+  allTags: string[],
+  currentVersion: string,
+  targetVersion: string,
+  compareVersions: (a: string, b: string) => -1 | 0 | 1,
+): string[] {
+  const chainTags: { tag: string; version: string }[] = [];
+
+  for (const tag of allTags) {
+    const version = tag.slice(PATCH_TAG_PREFIX.length);
+    if (
+      compareVersions(version, currentVersion) === 1 &&
+      compareVersions(version, targetVersion) !== 1
+    ) {
+      chainTags.push({ tag, version });
+    }
+  }
+  chainTags.sort((a, b) => compareVersions(a.version, b.version));
+  return chainTags.map((t) => t.tag);
+}
+
+type ChainStepResult =
+  | { ok: true; digest: string; size: number }
+  | { ok: false };
+
+export function validateChainStep(
+  manifest: OciManifest,
+  opts: { expectedFrom: string; patchLayerName: string; sizeLimit: number },
+): ChainStepResult {
+  const fromVersion = getPatchFromVersion(manifest);
+  if (fromVersion !== opts.expectedFrom) {
+    return { ok: false };
+  }
+
+  const layer = manifest.layers.find(
+    (l) =>
+      l.annotations?.["org.opencontainers.image.title"] === opts.patchLayerName,
+  );
+  if (!layer) return { ok: false };
+  if (layer.size > opts.sizeLimit) return { ok: false };
+
+  return { ok: true, digest: layer.digest, size: layer.size };
+}
+
+type NightlyChainValidation = {
+  digests: string[];
+  totalSize: number;
+  expectedSha256: string;
+};
+
+type ValidateChainOpts = {
+  manifests: OciManifest[];
+  chainTags: string[];
+  currentVersion: string;
+  targetVersion: string;
+  patchLayerName: string;
+  binaryName: string;
+  fullGzSize: number;
+};
+
+function validateNightlyChain(
+  opts: ValidateChainOpts,
+): NightlyChainValidation | null {
+  const {
+    manifests,
+    chainTags,
+    currentVersion,
+    targetVersion,
+    patchLayerName,
+    binaryName,
+    fullGzSize,
+  } = opts;
+  const digests: string[] = [];
+  let totalSize = 0;
+  let prevVersion = currentVersion;
+
+  for (let i = 0; i < manifests.length; i++) {
+    const manifest = manifests[i];
+    const tag = chainTags[i];
+    if (!(manifest && tag)) return null;
+
+    const remainingBudget = fullGzSize * SIZE_THRESHOLD_RATIO - totalSize;
+    const result = validateChainStep(manifest, {
+      expectedFrom: prevVersion,
+      patchLayerName,
+      sizeLimit: remainingBudget,
+    });
+    if (!result.ok) return null;
+
+    digests.push(result.digest);
+    totalSize += result.size;
+    prevVersion = tag.slice(PATCH_TAG_PREFIX.length);
+
+    if (i === manifests.length - 1) {
+      if (prevVersion !== targetVersion) return null;
+      const sha256 = getPatchTargetSha256(manifest, binaryName) ?? "";
+      if (!sha256) return null;
+      return { digests, totalSize, expectedSha256: sha256 };
+    }
+  }
+
+  return null;
+}
+
+/** Configuration for {@link ghcrSource}. */
+export type GhcrSourceConfig = OciClientConfig & {
+  /** Platform binary name, e.g. `lore-linux-x64` (used for layer/annotation keys). */
+  binaryName: string;
+  /**
+   * Map a target version to the OCI tag of its full image manifest, whose
+   * `<binaryName>.gz` layer size feeds the ratio gate, e.g.
+   * `(v) => `nightly-${v}``.
+   */
+  targetTag: (version: string) => string;
+  /** Version comparator (semver-aware), for ordering patch tags. */
+  compareVersions: (a: string, b: string) => -1 | 0 | 1;
+};
+
+/**
+ * Build a {@link SourceStrategy} backed by OCI patch-manifest tags (GHCR).
+ */
+export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
+  const { binaryName, targetTag, compareVersions } = config;
+  const client = new OciClient(config);
+  const patchLayerName = `${binaryName}.patch`;
+
+  async function resolveNightlyChain(opts: {
+    token: string;
+    currentVersion: string;
+    targetVersion: string;
+    fullGzSize: number;
+    preloadedTags: string[];
+    signal?: AbortSignal;
+  }): Promise<PatchChain | null> {
+    const {
+      token,
+      currentVersion,
+      targetVersion,
+      fullGzSize,
+      preloadedTags,
+      signal,
+    } = opts;
+
+    const chainTags = filterAndSortChainTags(
+      preloadedTags,
+      currentVersion,
+      targetVersion,
+      compareVersions,
+    );
+    if (chainTags.length === 0 || chainTags.length > MAX_NIGHTLY_CHAIN_DEPTH) {
+      return null;
+    }
+
+    // Fetch manifests for all chain tags in parallel.
+    const fetchedManifests = new Map<string, OciManifest>();
+    const results = await Promise.all(
+      chainTags.map(async (tag) => {
+        try {
+          const manifest = await client.fetchManifest(token, tag, signal);
+          return { tag, manifest };
+        } catch {
+          return { tag, manifest: null };
+        }
+      }),
+    );
+    for (const { tag, manifest } of results) {
+      if (manifest) fetchedManifests.set(tag, manifest);
+    }
+
+    const manifests = chainTags.map((tag) => fetchedManifests.get(tag));
+    if (manifests.some((m) => !m)) return null;
+
+    const validation = validateNightlyChain({
+      manifests: manifests as OciManifest[],
+      chainTags,
+      currentVersion,
+      targetVersion,
+      patchLayerName,
+      binaryName,
+      fullGzSize,
+    });
+    if (!validation) return null;
+
+    const downloadResults = await Promise.all(
+      validation.digests.map((digest) =>
+        client
+          .downloadBlobBuffer(token, digest, signal)
+          .then((buf) => new Uint8Array(buf)),
+      ),
+    );
+
+    const patches: PatchLink[] = [];
+    let downloadedSize = 0;
+    for (const data of downloadResults) {
+      patches.push({ data, size: data.byteLength });
+      downloadedSize += data.byteLength;
+    }
+
+    const steps: { fromVersion: string; toVersion: string }[] = [];
+    let prevVersion = currentVersion;
+    for (const tag of chainTags) {
+      const toVersion = tag.slice(PATCH_TAG_PREFIX.length);
+      steps.push({ fromVersion: prevVersion, toVersion });
+      prevVersion = toVersion;
+    }
+
+    return {
+      patches,
+      totalSize: downloadedSize,
+      expectedSha256: validation.expectedSha256,
+      steps,
+    } satisfies PatchChain;
+  }
+
+  return {
+    async resolveChain(currentVersion, targetVersion, signal) {
+      const token = await client.getAnonymousToken(signal);
+
+      const [targetManifest, patchTags] = await Promise.all([
+        client.fetchManifest(token, targetTag(targetVersion), signal),
+        client.listTags(token, PATCH_TAG_PREFIX, signal),
+      ]);
+
+      const gzLayer = targetManifest.layers.find(
+        (l) =>
+          l.annotations?.["org.opencontainers.image.title"] ===
+          `${binaryName}.gz`,
+      );
+      if (!gzLayer) return null;
+
+      return resolveNightlyChain({
+        token,
+        currentVersion,
+        targetVersion,
+        fullGzSize: gzLayer.size,
+        preloadedTags: patchTags,
+        signal,
+      });
+    },
+  };
+}

--- a/packages/binpatch/src/sources/github-release.ts
+++ b/packages/binpatch/src/sources/github-release.ts
@@ -1,0 +1,223 @@
+/**
+ * GitHub Release-asset patch source (the "stable" channel).
+ *
+ * Resolves a patch chain from GitHub Release assets. Each release for the
+ * target platform publishes three assets:
+ * - `<binaryName>`        — the binary (its digest → expected SHA-256)
+ * - `<binaryName>.gz`     — gzipped binary (its size → the ratio gate)
+ * - `<binaryName>.patch`  — the delta patch from the previous release
+ *
+ * The chain is the releases between current and target, oldest-first, capped
+ * at {@link MAX_STABLE_CHAIN_DEPTH} and by {@link SIZE_THRESHOLD_RATIO}.
+ *
+ * All product specifics (owner/repo, binary name, user-agent, fetch) are
+ * injected. Generalized from Lore's stable-channel resolver.
+ */
+
+import {
+  MAX_STABLE_CHAIN_DEPTH,
+  type PatchChain,
+  type PatchLink,
+  SIZE_THRESHOLD_RATIO,
+} from "../contract";
+import type { SourceStrategy } from "../discover";
+
+const SHA256_DIGEST_PATTERN = /^sha256:([0-9a-f]+)$/i;
+
+export type GitHubAsset = {
+  name: string;
+  size: number;
+  digest?: string;
+  browser_download_url: string;
+};
+
+export type GitHubRelease = {
+  tag_name: string;
+  assets: GitHubAsset[];
+  body?: string;
+};
+
+/** Extract the SHA-256 hex digest from a GitHub asset's `digest` field. */
+export function extractSha256(asset: GitHubAsset): string | null {
+  if (!asset.digest) return null;
+  const match = SHA256_DIGEST_PATTERN.exec(asset.digest);
+  return match ? (match[1]?.toLowerCase() ?? null) : null;
+}
+
+/** Extract the target binary's SHA-256 from a release. */
+export function getStableTargetSha256(
+  release: GitHubRelease,
+  binaryName: string,
+): string | null {
+  const binaryAsset = release.assets.find((a) => a.name === binaryName);
+  if (!binaryAsset) return null;
+  return extractSha256(binaryAsset);
+}
+
+export type ExtractStableChainOpts = {
+  releases: GitHubRelease[];
+  currentVersion: string;
+  targetVersion: string;
+  binaryName: string;
+  fullGzSize: number;
+};
+
+export type StableChainInfo = {
+  patchUrls: string[];
+  expectedSha256: string;
+  steps: { fromVersion: string; toVersion: string }[];
+};
+
+/**
+ * Extract the chain of patch URLs from an already-fetched release list.
+ * Pure computation — no HTTP.
+ */
+export function extractStableChain(
+  opts: ExtractStableChainOpts,
+): StableChainInfo | null {
+  const { releases, currentVersion, targetVersion, binaryName, fullGzSize } =
+    opts;
+  const patchAssetName = `${binaryName}.patch`;
+
+  const targetIdx = releases.findIndex((r) => r.tag_name === targetVersion);
+  const currentIdx = releases.findIndex((r) => r.tag_name === currentVersion);
+  if (targetIdx === -1 || currentIdx === -1 || targetIdx >= currentIdx) {
+    return null;
+  }
+
+  const chainReleases = releases.slice(targetIdx, currentIdx);
+  if (chainReleases.length > MAX_STABLE_CHAIN_DEPTH) {
+    return null;
+  }
+
+  const targetRelease = chainReleases[0];
+  if (!targetRelease) return null;
+  const expectedSha256 = getStableTargetSha256(targetRelease, binaryName) ?? "";
+  if (!expectedSha256) return null;
+
+  const patchUrls: string[] = [];
+  let totalSize = 0;
+  for (const release of chainReleases) {
+    const patchAsset = release.assets.find((a) => a.name === patchAssetName);
+    if (!patchAsset) return null;
+    patchUrls.push(patchAsset.browser_download_url);
+    totalSize += patchAsset.size;
+    if (totalSize > fullGzSize * SIZE_THRESHOLD_RATIO) {
+      return null;
+    }
+  }
+
+  // Reverse to apply order: oldest patch first.
+  patchUrls.reverse();
+
+  const reversedReleases = [...chainReleases].reverse();
+  const steps: { fromVersion: string; toVersion: string }[] = [];
+  let prevVersion = currentVersion;
+  for (const release of reversedReleases) {
+    steps.push({ fromVersion: prevVersion, toVersion: release.tag_name });
+    prevVersion = release.tag_name;
+  }
+
+  return { patchUrls, expectedSha256, steps };
+}
+
+/** Configuration for {@link githubReleaseSource}. */
+export type GitHubReleaseSourceConfig = {
+  /** GitHub API releases URL, e.g.
+   * `https://api.github.com/repos/<owner>/<repo>/releases`. */
+  releasesUrl: string;
+  /** Platform binary asset name, e.g. `lore-linux-x64`. */
+  binaryName: string;
+  /** User-Agent header for GitHub API requests. */
+  userAgent: string;
+  /** Injectable fetch (defaults to global `fetch`). */
+  fetch?: typeof fetch;
+};
+
+/**
+ * Build a {@link SourceStrategy} backed by GitHub Release assets.
+ */
+export function githubReleaseSource(
+  config: GitHubReleaseSourceConfig,
+): SourceStrategy {
+  const doFetch = config.fetch ?? fetch;
+  const { releasesUrl, binaryName, userAgent } = config;
+
+  async function fetchRecentReleases(
+    signal?: AbortSignal,
+  ): Promise<GitHubRelease[]> {
+    const perPage = MAX_STABLE_CHAIN_DEPTH + 2;
+    let response: Response;
+    try {
+      response = await doFetch(`${releasesUrl}?per_page=${perPage}`, {
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          "User-Agent": userAgent,
+        },
+        signal,
+      });
+    } catch {
+      return [];
+    }
+    if (!response.ok) return [];
+    return (await response.json()) as GitHubRelease[];
+  }
+
+  async function downloadPatch(
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array | null> {
+    let response: Response;
+    try {
+      response = await doFetch(url, {
+        headers: { "User-Agent": userAgent },
+        signal,
+      });
+    } catch {
+      return null;
+    }
+    if (!response.ok) return null;
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  return {
+    async resolveChain(currentVersion, targetVersion, signal) {
+      const releases = await fetchRecentReleases(signal);
+
+      const targetRelease = releases.find((r) => r.tag_name === targetVersion);
+      if (!targetRelease) return null;
+      const gzAsset = targetRelease.assets.find(
+        (a) => a.name === `${binaryName}.gz`,
+      );
+      if (!gzAsset) return null;
+
+      const chainInfo = extractStableChain({
+        releases,
+        currentVersion,
+        targetVersion,
+        binaryName,
+        fullGzSize: gzAsset.size,
+      });
+      if (!chainInfo) return null;
+
+      const downloadResults = await Promise.all(
+        chainInfo.patchUrls.map((url) => downloadPatch(url, signal)),
+      );
+
+      const patches: PatchLink[] = [];
+      let totalSize = 0;
+      for (const data of downloadResults) {
+        if (!data) return null;
+        patches.push({ data, size: data.byteLength });
+        totalSize += data.byteLength;
+      }
+
+      return {
+        patches,
+        totalSize,
+        expectedSha256: chainInfo.expectedSha256,
+        steps: chainInfo.steps,
+      } satisfies PatchChain;
+    },
+  };
+}

--- a/packages/binpatch/src/sources/oci.ts
+++ b/packages/binpatch/src/sources/oci.ts
@@ -1,0 +1,332 @@
+/**
+ * OCI (GHCR-style) anonymous-pull client.
+ *
+ * Encapsulates the OCI download protocol for fetching binaries and patch
+ * artifacts from a container registry (ghcr.io by default). Anonymous,
+ * read-only: performs the standard token exchange, fetches manifests, lists
+ * tags, and downloads blobs.
+ *
+ * Registry / repository / user-agent are all injected — no product coupling.
+ * Generalized from Lore's `ghcr.ts`.
+ *
+ * Redirect quirk: ghcr.io blob downloads return a 307 to Azure Blob Storage.
+ * Following the redirect automatically would forward the Authorization header
+ * to Azure (→ 404), so redirects are followed manually WITHOUT the auth header.
+ */
+
+import { BinpatchError } from "../errors";
+
+/** Default timeout for registry metadata requests (10s). */
+const REQUEST_TIMEOUT = 10_000;
+
+/** Retry attempts for transient failures. */
+const MAX_RETRIES = 1;
+
+/** Timeout for (larger) blob downloads (30s). */
+const BLOB_TIMEOUT = 30_000;
+
+/** Page size for tag-listing pagination. */
+const TAGS_PAGE_SIZE = 100;
+
+/** OCI manifest media type. */
+const OCI_MANIFEST_TYPE = "application/vnd.oci.image.manifest.v1+json";
+
+/** A single layer entry from an OCI manifest. */
+export type OciLayer = {
+  digest: string;
+  mediaType: string;
+  size: number;
+  annotations?: Record<string, string>;
+};
+
+/** An OCI image manifest returned by the registry. */
+export type OciManifest = {
+  schemaVersion: number;
+  mediaType?: string;
+  config?: OciLayer;
+  layers: OciLayer[];
+  annotations?: Record<string, string>;
+};
+
+/** Configuration for an {@link OciClient}. */
+export type OciClientConfig = {
+  /** Registry base URL, e.g. `https://ghcr.io`. */
+  registry: string;
+  /** Repository path, e.g. `BYK/loreai`. */
+  repo: string;
+  /** User-Agent header sent on every request. */
+  userAgent: string;
+};
+
+function isRetryableError(error: Error): boolean {
+  if (error.name === "TimeoutError" || error.name === "AbortError") {
+    return true;
+  }
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes("timeout") ||
+    msg.includes("econnreset") ||
+    msg.includes("econnrefused") ||
+    msg.includes("network") ||
+    msg.includes("fetch failed")
+  );
+}
+
+function buildSignal(
+  timeout: number,
+  externalSignal?: AbortSignal,
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeout);
+  return externalSignal
+    ? AbortSignal.any([timeoutSignal, externalSignal])
+    : timeoutSignal;
+}
+
+function isExternalAbort(error: Error, externalSignal?: AbortSignal): boolean {
+  return Boolean(externalSignal?.aborted && error.name === "AbortError");
+}
+
+/**
+ * An OCI registry client bound to one registry + repository. All methods are
+ * anonymous (read-only). Every method accepts an optional AbortSignal.
+ */
+export class OciClient {
+  private readonly registry: string;
+  private readonly repo: string;
+  private readonly userAgent: string;
+
+  constructor(config: OciClientConfig) {
+    this.registry = config.registry;
+    this.repo = config.repo;
+    this.userAgent = config.userAgent;
+  }
+
+  private async fetchWithRetry(
+    url: string,
+    init: RequestInit,
+    context: string,
+    options?: { timeout?: number; signal?: AbortSignal },
+  ): Promise<Response> {
+    const timeout = options?.timeout ?? REQUEST_TIMEOUT;
+    const externalSignal = options?.signal;
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        return await fetch(url, {
+          ...init,
+          signal: buildSignal(timeout, externalSignal),
+        });
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (isExternalAbort(lastError, externalSignal)) break;
+        if (attempt >= MAX_RETRIES || !isRetryableError(lastError)) break;
+      }
+    }
+
+    throw new BinpatchError(
+      "network_error",
+      `${context}: ${lastError?.message ?? "unknown error"}`,
+    );
+  }
+
+  /** Exchange for a short-lived anonymous pull token. */
+  async getAnonymousToken(signal?: AbortSignal): Promise<string> {
+    const url = `${this.registry}/token?scope=repository:${this.repo}:pull`;
+    const response = await this.fetchWithRetry(
+      url,
+      { headers: { "User-Agent": this.userAgent } },
+      "Failed to connect to registry",
+      { signal },
+    );
+
+    if (!response.ok) {
+      throw new BinpatchError(
+        "network_error",
+        `Registry token exchange failed: HTTP ${response.status}`,
+      );
+    }
+
+    const data = (await response.json()) as { token?: string };
+    if (!data.token) {
+      throw new BinpatchError(
+        "network_error",
+        "Registry token exchange returned no token",
+      );
+    }
+
+    return data.token;
+  }
+
+  /** Fetch the OCI manifest for an arbitrary tag. */
+  async fetchManifest(
+    token: string,
+    tag: string,
+    signal?: AbortSignal,
+  ): Promise<OciManifest> {
+    const url = `${this.registry}/v2/${this.repo}/manifests/${tag}`;
+    const response = await this.fetchWithRetry(
+      url,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: OCI_MANIFEST_TYPE,
+          "User-Agent": this.userAgent,
+        },
+      },
+      `Failed to fetch manifest for tag "${tag}"`,
+      { signal },
+    );
+
+    if (!response.ok) {
+      throw new BinpatchError(
+        "network_error",
+        `Failed to fetch manifest for tag "${tag}": HTTP ${response.status}`,
+      );
+    }
+
+    return (await response.json()) as OciManifest;
+  }
+
+  private async fetchTagPage(
+    token: string,
+    lastTag?: string,
+    signal?: AbortSignal,
+  ): Promise<string[]> {
+    let url = `${this.registry}/v2/${this.repo}/tags/list?n=${TAGS_PAGE_SIZE}`;
+    if (lastTag) {
+      url += `&last=${encodeURIComponent(lastTag)}`;
+    }
+
+    const response = await this.fetchWithRetry(
+      url,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "User-Agent": this.userAgent,
+        },
+      },
+      "Failed to list registry tags",
+      { signal },
+    );
+
+    if (!response.ok) {
+      throw new BinpatchError(
+        "network_error",
+        `Failed to list registry tags: HTTP ${response.status}`,
+      );
+    }
+
+    const data = (await response.json()) as { tags?: string[] };
+    return data.tags ?? [];
+  }
+
+  /** List tags in the repository, optionally filtered by prefix. */
+  async listTags(
+    token: string,
+    prefix?: string,
+    signal?: AbortSignal,
+  ): Promise<string[]> {
+    const allTags: string[] = [];
+    let lastTag: string | undefined;
+
+    for (;;) {
+      const tags = await this.fetchTagPage(token, lastTag, signal);
+      if (tags.length === 0) break;
+
+      for (const tag of tags) {
+        if (!prefix || tag.startsWith(prefix)) allTags.push(tag);
+      }
+
+      if (tags.length < TAGS_PAGE_SIZE) break;
+      lastTag = tags.at(-1);
+    }
+
+    return allTags;
+  }
+
+  /**
+   * Download a blob by digest. The registry returns a 3xx redirect to blob
+   * storage; the redirect is followed manually without the auth header.
+   */
+  async downloadBlob(
+    token: string,
+    digest: string,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    const blobUrl = `${this.registry}/v2/${this.repo}/blobs/${digest}`;
+
+    let blobResponse: Response;
+    try {
+      blobResponse = await fetch(blobUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "User-Agent": this.userAgent,
+        },
+        redirect: "manual",
+        signal: buildSignal(BLOB_TIMEOUT, signal),
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new BinpatchError(
+        "network_error",
+        `Failed to connect to registry: ${msg}`,
+      );
+    }
+
+    if (blobResponse.status === 200) return blobResponse;
+
+    if (
+      blobResponse.status === 301 ||
+      blobResponse.status === 302 ||
+      blobResponse.status === 307 ||
+      blobResponse.status === 308
+    ) {
+      const redirectUrl = blobResponse.headers.get("location");
+      if (!redirectUrl) {
+        throw new BinpatchError(
+          "network_error",
+          `Registry blob redirect (${blobResponse.status}) had no Location header`,
+        );
+      }
+
+      let redirectResponse: Response;
+      try {
+        redirectResponse = await fetch(redirectUrl, {
+          headers: { "User-Agent": this.userAgent },
+          signal,
+        });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        throw new BinpatchError(
+          "network_error",
+          `Failed to download from blob storage: ${msg}`,
+        );
+      }
+
+      if (!redirectResponse.ok) {
+        throw new BinpatchError(
+          "network_error",
+          `Blob storage download failed: HTTP ${redirectResponse.status}`,
+        );
+      }
+
+      return redirectResponse;
+    }
+
+    throw new BinpatchError(
+      "network_error",
+      `Unexpected registry blob response: HTTP ${blobResponse.status}`,
+    );
+  }
+
+  /** Download a blob by digest as an ArrayBuffer. */
+  async downloadBlobBuffer(
+    token: string,
+    digest: string,
+    signal?: AbortSignal,
+  ): Promise<ArrayBuffer> {
+    const response = await this.downloadBlob(token, digest, signal);
+    return response.arrayBuffer();
+  }
+}

--- a/packages/binpatch/src/sources/oci.ts
+++ b/packages/binpatch/src/sources/oci.ts
@@ -294,7 +294,11 @@ export class OciClient {
       try {
         redirectResponse = await fetch(redirectUrl, {
           headers: { "User-Agent": this.userAgent },
-          signal,
+          // Apply the same blob timeout to the redirected (e.g. Azure Blob
+          // Storage) download. Passing the raw `signal` alone means no timeout
+          // when the caller supplied none (e.g. prefetch), so a stalled
+          // connection could hang the CLI forever.
+          signal: buildSignal(BLOB_TIMEOUT, signal),
         });
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);

--- a/packages/binpatch/test/discover.test.ts
+++ b/packages/binpatch/test/discover.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Orchestration tests for resolveAndApply — the cache-first / network /
+ * offline / verify decision logic and progress-event emission. Uses real
+ * hand-crafted TRDIFF10 patches (a pure-extra passthrough patch: it ignores
+ * the old file and emits `extra` verbatim) so we exercise the genuine apply +
+ * SHA-256 path, and fake SourceStrategy/PatchCache to drive the branches.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { zstdCompressSync } from "node:zlib";
+
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import {
+  type PatchCache,
+  type PatchChain,
+  type ProgressEvent,
+  resolveAndApply,
+  type SourceStrategy,
+} from "../src";
+
+const WORK_DIR = mkdtempSync(join(tmpdir(), "discover-test-"));
+afterAll(() => rmSync(WORK_DIR, { recursive: true, force: true }));
+
+function offtout(value: number): Buffer {
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64LE(BigInt(value), 0);
+  return buf;
+}
+
+/** Build a pure-passthrough TRDIFF10 patch that emits `extra` verbatim. */
+function passthroughPatch(extra: Buffer): Uint8Array {
+  const control = zstdCompressSync(
+    Buffer.concat([offtout(0), offtout(extra.length), offtout(0)]),
+  );
+  const diff = zstdCompressSync(Buffer.alloc(0));
+  const extraZ = zstdCompressSync(extra);
+  const header = Buffer.concat([
+    Buffer.from("TRDIFF10", "utf8"),
+    offtout(control.length),
+    offtout(diff.length),
+    offtout(extra.length),
+  ]);
+  return new Uint8Array(Buffer.concat([header, control, diff, extraZ]));
+}
+
+function sha256(buf: Buffer | Uint8Array): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function writeTemp(name: string, data: Buffer | Uint8Array): string {
+  const p = join(WORK_DIR, name);
+  writeFileSync(p, data);
+  return p;
+}
+
+/** A single-hop chain producing `output` from any old file. */
+function makeChain(output: Buffer): PatchChain {
+  const patch = passthroughPatch(output);
+  return {
+    patches: [{ data: patch, size: patch.byteLength }],
+    totalSize: patch.byteLength,
+    expectedSha256: sha256(output),
+    steps: [{ fromVersion: "1.0.0", toVersion: "1.1.0" }],
+  };
+}
+
+const OLD = writeTemp("old.bin", Buffer.from("old binary contents"));
+
+describe("resolveAndApply", () => {
+  it("applies a chain resolved from the network and reports source=network", async () => {
+    const output = Buffer.from("the new binary payload");
+    const chain = makeChain(output);
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => chain) };
+    const onResolved = vi.fn();
+    const dest = writeTemp("out-network.bin", Buffer.alloc(0));
+
+    const result = await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      telemetry: { onResolved },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.sha256).toBe(chain.expectedSha256);
+    expect(result?.chainLength).toBe(1);
+    expect(onResolved).toHaveBeenCalledWith({ source: "network", chain });
+    expect(new Uint8Array(await readFile(dest))).toEqual(
+      new Uint8Array(output),
+    );
+  });
+
+  it("checks the cache first and never touches the source on a hit", async () => {
+    const output = Buffer.from("cached payload!!");
+    const chain = makeChain(output);
+    const cache: PatchCache = {
+      save: vi.fn(async () => {}),
+      load: vi.fn(async () => chain),
+      cleanup: vi.fn(async () => {}),
+      clear: vi.fn(async () => {}),
+    };
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => null) };
+    const onResolved = vi.fn();
+    const dest = writeTemp("out-cache.bin", Buffer.alloc(0));
+
+    const result = await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      cache,
+      telemetry: { onResolved },
+    });
+
+    expect(result?.sha256).toBe(chain.expectedSha256);
+    expect(cache.load).toHaveBeenCalledOnce();
+    expect(source.resolveChain).not.toHaveBeenCalled();
+    expect(onResolved).toHaveBeenCalledWith({ source: "cache", chain });
+  });
+
+  it("saves a network-resolved chain to the cache", async () => {
+    const chain = makeChain(Buffer.from("save me"));
+    const cache: PatchCache = {
+      save: vi.fn(async () => {}),
+      load: vi.fn(async () => null),
+      cleanup: vi.fn(async () => {}),
+      clear: vi.fn(async () => {}),
+    };
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => chain) };
+    const dest = writeTemp("out-save.bin", Buffer.alloc(0));
+
+    await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      cache,
+    });
+
+    expect(cache.save).toHaveBeenCalledWith(chain, chain.steps);
+  });
+
+  it("returns null and fires onOfflineMiss when offline with no cache hit", async () => {
+    const cache: PatchCache = {
+      save: vi.fn(async () => {}),
+      load: vi.fn(async () => null),
+      cleanup: vi.fn(async () => {}),
+      clear: vi.fn(async () => {}),
+    };
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => null) };
+    const onOfflineMiss = vi.fn();
+    const dest = writeTemp("out-offline.bin", Buffer.alloc(0));
+
+    const result = await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      cache,
+      offline: true,
+      telemetry: { onOfflineMiss },
+    });
+
+    expect(result).toBeNull();
+    expect(onOfflineMiss).toHaveBeenCalledOnce();
+    // Offline must never hit the network.
+    expect(source.resolveChain).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the source has no usable chain", async () => {
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => null) };
+    const dest = writeTemp("out-none.bin", Buffer.alloc(0));
+
+    const result = await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("throws on a SHA-256 mismatch (caller falls back to full download)", async () => {
+    const chain = makeChain(Buffer.from("real output"));
+    // Corrupt the expected hash so the applied result cannot match.
+    const badChain: PatchChain = { ...chain, expectedSha256: "0".repeat(64) };
+    const source: SourceStrategy = {
+      resolveChain: vi.fn(async () => badChain),
+    };
+    const dest = writeTemp("out-mismatch.bin", Buffer.alloc(0));
+
+    await expect(
+      resolveAndApply({
+        source,
+        currentVersion: "1.0.0",
+        targetVersion: "1.1.0",
+        oldPath: OLD,
+        destPath: dest,
+      }),
+    ).rejects.toThrow(/SHA-256 mismatch/);
+  });
+
+  it("emits ordered progress events (resolve -> apply bytes -> done -> verify)", async () => {
+    const output = Buffer.from("progress payload");
+    const chain = makeChain(output);
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => chain) };
+    const events: ProgressEvent[] = [];
+    const dest = writeTemp("out-progress.bin", Buffer.alloc(0));
+
+    await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      onProgress: (e) => events.push(e),
+    });
+
+    const phases = events
+      .filter((e) => e.type === "phase")
+      .map((e) => (e as { phase: string }).phase);
+    expect(phases).toEqual(["resolve", "apply", "verify"]);
+
+    // The apply-phase byte total must equal the output size (single hop), and
+    // the final written count must reach it.
+    const byteEvents = events.filter(
+      (e): e is Extract<ProgressEvent, { type: "bytes" }> => e.type === "bytes",
+    );
+    expect(byteEvents.length).toBeGreaterThan(0);
+    const last = byteEvents.at(-1);
+    expect(last?.total).toBe(output.byteLength);
+    expect(last?.written).toBe(output.byteLength);
+  });
+
+  it("never lets a throwing progress handler abort the apply", async () => {
+    const output = Buffer.from("resilient");
+    const chain = makeChain(output);
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => chain) };
+    const dest = writeTemp("out-throwing.bin", Buffer.alloc(0));
+
+    const result = await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      onProgress: () => {
+        throw new Error("handler blew up");
+      },
+    });
+
+    expect(result?.sha256).toBe(chain.expectedSha256);
+    expect(new Uint8Array(await readFile(dest))).toEqual(
+      new Uint8Array(output),
+    );
+  });
+});

--- a/packages/binpatch/test/sources.test.ts
+++ b/packages/binpatch/test/sources.test.ts
@@ -8,6 +8,7 @@ import {
   ghcrSource,
   type GitHubRelease,
   getStableTargetSha256,
+  OciClient,
   type OciManifest,
   validateChainStep,
 } from "../src";
@@ -293,5 +294,50 @@ describe("ghcrSource resolveChain — SourceStrategy contract on network failure
     });
 
     await expect(source.resolveChain("1.0.0", "1.1.0")).resolves.toBeNull();
+  });
+});
+
+describe("OciClient.downloadBlob — redirect always carries a timeout signal", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("applies a timeout to the redirected blob fetch even when no signal is passed", async () => {
+    // First call: registry returns a 307 to blob storage. Second call: the
+    // redirect target. Capture the redirect call's signal — it MUST be a live
+    // AbortSignal (buildSignal's timeout) even though downloadBlob is called
+    // with signal=undefined (e.g. from prefetch), so a stalled Azure blob
+    // download can never hang the CLI forever.
+    let redirectSignal: AbortSignal | null | undefined;
+    let sawRedirectCall = false;
+    let call = 0;
+    globalThis.fetch = vi.fn(
+      async (_url: unknown, init?: { signal?: AbortSignal | null }) => {
+        call++;
+        if (call === 1) {
+          return new Response(null, {
+            status: 307,
+            headers: { location: "https://blob.example.com/obj" },
+          });
+        }
+        sawRedirectCall = true;
+        redirectSignal = init?.signal;
+        return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+      },
+    );
+
+    const client = new OciClient({
+      registry: "https://ghcr.io",
+      repo: "owner/project",
+      userAgent: "test/1.0.0",
+    });
+
+    // No signal argument — the redirect must still get a timeout signal.
+    const res = await client.downloadBlob("tok", "sha256:abc");
+    expect(res.status).toBe(200);
+    expect(sawRedirectCall).toBe(true);
+    expect(redirectSignal).toBeInstanceOf(AbortSignal);
+    expect(redirectSignal?.aborted).toBe(false);
   });
 });

--- a/packages/binpatch/test/sources.test.ts
+++ b/packages/binpatch/test/sources.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractSha256,
+  extractStableChain,
+  filterAndSortChainTags,
+  getPatchFromVersion,
+  getPatchTargetSha256,
+  type GitHubRelease,
+  getStableTargetSha256,
+  type OciManifest,
+  validateChainStep,
+} from "../src";
+
+// A semver-ish comparator matching the gateway's compareVersions contract
+// (returns -1 | 0 | 1) for the nightly tag-ordering tests.
+function cmp(a: string, b: string): -1 | 0 | 1 {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+
+function release(
+  tag: string,
+  assets: { name: string; size: number; digest?: string }[],
+): GitHubRelease {
+  return {
+    tag_name: tag,
+    assets: assets.map((a) => ({
+      ...a,
+      browser_download_url: `https://example.test/${tag}/${a.name}`,
+    })),
+  };
+}
+
+const BINARY = "tool-linux-x64";
+
+describe("extractSha256", () => {
+  it("parses a sha256: digest to lowercase hex", () => {
+    expect(
+      extractSha256({
+        name: BINARY,
+        size: 1,
+        digest: "sha256:ABCDEF01",
+        browser_download_url: "",
+      }),
+    ).toBe("abcdef01");
+  });
+
+  it("returns null for a missing or non-sha256 digest", () => {
+    expect(
+      extractSha256({ name: BINARY, size: 1, browser_download_url: "" }),
+    ).toBeNull();
+    expect(
+      extractSha256({
+        name: BINARY,
+        size: 1,
+        digest: "md5:deadbeef",
+        browser_download_url: "",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("getStableTargetSha256", () => {
+  it("reads the binary asset's digest", () => {
+    const r = release("1.2.0", [
+      { name: BINARY, size: 100, digest: "sha256:cafe" },
+      { name: `${BINARY}.gz`, size: 40 },
+      { name: `${BINARY}.patch`, size: 5 },
+    ]);
+    expect(getStableTargetSha256(r, BINARY)).toBe("cafe");
+  });
+
+  it("returns null when the binary asset is absent", () => {
+    const r = release("1.2.0", [{ name: `${BINARY}.gz`, size: 40 }]);
+    expect(getStableTargetSha256(r, BINARY)).toBeNull();
+  });
+});
+
+describe("extractStableChain", () => {
+  // Releases are newest-first (as GitHub returns them). Digests are hex.
+  const releases: GitHubRelease[] = [
+    release("1.2.0", [
+      { name: BINARY, size: 100, digest: "sha256:aaaa" },
+      { name: `${BINARY}.gz`, size: 40 },
+      { name: `${BINARY}.patch`, size: 5 },
+    ]),
+    release("1.1.0", [
+      { name: BINARY, size: 100, digest: "sha256:bbbb" },
+      { name: `${BINARY}.gz`, size: 40 },
+      { name: `${BINARY}.patch`, size: 6 },
+    ]),
+    release("1.0.0", [
+      { name: BINARY, size: 100, digest: "sha256:cccc" },
+      { name: `${BINARY}.gz`, size: 40 },
+    ]),
+  ];
+
+  it("builds the oldest-first chain and steps from current to target", () => {
+    const info = extractStableChain({
+      releases,
+      currentVersion: "1.0.0",
+      targetVersion: "1.2.0",
+      binaryName: BINARY,
+      fullGzSize: 40,
+    });
+    expect(info).not.toBeNull();
+    // Two hops: 1.0.0 -> 1.1.0 -> 1.2.0. Expected sha is the target's.
+    expect(info?.expectedSha256).toBe("aaaa");
+    expect(info?.steps).toEqual([
+      { fromVersion: "1.0.0", toVersion: "1.1.0" },
+      { fromVersion: "1.1.0", toVersion: "1.2.0" },
+    ]);
+    // patchUrls are apply-order: 1.1.0's patch first, then 1.2.0's.
+    expect(info?.patchUrls).toEqual([
+      "https://example.test/1.1.0/tool-linux-x64.patch",
+      "https://example.test/1.2.0/tool-linux-x64.patch",
+    ]);
+  });
+
+  it("returns null when a hop is missing its patch asset", () => {
+    // 1.0.0 has no patch asset, but it is the current version (not in the
+    // chain slice), so drop 1.1.0's patch instead to force a gap.
+    const broken = releases.map((r) =>
+      r.tag_name === "1.1.0"
+        ? { ...r, assets: r.assets.filter((a) => !a.name.endsWith(".patch")) }
+        : r,
+    );
+    expect(
+      extractStableChain({
+        releases: broken,
+        currentVersion: "1.0.0",
+        targetVersion: "1.2.0",
+        binaryName: BINARY,
+        fullGzSize: 40,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the chain exceeds the size ratio gate", () => {
+    // fullGzSize tiny → 60% ratio easily exceeded by the 5+6 byte patches.
+    expect(
+      extractStableChain({
+        releases,
+        currentVersion: "1.0.0",
+        targetVersion: "1.2.0",
+        binaryName: BINARY,
+        fullGzSize: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when target is not older than current in the list", () => {
+    expect(
+      extractStableChain({
+        releases,
+        currentVersion: "1.2.0",
+        targetVersion: "1.0.0",
+        binaryName: BINARY,
+        fullGzSize: 40,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("filterAndSortChainTags", () => {
+  it("keeps only (current, target] tags, sorted ascending", () => {
+    const tags = [
+      "patch-1.3.0",
+      "patch-1.1.0",
+      "patch-1.2.0",
+      "patch-0.9.0",
+      "patch-2.0.0",
+    ];
+    expect(filterAndSortChainTags(tags, "1.0.0", "1.3.0", cmp)).toEqual([
+      "patch-1.1.0",
+      "patch-1.2.0",
+      "patch-1.3.0",
+    ]);
+  });
+
+  it("excludes the current version and anything past the target", () => {
+    const tags = ["patch-1.0.0", "patch-1.1.0", "patch-1.2.0"];
+    expect(filterAndSortChainTags(tags, "1.0.0", "1.1.0", cmp)).toEqual([
+      "patch-1.1.0",
+    ]);
+  });
+});
+
+describe("validateChainStep", () => {
+  function manifest(fromVersion: string, patchSize: number): OciManifest {
+    return {
+      schemaVersion: 2,
+      annotations: { "from-version": fromVersion },
+      layers: [
+        {
+          digest: "sha256:deadbeef",
+          mediaType: "application/octet-stream",
+          size: patchSize,
+          annotations: {
+            "org.opencontainers.image.title": `${BINARY}.patch`,
+          },
+        },
+      ],
+    };
+  }
+
+  it("accepts a step whose from-version and patch layer match", () => {
+    const res = validateChainStep(manifest("1.0.0", 50), {
+      expectedFrom: "1.0.0",
+      patchLayerName: `${BINARY}.patch`,
+      sizeLimit: 100,
+    });
+    expect(res).toEqual({ ok: true, digest: "sha256:deadbeef", size: 50 });
+  });
+
+  it("rejects a from-version mismatch (broken chain link)", () => {
+    const res = validateChainStep(manifest("9.9.9", 50), {
+      expectedFrom: "1.0.0",
+      patchLayerName: `${BINARY}.patch`,
+      sizeLimit: 100,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects a patch layer over the size limit", () => {
+    const res = validateChainStep(manifest("1.0.0", 500), {
+      expectedFrom: "1.0.0",
+      patchLayerName: `${BINARY}.patch`,
+      sizeLimit: 100,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects when the named patch layer is absent", () => {
+    const res = validateChainStep(manifest("1.0.0", 50), {
+      expectedFrom: "1.0.0",
+      patchLayerName: "other.patch",
+      sizeLimit: 100,
+    });
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe("OCI manifest annotation helpers", () => {
+  const m: OciManifest = {
+    schemaVersion: 2,
+    annotations: {
+      "from-version": "1.0.0",
+      [`sha256-${BINARY}`]: "abc123",
+    },
+    layers: [],
+  };
+  it("reads from-version", () => {
+    expect(getPatchFromVersion(m)).toBe("1.0.0");
+    expect(getPatchFromVersion({ schemaVersion: 2, layers: [] })).toBeNull();
+  });
+  it("reads the per-binary target sha256", () => {
+    expect(getPatchTargetSha256(m, BINARY)).toBe("abc123");
+    expect(getPatchTargetSha256(m, "other")).toBeNull();
+  });
+});

--- a/packages/binpatch/test/sources.test.ts
+++ b/packages/binpatch/test/sources.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractSha256,
   extractStableChain,
   filterAndSortChainTags,
   getPatchFromVersion,
   getPatchTargetSha256,
+  ghcrSource,
   type GitHubRelease,
   getStableTargetSha256,
   type OciManifest,
@@ -264,5 +265,33 @@ describe("OCI manifest annotation helpers", () => {
   it("reads the per-binary target sha256", () => {
     expect(getPatchTargetSha256(m, BINARY)).toBe("abc123");
     expect(getPatchTargetSha256(m, "other")).toBeNull();
+  });
+});
+
+describe("ghcrSource resolveChain — SourceStrategy contract on network failure", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("returns null (not throw) when the registry is unreachable", async () => {
+    // The OCI client uses global fetch; make every call fail like a network
+    // outage. Per the SourceStrategy contract a resolution failure must be a
+    // null (→ fall back to full download, reported `unavailable`), never a
+    // thrown system error.
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    const source = ghcrSource({
+      registry: "https://ghcr.io",
+      repo: "owner/project",
+      userAgent: "test/1.0.0",
+      binaryName: BINARY,
+      targetTag: (v) => `nightly-${v}`,
+      compareVersions: cmp,
+    });
+
+    await expect(source.resolveChain("1.0.0", "1.1.0")).resolves.toBeNull();
   });
 });

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -1,23 +1,15 @@
 /**
- * Delta Upgrade Module
+ * Delta Upgrade Glue
  *
- * Discovers and applies binary delta patches for CLI self-upgrades.
- * Instead of downloading the full ~30 MB gzipped binary, downloads
- * tiny patches (50-500 KB) and applies them to the currently installed
- * binary using the TRDIFF10 format (zig-bsdiff with zstd compression).
+ * Thin gateway-side glue over `binpatch`'s chain discovery + apply. All the
+ * generic delta machinery (chain resolution from GHCR / GitHub Releases, the
+ * offline cache, apply + SHA verification, progress) lives in `binpatch`; this
+ * module only injects Lore-specific product values (version, binary name,
+ * GHCR/Release coordinates, user-agent, cache location, Sentry telemetry) and
+ * decides the channel.
  *
- * Supports two channels:
- * - **Stable**: patches stored as GitHub Release assets with predictable names
- * - **Nightly**: patches stored in GHCR with `:patch-<version>` tags
- *
- * Falls back to full download when:
- * - No patch is available (404)
- * - Chain of patches exceeds 60% of the full download size
- * - Chain exceeds the maximum depth (10 steps)
- * - Any error occurs during patch download or application
- *
- * Adapted from Sentry CLI's delta-upgrade.ts for Lore.
- * All Sentry SDK telemetry removed — uses plain logging.
+ * Falls back to a full download when no usable chain exists or any error
+ * occurs.
  */
 
 import {
@@ -29,70 +21,33 @@ import {
   isDowngrade,
   isNightlyVersion,
 } from "./binary";
+import { GHCR_REGISTRY, GHCR_REPO } from "./ghcr";
 import {
-  applyPatchChainInMemory,
-  makeByteProgress,
-  parsePatchHeader,
+  type DeltaResult,
+  type DeltaSource,
+  ghcrSource,
+  githubReleaseSource,
+  resolveAndApply,
+  type SourceStrategy,
 } from "binpatch";
-import { spanDeltaUpgrade, type DeltaUpgradeTelemetry } from "../../sentry";
+import { spanDeltaUpgrade } from "../../sentry";
 import { VERSION } from "../version";
-import {
-  downloadLayerBlob,
-  fetchManifest,
-  getAnonymousToken,
-  listTags,
-  type OciManifest,
-} from "./ghcr";
 
-/** Maximum stable patches to chain before falling back to full download */
-const MAX_STABLE_CHAIN_DEPTH = 10;
-
-/**
- * Maximum nightly patches to chain before falling back to full download.
- */
-const MAX_NIGHTLY_CHAIN_DEPTH = 30;
-
-/**
- * Maximum ratio of total patch chain size to full download size.
- */
-const SIZE_THRESHOLD_RATIO = 0.6;
-
-const SHA256_DIGEST_PATTERN = /^sha256:([0-9a-f]+)$/i;
-
-/** A single link in the patch chain */
-type PatchLink = {
-  data: Uint8Array;
-  size: number;
-};
-
-/** A resolved chain of patches from current version to target version */
-export type PatchChain = {
-  patches: PatchLink[];
-  totalSize: number;
-  expectedSha256: string;
-  steps?: { fromVersion: string; toVersion: string }[];
-};
-
-/** Result of a successful delta upgrade */
-export type DeltaResult = {
-  sha256: string;
-  patchBytes: number;
-  chainLength: number;
-};
+export type { DeltaResult, PatchChain } from "binpatch";
 
 // ---------------------------------------------------------------------------
 // Pre-flight check
 // ---------------------------------------------------------------------------
 
 /**
- * Check whether delta upgrade can be attempted.
+ * Check whether a delta upgrade can be attempted.
  */
 export function canAttemptDelta(targetVersion: string): boolean {
   if (VERSION === "dev" || VERSION === "0.0.0-dev") {
     return false;
   }
 
-  // Cross-channel upgrades are rare one-off operations; skip delta
+  // Cross-channel upgrades are rare one-off operations; skip delta.
   if (isNightlyVersion(VERSION) !== isNightlyVersion(targetVersion)) {
     return false;
   }
@@ -105,421 +60,32 @@ export function canAttemptDelta(targetVersion: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Stable channel: GitHub Releases
+// Source construction (inject Lore product values into binpatch sources)
 // ---------------------------------------------------------------------------
 
-export type GitHubAsset = {
-  name: string;
-  size: number;
-  digest?: string;
-  browser_download_url: string;
-};
-
-export type GitHubRelease = {
-  tag_name: string;
-  assets: GitHubAsset[];
-  body?: string;
-};
-
-/**
- * Fetch recent releases from GitHub, ordered newest-first.
- */
-export async function fetchRecentReleases(
-  signal?: AbortSignal,
-): Promise<GitHubRelease[]> {
-  const perPage = MAX_STABLE_CHAIN_DEPTH + 2;
-  let response: Response;
-  try {
-    response = await fetch(`${GITHUB_RELEASES_URL}?per_page=${perPage}`, {
-      headers: {
-        Accept: "application/vnd.github.v3+json",
-        "User-Agent": getUserAgent(),
-      },
-      signal,
-    });
-  } catch {
-    return [];
-  }
-  if (!response.ok) return [];
-  return (await response.json()) as GitHubRelease[];
-}
-
-/**
- * Extract SHA-256 hex digest from a GitHub asset's digest field.
- */
-export function extractSha256(asset: GitHubAsset): string | null {
-  if (!asset.digest) return null;
-  const match = SHA256_DIGEST_PATTERN.exec(asset.digest);
-  return match ? (match[1]?.toLowerCase() ?? null) : null;
-}
-
-/**
- * Download a patch file from a GitHub Release asset URL.
- */
-export async function downloadStablePatch(
-  url: string,
-  signal?: AbortSignal,
-): Promise<Uint8Array | null> {
-  let response: Response;
-  try {
-    response = await fetch(url, {
-      headers: { "User-Agent": getUserAgent() },
-      signal,
-    });
-  } catch {
-    return null;
-  }
-  if (!response.ok) return null;
-  return new Uint8Array(await response.arrayBuffer());
-}
-
-/**
- * Extract the target binary SHA-256 from a GitHub Release.
- */
-export function getStableTargetSha256(
-  release: GitHubRelease,
-  binaryName: string,
-): string | null {
-  const binaryAsset = release.assets.find((a) => a.name === binaryName);
-  if (!binaryAsset) return null;
-  return extractSha256(binaryAsset);
-}
-
-export type ExtractStableChainOpts = {
-  releases: GitHubRelease[];
-  currentVersion: string;
-  targetVersion: string;
-  binaryName: string;
-  fullGzSize: number;
-};
-
-export type StableChainInfo = {
-  patchUrls: string[];
-  expectedSha256: string;
-  steps: { fromVersion: string; toVersion: string }[];
-};
-
-/**
- * Extract the chain of patch URLs from an already-fetched release list.
- * Pure computation — no HTTP calls.
- */
-export function extractStableChain(
-  opts: ExtractStableChainOpts,
-): StableChainInfo | null {
-  const { releases, currentVersion, targetVersion, binaryName, fullGzSize } =
-    opts;
-  const patchAssetName = `${binaryName}.patch`;
-
-  const targetIdx = releases.findIndex((r) => r.tag_name === targetVersion);
-  const currentIdx = releases.findIndex((r) => r.tag_name === currentVersion);
-  if (targetIdx === -1 || currentIdx === -1 || targetIdx >= currentIdx) {
-    return null;
-  }
-
-  const chainReleases = releases.slice(targetIdx, currentIdx);
-  if (chainReleases.length > MAX_STABLE_CHAIN_DEPTH) {
-    return null;
-  }
-
-  const targetRelease = chainReleases[0];
-  if (!targetRelease) return null;
-  const expectedSha256 = getStableTargetSha256(targetRelease, binaryName) ?? "";
-  if (!expectedSha256) return null;
-
-  const patchUrls: string[] = [];
-  let totalSize = 0;
-  for (const release of chainReleases) {
-    const patchAsset = release.assets.find((a) => a.name === patchAssetName);
-    if (!patchAsset) return null;
-    patchUrls.push(patchAsset.browser_download_url);
-    totalSize += patchAsset.size;
-    if (totalSize > fullGzSize * SIZE_THRESHOLD_RATIO) {
-      return null;
-    }
-  }
-
-  // Reverse to get apply order: oldest patch first
-  patchUrls.reverse();
-
-  const reversedReleases = [...chainReleases].reverse();
-  const steps: { fromVersion: string; toVersion: string }[] = [];
-  let prevVersion = currentVersion;
-  for (const release of reversedReleases) {
-    steps.push({ fromVersion: prevVersion, toVersion: release.tag_name });
-    prevVersion = release.tag_name;
-  }
-
-  return { patchUrls, expectedSha256, steps };
-}
-
-/**
- * Resolve a chain of stable patches from current to target version.
- */
-export async function resolveStableChain(
-  currentVersion: string,
-  targetVersion: string,
-  signal?: AbortSignal,
-): Promise<PatchChain | null> {
-  const binaryName = getPlatformBinaryName();
-  const releases = await fetchRecentReleases(signal);
-
-  const targetRelease = releases.find((r) => r.tag_name === targetVersion);
-  if (!targetRelease) return null;
-  const gzAsset = targetRelease.assets.find(
-    (a) => a.name === `${binaryName}.gz`,
-  );
-  if (!gzAsset) return null;
-
-  const chainInfo = extractStableChain({
-    releases,
-    currentVersion,
-    targetVersion,
-    binaryName,
-    fullGzSize: gzAsset.size,
+/** Build the GHCR (nightly) source for the current platform binary. */
+function nightlySource(): SourceStrategy {
+  return ghcrSource({
+    registry: GHCR_REGISTRY,
+    repo: GHCR_REPO,
+    userAgent: getUserAgent(),
+    binaryName: getPlatformBinaryName(),
+    targetTag: (version) => `nightly-${version}`,
+    compareVersions,
   });
-  if (!chainInfo) return null;
-
-  // Parallel patch download
-  const downloadResults = await Promise.all(
-    chainInfo.patchUrls.map((url) => downloadStablePatch(url, signal)),
-  );
-
-  const patches: PatchLink[] = [];
-  let totalSize = 0;
-  for (const data of downloadResults) {
-    if (!data) return null;
-    patches.push({ data, size: data.byteLength });
-    totalSize += data.byteLength;
-  }
-
-  return {
-    patches,
-    totalSize,
-    expectedSha256: chainInfo.expectedSha256,
-    steps: chainInfo.steps,
-  };
 }
 
-// ---------------------------------------------------------------------------
-// Nightly channel: GHCR
-// ---------------------------------------------------------------------------
-
-export function getPatchFromVersion(manifest: OciManifest): string | null {
-  return manifest.annotations?.["from-version"] ?? null;
-}
-
-export function getPatchTargetSha256(
-  manifest: OciManifest,
-  binaryName: string,
-): string | null {
-  return manifest.annotations?.[`sha256-${binaryName}`] ?? null;
-}
-
-export const PATCH_TAG_PREFIX = "patch-";
-
-/**
- * Filter patch tags to only those in the upgrade chain, sorted in apply order.
- */
-export function filterAndSortChainTags(
-  allTags: string[],
-  currentVersion: string,
-  targetVersion: string,
-): string[] {
-  const chainTags: { tag: string; version: string }[] = [];
-
-  for (const tag of allTags) {
-    const version = tag.slice(PATCH_TAG_PREFIX.length);
-    if (
-      compareVersions(version, currentVersion) === 1 &&
-      compareVersions(version, targetVersion) !== 1
-    ) {
-      chainTags.push({ tag, version });
-    }
-  }
-  chainTags.sort((a, b) => compareVersions(a.version, b.version));
-  return chainTags.map((t) => t.tag);
-}
-
-type NightlyChainValidation = {
-  digests: string[];
-  totalSize: number;
-  expectedSha256: string;
-};
-
-type ValidateChainOpts = {
-  manifests: OciManifest[];
-  chainTags: string[];
-  currentVersion: string;
-  targetVersion: string;
-  patchLayerName: string;
-  binaryName: string;
-  fullGzSize: number;
-};
-
-type ChainStepResult =
-  | { ok: true; digest: string; size: number }
-  | { ok: false };
-
-export function validateChainStep(
-  manifest: OciManifest,
-  opts: { expectedFrom: string; patchLayerName: string; sizeLimit: number },
-): ChainStepResult {
-  const fromVersion = getPatchFromVersion(manifest);
-  if (fromVersion !== opts.expectedFrom) {
-    return { ok: false };
-  }
-
-  const layer = manifest.layers.find((l) => {
-    const title = l.annotations?.["org.opencontainers.image.title"];
-    return title === opts.patchLayerName;
+/** Build the GitHub Release (stable) source for the current platform binary. */
+function stableSource(): SourceStrategy {
+  return githubReleaseSource({
+    releasesUrl: GITHUB_RELEASES_URL,
+    binaryName: getPlatformBinaryName(),
+    userAgent: getUserAgent(),
   });
-  if (!layer) return { ok: false };
-  if (layer.size > opts.sizeLimit) return { ok: false };
-
-  return { ok: true, digest: layer.digest, size: layer.size };
 }
 
-function validateNightlyChain(
-  opts: ValidateChainOpts,
-): NightlyChainValidation | null {
-  const {
-    manifests,
-    chainTags,
-    currentVersion,
-    targetVersion,
-    patchLayerName,
-    binaryName,
-    fullGzSize,
-  } = opts;
-  const digests: string[] = [];
-  let totalSize = 0;
-  let prevVersion = currentVersion;
-
-  for (let i = 0; i < manifests.length; i++) {
-    const manifest = manifests[i];
-    const tag = chainTags[i];
-    if (!(manifest && tag)) return null;
-
-    const remainingBudget = fullGzSize * SIZE_THRESHOLD_RATIO - totalSize;
-    const result = validateChainStep(manifest, {
-      expectedFrom: prevVersion,
-      patchLayerName,
-      sizeLimit: remainingBudget,
-    });
-    if (!result.ok) return null;
-
-    digests.push(result.digest);
-    totalSize += result.size;
-    prevVersion = tag.slice(PATCH_TAG_PREFIX.length);
-
-    if (i === manifests.length - 1) {
-      if (prevVersion !== targetVersion) return null;
-      const sha256 = getPatchTargetSha256(manifest, binaryName) ?? "";
-      if (!sha256) return null;
-      return { digests, totalSize, expectedSha256: sha256 };
-    }
-  }
-
-  return null;
-}
-
-/**
- * Resolve a chain of nightly patches from current to target version.
- */
-export async function resolveNightlyChain(opts: {
-  token: string;
-  currentVersion: string;
-  targetVersion: string;
-  fullGzSize: number;
-  preloadedTags?: string[];
-  signal?: AbortSignal;
-}): Promise<PatchChain | null> {
-  const {
-    token,
-    currentVersion,
-    targetVersion,
-    fullGzSize,
-    preloadedTags,
-    signal,
-  } = opts;
-  const binaryName = getPlatformBinaryName();
-  const patchLayerName = `${binaryName}.patch`;
-
-  const allTags =
-    preloadedTags ?? (await listTags(token, PATCH_TAG_PREFIX, signal));
-
-  const chainTags = filterAndSortChainTags(
-    allTags,
-    currentVersion,
-    targetVersion,
-  );
-  if (chainTags.length === 0 || chainTags.length > MAX_NIGHTLY_CHAIN_DEPTH) {
-    return null;
-  }
-
-  // Fetch manifests for chain tags
-  const fetchedManifests = new Map<string, OciManifest>();
-  const results = await Promise.all(
-    chainTags.map(async (tag) => {
-      try {
-        const manifest = await fetchManifest(token, tag, signal);
-        return { tag, manifest };
-      } catch {
-        return { tag, manifest: null };
-      }
-    }),
-  );
-
-  for (const { tag, manifest } of results) {
-    if (manifest) fetchedManifests.set(tag, manifest);
-  }
-
-  const manifests: (OciManifest | undefined)[] = chainTags.map((tag) =>
-    fetchedManifests.get(tag),
-  );
-  if (manifests.some((m) => !m)) return null;
-
-  const validation = validateNightlyChain({
-    manifests: manifests as OciManifest[],
-    chainTags,
-    currentVersion,
-    targetVersion,
-    patchLayerName,
-    binaryName,
-    fullGzSize,
-  });
-  if (!validation) return null;
-
-  // Parallel blob download
-  const downloadResults = await Promise.all(
-    validation.digests.map((digest) =>
-      downloadLayerBlob(token, digest, signal).then(
-        (buf) => new Uint8Array(buf),
-      ),
-    ),
-  );
-
-  const patches: PatchLink[] = [];
-  let downloadedSize = 0;
-  for (const data of downloadResults) {
-    patches.push({ data, size: data.byteLength });
-    downloadedSize += data.byteLength;
-  }
-
-  const steps: { fromVersion: string; toVersion: string }[] = [];
-  let prevVersion = currentVersion;
-  for (const tag of chainTags) {
-    const toVersion = tag.slice(PATCH_TAG_PREFIX.length);
-    steps.push({ fromVersion: prevVersion, toVersion });
-    prevVersion = toVersion;
-  }
-
-  return {
-    patches,
-    totalSize: downloadedSize,
-    expectedSha256: validation.expectedSha256,
-    steps,
-  };
+function sourceForChannel(channel: "nightly" | "stable"): SourceStrategy {
+  return channel === "nightly" ? nightlySource() : stableSource();
 }
 
 // ---------------------------------------------------------------------------
@@ -529,8 +95,8 @@ export async function resolveNightlyChain(opts: {
 /**
  * Attempt to download and apply delta patches instead of a full binary.
  *
- * This is the main entry point called by `downloadBinaryToTemp()` in
- * the upgrade module. Falls back gracefully to null on any failure.
+ * This is the main entry point called by `downloadBinaryToTemp()` in the
+ * upgrade module. Falls back gracefully to null on any failure.
  */
 export async function attemptDeltaUpgrade(
   targetVersion: string,
@@ -546,33 +112,37 @@ export async function attemptDeltaUpgrade(
 
   // Wrap the attempt in a `lore.upgrade.delta` span recording the same decision
   // points Sentry CLI captures (result/source/patch_bytes/chain_length). The
-  // report callback is filled in by resolveAndApplyDelta as facts become known.
+  // report callback is filled in as facts become known.
   return spanDeltaUpgrade(
     { channel, fromVersion: VERSION, toVersion: targetVersion },
     async (report) => {
+      // Record where the chain resolved from so the final "ok" report can
+      // attribute cache vs network; `offline_miss` is reported directly.
+      let resolvedSource: DeltaSource | undefined;
       try {
-        const result =
-          channel === "nightly"
-            ? await resolveAndApplyDelta({
-                targetVersion,
-                oldBinaryPath,
-                destPath,
-                resolveFromNetwork: () =>
-                  resolveNightlyChainWithContext(targetVersion),
-                channel: "nightly",
-                offline,
-                report,
-              })
-            : await resolveAndApplyDelta({
-                targetVersion,
-                oldBinaryPath,
-                destPath,
-                resolveFromNetwork: () =>
-                  resolveStableChain(VERSION, targetVersion),
-                channel: "stable",
-                offline,
-                report,
+        const result = await resolveAndApply({
+          source: sourceForChannel(channel),
+          currentVersion: VERSION,
+          targetVersion,
+          oldPath: oldBinaryPath,
+          destPath,
+          cache: getPatchCache(),
+          offline,
+          telemetry: {
+            onResolved: (info) => {
+              resolvedSource = info.source;
+            },
+            onOfflineMiss: () => {
+              report({
+                channel,
+                fromVersion: VERSION,
+                toVersion: targetVersion,
+                source: "offline_miss",
+                result: "unavailable",
               });
+            },
+          },
+        });
 
         if (result === null) {
           report({
@@ -580,6 +150,17 @@ export async function attemptDeltaUpgrade(
             fromVersion: VERSION,
             toVersion: targetVersion,
             result: "unavailable",
+          });
+        } else {
+          report({
+            channel,
+            fromVersion: VERSION,
+            toVersion: targetVersion,
+            source: resolvedSource,
+            result: "ok",
+            patchBytes: result.patchBytes,
+            chainLength: result.chainLength,
+            sha256: result.sha256,
           });
         }
         return result;
@@ -602,216 +183,19 @@ export async function attemptDeltaUpgrade(
 }
 
 // ---------------------------------------------------------------------------
-// Shared cache-first resolve + apply logic
-// ---------------------------------------------------------------------------
-
-type ResolveAndApplyOpts = {
-  targetVersion: string;
-  oldBinaryPath: string;
-  destPath: string;
-  resolveFromNetwork: () => Promise<PatchChain | null>;
-  channel: string;
-  offline?: boolean;
-  report?: (t: DeltaUpgradeTelemetry) => void;
-};
-
-async function resolveAndApplyDelta(
-  opts: ResolveAndApplyOpts,
-): Promise<DeltaResult | null> {
-  const {
-    targetVersion,
-    oldBinaryPath,
-    destPath,
-    resolveFromNetwork,
-    channel,
-    offline,
-    report,
-  } = opts;
-
-  const reportOk = (
-    source: string,
-    r: { sha256: string; patchBytes: number; chainLength: number },
-  ): void => {
-    report?.({
-      channel,
-      fromVersion: VERSION,
-      toVersion: targetVersion,
-      source,
-      result: "ok",
-      patchBytes: r.patchBytes,
-      chainLength: r.chainLength,
-      sha256: r.sha256,
-    });
-  };
-
-  // Check patch cache first — enables fully offline upgrades
-  const cached = await tryLoadCachedChain(VERSION, targetVersion);
-  if (cached) {
-    const r = await applyChainAndReturn(cached, oldBinaryPath, destPath);
-    reportOk("cache", r);
-    return r;
-  }
-
-  if (offline) {
-    report?.({
-      channel,
-      fromVersion: VERSION,
-      toVersion: targetVersion,
-      source: "offline_miss",
-      result: "unavailable",
-    });
-    return null;
-  }
-
-  const chain = await resolveFromNetwork();
-  if (!chain) return null;
-
-  // Save to cache for future offline upgrades, then apply
-  if (chain.steps) {
-    getPatchCache()
-      .save(chain, chain.steps)
-      .catch(() => {});
-  }
-
-  const r = await applyChainAndReturn(chain, oldBinaryPath, destPath);
-  reportOk("network", r);
-  return r;
-}
-
-async function tryLoadCachedChain(
-  currentVersion: string,
-  targetVersion: string,
-): Promise<PatchChain | null> {
-  try {
-    return await getPatchCache().load(currentVersion, targetVersion);
-  } catch {
-    return null;
-  }
-}
-
-async function applyChainAndReturn(
-  chain: PatchChain,
-  oldBinaryPath: string,
-  destPath: string,
-): Promise<DeltaResult> {
-  // Progress bar for the apply phase. `onBytes` fires for the output bytes of
-  // EVERY hop — the in-memory intermediates AND the final disk write — so the
-  // bar's total must be the SUM of all hops' output sizes (each patch's
-  // declared `newSize`), not just the final binary size. Using only the last
-  // patch's `newSize` makes a multi-hop bar reach 100% before the final hop and
-  // then clamp (freeze). The bar advances per byte written across all hops, so
-  // it stays smooth through the chain.
-  let totalBytes: number | null = 0;
-  try {
-    for (const patch of chain.patches) {
-      totalBytes += parsePatchHeader(patch.data).newSize;
-    }
-  } catch {
-    // Header parse is best-effort for the bar; a corrupt header is rejected
-    // properly downstream. Leave the bar indeterminate in that case.
-    totalBytes = null;
-  }
-  const label = `Applying ${chain.patches.length} patch(es)`;
-  const progress = makeByteProgress(label, totalBytes);
-  try {
-    const sha256 = await applyPatchChain(
-      chain,
-      oldBinaryPath,
-      destPath,
-      progress.onProgress,
-    );
-    return {
-      sha256,
-      patchBytes: chain.totalSize,
-      chainLength: chain.patches.length,
-    };
-  } finally {
-    progress.done();
-  }
-}
-
-/**
- * Resolve a nightly chain with full context setup.
- */
-async function resolveNightlyChainWithContext(
-  targetVersion: string,
-  signal?: AbortSignal,
-): Promise<PatchChain | null> {
-  const token = await getAnonymousToken(signal);
-
-  const binaryName = getPlatformBinaryName();
-  const targetTag = `nightly-${targetVersion}`;
-
-  const [nightlyManifest, patchTags] = await Promise.all([
-    fetchManifest(token, targetTag, signal),
-    listTags(token, PATCH_TAG_PREFIX, signal),
-  ]);
-
-  const gzLayer = nightlyManifest.layers.find((l) => {
-    const title = l.annotations?.["org.opencontainers.image.title"];
-    return title === `${binaryName}.gz`;
-  });
-  if (!gzLayer) return null;
-
-  return await resolveNightlyChain({
-    token,
-    currentVersion: VERSION,
-    targetVersion,
-    fullGzSize: gzLayer.size,
-    preloadedTags: patchTags,
-    signal,
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Patch application
-// ---------------------------------------------------------------------------
-
-/**
- * Apply a resolved patch chain and verify the result.
- *
- * Delegates to {@link applyPatchChainInMemory}, which loads the base binary
- * once, keeps every intermediate hop in memory (no per-hop disk writes,
- * temp-copies, or SHA-256 passes), and streams only the final binary to
- * `destPath`. Because reads and writes never target the same path, there is
- * no read/write truncation hazard.
- */
-export async function applyPatchChain(
-  chain: PatchChain,
-  oldBinaryPath: string,
-  destPath: string,
-  onBytes?: (bytes: number) => void,
-): Promise<string> {
-  const sha256 = await applyPatchChainInMemory(
-    oldBinaryPath,
-    chain.patches.map((p) => p.data),
-    destPath,
-    onBytes,
-  );
-
-  if (sha256 !== chain.expectedSha256) {
-    throw new Error(
-      `SHA-256 mismatch after patching: got ${sha256}, expected ${chain.expectedSha256}`,
-    );
-  }
-
-  return sha256;
-}
-
-// ---------------------------------------------------------------------------
-// Patch Pre-fetching (can be called during background version checks)
+// Patch pre-fetching (called during background version checks)
 // ---------------------------------------------------------------------------
 
 async function prefetchAndCache(
   targetVersion: string,
+  source: SourceStrategy,
   signal: AbortSignal | undefined,
-  resolveChain: () => Promise<PatchChain | null>,
 ): Promise<void> {
   if (!canAttemptDelta(targetVersion) || signal?.aborted) {
     return;
   }
 
-  const chain = await resolveChain();
+  const chain = await source.resolveChain(VERSION, targetVersion, signal);
   if (!chain?.steps || signal?.aborted) {
     return;
   }
@@ -819,26 +203,18 @@ async function prefetchAndCache(
   await getPatchCache().save(chain, chain.steps);
 }
 
-/**
- * Pre-fetch nightly delta patches for a future upgrade.
- */
+/** Pre-fetch nightly delta patches for a future upgrade. */
 export function prefetchNightlyPatches(
   targetVersion: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  return prefetchAndCache(targetVersion, signal, () =>
-    resolveNightlyChainWithContext(targetVersion, signal),
-  );
+  return prefetchAndCache(targetVersion, nightlySource(), signal);
 }
 
-/**
- * Pre-fetch stable delta patches for a future upgrade.
- */
+/** Pre-fetch stable delta patches for a future upgrade. */
 export function prefetchStablePatches(
   targetVersion: string,
   signal?: AbortSignal,
 ): Promise<void> {
-  return prefetchAndCache(targetVersion, signal, () =>
-    resolveStableChain(VERSION, targetVersion, signal),
-  );
+  return prefetchAndCache(targetVersion, stableSource(), signal);
 }

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -23,10 +23,13 @@ import {
 } from "./binary";
 import { GHCR_REGISTRY, GHCR_REPO } from "./ghcr";
 import {
+  type ByteProgress,
   type DeltaResult,
   type DeltaSource,
   ghcrSource,
   githubReleaseSource,
+  makeByteProgress,
+  type ProgressEvent,
   resolveAndApply,
   type SourceStrategy,
 } from "binpatch";
@@ -119,6 +122,10 @@ export async function attemptDeltaUpgrade(
       // Record where the chain resolved from so the final "ok" report can
       // attribute cache vs network; `offline_miss` is reported directly.
       let resolvedSource: DeltaSource | undefined;
+      // Render the apply-phase byte bar from binpatch's progress events. The
+      // bar is created lazily on the first `bytes` event (which carries the
+      // total) and fed per-hop deltas (events report cumulative `written`).
+      const applyBar = makeApplyProgress();
       try {
         const result = await resolveAndApply({
           source: sourceForChannel(channel),
@@ -128,6 +135,7 @@ export async function attemptDeltaUpgrade(
           destPath,
           cache: getPatchCache(),
           offline,
+          onProgress: applyBar.onEvent,
           telemetry: {
             onResolved: (info) => {
               resolvedSource = info.source;
@@ -177,9 +185,38 @@ export async function attemptDeltaUpgrade(
           `[lore] Delta upgrade failed (${msg}), falling back to full download`,
         );
         return null;
+      } finally {
+        applyBar.done();
       }
     },
   );
+}
+
+/**
+ * Adapt binpatch `ProgressEvent`s to the gateway's byte-progress bar. The bar
+ * is created on the first apply-phase `bytes` event (which carries the total),
+ * then advanced by the per-event delta (events report cumulative `written`).
+ * Purely cosmetic — never throws, never aborts the upgrade.
+ */
+function makeApplyProgress(): {
+  onEvent: (event: ProgressEvent) => void;
+  done: () => void;
+} {
+  let bar: ByteProgress | undefined;
+  let lastWritten = 0;
+  return {
+    onEvent: (event) => {
+      if (event.type === "bytes" && event.phase === "apply") {
+        if (!bar) {
+          bar = makeByteProgress("Applying patches", event.total);
+        }
+        const delta = event.written - lastWritten;
+        lastWritten = event.written;
+        if (delta > 0) bar.onProgress(delta);
+      }
+    },
+    done: () => bar?.done(),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -122,6 +122,11 @@ export async function attemptDeltaUpgrade(
       // Record where the chain resolved from so the final "ok" report can
       // attribute cache vs network; `offline_miss` is reported directly.
       let resolvedSource: DeltaSource | undefined;
+      // Whether the offline-miss path already emitted its own `unavailable`
+      // report (with source=offline_miss). If so, don't emit a second,
+      // source-less `unavailable` report below — that would overwrite the
+      // telemetry outcome and drop the source attribution.
+      let reported = false;
       // Render the apply-phase byte bar from binpatch's progress events. The
       // bar is created lazily on the first `bytes` event (which carries the
       // total) and fed per-hop deltas (events report cumulative `written`).
@@ -141,6 +146,7 @@ export async function attemptDeltaUpgrade(
               resolvedSource = info.source;
             },
             onOfflineMiss: () => {
+              reported = true;
               report({
                 channel,
                 fromVersion: VERSION,
@@ -153,12 +159,14 @@ export async function attemptDeltaUpgrade(
         });
 
         if (result === null) {
-          report({
-            channel,
-            fromVersion: VERSION,
-            toVersion: targetVersion,
-            result: "unavailable",
-          });
+          if (!reported) {
+            report({
+              channel,
+              fromVersion: VERSION,
+              toVersion: targetVersion,
+              result: "unavailable",
+            });
+          }
         } else {
           report({
             channel,

--- a/packages/gateway/src/cli/lib/ghcr.ts
+++ b/packages/gateway/src/cli/lib/ghcr.ts
@@ -104,7 +104,7 @@ export const GHCR_REPO = "BYK/loreai";
 export const GHCR_TAG = "nightly";
 
 /** Base URL for GHCR registry API */
-const GHCR_REGISTRY = "https://ghcr.io";
+export const GHCR_REGISTRY = "https://ghcr.io";
 
 /** OCI manifest media type */
 const OCI_MANIFEST_TYPE = "application/vnd.oci.image.manifest.v1+json";


### PR DESCRIPTION
PR2 of the [binpatch extraction plan](../blob/main/.opencode/plans/binpatch-reusable-delta-update.md). Lifts delta-upgrade **chain discovery + apply orchestration** out of the gateway into the `binpatch` library, behind a pluggable `SourceStrategy`, so the engine has zero product coupling and can resolve chains from any layout. Behavior-preserving for Lore.

Follows PR1 (#1458, apply-core extraction).

## New in `packages/binpatch/`

| File | Role |
|---|---|
| `discover.ts` | `SourceStrategy` interface + `resolveAndApply()` — cache-first resolution, apply, SHA-256 verify, progress events. All product concerns injected. |
| `sources/oci.ts` | Generalized OCI anonymous-pull `OciClient` (registry/repo/user-agent injected), incl. the GHCR 307→blob-storage redirect dance. |
| `sources/ghcr.ts` | `ghcrSource()` — nightly chain resolution over `patch-<version>` manifest tags; version→target-tag scheme + semver comparator injected. |
| `sources/github-release.ts` | `githubReleaseSource()` — stable chain over Release assets; releasesUrl/binaryName/userAgent/fetch injected. |
| `contract.ts` | Wire-contract constants + shared types (`PatchChain`, `PatchLink`, `ChainStep`, `DeltaResult`). |
| `errors.ts` | Product-neutral `BinpatchError` (generalized from `UpgradeError`). |
| `events.ts` | `ProgressEvent`/`ProgressHandler` + `safeProgress`. The library **never renders** — it emits phase/bytes/done events; a throwing handler can never abort the operation. |

## Gateway becomes thin glue

`delta-upgrade.ts` now injects Lore's GHCR/Release coordinates, binary name, user-agent, `getPatchCache()`, `compareVersions`, and the Sentry `spanDeltaUpgrade` telemetry, picks the channel, and calls `resolveAndApply`. `canAttemptDelta`, channel selection, and the prefetch wrappers stay in the gateway. `ghcr.ts` keeps serving the **full-download** path (`upgrade.ts`); it only gains an exported `GHCR_REGISTRY`.

Progress migrates to the decided **pure event-hook** API (plan Open Q1): the library emits `{ type: "phase" | "bytes" | "done"; ... }`; Lore's bar and sentry-cli's spinner become thin consumers. Telemetry stays in the gateway, injected as an optional hook (plan Open Q3).

## Tests (new coverage — discovery had none before)

- `test/sources.test.ts` (16) — pure logic: `extractStableChain`, `extractSha256`, `filterAndSortChainTags`, `validateChainStep`, annotation helpers.
- `test/discover.test.ts` (8) — `resolveAndApply` orchestration with **real TRDIFF10 patches** + fake source/cache: cache-first hit, network+save, offline miss, no-chain, SHA-mismatch throw, ordered progress events, throwing-handler resilience.

**Mutation-verified:** break SHA verify → mismatch test RED; break offline gate → offline test RED; flip `filterAndSortChainTags` bound → 2 tests RED; all restored GREEN.

## Verification

- typecheck (6 packages), lint (exit 0, only pre-existing `unbound-method` warnings), format:check — all clean.
- Full suite: **343 files, 6563 tests, 0 failed** (+24 new binpatch tests).
- Real gateway `bundle` inlines binpatch's discovery with **zero** leftover `binpatch` external.

## Not in scope (later PRs)

PR3 the reusable generation composite Action; PR4 graduate to a standalone public repo + `sentry-cli` adoption.