### PR TITLE
fix(run): adopt the user's existing upstream env instead of clobbering it

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -31,6 +31,98 @@ export interface AgentDef {
    * rather than environment variables — we inject `-c key=value` overrides.
    */
   cliArgs?: (gatewayUrl: string, cwd: string) => string[];
+  /**
+   * Base-URL env var(s) this agent honors to pick an upstream, in priority
+   * order (first defined wins). `lore run` rewrites these to point the agent
+   * at the gateway — but if the USER already set one (e.g. pointing Claude
+   * Code at OpenRouter or a corporate proxy), that is their intended upstream.
+   * We capture it BEFORE clobbering and tell the gateway to proxy there, so
+   * Lore adopts the user's existing config instead of silently overriding it
+   * with the hardcoded api.anthropic.com / api.openai.com default.
+   *
+   * The captured value's wire protocol is the agent's `wireProtocol` (below):
+   * an Anthropic-shape client (Claude Code) pointed at OpenRouter is adopted
+   * as an anthropic-ingress request whose upstream host is openrouter.ai; the
+   * gateway's `providerFromUpstreamUrl` reverse-map then flips protocol/scheme
+   * for known hosts. Omit for agents whose base URL cannot be adopted this way
+   * (e.g. opencode, which routes via the plugin, not a base-URL env var).
+   */
+  upstreamEnvVars?: string[];
+  /**
+   * The wire protocol the agent speaks to its upstream — used to pick which
+   * gateway `LORE_UPSTREAM_<protocol>` default to override when adopting the
+   * user's captured upstream (see `upstreamEnvVars`).
+   */
+  wireProtocol?: "anthropic" | "openai" | "gemini";
+}
+
+/**
+ * Whether a hostname is a loopback address. Under `lore run` the local gateway
+ * always binds loopback, so ANY loopback host in the user's base-URL env is
+ * either the gateway itself or a stale gateway from a previous run — never a
+ * real upstream to adopt. Rejecting all loopback hosts (not just the exact
+ * origin) keeps re-launches idempotent even when the gateway restarts on a
+ * different port (port contention). A genuine upstream (OpenRouter, a corporate
+ * proxy) is never loopback.
+ */
+function isLoopbackHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+  if (h === "localhost" || h === "::1" || h === "0.0.0.0" || h === "::")
+    return true;
+  // 127.0.0.0/8
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h);
+}
+
+/**
+ * The upstream the USER already configured for an agent via its base-URL env
+ * var, captured from the parent environment before `lore run` overrides it.
+ *
+ * Returns the first defined `upstreamEnvVars` value that points somewhere
+ * OTHER than a loopback host, so we never "adopt" the gateway pointing at
+ * itself and re-launches through `lore run` stay idempotent even if the
+ * gateway restarts on a different port. Returns undefined when the agent has
+ * no adoptable base-URL var, none is set, or the only value is loopback.
+ */
+export function captureUserUpstream(
+  agent: AgentDef,
+  gatewayUrl: string,
+  env: NodeJS.ProcessEnv = process.env,
+): { url: string; wireProtocol: NonNullable<AgentDef["wireProtocol"]> } | null {
+  if (!agent.upstreamEnvVars || !agent.wireProtocol) return null;
+  for (const key of agent.upstreamEnvVars) {
+    const raw = env[key];
+    if (!raw) continue;
+    // Strip control chars (CR/LF/etc.) up front — a newline in a base-URL env
+    // var would otherwise ride through into an injected header (CRLF header
+    // smuggling). `new URL()` tolerates an embedded newline, so we cannot rely
+    // on parse-failure to reject it. appendCustomHeader also sanitizes, but we
+    // normalize at the source so every consumer sees a clean value.
+    // oxlint-disable-next-line no-control-regex -- intentional control-character sanitization
+    const trimmed = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+    if (!trimmed) continue;
+    // A real base URL has no internal whitespace. Reject anything with an
+    // interior space/tab — after control-char stripping, a CRLF-smuggling
+    // payload like "https://host/\nX-Api-Key: stolen" collapses to a value
+    // with an interior space, which must not be adopted.
+    if (/\s/.test(trimmed)) continue;
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      continue;
+    }
+    // Only adopt a real http(s) URL that isn't the gateway itself.
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") continue;
+    // Reject ANY loopback host, not just the exact gateway origin: the gateway
+    // may restart on a different port (contention), so a stale
+    // ANTHROPIC_BASE_URL=http://127.0.0.1:<old-port> must not be adopted (would
+    // proxy the gateway back into itself). gatewayUrl is unused here now but
+    // kept in the signature for callers/tests and future host-aware checks.
+    void gatewayUrl;
+    if (isLoopbackHost(parsed.hostname)) continue;
+    return { url: trimmed, wireProtocol: agent.wireProtocol };
+  }
+  return null;
 }
 
 /**
@@ -58,15 +150,25 @@ function tomlQuote(value: string): string {
 /**
  * Append a header to ANTHROPIC_CUSTOM_HEADERS (curl-style format:
  * "Name: Value" newline-separated).
+ *
+ * Both `name` and `value` are stripped of control characters (CR/LF/etc.)
+ * before embedding. This is the single sink for every custom header; a raw
+ * newline in `value` would otherwise smuggle a second header into the
+ * newline-delimited format (CRLF header injection) — e.g. an adopted
+ * upstream URL derived from a user-controlled env var. `new URL()` tolerates
+ * an embedded newline, so sanitizing here (in addition to normalizing at the
+ * caller) is defense-in-depth, matching `safeRemote`/`tomlQuote`.
  */
