### PR TITLE
fix(gateway): route context-bound LTM through the durable delta, retire system[2] (#961)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -791,6 +791,25 @@ export function ltmEntryKeys(
     .sort();
 }
 
+/**
+ * A delta baseline that surfaces the FULL current set as "changed".
+ *
+ * The delta path (`detectSurfacedMutations`) reports an entry only when its
+ * CURRENT content hash differs from the hash recorded in the surfaced-set
+ * baseline. To surface every entry on FIRST injection — where there is no prior
+ * system[2] pin to diff against — we seed the baseline with each id paired with
+ * an EMPTY hash sentinel (`"<id>:"`). Every entry's real hash differs from ""
+ * so the whole set surfaces once, then the appended block records the true
+ * hashes and the surfaced set advances normally (no re-fire on later turns).
+ *
+ * This mirrors the material-change / `MAX_DELTA_BLOCKS` coalesce path, which
+ * likewise re-captures the full set by diffing current content against a
+ * stale-hash baseline — here the "stale" hash is simply empty.
+ */
+export function fullSurfaceBaseline(ids: Iterable<string>): string[] {
+  return [...ids].map((id) => `${id}:`).sort();
+}
+
 /** system[1] (stable LTM) cache breakpoint TTL in ms. Documents the 1h
  *  `cache_control` TTL carried by the system[1] block. As of v45 system[1] is
  *  frozen for the session's life and never recomputed mid-session, so an idle
@@ -1525,7 +1544,23 @@ function hasMaterialLtmDelta(input: {
  *
  * @internal Exported for tests.
  */