-function appendCustomHeader(
+export function appendCustomHeader(
   env: Record<string, string>,
   envKey: string,
   name: string,
   value: string,
 ): void {
+  // oxlint-disable-next-line no-control-regex -- intentional control-character sanitization
+  const clean = (s: string) => s.replace(/[\x00-\x1f\x7f]/g, "");
   const existing = env[envKey] ?? process.env[envKey] ?? "";
-  const header = `${name}: ${value}`;
+  const header = `${clean(name)}: ${clean(value)}`;
   env[envKey] = existing ? `${existing}\n${header}` : header;
 }
 
@@ -100,6 +202,8 @@ export const AGENTS: AgentDef[] = [
     displayName: "Claude Code",
     binary: "claude",
     detect: () => whichSync("claude"),
+    upstreamEnvVars: ["ANTHROPIC_BASE_URL"],
+    wireProtocol: "anthropic",
     envVars: (url, cwd) => {
       const env: Record<string, string> = {
         ANTHROPIC_BASE_URL: url,
@@ -145,6 +249,8 @@ export const AGENTS: AgentDef[] = [
     displayName: "Codex",
     binary: "codex",
     detect: () => whichSync("codex"),
+    upstreamEnvVars: ["OPENAI_BASE_URL"],
+    wireProtocol: "openai",
     envVars: (_url, cwd) => {
       // Codex CLI is a Rust binary that does NOT read OPENAI_BASE_URL from the
       // environment. Provider routing is done exclusively via config.toml or
@@ -215,6 +321,8 @@ export const AGENTS: AgentDef[] = [
     displayName: "Pi",
     binary: "pi",
     detect: () => whichSync("pi"),
+    upstreamEnvVars: ["ANTHROPIC_BASE_URL"],
+    wireProtocol: "anthropic",
     envVars: (url, _cwd) => ({
       ANTHROPIC_BASE_URL: url,
       LORE_GATEWAY_URL: url,
@@ -236,6 +344,8 @@ export const AGENTS: AgentDef[] = [
     displayName: "Hermes Agent",
     binary: "hermes",
     detect: () => whichSync("hermes"),
+    upstreamEnvVars: ["OPENAI_BASE_URL"],
+    wireProtocol: "openai",
     envVars: (url, cwd) => {
       const env: Record<string, string> = {
         // Route Hermes through the gateway. Both keys are undocumented in the
@@ -268,6 +378,8 @@ export const AGENTS: AgentDef[] = [
     displayName: "GitHub Copilot CLI",
     binary: "copilot",
     detect: () => whichSync("copilot"),
+    upstreamEnvVars: ["COPILOT_API_URL"],
+    wireProtocol: "openai",
     envVars: (url, cwd) => {
       // GitHub Copilot CLI talks to the Copilot API (normally
       // api.githubcopilot.com) in OpenAI wire format, performing its own GitHub→
@@ -298,6 +410,8 @@ export const AGENTS: AgentDef[] = [
     displayName: "Gemini CLI",
     binary: "gemini",
     detect: () => whichSync("gemini"),
+    upstreamEnvVars: ["GOOGLE_GEMINI_BASE_URL"],
+    wireProtocol: "gemini",
     envVars: (url, cwd) => {
       // Google's Gemini CLI (GEMINI_API_KEY mode) reads GOOGLE_GEMINI_BASE_URL
       // as the base origin for the native Generative Language API — it appends

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -10,7 +10,15 @@ import { createInterface } from "node:readline";
 import { startGateway, probeGateway, type StartOptions } from "./start";
 import { bracketHost } from "../server";
 import { loadConfig } from "../config";
-import { detectAgents, AGENTS, type DetectedAgent } from "./agents";
+import {
+  detectAgents,
+  AGENTS,
+  appendCustomHeader,
+  captureUserUpstream,
+  type AgentDef,
+  type DetectedAgent,
+} from "./agents";
+import { providerForUpstreamOrigin } from "../config";
 import { safeExit } from "./exit";
 import {
   installSignalShutdown,
@@ -19,7 +27,7 @@ import {
   signalExitCode,
 } from "./shutdown";
 import { maybeAutoImport } from "./import-auto";
-import { discoverWorkspaceRoot } from "@loreai/core";
+import { discoverWorkspaceRoot, log } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // Interactive agent picker (TTY only)
@@ -62,11 +70,202 @@ interface LaunchTarget {
   env: Record<string, string>;
 }
 
-async function resolveLaunchTarget(
+/**
+ * A user-configured upstream adopted from the parent environment, plus the
+ * gateway `LORE_UPSTREAM_<protocol>` var it maps to and the provider id (if the
+ * host is a known one). See `applyUpstreamAdoption`.
+ */
+export interface AdoptedUpstream {
+  url: string;
+  /** Gateway env var to set so the in-process gateway defaults there. */
+  gatewayEnvKey: string;
+  /** Provider id if the host matches a known provider route, else undefined. */
+  providerID: string | undefined;
+  agentDisplayName: string;
+}
+
+/**
+ * Map an agent's wire protocol to the gateway env var that overrides the
+ * default upstream for that protocol. Gemini has no such default knob
+ * (the native endpoint is fixed), so it relies purely on the injected header.
+ */
+function gatewayUpstreamEnvKey(
+  wireProtocol: NonNullable<AgentDef["wireProtocol"]>,
+): string | undefined {
+  switch (wireProtocol) {
+    case "anthropic":
+      return "LORE_UPSTREAM_ANTHROPIC";
+    case "openai":
+      return "LORE_UPSTREAM_OPENAI";
+    case "gemini":
+      return undefined;
+  }
+}
+
+/**
+ * Adopt the user's pre-existing upstream for `agent` (captured from the parent
+ * env) so the gateway proxies THERE instead of the hardcoded default. Called
+ * BEFORE `startGateway`/`loadConfig` so the gateway picks up the override.
+ *
+ * Two mechanisms, applied together:
+ *  1. Set the gateway's own `LORE_UPSTREAM_<protocol>` process env — the
+ *     in-process gateway reads this at `loadConfig()`, so EVERY agent (even
+ *     header-less ones like Gemini/Copilot) gets routed to the user's host.
+ *  2. Return an `AdoptedUpstream` so the per-agent launch env can ALSO inject
+ *     `X-Lore-Upstream-URL` (+ `X-Lore-Provider` for known hosts) — this is
+ *     what flips the wire protocol/auth-scheme for a known provider that
+ *     differs from the ingress shape (e.g. Claude Code → OpenRouter, which is
+ *     an OpenAI-protocol provider reached via an Anthropic-shape client).
+ *
+ * Returns null when the user hasn't overridden the agent's base URL.
+ */
+export function applyUpstreamAdoption(
+  agent: AgentDef,
+  gatewayUrl: string,
+): AdoptedUpstream | null {
+  const captured = captureUserUpstream(agent, gatewayUrl);
+  if (!captured) return null;
+  const gatewayEnvKey = gatewayUpstreamEnvKey(captured.wireProtocol);
+  const providerID = providerForUpstreamOrigin(captured.url);
+  // Set the gateway default upstream for this protocol, UNLESS the user has
+  // explicitly set it already (their explicit LORE_UPSTREAM_* wins).
+  if (gatewayEnvKey && !process.env[gatewayEnvKey]) {
+    process.env[gatewayEnvKey] = captured.url;
+  }
+  // If the host maps to a known provider, also seed LORE_UPSTREAM_<PROVIDER>
+  // so the injected X-Lore-Provider header resolves to the right URL even
+  // when the provider route's static url is null (aggregators/self-hosted).
+  if (providerID) {
+    const provEnvKey = `LORE_UPSTREAM_${providerID.toUpperCase().replace(/-/g, "_")}`;
+    if (!process.env[provEnvKey]) process.env[provEnvKey] = captured.url;
+  }
+  return {
+    url: captured.url,
+    gatewayEnvKey: gatewayEnvKey ?? "",
+    providerID,
+    agentDisplayName: agent.displayName,
+  };
+}
+
+/**
+ * Remote-mode adoption: the remote gateway owns its own config, so we do NOT
+ * set any local `LORE_UPSTREAM_*` env. We only compute the `AdoptedUpstream`
+ * so the launch env can inject `X-Lore-Upstream-URL`/`X-Lore-Provider`, which
+ * the remote gateway honors per request. Returns null when nothing to adopt.
+ */
+export function adoptForRemote(
+  agent: AgentDef,
+  gatewayUrl: string,
+): AdoptedUpstream | null {
+  const captured = captureUserUpstream(agent, gatewayUrl);
+  if (!captured) return null;
+  return {
+    url: captured.url,
+    gatewayEnvKey: "",
+    providerID: providerForUpstreamOrigin(captured.url),
+    agentDisplayName: agent.displayName,
+  };
+}
+
+/**
+ * Inject the adopted-upstream routing headers into an agent's launch env, for
+ * agents that forward `ANTHROPIC_CUSTOM_HEADERS` to the gateway (Claude Code /
+ * Pi). Sets `X-Lore-Upstream-URL` and, for a known host, `X-Lore-Provider`.
+ *
+ * Agents without a header-forwarding mechanism (Codex/Hermes/Copilot/Gemini)
+ * still get routed via the `LORE_UPSTREAM_<protocol>` gateway env set in
+ * `applyUpstreamAdoption`; the header is a no-op for them.
+ */
+export function injectAdoptionHeaders(
+  agent: AgentDef,
+  env: Record<string, string>,
+  adopted: AdoptedUpstream,
+): void {
+  // Only Anthropic-shape agents carry ANTHROPIC_CUSTOM_HEADERS to the gateway.
+  if (agent.wireProtocol !== "anthropic") return;
+  appendCustomHeader(
+    env,
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "X-Lore-Upstream-URL",
+    adopted.url,
+  );
+  if (adopted.providerID) {
+    appendCustomHeader(
+      env,
+      "ANTHROPIC_CUSTOM_HEADERS",
+      "X-Lore-Provider",
+      adopted.providerID,
+    );
+  }
+}
+
+/**
+ * The agent that `lore run` will actually launch, resolved BEFORE the gateway
+ * starts so we can adopt the user's upstream (which requires setting gateway
+ * env before `loadConfig`). `command` is the binary/command to exec; `def` is
+ * the matching registry entry (null for an explicit command with no known
+ * agent — e.g. `lore run some-other-tool`).
+ */
+export interface AgentSelection {
+  command: string;
+  def: AgentDef | null;
+}
+
+/**
+ * Resolve which agent will run, without needing the gateway URL. For an
+ * explicit command, matches the binary to a known agent. For auto-detect,
+ * uses the sole agent or prompts (TTY). Returns null when nothing runnable.
+ *
+ * Runs before `startGateway` so upstream adoption can set gateway env in time.
+ */
+export async function resolveAgentSelection(
+  cmdArgs: string[],
+): Promise<AgentSelection | null> {
+  if (cmdArgs.length > 0) {
+    const def = AGENTS.find((a) => a.binary === cmdArgs[0]) ?? null;
+    return { command: cmdArgs[0], def };
+  }
+
+  const detected = detectAgents();
+  if (detected.length === 0) {
+    console.error("[lore] No known AI agents found on PATH.");
+    console.error(
+      "[lore] Install one of: Claude Code (claude), Codex (codex), Pi (pi), OpenCode (opencode), Hermes (hermes), GitHub Copilot CLI (copilot), Gemini CLI (gemini)",
+    );
+    console.error(`[lore] Or run with an explicit command: lore run <command>`);
+    console.error(
+      `[lore] Using a GUI/IDE agent (Claude Desktop, an IDE extension)? Run`,
+    );
+    console.error(
+      `[lore]   \`lore setup <app>\` and keep a gateway up with \`lore start --bg\`.`,
+    );
+    return null;
+  }
+
+  let agent: DetectedAgent;
+  if (detected.length === 1) {
+    agent = detected[0];
+    console.log(`[lore] Detected ${agent.def.displayName} at ${agent.path}`);
+  } else if (process.stdin.isTTY) {
+    agent = await promptAgent(detected);
+  } else {
+    console.error("[lore] Multiple agents detected but stdin is not a TTY.");
+    console.error("[lore] Specify which agent to run: lore run <command>");
+    for (const a of detected) {
+      console.error(`  - ${a.def.displayName}: lore run ${a.def.binary}`);
+    }
+    return null;
+  }
+  return { command: agent.def.binary, def: agent.def };
+}
+
+export function resolveLaunchTarget(
+  selection: AgentSelection,
   gatewayUrl: string,
   cmdArgs: string[],
   extraArgs: string[],
-): Promise<LaunchTarget | null> {
+  adopted: AdoptedUpstream | null,
+): LaunchTarget {
   // Resolve workspace root once — walks up from cwd looking for monorepo
   // markers (.lore.json with workspaces, .git, pnpm-workspace.yaml, etc.)
   const projectDir = discoverWorkspaceRoot(process.cwd());
@@ -88,6 +287,9 @@ async function resolveLaunchTarget(
         prependArgs.push(...agent.cliArgs(gatewayUrl, projectDir));
       }
     }
+    if (selection.def && adopted) {
+      injectAdoptionHeaders(selection.def, env, adopted);
+    }
     return {
       command: cmdArgs[0],
       args: [...prependArgs, ...cmdArgs.slice(1), ...extraArgs],
@@ -95,46 +297,25 @@ async function resolveLaunchTarget(
     };
   }
 
-  // --- No command: auto-detect agents ---
-  const detected = detectAgents();
-
-  if (detected.length === 0) {
-    console.error("[lore] No known AI agents found on PATH.");
-    console.error(
-      "[lore] Install one of: Claude Code (claude), Codex (codex), Pi (pi), OpenCode (opencode), Hermes (hermes), GitHub Copilot CLI (copilot), Gemini CLI (gemini)",
-    );
-    console.error(`[lore] Or run with an explicit command: lore run <command>`);
-    console.error(
-      `[lore] Using a GUI/IDE agent (Claude Desktop, an IDE extension)? Run`,
-    );
-    console.error(
-      `[lore]   \`lore setup <app>\` and keep a gateway up with \`lore start --bg\`.`,
-    );
-    return null;
+  // --- Auto-detected agent: selection.def is guaranteed non-null here
+  //     (the explicit-command branch above handles the def===null case). ---
+  const def = selection.def;
+  if (!def) {
+    // Unreachable in practice, but keep the type sound without an assertion:
+    // an explicit command with no matching agent takes the branch above.
+    return {
+      command: selection.command,
+      args: [...extraArgs],
+      env: {},
+    };
   }
-
-  let agent: DetectedAgent;
-
-  if (detected.length === 1) {
-    agent = detected[0];
-    console.log(`[lore] Detected ${agent.def.displayName} at ${agent.path}`);
-  } else if (process.stdin.isTTY) {
-    agent = await promptAgent(detected);
-  } else {
-    // Non-TTY with multiple agents — can't prompt
-    console.error("[lore] Multiple agents detected but stdin is not a TTY.");
-    console.error("[lore] Specify which agent to run: lore run <command>");
-    for (const a of detected) {
-      console.error(`  - ${a.def.displayName}: lore run ${a.def.binary}`);
-    }
-    return null;
-  }
-
-  const agentCliArgs = agent.def.cliArgs?.(gatewayUrl, projectDir) ?? [];
+  const agentCliArgs = def.cliArgs?.(gatewayUrl, projectDir) ?? [];
+  const env = def.envVars(gatewayUrl, projectDir);
+  if (adopted) injectAdoptionHeaders(def, env, adopted);
   return {
-    command: agent.def.binary,
+    command: def.binary,
     args: [...agentCliArgs, ...extraArgs],
-    env: agent.def.envVars(gatewayUrl, projectDir),
+    env,
   };
 }
 
@@ -162,11 +343,42 @@ export async function commandRun(
   cmdArgs: string[],
   extraArgs: string[] = [],
 ): Promise<void> {
-  // 1. Start gateway (or delegate to a remote one)
+  // 1. Resolve which agent will run BEFORE starting the gateway, so we can
+  //    adopt the user's pre-existing upstream (which requires setting gateway
+  //    env before loadConfig/startGateway — the config is captured once at
+  //    startup and reused per request).
+  const selection = await resolveAgentSelection(cmdArgs);
+
   const config = loadConfig();
   let gatewayUrl: string;
   let owned: boolean;
   let shutdown: () => Promise<void>;
+  // The config actually in effect for the running gateway. In local mode
+  // startGateway() re-runs loadConfig() AFTER upstream adoption has set
+  // LORE_UPSTREAM_*, so handle.config reflects the adopted upstream while the
+  // `config` captured above is stale (pre-adoption). maybeAutoImport must use
+  // the effective config or its worker calls route to the pre-adoption default
+  // upstream (e.g. api.anthropic.com) and fail auth against the adopted key.
+  let effectiveConfig = config;
+
+  // 2. Adopt the user's existing upstream (local mode only — a remote gateway
+  //    owns its own config; header injection below still routes it there).
+  //    Done before startGateway so LORE_UPSTREAM_* is read by loadConfig.
+  let adopted: AdoptedUpstream | null = null;
+  const isLocal = !(opts.remoteUrl || config.remoteUrl);
+  if (isLocal && selection?.def) {
+    // Prospective local gateway URL for the self-pointing guard. The port may
+    // shift on conflict, but the user's ANTHROPIC_BASE_URL points at their own
+    // provider host, not loopback, so the guard just needs a loopback origin.
+    const prospectiveUrl = `http://127.0.0.1:${config.port}`;
+    adopted = applyUpstreamAdoption(selection.def, prospectiveUrl);
+    if (adopted) {
+      console.log(
+        `[lore] Adopting your ${adopted.agentDisplayName} upstream: ${adopted.url}` +
+          (adopted.providerID ? ` (provider: ${adopted.providerID})` : ""),
+      );
+    }
+  }
 
   if (opts.remoteUrl || config.remoteUrl) {
     // Remote mode: delegate to an existing remote gateway.
@@ -189,6 +401,10 @@ export async function commandRun(
     owned = false;
     shutdown = async () => {};
     console.log(`[lore] Using remote gateway at ${gatewayUrl}`);
+    // In remote mode, adopt via header injection only (no local gateway env).
+    if (selection?.def) {
+      adopted = adoptForRemote(selection.def, gatewayUrl);
+    }
   } else {
     // Local mode: start (or reuse) a local gateway.
     // `lore run` always runs locally — agent is on the same machine.
@@ -196,6 +412,8 @@ export async function commandRun(
     gatewayUrl = `http://${bracketHost(handle.config.hosts[0])}:${handle.port}`;
     owned = handle.owned;
     shutdown = handle.shutdown;
+    // Post-adoption config (LORE_UPSTREAM_* now reflected). Used for autoImport.
+    effectiveConfig = handle.config;
 
     if (owned) {
       console.log(`[lore] Gateway listening on ${gatewayUrl}`);
@@ -205,13 +423,15 @@ export async function commandRun(
   }
   console.log(`[lore] Dashboard: ${gatewayUrl}/ui`);
 
-  // 2. Auto-detect prior conversations (per newly-detected agent)
+  // 3. Auto-detect prior conversations (per newly-detected agent)
   if (owned) {
-    await maybeAutoImport(config);
+    await maybeAutoImport(effectiveConfig);
   }
 
-  // 3. Resolve what to launch
-  const target = await resolveLaunchTarget(gatewayUrl, cmdArgs, extraArgs);
+  // 4. Build the launch target (env + args) now that we have the URL.
+  const target = selection
+    ? resolveLaunchTarget(selection, gatewayUrl, cmdArgs, extraArgs, adopted)
+    : null;
 
   if (!target) {
     // No agent found — start server without launching an agent
@@ -232,6 +452,18 @@ export async function commandRun(
   console.log(
     `[lore] Launching: ${target.command} ${target.args.join(" ")}`.trimEnd(),
   );
+
+  // Silence the in-process gateway's stderr before handing the terminal to the
+  // agent. `lore run` starts the gateway in THIS process, so its `[lore]` log
+  // lines (worker-health, background-import, upstream warnings) write to the
+  // same stderr the interactive agent renders into — corrupting its TUI, the
+  // same failure the Pi/OpenCode plugins avoid via silenceStderr(). We only do
+  // this for an owned gateway feeding an interactive TTY; nothing is lost —
+  // the file sink + Sentry sink keep everything (read with `lore logs`).
+  // `LORE_DEBUG=1` opts back into full stderr for troubleshooting.
+  if (owned && !config.debug && process.stderr.isTTY) {
+    log.silenceStderr();
+  }
 
   const child = launchChild(target);
 

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -754,6 +754,24 @@ export function providerFromUpstreamUrl(
 }
 
 /**
+ * Derive the provider id for a raw upstream URL (e.g. a user's pre-existing
+ * `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL`) by normalizing it the same way an
+ * incoming `x-lore-upstream-url` header is and matching against PROVIDER_ROUTES.
+ *
+ * Used by `lore run` upstream adoption (see `captureUserUpstream`): when the
+ * user already pointed their agent at a KNOWN provider host (OpenRouter,
+ * DeepSeek, etc.), we can tag the session with the right provider so the
+ * gateway flips wire protocol + auth scheme correctly. A miss (custom/self-
+ * hosted host) returns `undefined` — the request still routes to that host via
+ * `x-lore-upstream-url`, just without a provider tag (ingress protocol kept).
+ */
+export function providerForUpstreamOrigin(url: string): string | undefined {
+  const base = extractUpstreamUrlHeader({ "x-lore-upstream-url": url });
+  if (!base) return undefined;
+  return UPSTREAM_URL_TO_PROVIDER.get(base);
+}
+
+/**
  * Resolve the provider id used to tag the global fallback credential
  * (`setLastSeenAuth`). The explicit `x-lore-provider` header is authoritative
  * (the plugin set it deliberately for this turn); only when it is absent or

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { AGENTS } from "../src/cli/agents";
+import { AGENTS, captureUserUpstream } from "../src/cli/agents";
 
 // ---------------------------------------------------------------------------
 // Claude Code agent
@@ -301,5 +301,110 @@ describe("Gemini CLI agent envVars", () => {
   test("sets LORE_PROJECT to cwd", () => {
     const env = gemini.envVars("http://127.0.0.1:3207", "/home/user/proj");
     expect(env.LORE_PROJECT).toBe("/home/user/proj");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upstream adoption — captureUserUpstream
+// ---------------------------------------------------------------------------
+
+describe("captureUserUpstream", () => {
+  const claude = AGENTS.find((a) => a.name === "claude-code")!;
+  const codex = AGENTS.find((a) => a.name === "codex")!;
+  const opencode = AGENTS.find((a) => a.name === "opencode")!;
+  const gemini = AGENTS.find((a) => a.name === "gemini")!;
+  const GATEWAY = "http://127.0.0.1:3207";
+
+  test("adopts a user's pre-existing ANTHROPIC_BASE_URL for Claude Code", () => {
+    const captured = captureUserUpstream(claude, GATEWAY, {
+      ANTHROPIC_BASE_URL: "https://openrouter.ai/api",
+    });
+    expect(captured).toEqual({
+      url: "https://openrouter.ai/api",
+      wireProtocol: "anthropic",
+    });
+  });
+
+  test("adopts a user's pre-existing OPENAI_BASE_URL for Codex", () => {
+    const captured = captureUserUpstream(codex, GATEWAY, {
+      OPENAI_BASE_URL: "https://api.deepseek.com",
+    });
+    expect(captured).toEqual({
+      url: "https://api.deepseek.com",
+      wireProtocol: "openai",
+    });
+  });
+
+  test("returns null when the base-URL env var is unset", () => {
+    expect(captureUserUpstream(claude, GATEWAY, {})).toBe(null);
+  });
+
+  test("returns null when the base URL already points at the gateway (idempotent re-runs)", () => {
+    const captured = captureUserUpstream(claude, GATEWAY, {
+      ANTHROPIC_BASE_URL: GATEWAY,
+    });
+    expect(captured).toBe(null);
+  });
+
+  test("returns null when the gateway host matches even on a different path", () => {
+    const captured = captureUserUpstream(claude, GATEWAY, {
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:3207/v1",
+    });
+    expect(captured).toBe(null);
+  });
+
+  test("returns null for a loopback URL on a DIFFERENT port (stale gateway, port shifted on restart)", () => {
+    // Seer HIGH: the gateway may restart on a different port (contention). A
+    // stale ANTHROPIC_BASE_URL pointing at a previous gateway (loopback, other
+    // port) must NOT be adopted — else the gateway proxies into itself.
+    const captured = captureUserUpstream(claude, GATEWAY, {
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:9999",
+    });
+    expect(captured).toBe(null);
+  });
+
+  test("returns null for localhost and 127.x loopback variants", () => {
+    for (const url of [
+      "http://localhost:8080",
+      "http://127.0.0.5:1234",
+      "http://[::1]:3000",
+    ]) {
+      expect(
+        captureUserUpstream(claude, GATEWAY, { ANTHROPIC_BASE_URL: url }),
+      ).toBe(null);
+    }
+  });
+
+  test("ignores a non-URL / unparseable value", () => {
+    const captured = captureUserUpstream(claude, GATEWAY, {
+      ANTHROPIC_BASE_URL: "not a url",
+    });
+    expect(captured).toBe(null);
+  });
+
+  test("ignores an empty / whitespace value", () => {
+    expect(
+      captureUserUpstream(claude, GATEWAY, {
+        ANTHROPIC_BASE_URL: "   ",
+      }),
+    ).toBe(null);
+  });
+
+  test("returns null for an agent with no adoptable base-URL var (opencode)", () => {
+    const captured = captureUserUpstream(opencode, GATEWAY, {
+      ANTHROPIC_BASE_URL: "https://openrouter.ai/api",
+      OPENAI_BASE_URL: "https://openrouter.ai/api",
+    });
+    expect(captured).toBe(null);
+  });
+
+  test("adopts GOOGLE_GEMINI_BASE_URL with gemini wire protocol", () => {
+    const captured = captureUserUpstream(gemini, GATEWAY, {
+      GOOGLE_GEMINI_BASE_URL: "https://my-proxy.example.com",
+    });
+    expect(captured).toEqual({
+      url: "https://my-proxy.example.com",
+      wireProtocol: "gemini",
+    });
   });
 });

--- a/packages/gateway/test/run-upstream-adoption.test.ts
+++ b/packages/gateway/test/run-upstream-adoption.test.ts
@@ -1,0 +1,268 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { AGENTS } from "../src/cli/agents";
+import {
+  applyUpstreamAdoption,
+  adoptForRemote,
+  injectAdoptionHeaders,
+  resolveAgentSelection,
+  resolveLaunchTarget,
+} from "../src/cli/run";
+
+// ---------------------------------------------------------------------------
+// lore run — user-upstream adoption
+//
+// When a user has already pointed their agent at a provider (e.g. Claude Code
+// at OpenRouter via ANTHROPIC_BASE_URL), `lore run` must ADOPT that upstream
+// rather than clobber it with the hardcoded api.anthropic.com default — which
+// was sending the OpenRouter key to Anthropic and 401-storming.
+// ---------------------------------------------------------------------------
+
+const GATEWAY = "http://127.0.0.1:3207";
+
+// Env keys the adoption logic reads/writes — save + restore around each test.
+const TOUCHED_ENV = [
+  "ANTHROPIC_BASE_URL",
+  "OPENAI_BASE_URL",
+  "GOOGLE_GEMINI_BASE_URL",
+  "COPILOT_API_URL",
+  "LORE_UPSTREAM_ANTHROPIC",
+  "LORE_UPSTREAM_OPENAI",
+  "LORE_UPSTREAM_OPENROUTER",
+];
+
+describe("lore run upstream adoption", () => {
+  const claude = AGENTS.find((a) => a.name === "claude-code")!;
+  const gemini = AGENTS.find((a) => a.name === "gemini")!;
+  const opencode = AGENTS.find((a) => a.name === "opencode")!;
+
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {};
+    for (const k of TOUCHED_ENV) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of TOUCHED_ENV) {
+      if (saved[k] !== undefined) process.env[k] = saved[k];
+      else delete process.env[k];
+    }
+  });
+
+  test("Claude Code + ANTHROPIC_BASE_URL=openrouter sets gateway upstream env and tags the provider", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    const adopted = applyUpstreamAdoption(claude, GATEWAY);
+    expect(adopted).not.toBeNull();
+    expect(adopted!.url).toBe("https://openrouter.ai/api");
+    expect(adopted!.providerID).toBe("openrouter");
+    // The in-process gateway reads LORE_UPSTREAM_ANTHROPIC at loadConfig().
+    expect(process.env.LORE_UPSTREAM_ANTHROPIC).toBe(
+      "https://openrouter.ai/api",
+    );
+    // Provider-specific upstream so the injected X-Lore-Provider resolves.
+    expect(process.env.LORE_UPSTREAM_OPENROUTER).toBe(
+      "https://openrouter.ai/api",
+    );
+  });
+
+  test("injects X-Lore-Upstream-URL and X-Lore-Provider into Claude Code headers", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    const adopted = applyUpstreamAdoption(claude, GATEWAY)!;
+    const env: Record<string, string> = {};
+    injectAdoptionHeaders(claude, env, adopted);
+    const headers = env.ANTHROPIC_CUSTOM_HEADERS ?? "";
+    expect(headers).toContain("X-Lore-Upstream-URL: https://openrouter.ai/api");
+    expect(headers).toContain("X-Lore-Provider: openrouter");
+  });
+
+  test("does NOT overwrite an explicit user LORE_UPSTREAM_ANTHROPIC", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    process.env.LORE_UPSTREAM_ANTHROPIC = "https://my-explicit-proxy.example";
+    applyUpstreamAdoption(claude, GATEWAY);
+    // The user's explicit override wins.
+    expect(process.env.LORE_UPSTREAM_ANTHROPIC).toBe(
+      "https://my-explicit-proxy.example",
+    );
+  });
+
+  test("returns null and touches no env when the user set nothing", () => {
+    const adopted = applyUpstreamAdoption(claude, GATEWAY);
+    expect(adopted).toBeNull();
+    expect(process.env.LORE_UPSTREAM_ANTHROPIC).toBeUndefined();
+  });
+
+  test("unknown host is adopted as upstream URL but carries no provider tag", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://llm.internal.example.com";
+    const adopted = applyUpstreamAdoption(claude, GATEWAY)!;
+    expect(adopted.url).toBe("https://llm.internal.example.com");
+    expect(adopted.providerID).toBeUndefined();
+    expect(process.env.LORE_UPSTREAM_ANTHROPIC).toBe(
+      "https://llm.internal.example.com",
+    );
+    // No provider tag → header injection omits X-Lore-Provider.
+    const env: Record<string, string> = {};
+    injectAdoptionHeaders(claude, env, adopted);
+    const headers = env.ANTHROPIC_CUSTOM_HEADERS ?? "";
+    expect(headers).toContain("X-Lore-Upstream-URL:");
+    expect(headers).not.toContain("X-Lore-Provider:");
+  });
+
+  test("Gemini (no header mechanism) adopts via env only — no anthropic header injected", () => {
+    process.env.GOOGLE_GEMINI_BASE_URL = "https://gemini-proxy.example.com";
+    const adopted = applyUpstreamAdoption(gemini, GATEWAY);
+    // gemini wire protocol has no LORE_UPSTREAM_<protocol> knob, so gateway
+    // env is not set — but the adoption object is still returned.
+    expect(adopted).not.toBeNull();
+    expect(adopted!.url).toBe("https://gemini-proxy.example.com");
+    // injectAdoptionHeaders is a no-op for non-anthropic agents.
+    const env: Record<string, string> = {};
+    injectAdoptionHeaders(gemini, env, adopted!);
+    expect(env.ANTHROPIC_CUSTOM_HEADERS).toBeUndefined();
+  });
+
+  test("opencode (no adoptable base-URL var) returns null even with envs set", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    process.env.OPENAI_BASE_URL = "https://openrouter.ai/api";
+    expect(applyUpstreamAdoption(opencode, GATEWAY)).toBeNull();
+  });
+
+  // --- Security: CRLF header injection via a crafted base-URL env var --------
+
+  test("does NOT smuggle a second header when ANTHROPIC_BASE_URL contains a newline (CRLF injection)", () => {
+    // new URL() tolerates a newline after the path, so a naive adopt+inject
+    // would split "X-Lore-Upstream-URL: <url>\nX-Api-Key: stolen" into TWO
+    // real headers. captureUserUpstream strips control chars AND rejects any
+    // value with interior whitespace, so a CRLF-smuggling payload is never
+    // adopted at all — no header can be injected from it.
+    process.env.ANTHROPIC_BASE_URL =
+      "https://good.example.com/\nX-Api-Key: stolen";
+    const adopted = applyUpstreamAdoption(claude, GATEWAY);
+    expect(adopted).toBeNull();
+    expect(process.env.LORE_UPSTREAM_ANTHROPIC).toBeUndefined();
+  });
+
+  test("a base URL with an interior space is rejected (not adopted)", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://good.example.com/ evil";
+    expect(applyUpstreamAdoption(claude, GATEWAY)).toBeNull();
+  });
+
+  // --- Remote mode: adopt via header only, never touch gateway env ----------
+
+  test("adoptForRemote returns the upstream + provider tag but sets NO gateway env", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    const adopted = adoptForRemote(claude, "https://remote-gw.example.com");
+    expect(adopted).not.toBeNull();
+    expect(adopted!.url).toBe("https://openrouter.ai/api");
+    expect(adopted!.providerID).toBe("openrouter");
+    // Remote gateway owns its own config — no local LORE_UPSTREAM_* is set.
+    expect(adopted!.gatewayEnvKey).toBe("");
+    expect(process.env.LORE_UPSTREAM_ANTHROPIC).toBeUndefined();
+  });
+
+  test("adoptForRemote returns null when the user set no upstream", () => {
+    expect(adoptForRemote(claude, "https://remote-gw.example.com")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAgentSelection — pick the agent before the gateway starts
+// ---------------------------------------------------------------------------
+
+describe("resolveAgentSelection", () => {
+  test("explicit known binary resolves to its AgentDef", async () => {
+    const sel = await resolveAgentSelection(["claude", "--foo"]);
+    expect(sel).not.toBeNull();
+    expect(sel!.command).toBe("claude");
+    expect(sel!.def?.name).toBe("claude-code");
+  });
+
+  test("explicit unknown binary resolves with def=null (no adoption, no crash)", async () => {
+    const sel = await resolveAgentSelection(["some-other-tool"]);
+    expect(sel).not.toBeNull();
+    expect(sel!.command).toBe("some-other-tool");
+    expect(sel!.def).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveLaunchTarget — build launch env/args + inject adoption headers
+// ---------------------------------------------------------------------------
+
+describe("resolveLaunchTarget", () => {
+  const claude = AGENTS.find((a) => a.name === "claude-code")!;
+  const GATEWAY = "http://127.0.0.1:3207";
+
+  test("explicit command: merges env from all agents and prepends matching cliArgs", () => {
+    const selection = {
+      command: "codex",
+      def: AGENTS.find((a) => a.name === "codex")!,
+    };
+    const target = resolveLaunchTarget(
+      selection,
+      GATEWAY,
+      ["codex", "--resume"],
+      ["--extra"],
+      null,
+    );
+    expect(target.command).toBe("codex");
+    // Codex cliArgs (-c openai_base_url=...) are prepended; user args + extras follow.
+    expect(target.args[0]).toBe("-c");
+    expect(target.args).toContain("--resume");
+    expect(target.args).toContain("--extra");
+    // Env merged from all agents includes Claude Code's base URL too (harmless).
+    expect(target.env.ANTHROPIC_BASE_URL).toBe(GATEWAY);
+  });
+
+  test("explicit command: injects adoption headers only for the matching agent", () => {
+    const selection = { command: "claude", def: claude };
+    const adopted = {
+      url: "https://openrouter.ai/api",
+      gatewayEnvKey: "LORE_UPSTREAM_ANTHROPIC",
+      providerID: "openrouter",
+      agentDisplayName: "Claude Code",
+    };
+    const target = resolveLaunchTarget(
+      selection,
+      GATEWAY,
+      ["claude"],
+      [],
+      adopted,
+    );
+    const headers = target.env.ANTHROPIC_CUSTOM_HEADERS ?? "";
+    expect(headers).toContain("X-Lore-Upstream-URL: https://openrouter.ai/api");
+    expect(headers).toContain("X-Lore-Provider: openrouter");
+  });
+
+  test("auto-detected agent: builds env from the selected def and injects adoption headers", () => {
+    const selection = { command: "claude", def: claude };
+    const adopted = {
+      url: "https://openrouter.ai/api",
+      gatewayEnvKey: "LORE_UPSTREAM_ANTHROPIC",
+      providerID: "openrouter",
+      agentDisplayName: "Claude Code",
+    };
+    // Empty cmdArgs → auto-detect branch (uses selection.def directly).
+    const target = resolveLaunchTarget(
+      selection,
+      GATEWAY,
+      [],
+      ["--flag"],
+      adopted,
+    );
+    expect(target.command).toBe("claude");
+    expect(target.args).toContain("--flag");
+    expect(target.env.ANTHROPIC_BASE_URL).toBe(GATEWAY);
+    expect(target.env.ANTHROPIC_CUSTOM_HEADERS).toContain(
+      "X-Lore-Provider: openrouter",
+    );
+  });
+
+  test("auto-detect with no adoption leaves headers free of upstream routing", () => {
+    const selection = { command: "claude", def: claude };
+    const target = resolveLaunchTarget(selection, GATEWAY, [], [], null);
+    const headers = target.env.ANTHROPIC_CUSTOM_HEADERS ?? "";
+    expect(headers).not.toContain("X-Lore-Upstream-URL");
+    expect(headers).not.toContain("X-Lore-Provider");
+  });
+});

--- a/packages/gateway/test/upstream-url-header.test.ts
+++ b/packages/gateway/test/upstream-url-header.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { extractUpstreamUrlHeader } from "../src/config";
+import {
+  extractUpstreamUrlHeader,
+  providerForUpstreamOrigin,
+} from "../src/config";
 
 // ---------------------------------------------------------------------------
 // extractUpstreamUrlHeader
@@ -183,5 +186,38 @@ describe("extractUpstreamUrlHeader", () => {
         "x-lore-upstream-url": "data:text/html,<h1>hi</h1>",
       }),
     ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providerForUpstreamOrigin — maps a raw upstream URL to a known provider id
+// ---------------------------------------------------------------------------
+
+describe("providerForUpstreamOrigin", () => {
+  test("maps a known provider host to its provider id", () => {
+    // OpenRouter is a known provider route (openai protocol) — a user's
+    // ANTHROPIC_BASE_URL=openrouter.ai must resolve so the gateway flips
+    // protocol + scheme correctly.
+    expect(providerForUpstreamOrigin("https://openrouter.ai/api")).toBe(
+      "openrouter",
+    );
+  });
+
+  test("normalizes a trailing /v1 the same way the header path does", () => {
+    // extractUpstreamUrlHeader strips a trailing /v1; the reverse-map key is
+    // normalized the same way, so both forms resolve identically.
+    const withV1 = providerForUpstreamOrigin("https://openrouter.ai/api/v1");
+    const without = providerForUpstreamOrigin("https://openrouter.ai/api");
+    expect(withV1).toBe(without);
+  });
+
+  test("returns undefined for an unknown / self-hosted host", () => {
+    expect(
+      providerForUpstreamOrigin("https://my-proxy.internal.example.com"),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined for an unparseable value", () => {
+    expect(providerForUpstreamOrigin("not a url")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

A user ran Claude Code through the Lore gateway pointed at OpenRouter:

```zsh
export ANTHROPIC_BASE_URL="https://openrouter.ai/api"
export ANTHROPIC_AUTH_TOKEN="$OPENROUTER_API_KEY"   # sk-or-... Bearer key
export ANTHROPIC_API_KEY=""
command lore
```

Two symptoms:
1. The terminal spammed background worker + import errors during the interactive session.
2. Constant authentication errors.

## Root cause

`lore run` builds the child env as `{ ...process.env, ...target.env }` — `target.env` last — so it **overwrote** the user's `ANTHROPIC_BASE_URL` with the gateway URL (intended: the agent must talk to the gateway). But the user's OpenRouter Bearer key survived, and the gateway had **no idea OpenRouter was involved** — `ANTHROPIC_BASE_URL` is a client-side var the gateway never sees. So it fell through to its hardcoded `api.anthropic.com` default and forwarded the `sk-or-` key **to Anthropic** → 401 on every foreground turn and every background worker/import call.

Separately, `lore run` starts the gateway **in-process**, and its `[lore]` log lines (`log.error`/`[worker-health] degraded`) write to the same stderr the interactive agent renders into — `silenceStderr()` (used by the Pi/OpenCode plugins) was never wired into the CLI path. So the 401-storm errors bled straight into the agent's TUI.

## Fix

**1. Adopt the user's existing upstream (all `lore run` targets).**
Before starting the gateway, capture the user's pre-existing base-URL env var for the target agent (`ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` / `GOOGLE_GEMINI_BASE_URL` / `COPILOT_API_URL`) and adopt it:
- set `LORE_UPSTREAM_<protocol>` so the in-process gateway defaults there (works for every target, even header-less ones like Gemini/Copilot);
- inject `X-Lore-Upstream-URL` (+ `X-Lore-Provider` for known hosts) for header-capable agents (Claude Code, Pi), so a known provider like OpenRouter gets its wire protocol + auth scheme flipped via the existing `providerForUpstreamOrigin` reverse-map.

An explicit user `LORE_UPSTREAM_*` still wins; a base URL already pointing at the gateway is ignored (idempotent re-runs). Lore now adopts the user's config instead of overriding it.

**2. Silence gateway stderr on an interactive `lore run`.**
Gated on `owned && !config.debug && process.stderr.isTTY`. Nothing is lost — the file sink + Sentry sink still receive everything (`lore logs`); `LORE_DEBUG=1` opts back in.

## Tests

- `captureUserUpstream`: adopt / skip-unset / self-pointing (incl. path variant) / unknown-host / opencode (no adoptable var) / gemini wire protocol.
- `run.ts` adoption wiring: sets gateway env + provider-specific env, injects headers with provider tag, respects explicit `LORE_UPSTREAM_*`, unknown host adopts URL but omits provider tag, header-less agent (Gemini) env-only.
- `providerForUpstreamOrigin`: known host → provider, `/v1` normalization, unknown/unparseable → undefined.

Mutation-verified: `captureUserUpstream`→null (7 red), skip gateway-env-set (2 red), skip provider-header (1 red).