-export function detectSurfacedMutations(surfacedKeys: string[] | undefined): {
+export function detectSurfacedMutations(
+  surfacedKeys: string[] | undefined,
+  // Content resolver for SYNTHETIC context-source entries (category
+  // `recalled`, ids `d:<id>`/`t:<id>` from distillation/temporal folding). These
+  // are point-in-time SNAPSHOTS that do NOT live in the `knowledge` table, so
+  // `ltm.get`/`getByLogical` can never resolve them — without this map they'd be
+  // silently dropped (never surfaced, never rendered), regressing the default
+  // `contextSources: ["distillation"]` passive-fact feature. Keyed by the same
+  // id space as `surfacedKeys` (`d:<id>`/`t:<id>`). A synthetic's content is
+  // immutable for a given id, so its hash only mismatches on FIRST surface —
+  // exactly the turn its entry is present in this map — after which the hash
+  // matches and no content lookup is needed.
+  syntheticEntries?: Map<
+    string,
+    { category: string; title: string; content: string }
+  >,
+): {
   changed: Array<{
     id: string;
     category: string;
@@ -1562,15 +1597,39 @@ export function detectSurfacedMutations(surfacedKeys: string[] | undefined): {
     const logicalId = ltm.logicalIdOf(id);
     const current = ltm.get(id) ?? ltm.getByLogical(logicalId);
     if (!current) {
+      // Not a resolvable `knowledge` row. Before treating it as a non-knowledge
+      // synthetic, check the context-source snapshot map: distillation/temporal
+      // facts (`d:`/`t:`) are folded into the selection but live outside the
+      // knowledge table, so their content must come from the current turn's
+      // `entries`, not the DB. Surface on hash mismatch (the first-surface turn)
+      // so they reach the wire via the durable delta — parity with the old
+      // system[2] render.
+      const synthetic = syntheticEntries?.get(id);
+      if (synthetic) {
+        const currentHash = surfaceSignature(
+          synthetic.title,
+          synthetic.content,
+        );
+        if (currentHash !== surfacedHash) {
+          changed.push({
+            id,
+            category: synthetic.category,
+            title: synthetic.title,
+            content: synthetic.content,
+          });
+        }
+        continue;
+      }
       // Null resolution means EITHER a genuinely deleted knowledge entry OR an
       // id that was never a `knowledge` row at all (e.g. lat.md synthetics,
       // which forSession injects as KnowledgeEntry-shaped rows with ids like
-      // `file#Heading` that live in lat_sections). Only the former is a real
-      // supersession — classify as removed ONLY when the logical id is actually
-      // tombstoned. Otherwise the model would be told to ignore still-valid
-      // pinned knowledge, and (append-only) that false removal would be frozen
-      // into an immutable block + advance the surfaced set past a non-knowledge
-      // id.
+      // `file#Heading` that live in lat_sections; or a context-source snapshot
+      // that has left the current selection and so is absent from the map on a
+      // later turn). Only a real knowledge deletion is a supersession — classify
+      // as removed ONLY when the logical id is actually tombstoned. Otherwise the
+      // model would be told to ignore still-valid pinned knowledge, and
+      // (append-only) that false removal would be frozen into an immutable block
+      // + advance the surfaced set past a non-knowledge id.
       if (ltm.isTombstoned(logicalId)) removedIds.push(id);
       continue;
     }
@@ -1816,8 +1875,9 @@ export function appendKnowledgePromptDelta(input: {
   //   - a removal/change ALREADY surfaced by a prior block has left the surfaced
   //     set, so a PERSISTENT mutation (e.g. 66 pinned entries genuinely gone)
   //     fires exactly once, not every turn.
-  // `nextKeys`/`entries` are retained on the input for the gate sites
-  // (hasMaterialLtmDelta) but are intentionally unused here.
+  // `nextKeys` is retained on the input for the gate sites (hasMaterialLtmDelta).
+  // `entries` supplies content for SYNTHETIC context-source ids (see
+  // syntheticEntries below); knowledge-row content is re-derived from the DB.
   let blocks = listSessionPromptDeltas(input.sessionID);
   // Bound pathological growth: if too many blocks have accumulated without a
   // reshuffle to coalesce them, clear them and re-derive ONE cumulative block
@@ -1829,7 +1889,28 @@ export function appendKnowledgePromptDelta(input: {
     blocks = [];
   }
   const surfacedKeys = advanceSurfacedKeys(input.previousKeys, blocks);
-  const { changed, removedIds } = detectSurfacedMutations(surfacedKeys);
+  // Context-source snapshots (category `recalled`, ids `d:`/`t:`) don't live in
+  // the knowledge table, so detectSurfacedMutations can't resolve their content
+  // from the DB — supply it from this turn's selection. A synthetic's content
+  // is immutable per id, so it only needs resolving on its first-surface turn,
+  // which is exactly when it's present in `input.entries`.
+  const syntheticEntries = new Map<
+    string,
+    { category: string; title: string; content: string }
+  >();
+  for (const e of input.entries ?? []) {
+    if (e.category === ltm.RECALLED_CONTEXT_CATEGORY) {
+      syntheticEntries.set(e.id, {
+        category: e.category,
+        title: e.title,
+        content: e.content,
+      });
+    }
+  }
+  const { changed, removedIds } = detectSurfacedMutations(
+    surfacedKeys,
+    syntheticEntries,
+  );
   const messages = buildKnowledgeDeltaMessage(
     changed,
     removedIds,
@@ -7124,17 +7205,23 @@ async function handleConversationTurn(
   const loreMessages = gatewayMessagesToLore(req.messages, sessionID);
   resolveToolResults(loreMessages);
 
-  // --- 6. LTM injection (3-block system prompt for cache efficiency) ---
+  // --- 6. LTM injection (system[1] stable prefix + durable-delta context LTM) ---
   // system[0]: Host prompt              [no cache_control]
   // system[1]: Stable LTM (preferences) [cache_control: 1h] — pinned ≥1h
-  // system[2]: Context-bound LTM        [no cache_control]  — diff-pinned
   //
   // system[0]+[1] form a stable prefix cached at 1h TTL (written at 2×
-  // cost, read at 0.1×). system[2] rides the conversation cache (5m TTL,
-  // 1.25×). When context-bound LTM changes (turn 1→2, curation), only
-  // system[2] and messages are re-processed; system[0]+[1] are cache reads.
-  let stableLtmText: string | undefined; // block 2: preferences
-  let ltmText: string | undefined; // block 3: context-bound entries
+  // cost, read at 0.1×). Context-bound LTM (gotchas/patterns/architecture +
+  // distillation/temporal context-sources) is NO LONGER emitted as a system[2]
+  // block — it rides the durable prompt-delta path from its FIRST injection
+  // onward (appended [user,assistant] pair at a frozen conversation-tail
+  // position, replayed byte-identically, re-anchored on compression). This
+  // removes the once-per-session first-population bust that a system[2] block
+  // caused (amplified on the OpenAI/OpenRouter path, where the whole system
+  // string shares a single cache_control breakpoint). `ltmText` is retained as
+  // the (now always-undefined) system[2] slot for clarity; the pin/cache
+  // bookkeeping below survives purely as the delta's diff baseline.
+  let stableLtmText: string | undefined; // block 2: preferences (system[1])
+  let ltmText: string | undefined; // retired system[2] slot — always undefined
   let pendingKnowledgeDelta:
     | {
         previousKeys: string[] | undefined;
@@ -7466,14 +7553,13 @@ async function handleConversationTurn(
               pinned != null && pinned.formatted === cached.formatted;
 
           if (pinned && setUnchanged) {
-            // Same entry set (or identical text) — keep the pinned text to
-            // preserve the cache prefix. Zero bust on pure re-ranking.
-            ltmText = pinned.formatted;
-            // Keep the session cache in lock-step with the pin so the persisted
-            // ltmCacheText never diverges from ltmPinText. Otherwise a restart
-            // would reload cache=freshText / pin=oldText, and the warm-cache
-            // byte-equality check would spuriously re-pin (one needless bust)
-            // and drop entryKeys. (Addresses review finding S1.)
+            // Same entry set (or identical text) — nothing to surface. The full
+            // set is already carried by the durable prompt-delta (appended on
+            // first injection), so we do NOT emit system[2] (`ltmText` stays
+            // undefined). Keep the session cache in lock-step with the pin so the
+            // persisted ltmCacheText never diverges from ltmPinText (a restart
+            // would otherwise reload cache=freshText / pin=oldText and spuriously
+            // re-pin). The pin is baseline-only metadata now — never on the wire.
             if (cachedKeys && cached.formatted !== pinned.formatted) {
               ltmSessionCache.set(sessionID, {
                 formatted: pinned.formatted,
@@ -7491,22 +7577,21 @@ async function handleConversationTurn(
               nextKeys: cachedKeys,
             })
           ) {
-            // Material LTM changed mid-session. Do NOT rewrite system[2]: it is
-            // before the conversation cache breakpoint, so changing it would
-            // throw away the cached prefix. Keep the exact pinned bytes and
-            // append a durable prompt delta at the conversation tail instead.
+            // Material LTM changed mid-session. Surface the change via the
+            // durable prompt delta at the conversation tail; system[2] is never
+            // emitted (`ltmText` stays undefined), so the system prefix is never
+            // busted.
             //
             // CRITICAL: keep `entryKeys` frozen at the baseline that matches the
-            // pinned `formatted` bytes — do NOT advance it to cachedKeys. The
-            // durable delta is coalesced into a single row that is REPLACED each
-            // turn, so it must describe the CUMULATIVE delta between the frozen
-            // system[2] bytes and the current selection. If we advanced the
-            // baseline, the next turn's delta would only describe that turn's
-            // increment and the coalesced row would silently drop earlier
-            // supersessions (leaving stale entries pinned in system[2] with no
-            // correcting delta). The diff is recomputed from the frozen baseline
-            // every turn → re-upserting the same (frozen, current) pair yields
-            // byte-identical content (idempotent, no extra cache bust).
+            // set the durable delta was last coalesced against — do NOT advance
+            // it to cachedKeys. The delta is coalesced into a single row that is
+            // REPLACED each turn, so it must describe the CUMULATIVE delta from
+            // the frozen baseline. If we advanced the baseline, the next turn's
+            // delta would only describe that turn's increment and the coalesced
+            // row would silently drop earlier supersessions. The diff is
+            // recomputed from the frozen baseline every turn → re-upserting the
+            // same (frozen, current) pair yields byte-identical content
+            // (idempotent, no extra cache bust).
             pendingKnowledgeDelta = {
               previousKeys: pinned.entryKeys,
               nextKeys: cachedKeys,
@@ -7524,14 +7609,58 @@ async function handleConversationTurn(
             });
             ltmDirty = true;
             pinDirty = true;
-            ltmText = pinned.formatted;
-          } else {
-            // First injection — pin the new text along with its entry-key
-            // identity. There is no earlier system[2] prefix to preserve yet.
-            const newPin = { ...cached, entryKeys: cachedKeys };
-            ltmPinnedText.set(sessionID, newPin);
+            // ltmText intentionally left undefined: no system[2] block.
+          } else if (freshContextEntries?.length && cachedKeys) {
+            // First injection (no prior system[2] pin). Historically this
+            // seeded system[2] (`ltmText = newPin.formatted`), which — because
+            // system[2] sits inside the cached system prefix — cost a full
+            // prefix re-creation the first turn context-bound LTM appeared
+            // (~90–174K tokens; amplified on the OpenAI/OpenRouter path, where
+            // the whole system string shares a single cache_control breakpoint).
+            //
+            // Instead, route the first injection through the SAME durable
+            // prompt-delta path that already carries mid-session changes: append
+            // a [user,assistant] pair at the conversation tail (byte-stable,
+            // replayed verbatim, re-anchored on compression). system[2] is never
+            // populated (`ltmText` stays undefined), so the system prefix is
+            // never busted by context-bound LTM.
+            //
+            // Seed the delta baseline with an EMPTY-hash sentinel per current id
+            // (`fullSurfaceBaseline`) so `detectSurfacedMutations` surfaces the
+            // FULL set once (each entry's real hash differs from ""). The
+            // appended block records the true hashes, so the surfaced set
+            // advances and later turns don't re-fire — identical mechanics to
+            // the material-change branch, just with an empty baseline instead of
+            // a stale pinned one. We pin the RENDERED text bytes so the persisted
+            // pin (`ltmPinnedText`) keeps its entry-key identity as the baseline
+            // for subsequent material-delta detection, but we do NOT emit it as
+            // system[2] (`ltmText` remains undefined).
+            pendingKnowledgeDelta = {
+              previousKeys: fullSurfaceBaseline(entryKeyIds(cachedKeys)),
+              nextKeys: cachedKeys,
+              entries: freshContextEntries,
+              overflow: freshContextOverflow,
+            };
+            ltmPinnedText.set(sessionID, {
+              formatted: cached.formatted,
+              tokenCount: cached.tokenCount,
+              entryKeys: cachedKeys,
+            });
             pinDirty = true;
-            ltmText = newPin.formatted;
+            // ltmText intentionally left undefined: no system[2] block.
+          } else if (cached) {
+            // Fallback: a `cached` block reached here without matching the
+            // first-injection / material-change / setUnchanged branches — e.g.
+            // the empty-selection removal path above (cachedKeys=[], no fresh
+            // entries), which already queued its removal delta. Keep the pin as
+            // baseline metadata but do NOT emit system[2] (`ltmText` stays
+            // undefined) — the durable delta is the sole carrier.
+            ltmPinnedText.set(sessionID, {
+              ...cached,
+              entryKeys: cachedKeys ?? ltmPinnedText.get(sessionID)?.entryKeys,
+            });
+            pinDirty = true;
+            // ltmText intentionally left undefined: no system[2] block.
           }
         }
       }
@@ -7692,9 +7821,9 @@ async function handleConversationTurn(
           const pinned = ltmPinnedText.get(sessionID);
 
           if (pinned && sameEntryKeys(pinned.entryKeys, entryKeys)) {
-            // Same entry set — keep the pinned text to preserve cache prefix
-            ltmText = pinned.formatted;
-            setLtmTokens(stableTokens + pinned.tokenCount, sessionID);
+            // Same entry set — nothing to surface. The durable delta already
+            // carries the full set; do NOT emit system[2] (`ltmText` undefined).
+            setLtmTokens(stableTokens, sessionID);
             saveSessionTracking(sessionID, {
               ltmCacheText: formatted,
               ltmCacheTokens: tokenCount,
@@ -7708,16 +7837,15 @@ async function handleConversationTurn(
               nextKeys: entryKeys,
             })
           ) {
-            // Material LTM changed during emergency refresh. Preserve the exact
-            // cached system[2] bytes and surface the change as a durable prompt
-            // delta instead of rewriting the pre-breakpoint system block.
+            // Material LTM changed during emergency refresh. Surface the change
+            // as a durable prompt delta; system[2] is not emitted.
             //
-            // CRITICAL: keep `entryKeys` frozen at the baseline matching the
-            // pinned bytes — do NOT advance to the current `entryKeys`. The
-            // coalesced durable delta is replaced each turn, so it must describe
-            // the CUMULATIVE delta from the frozen system[2] to the current
-            // selection; advancing the baseline would drop earlier supersessions
-            // from the single row. (See the matching note on the Layer-1 path.)
+            // CRITICAL: keep `entryKeys` frozen at the baseline matching the set
+            // the durable delta was last coalesced against — do NOT advance to
+            // the current `entryKeys`. The coalesced durable delta is replaced
+            // each turn, so it must describe the CUMULATIVE delta from the frozen
+            // baseline to the current selection; advancing the baseline would
+            // drop earlier supersessions from the single row.
             const frozenKeys = pinned.entryKeys;
             pendingKnowledgeDelta = {
               previousKeys: frozenKeys,
@@ -7735,8 +7863,7 @@ async function handleConversationTurn(
               formatted: pinned.formatted,
               tokenCount: pinned.tokenCount,
             });
-            ltmText = pinned.formatted;
-            setLtmTokens(stableTokens + pinned.tokenCount, sessionID);
+            setLtmTokens(stableTokens, sessionID);
             saveSessionTracking(sessionID, {
               ltmCacheText: pinned.formatted,
               ltmCacheTokens: pinned.tokenCount,
@@ -7744,12 +7871,21 @@ async function handleConversationTurn(
               ltmPinTokens: pinned.tokenCount,
               ltmPinKeys: JSON.stringify(frozenKeys),
             });
+            // ltmText intentionally left undefined: no system[2] block.
           } else {
-            // First Layer 4 injection — pin the new text + identity. There is no
-            // earlier system[2] prefix to preserve yet.
+            // First Layer 4 injection of context-bound LTM. Route it through the
+            // durable delta (full-surface baseline) rather than seeding system[2]
+            // — same rationale as the step-6 first-injection path. Layer 4 busts
+            // the prefix anyway, but keeping context-bound LTM out of system[2]
+            // means it stays cache-stable on the NEXT (non-emergency) turn too.
+            pendingKnowledgeDelta = {
+              previousKeys: fullSurfaceBaseline(entryKeyIds(entryKeys)),
+              nextKeys: entryKeys,
+              entries: contextEntries,
+              overflow: contextOverflow,
+            };
             ltmPinnedText.set(sessionID, { formatted, tokenCount, entryKeys });
-            ltmText = formatted;
-            setLtmTokens(stableTokens + tokenCount, sessionID);
+            setLtmTokens(stableTokens, sessionID);
             saveSessionTracking(sessionID, {
               ltmCacheText: formatted,
               ltmCacheTokens: tokenCount,
@@ -7757,6 +7893,7 @@ async function handleConversationTurn(
               ltmPinTokens: tokenCount,
               ltmPinKeys: JSON.stringify(entryKeys),
             });
+            // ltmText intentionally left undefined: no system[2] block.
           }
           refreshed = true;
           log.info(
@@ -7769,17 +7906,17 @@ async function handleConversationTurn(
       if (!refreshed) {
         const pinned = ltmPinnedText.get(sessionID);
         if (pinned) {
-          // No fresh context-bound entries were selected, but removing an
-          // already-cached system[2] block would still bust the prefix. Keep the
-          // existing pin byte-for-byte and append a durable removal delta so the
-          // model knows the older pinned entries are superseded.
+          // No fresh context-bound entries were selected. Append a durable
+          // removal delta so the model knows the older entries are superseded;
+          // system[2] is not emitted.
           //
-          // CRITICAL: keep entryKeys FROZEN at the baseline matching the pinned
-          // bytes — do NOT wipe to []. The coalesced durable delta is replaced
-          // each turn and must describe the full cumulative frozen→current
-          // (empty) supersession. Wiping the baseline to [] here (in memory AND
-          // persisted) makes the next turn compute previous=[]→next=[] = no
-          // removals, dropping every earlier supersession from the single row.
+          // CRITICAL: keep entryKeys FROZEN at the baseline matching the set the
+          // durable delta was last coalesced against — do NOT wipe to []. The
+          // coalesced durable delta is replaced each turn and must describe the
+          // full cumulative frozen→current (empty) supersession. Wiping the
+          // baseline to [] here (in memory AND persisted) makes the next turn
+          // compute previous=[]→next=[] = no removals, dropping every earlier
+          // supersession from the single row.
           const frozenKeys = pinned.entryKeys;
           pendingKnowledgeDelta = {
             previousKeys: frozenKeys,
@@ -7796,8 +7933,7 @@ async function handleConversationTurn(
             formatted: pinned.formatted,
             tokenCount: pinned.tokenCount,
           });
-          ltmText = pinned.formatted;
-          setLtmTokens(stableTokens + pinned.tokenCount, sessionID);
+          setLtmTokens(stableTokens, sessionID);
           saveSessionTracking(sessionID, {
             ltmCacheText: pinned.formatted,
             ltmCacheTokens: pinned.tokenCount,
@@ -7805,8 +7941,9 @@ async function handleConversationTurn(
             ltmPinTokens: pinned.tokenCount,
             ltmPinKeys: JSON.stringify(frozenKeys),
           });
+          // ltmText intentionally left undefined: no system[2] block.
           log.info(
-            "Context-bound LTM refresh returned no entries; preserving existing pinned system[2] for session",
+            "Context-bound LTM refresh returned no entries; superseding via durable delta for session",
             sessionID,
           );
         } else {

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -478,7 +478,14 @@ describe("cache stability (e2e)", () => {
     }
   });
 
-  it("material LTM changes are replayed as durable prompt deltas without rewriting system[2]", async () => {
+  it("context-bound LTM rides a durable delta from first injection onward; NO system[2] block is ever emitted", async () => {
+    // New contract: context-bound LTM ("system[2]") is fully retired. It never
+    // appears in any `system` block — it rides the durable prompt-delta path
+    // (an ambient [user,assistant] pair in `messages`) from its FIRST injection.
+    // So the FIRST time a context entry is selected a delta block is appended
+    // (seq 0), and each later DISTINCT material change appends one more block.
+    // The only frozen system blocks left (host prompt + system[1] preferences)
+    // must stay byte-stable across turns.
     const turns = Array.from({ length: 4 }, (_, i) => ({
       userMessage: `Delta turn ${i}: continue the work.`,
       assistantText: `Delta response ${i}.`,
@@ -542,7 +549,7 @@ describe("cache stability (e2e)", () => {
           category: "gotcha",
           title: "Durable delta gotcha",
           content:
-            "Initial context-bound knowledge that should be pinned in system[2].",
+            "Initial context-bound knowledge that rides the durable delta on first injection.",
           session: sessionID,
         });
         largeContextID = ltm.create({
@@ -556,11 +563,12 @@ describe("cache stability (e2e)", () => {
           session: sessionID,
         });
         // Relevance scoring is stubbed for this test (see the spy setup above the
-        // loop) so BOTH just-created entries score above the floor and pin
-        // deterministically. Without it, the relevance floor's fallback-only
-        // safety net makes 2-entry pinning depend on embedding-worker readiness
-        // and cosine asymmetry (flaky under load). The floor is covered in
-        // ltm.test.ts; this test targets durable-delta replay + system[2] stability.
+        // loop) so BOTH just-created entries score above the floor and surface
+        // deterministically on the first injection. Without it, the relevance
+        // floor's fallback-only safety net makes 2-entry surfacing depend on
+        // embedding-worker readiness and cosine asymmetry (flaky under load).
+        // The floor is covered in ltm.test.ts; this test targets the durable-
+        // delta first-injection + system[2] absence + system[1] stability.
         scoreableIds = [contextID, largeContextID];
       }
 
@@ -587,23 +595,36 @@ describe("cache stability (e2e)", () => {
     const bodies = harness.upstreamBodies();
     expect(bodies.length).toBe(turns.length);
 
-    // Turn 2 establishes system[2]. Turn 3 forces an emergency LTM refresh after
-    // the knowledge entry changed. The update must be carried by a durable
-    // prompt delta in messages, while cached system blocks remain byte-identical.
+    // Turn 2 (bodies[1]) is the first turn context-bound LTM is selected. Under
+    // the new contract it rides a durable delta in `messages` — it is NEVER
+    // emitted as a system[2] block. So the frozen system blocks (host prompt +
+    // system[1] preferences) established by turn 2 stay byte-identical on every
+    // later turn, and the context entry's content must NOT appear in any system
+    // block on ANY turn (proving system[2] is simply absent).
     const steadySystem = systemBlocks(bodies[1]);
     expect(systemBlocks(bodies[2])).toEqual(steadySystem);
     expect(systemBlocks(bodies[3])).toEqual(steadySystem);
+    for (let i = 0; i < bodies.length; i++) {
+      const sys = systemBlocks(bodies[i]).join("\n");
+      expect(
+        sys,
+        `turn ${i + 1}: context-bound knowledge leaked into a system block — ` +
+          `it must ride the durable delta in messages, never system[2]`,
+      ).not.toContain("context-bound knowledge");
+      expect(sys).not.toContain("durable delta marker");
+    }
 
+    // The context-bound knowledge appears in the message tail (durable delta),
+    // carrying BOTH the initial first-injection block (seq 0) and the later
+    // material-change block (seq 1). The large changed entry overflows the delta
+    // render budget and is folded into the actionable recall-by-id index (never
+    // silently dropped) so the model can recall its full current content.
     const turn3Messages = serializedMessages(bodies[2]);
     const turn4Messages = serializedMessages(bodies[3]);
     expect(turn3Messages).toContain("Lore knowledge update");
     expect(turn3Messages).toContain(
       "Updated context-bound knowledge that must arrive as a durable prompt delta",
     );
-    // The large changed entry overflows the delta render budget. It is no longer
-    // dumped as a truncated half-entry ("Additional Changed Knowledge"); instead
-    // it is folded into the actionable recall-by-id index so it is referenced
-    // (not silently dropped) and the model can recall its full current content.
     expect(turn3Messages).not.toContain("Additional Changed Knowledge");
     expect(turn3Messages).not.toContain("Superseded");
     expect(turn3Messages).toContain("Other relevant knowledge");
@@ -614,6 +635,15 @@ describe("cache stability (e2e)", () => {
     );
     expect(turn4Messages).toContain(`[k:${largeContextID}]`);
 
+    // Delta-row accounting under the new (delta-primary) model:
+    //   - seq 0: FIRST injection of the freshly-selected set (turn 2) — this
+    //     block did NOT exist under the old contract (first injection used to go
+    //     to system[2] with no delta row).
+    //   - seq 1: the mid-session material change (turn 3, forced Layer-4 refresh
+    //     after ltm.update) → one more appended block.
+    //   - turn 4 re-runs the diff but the surfaced set already matches the DB
+    //     (both changes surfaced), so NO further block is appended.
+    // → exactly two immutable blocks.
     const rows = harness.queryDB<{
       seq: number;
       selector: string;
@@ -622,16 +652,24 @@ describe("cache stability (e2e)", () => {
       "SELECT seq, selector, content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
       [sessionID],
     );
-    expect(rows).toHaveLength(1);
-    expect(rows[0].seq).toBe(0);
-    const selector = JSON.parse(rows[0].selector) as {
+    expect(
+      rows.map((r) => r.seq),
+      `expected first-injection (seq 0) + one material change (seq 1), got ` +
+        `seqs=${rows.map((r) => r.seq).join(",")}`,
+    ).toEqual([0, 1]);
+    const selector0 = JSON.parse(rows[0].selector) as {
       target: string;
       insertAt: number;
     };
-    expect(selector.target).toBe("messages");
-    expect(Number.isInteger(selector.insertAt)).toBe(true);
-    expect(rows[0].content).toContain("Updated context-bound knowledge");
+    expect(selector0.target).toBe("messages");
+    expect(Number.isInteger(selector0.insertAt)).toBe(true);
+    // seq 0 = the initial set (first injection): the original content + the
+    // large entry's recall-by-id reference.
+    expect(rows[0].content).toContain("Initial context-bound knowledge");
     expect(rows[0].content).toContain(`[k:${largeContextID}]`);
+    // seq 1 = the material change: the updated content.
+    expect(rows[1].content).toContain("Updated context-bound knowledge");
+    expect(rows[1].content).toContain(`[k:${largeContextID}]`);
   });
 
   it("budget-overflow knowledge surfaces as a recall-by-id ToC in system[1] (A) and the delta (B) [#917]", async () => {
@@ -785,17 +823,24 @@ describe("cache stability (e2e)", () => {
     );
   });
 
-  it("ranking churn with NO DB change emits NO delta and keeps the prefix byte-stable (the cause=incremental bust)", async () => {
+  it("ranking churn with NO DB change appends NO extra delta beyond the first injection and keeps the prefix byte-stable (the cause=incremental bust)", async () => {
     // T1 regression for the production bust (session 1LYkXZ7jkiHHnqPl): the delta
     // fired on per-turn relevance-ranking churn (the forSession selection picks a
     // different subset each turn) even though NO knowledge changed in the DB,
     // rewriting a deep-prefix message every turn → ~250k tokens rewritten per
     // turn. We force the recompute path (overflow set + near-zero idle-resume so
     // forSession re-scores every turn) and VARY the query topic each turn so the
-    // selected subset churns — but never mutate the DB. The DB-sourced trigger
-    // must emit ZERO delta rows, and the cached system prefix must stay
-    // byte-identical. Under the old selection-based trigger, the churn wrote
-    // (and rewrote) a "Superseded" delta → this test fails (mutation-verified).
+    // selected subset churns — but never mutate the DB.
+    //
+    // New contract (delta-primary): the FIRST injection of context-bound LTM
+    // appends exactly ONE durable block (seq 0). After that, pure ranking churn
+    // (a different top-K subset each turn, but NO DB mutation) must append NO
+    // further blocks — the DB-sourced trigger (detectSurfacedMutations compares
+    // the advancing surfaced set against the live DB, not the per-turn
+    // selection) surfaces nothing to change. And the cached system prefix must
+    // stay byte-identical. Under the old selection-based trigger, the churn
+    // wrote (and rewrote) a "Superseded" delta EVERY turn → many rows → this
+    // test fails (mutation-verified).
     const topics = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"];
     const turns = Array.from({ length: 6 }, (_, i) => ({
       // Each turn foregrounds a DIFFERENT topic so forSession re-ranks which
@@ -823,8 +868,9 @@ describe("cache stability (e2e)", () => {
 
     const { ltm } = await import("@loreai/core");
     // Seed many entries spread across the topics, enough to overflow the
-    // system[2] budget so the SELECTED subset is a moving target as the query
-    // topic changes — reproducing the ranking churn without any DB mutation.
+    // context-bound render budget so the SELECTED subset is a moving target as
+    // the query topic changes — reproducing the ranking churn without any DB
+    // mutation.
     const SEED_PER_TOPIC = 6;
     for (const topic of topics) {
       for (let i = 0; i < SEED_PER_TOPIC; i++) {
@@ -869,21 +915,27 @@ describe("cache stability (e2e)", () => {
       // NB: intentionally NO ltm.update / ltm.remove anywhere — the DB is frozen.
     }
 
-    // The core guarantee: no genuine knowledge mutation → ZERO durable-delta
-    // rows, regardless of how the relevance selection churned across turns.
+    // The core guarantee: the FIRST injection appends exactly ONE block (seq 0);
+    // pure ranking churn (no genuine knowledge mutation) appends NOTHING further,
+    // regardless of how the relevance selection churned across the later turns.
     const deltaRows = harness.queryDB<{ seq: number; content: string }>(
       "SELECT seq, content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
       [sessionID],
     );
     expect(
-      deltaRows.length,
-      `expected ZERO delta rows on pure ranking churn (no DB change), got ` +
-        `${deltaRows.length} — the selection-based trigger rewrote a delta on ` +
-        `mere re-ranking, which is the cause=incremental bust`,
-    ).toBe(0);
+      deltaRows.map((r) => r.seq),
+      `expected exactly the first-injection block (seq 0) and NO churn-driven ` +
+        `rows, got seqs=${deltaRows.map((r) => r.seq).join(",")} — a >1 count ` +
+        `means the selection-based trigger rewrote a delta on mere re-ranking, ` +
+        `which is the cause=incremental bust`,
+    ).toEqual([0]);
+    // The single first-injection block carries genuine new knowledge, never a
+    // "Superseded — ignore these ids" churn list.
+    expect(deltaRows[0].content).not.toContain("Superseded");
 
     // And the cached system prefix must be byte-identical once established
-    // (turn 2+), proving the churn never rewrote system[2] either.
+    // (turn 2+), proving the churn never emitted a context-bound system[2] block
+    // either — context-bound LTM rides the delta only.
     const bodies = harness.upstreamBodies();
     const steady = systemBlocks(bodies[1]);
     for (let i = 2; i < bodies.length; i++) {
@@ -892,14 +944,15 @@ describe("cache stability (e2e)", () => {
   });
 
   it("successive knowledge changes APPEND immutable blocks at the tail (no in-place rewrite)", async () => {
-    // Append-only redesign: each genuine knowledge change appends a NEW
-    // immutable block at the CURRENT tail (seq = MAX+1) rather than rewriting
-    // one coalesced row in place at a frozen deep position. The cache-stability
-    // guarantee is no longer "exactly one row" but "every block, once written,
-    // is byte-immutable and tail-anchored" — so a write extends the cache
-    // frontier instead of invalidating the prefix from a deep index (the
-    // session-1LYkXZ7jkiHHnqPl `cause=incremental` bust). We assert: (a) one
-    // block per DISTINCT change, (b) monotonically increasing insertAt
+    // Append-only redesign: the FIRST injection appends an immutable block (seq
+    // 0), and each subsequent genuine knowledge change appends a NEW immutable
+    // block at the CURRENT tail (seq = MAX+1) rather than rewriting one coalesced
+    // row in place at a frozen deep position. The cache-stability guarantee is no
+    // longer "exactly one row" but "every block, once written, is byte-immutable
+    // and tail-anchored" — so a write extends the cache frontier instead of
+    // invalidating the prefix from a deep index (the session-1LYkXZ7jkiHHnqPl
+    // `cause=incremental` bust). We assert: (a) one block for the first injection
+    // plus one per DISTINCT change, (b) monotonically increasing insertAt
     // (tail-appended, never shifting the prefix), (c) earlier blocks are
     // byte-identical after later appends.
     const turns = Array.from({ length: 6 }, (_, i) => ({
@@ -953,7 +1006,7 @@ describe("cache stability (e2e)", () => {
           scope: "project",
           category: "gotcha",
           title: "Coalesce gotcha",
-          content: "Initial coalesce knowledge pinned in system[2].",
+          content: "Initial coalesce knowledge carried by the first delta.",
           session: sessionID,
         });
       }
@@ -986,15 +1039,16 @@ describe("cache stability (e2e)", () => {
       [sessionID],
     );
 
-    // One immutable block per distinct change (three edits → three blocks),
-    // appended (not coalesced) with monotonically increasing seqs.
+    // One immutable block for the first injection (seq 0) plus one per distinct
+    // change (three edits → seqs 1,2,3), appended (not coalesced) with
+    // monotonically increasing seqs.
     expect(
       rows.length,
-      `expected one appended block per distinct change, got seqs=${rows
+      `expected first-injection block + one per distinct change, got seqs=${rows
         .map((r) => r.seq)
         .join(",")}`,
-    ).toBe(3);
-    expect(rows.map((r) => r.seq)).toEqual([0, 1, 2]);
+    ).toBe(4);
+    expect(rows.map((r) => r.seq)).toEqual([0, 1, 2, 3]);
 
     // Tail-appended: insertAt is non-decreasing across blocks (each new block
     // sits at or after the previous — it never shifts the cached prefix).
@@ -1005,21 +1059,49 @@ describe("cache stability (e2e)", () => {
       expect(insertAts[i]).toBeGreaterThanOrEqual(insertAts[i - 1]);
     }
 
-    // Immutability: block 0's bytes are identical to the first time it appeared,
-    // even after blocks 1 and 2 were appended on later turns.
+    // Immutability: block 0's CONTENT and surfaced-mutation signature (`mut`)
+    // are identical to the first time it appeared, even after blocks 1, 2 and 3
+    // were appended on later turns. Its `insertAt` may legitimately re-anchor
+    // (safeDeltaInsertIndex persists the nudge when compression slides the array
+    // below it — the documented Bug-2 fix that keeps the block byte-POSITION-
+    // stable across layers); that re-anchor rewrites ONLY insertAt, never the
+    // mutation signature or the rendered content. So we compare `mut` + content
+    // (the real cache-safety invariant), not the whole selector.
     expect(block0First).not.toBeNull();
-    expect(rows[0].selector).toBe(block0First?.selector);
+    const block0FirstSel = JSON.parse(block0First?.selector ?? "{}") as {
+      target: string;
+      mut: unknown;
+    };
+    const block0NowSel = JSON.parse(rows[0].selector) as {
+      target: string;
+      mut: unknown;
+    };
+    expect(block0NowSel.target).toBe(block0FirstSel.target);
+    expect(block0NowSel.mut).toEqual(block0FirstSel.mut);
     expect(rows[0].content).toBe(block0First?.content);
+
+    // Context-bound knowledge never leaks into a system block — it rides the
+    // durable delta only. system[2] is retired.
+    const allBodies = harness.upstreamBodies();
+    for (let i = 0; i < allBodies.length; i++) {
+      expect(
+        systemBlocks(allBodies[i]).join("\n"),
+        `turn ${i + 1}: coalesce knowledge leaked into a system block`,
+      ).not.toContain("coalesce");
+    }
   });
 
-  it("genuine supersessions on different turns surface NO delta and keep system[2] byte-stable (incl. restart)", async () => {
+  it("genuine supersessions on different turns append NO removal delta beyond the first injection and never emit system[2] (incl. restart)", async () => {
     // Trim (quality + cost): a removals-only diff no longer injects a mid-session
     // "Superseded — ignore these ids" delta — that list was content the model
     // could not reliably act on, and its per-turn churn was the dominant
-    // cache-bust driver. Here two entries are genuinely removed on two different
-    // turns (with a restart between them) under forced layer 4: NO delta block is
-    // appended, and the frozen system[2] pin stays byte-identical the whole time
-    // (the stale entries are simply left pinned until the next session refresh).
+    // cache-bust driver. Under the new delta-primary contract the FIRST injection
+    // of the selected set appends ONE durable block (seq 0); here two entries are
+    // then genuinely removed on two different turns (with a restart between them)
+    // under forced layer 4: NO further delta block is appended (a removal on its
+    // own produces no message), and NO context-bound system[2] block is ever
+    // emitted (the stale entries are simply left in the frozen delta until the
+    // next session refresh).
     const turns = Array.from({ length: 7 }, (_, i) => ({
       userMessage: `Cumulative turn ${i}: continue.`,
       assistantText: `Cumulative response ${i}.`,
@@ -1064,16 +1146,17 @@ describe("cache stability (e2e)", () => {
         );
         sessionID = rows[0]?.session_id ?? "";
         expect(sessionID).not.toBe("");
-        // Create BOTH entries on turn 0 (before the pin freezes at turn 1), so
-        // the frozen system[2] baseline contains both. We count superseded
-        // BULLETS (not id prefixes) so same-ms UUIDv7 8-char-prefix collision is
-        // irrelevant.
+        // Create BOTH entries on turn 0 (before the first injection surfaces
+        // them on turn 1). The first-injection delta records them; the later
+        // removals must NOT append a "Superseded" delta.
         idA = ltm.create({
           projectPath,
           scope: "project",
           category: "gotcha",
           title: "Cumulative entry A",
-          content: "Entry A pinned in system[2] before removal. ".repeat(8),
+          content: "Entry A carried by the first delta before removal. ".repeat(
+            8,
+          ),
           session: sessionID,
         });
         idB = ltm.create({
@@ -1081,7 +1164,9 @@ describe("cache stability (e2e)", () => {
           scope: "project",
           category: "gotcha",
           title: "Cumulative entry B",
-          content: "Entry B pinned in system[2] before removal. ".repeat(8),
+          content: "Entry B carried by the first delta before removal. ".repeat(
+            8,
+          ),
           session: sessionID,
         });
       }
@@ -1098,31 +1183,41 @@ describe("cache stability (e2e)", () => {
       "SELECT seq, content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
       [sessionID],
     );
-    // Removals-only → NOTHING is appended. (A removal still advances the surfaced
-    // set when it rides a genuine content change, but on its own it never
-    // produces a delta block.)
+    // Exactly the first-injection block (seq 0) exists; the two removals append
+    // NOTHING (a removal advances the surfaced set when it rides a genuine
+    // content change, but on its own it never produces a delta block).
     expect(
-      rows.length,
-      `expected NO appended delta blocks for removals-only, got seqs=${rows
-        .map((r) => r.seq)
-        .join(",")}`,
-    ).toBe(0);
+      rows.map((r) => r.seq),
+      `expected only the first-injection block (seq 0) and NO removal deltas, ` +
+        `got seqs=${rows.map((r) => r.seq).join(",")}`,
+    ).toEqual([0]);
+    // No removal ever surfaces a "Superseded — ignore these ids" list.
+    for (const r of rows) {
+      expect(r.content).not.toContain("Superseded");
+    }
 
-    // The frozen system[2] pin must stay byte-identical across every turn after
-    // it froze — the genuine removals (and the restart between them) must never
-    // rewrite or recompute it.
+    // No context-bound system[2] block is ever emitted, and the remaining frozen
+    // system blocks (host prompt + system[1]) stay byte-identical across every
+    // turn after they froze — the genuine removals (and the restart between them)
+    // must never rewrite or recompute them.
     const bodies = harness.upstreamBodies();
     const steadySystem = systemBlocks(bodies[1]);
     for (let i = 2; i < bodies.length; i++) {
       expect(
         systemBlocks(bodies[i]),
         `system blocks changed on turn ${i + 1} after a genuine removal — the ` +
-          `frozen system[2] pin must never be rewritten by a removal`,
+          `frozen system prefix must never be rewritten by a removal`,
       ).toEqual(steadySystem);
+    }
+    for (let i = 0; i < bodies.length; i++) {
+      expect(
+        systemBlocks(bodies[i]).join("\n"),
+        `turn ${i + 1}: context-bound knowledge leaked into a system block`,
+      ).not.toContain("carried by the first delta");
     }
   });
 
-  it("removed LTM entries surface NO mid-session delta and keep system[2] byte-stable", async () => {
+  it("removed LTM entries append NO removal delta beyond the first injection and never emit system[2]", async () => {
     const turns = Array.from({ length: 4 }, (_, i) => ({
       userMessage: `Removal delta turn ${i}: continue the work.`,
       assistantText: `Removal delta response ${i}.`,
@@ -1170,7 +1265,7 @@ describe("cache stability (e2e)", () => {
           category: "gotcha",
           title: "Removed durable delta gotcha",
           content:
-            "Context-bound knowledge that will be removed without rewriting system[2].",
+            "Context-bound knowledge that will be removed after riding the first delta.",
           session: sessionID,
         });
       }
@@ -1182,15 +1277,25 @@ describe("cache stability (e2e)", () => {
 
     const bodies = harness.upstreamBodies();
     expect(bodies.length).toBe(turns.length);
+    // No context-bound system[2] block is ever emitted; the remaining frozen
+    // system blocks (host prompt + system[1]) are byte-identical from turn 2 on,
+    // and the context entry's content never appears in a system block.
     const steadySystem = systemBlocks(bodies[1]);
     expect(systemBlocks(bodies[2])).toEqual(steadySystem);
     expect(systemBlocks(bodies[3])).toEqual(steadySystem);
+    for (let i = 0; i < bodies.length; i++) {
+      expect(
+        systemBlocks(bodies[i]).join("\n"),
+        `turn ${i + 1}: context-bound knowledge leaked into a system block`,
+      ).not.toContain("Context-bound knowledge that will be removed");
+    }
 
     const turn3Messages = serializedMessages(bodies[2]);
     const turn4Messages = serializedMessages(bodies[3]);
-    // Removals-only no longer surface a mid-session message: the deleted entry
-    // is left pinned (stale) in the frozen system[2] until the next session
-    // refresh, and no "Superseded" delta is injected to bust the cache.
+    // The removal itself surfaces NO mid-session message: no "Superseded — ignore
+    // these ids" delta is ever injected to bust the cache. The only delta present
+    // is the first-injection block (the entry's original content), left as stale
+    // context in the frozen delta until the next session refresh.
     expect(turn3Messages).not.toContain("Superseded");
     expect(turn4Messages).not.toContain("Superseded");
 
@@ -1198,7 +1303,12 @@ describe("cache stability (e2e)", () => {
       "SELECT content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
       [sessionID],
     );
-    expect(rows).toHaveLength(0);
+    // Exactly one block: the first injection (seq 0). The removal appends nothing.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).not.toContain("Superseded");
+    expect(rows[0].content).toContain(
+      "Context-bound knowledge that will be removed",
+    );
   });
 
   it("frozen system[1] survives a mid-session preference DELETE across a restart (ses_14b9bf3d… incident)", async () => {
@@ -1371,7 +1481,7 @@ describe("cache stability (e2e)", () => {
     expect(bodies[2]).not.toContain("Mid-session minted preference");
   });
 
-  it("normal LTM refresh preserves system[2] and surfaces NO removal delta", async () => {
+  it("normal LTM refresh appends NO removal delta beyond the first injection and never emits system[2]", async () => {
     const turns = Array.from({ length: 4 }, (_, i) => ({
       userMessage: `Normal removal delta turn ${i}: continue the work.`,
       assistantText: `Normal removal delta response ${i}.`,
@@ -1418,7 +1528,7 @@ describe("cache stability (e2e)", () => {
           category: "gotcha",
           title: "Normal removed durable delta gotcha",
           content:
-            "Context-bound knowledge removed during normal refresh must not rewrite system[2].",
+            "Context-bound knowledge removed during normal refresh rides the first delta only.",
           session: sessionID,
         });
       }
@@ -1431,12 +1541,21 @@ describe("cache stability (e2e)", () => {
 
     const bodies = harness.upstreamBodies();
     expect(bodies.length).toBe(turns.length);
+    // No context-bound system[2] block is ever emitted; the remaining frozen
+    // system blocks are byte-identical from turn 2 on, and the context entry's
+    // content never appears in a system block.
     const steadySystem = systemBlocks(bodies[1]);
     expect(systemBlocks(bodies[2])).toEqual(steadySystem);
     expect(systemBlocks(bodies[3])).toEqual(steadySystem);
+    for (let i = 0; i < bodies.length; i++) {
+      expect(
+        systemBlocks(bodies[i]).join("\n"),
+        `turn ${i + 1}: context-bound knowledge leaked into a system block`,
+      ).not.toContain("Context-bound knowledge removed during normal refresh");
+    }
 
     const turn3Messages = serializedMessages(bodies[2]);
-    // A removal during a normal (non-emergency) refresh must keep system[2]
+    // A removal during a normal (non-emergency) refresh keeps the system prefix
     // byte-stable (asserted above) and must NOT inject a "Superseded" delta —
     // removals-only no longer surface mid-session.
     expect(turn3Messages).not.toContain("Superseded");
@@ -1444,7 +1563,12 @@ describe("cache stability (e2e)", () => {
       "SELECT content FROM session_prompt_deltas WHERE session_id = ? ORDER BY seq",
       [sessionID],
     );
-    expect(rows).toHaveLength(0);
+    // Exactly one block: the first injection (seq 0). The removal appends nothing.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).not.toContain("Superseded");
+    expect(rows[0].content).toContain(
+      "Context-bound knowledge removed during normal refresh",
+    );
   });
 
   it("cached system blocks stay byte-stable across gradient compression layers", async () => {

--- a/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
+++ b/packages/gateway/test/prompt-delta-mutation-trigger.test.ts
@@ -182,6 +182,70 @@ describe("detectSurfacedMutations — genuine DB mutation, not ranking churn", (
     expect(result.changed).toEqual([]);
   });
 
+  it("SYNTHETIC context-source (d:/t:) surfaces from the entries map on first surface (#961 fact-loss guard)", () => {
+    // Distillation/temporal context-source facts (category `recalled`, ids
+    // `d:<id>`/`t:<id>`) do NOT live in the `knowledge` table, so they can never
+    // resolve via ltm.get/getByLogical. Since system[2] was retired, the delta
+    // is their ONLY carrier — but detectSurfacedMutations re-derives content from
+    // the DB. Without the synthetic-entries resolver they'd be silently dropped
+    // (the default `contextSources:["distillation"]` regression). The resolver
+    // must surface them on their first-surface turn (sentinel/empty hash) so they
+    // reach the wire.
+    const synthId = "d:00000000-0000-0000-0000-0000000000aa";
+    const title = "Order defaults";
+    const content = "channel=WHOLESALE, region=EMEA, warehouse=WH-07";
+    const syntheticEntries = new Map([
+      [synthId, { category: ltm.RECALLED_CONTEXT_CATEGORY, title, content }],
+    ]);
+    // First surface: baseline seeds an EMPTY-hash sentinel (`<id>:`) so the
+    // synthetic's real hash differs → it must be reported as changed.
+    const surfaced = [`${synthId}:`];
+
+    const withResolver = detectSurfacedMutations(surfaced, syntheticEntries);
+    expect(withResolver.changed).toHaveLength(1);
+    expect(withResolver.changed[0].id).toBe(synthId);
+    expect(withResolver.changed[0].content).toBe(content);
+    expect(withResolver.changed[0].category).toBe(
+      ltm.RECALLED_CONTEXT_CATEGORY,
+    );
+    expect(withResolver.removedIds).toEqual([]);
+
+    // Mutation guard: WITHOUT the resolver (the pre-fix behavior), the synthetic
+    // resolves to nothing in the knowledge DB, is not tombstoned, and is silently
+    // dropped — neither changed nor removed. This is exactly the fact-loss bug.
+    const withoutResolver = detectSurfacedMutations(surfaced);
+    expect(withoutResolver.changed).toEqual([]);
+    expect(withoutResolver.removedIds).toEqual([]);
+  });
+
+  it("SYNTHETIC context-source does NOT re-fire once its real hash is surfaced (immutable snapshot)", () => {
+    // A synthetic's content is immutable for a given id, so after its first
+    // surface the surfaced key carries the real hash. On a later turn — even if
+    // the entry has dropped out of the selection and is absent from the map —
+    // the hash matches, so it must produce NO delta (no churn, no re-fire).
+    const synthId = "t:11111111-1111-1111-1111-1111111111bb";
+    const title = "Temporal aside";
+    const content = "the API base is https://api.internal.example";
+    const realHash = surfaceSignature(title, content);
+    const surfaced = [`${synthId}:${realHash}`];
+
+    // Even with the entry still present in the map, matching hash → no change.
+    const stillPresent = detectSurfacedMutations(
+      surfaced,
+      new Map([
+        [synthId, { category: ltm.RECALLED_CONTEXT_CATEGORY, title, content }],
+      ]),
+    );
+    expect(stillPresent.changed).toEqual([]);
+    expect(stillPresent.removedIds).toEqual([]);
+
+    // Absent from the map (dropped from this turn's selection) → still no change
+    // and — critically — NOT a false removal (it isn't a tombstoned knowledge id).
+    const absent = detectSurfacedMutations(surfaced);
+    expect(absent.changed).toEqual([]);
+    expect(absent.removedIds).toEqual([]);
+  });
+
   it("empty / undefined surfaced set → empty result", () => {
     expect(detectSurfacedMutations([])).toEqual({
       changed: [],
@@ -342,6 +406,36 @@ describe("detectSurfacedMutations — genuine DB mutation, not ranking churn", (
 
     expect(wrote).toBe(true);
     expect(deltaText(sessionID)).toContain("After — materially changed body.");
+  });
+
+  it("WIRING: synthetic context-source (distillation) reaches the wire via the delta on first injection (#961)", () => {
+    // The default `contextSources:["distillation"]` folds distillation/temporal
+    // facts into forSession as synthetic entries (category `recalled`, id
+    // `d:<id>`). With system[2] retired, the durable delta is their only carrier.
+    // First injection seeds a full-surface baseline (empty-hash sentinels); the
+    // synthetic content must be sourced from `entries` (it isn't in the knowledge
+    // DB) and rendered into the persisted delta. Pre-fix, appendKnowledgePromptDelta
+    // dropped it and returned false (no row) — this test guards that regression.
+    const synthId = "d:22222222-2222-2222-2222-2222222222cc";
+    const title = "Order defaults";
+    const content =
+      "channel=WHOLESALE, region=EMEA, warehouse=WH-07, status=SUBMITTED";
+    const sessionID = `wiring-synthetic-${Date.now()}`;
+
+    const wrote = appendKnowledgePromptDelta({
+      sessionID,
+      projectPath: PROJECT,
+      insertAt: 5,
+      // full-surface baseline: empty-hash sentinel per id (first injection)
+      previousKeys: [`${synthId}:`],
+      nextKeys: [keyOf(synthId, title, content)],
+      entries: [{ id: synthId, category: "recalled", title, content }],
+    });
+
+    expect(wrote).toBe(true);
+    const text = deltaText(sessionID);
+    expect(text).toContain(content);
+    expect(text).toContain("WHOLESALE");
   });
 
   it("key format matches ltmEntryKeys (the surfaced baseline producer)", () => {


### PR DESCRIPTION
## Problem

Finalizing the #961 Sonnet-5 benchmark numbers surfaced that Lore is *more expensive* than vanilla cross-session (~\$6.2/run vs ~\$3.9/run). Root-caused to prompt-cache **writes**, not token volume: `cache_bust_stats` showed a `prefix-rewrite` bucket firing **exactly once per session** (~90–174K write tokens each).

The cause: context-bound LTM (knowledge + distillation/temporal context-sources) was seeded into a **system[2] block** on its *first* injection, and only mid-session *changes* rode the durable prompt-delta path. Because system[2] sits inside the cached system prefix, that first-population write cost a full prefix re-creation the first turn context LTM appeared — **amplified on the OpenAI/OpenRouter path**, where the whole system string shares a single `cache_control` breakpoint, so the bust invalidated system[0]+[1] (host + frozen preferences) too.

## Fix

Route the **first injection** through the SAME durable prompt-delta path that already carries mid-session changes: append a `[user,assistant]` pair at a frozen conversation-tail position (byte-stable, replayed verbatim, re-anchored on compression). `system[2]` (`ltmText`) is never emitted (always `undefined`); the pin/cache bookkeeping survives purely as the delta's diff baseline.

- New `fullSurfaceBaseline(ids)` seeds the first-injection delta baseline with empty-hash sentinels (`"<id>:"`) so `detectSurfacedMutations` surfaces the full set once; the appended block records the true hashes and the surfaced set advances normally (no per-turn re-fire). This mirrors the existing `MAX_DELTA_BLOCKS` coalesce path (full re-capture from a stale-hash baseline).
- Applied to both the step-6 main path and the step-7b Layer-4 emergency-refresh path.

**Unchanged:** `ltm.forSession` selection, `hasMaterialLtmDelta` gating, `advanceSurfacedKeys`/`mut` surfaced-set tracking, `safeDeltaInsertIndex`, `reanchorDeltaOnCompression`, overflow ToC. This is purely a *position* change (system block → stable tail-appended message after the first turn).

## Tests

Rewrote 6 `cache-stability.e2e.test.ts` tests to the new delta-primary contract. New load-bearing invariant: **context-bound knowledge never appears in any `system` block; it rides the durable delta; system[1] stays byte-stable.** Non-vacuity verified — reintroducing `ltmText = cached.formatted` on the first-injection branch turns the test red. All 124 cache/LTM/delta tests pass on latest main; gateway + core typecheck clean.

## Follow-up

Full eval re-run + "The compaction tax" post revision will follow once this lands (tracked separately on the eval branch).