### PR TITLE
fix(gradient): strict monotonic compression-layer ratchet — never decompress except emergency (#961)

### DIFF
--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -790,6 +790,22 @@ type SessionState = {
   lastTransformedCount: number;
   /** Layer used by the most recent transform() call — sticky-layer guard */
   lastLayer: SafetyLayer;
+  /**
+   * High-water compression layer (1-3) this session has ever sustained. Once a
+   * session compresses to layer L, decompressing to a LOWER layer re-renders the
+   * distilled prefix at messages[0/1] (different budget/strip level) and
+   * front-busts the whole prompt cache — then the next turn re-compresses and
+   * busts again (0<->N / 2<->1 thrash). Reclaiming window by decompressing is a
+   * false economy: the reclaim itself is a full cache write. So the layer is a
+   * strict monotonic RATCHET — `effectiveMinLayer` is floored at this every turn,
+   * unconditionally (no release on a genuine host-side context shrink).
+   *
+   * Layer 4 (emergency overflow) is EXCLUDED: it is a deliberate one-shot bust to
+   * recover from "prompt too long", not a sustained level, and must never be
+   * latched here (that would trap the session at emergency permanently). Only
+   * layers 1-3 ratchet.
+   */
+  maxSustainedLayer: SafetyLayer;
   /** Message IDs in the most recent transform() output — ID-based delta estimation */
   lastWindowMessageIDs: Set<string>;
   /** One-shot force escalation: skip layers below this on the next transform() */
@@ -935,6 +951,7 @@ function makeSessionState(): SessionState {
     lastKnownMessageCount: 0,
     lastTransformedCount: 0,
     lastLayer: 0,
+    maxSustainedLayer: 0,
     lastWindowMessageIDs: new Set(),
     forceMinLayer: 0,
     lastTransformEstimate: 0,
@@ -987,6 +1004,24 @@ function getSessionState(sessionID: string): SessionState {
     const persisted = loadSessionTracking(sessionID);
     if (persisted && persisted.lastTurnAt > 0) {
       state.lastLayer = persisted.lastLayer as SafetyLayer;
+      // Re-seed the monotonic layer ratchet from the restored layer. We don't
+      // persist maxSustainedLayer separately (no migration): a session restored
+      // at layer L (1-3) had sustained at least L, so lastLayer is a safe lower
+      // bound for the floor. If the true high-water was higher, the ratchet
+      // re-establishes within a turn.
+      //
+      // A restored lastLayer === 4 means the last turn was an emergency overflow
+      // bust. Layer 4 itself never latches the ratchet (it is not a sustained
+      // level), but the session WAS compressed before the emergency, so on resume
+      // it must still hold the prefix — floor at >= 1 (matching the old
+      // prefix-present floor's documented lastLayer===4 coverage). Without this,
+      // a small resume turn would re-enter layer 0 and front-bust the prefix for
+      // a turn until the next compressed turn re-latches the ratchet.
+      if (state.lastLayer >= 1 && state.lastLayer <= 3) {
+        state.maxSustainedLayer = state.lastLayer;
+      } else if (state.lastLayer === 4) {
+        state.maxSustainedLayer = 1;
+      }
       state.lastKnownInput = persisted.lastKnownInput;
       // v43: restore the last-sent message count so the calibrated-delta
       // estimate identifies only genuinely-new messages on the resume turn
@@ -1557,35 +1592,6 @@ export function getLastLayer(sessionID?: string): SafetyLayer {
   // Fallback for tests: return from the first (and usually only) session state
   const first = sessionStates.values().next().value;
   return first?.lastLayer ?? 0;
-}
-
-/**
- * Decide whether the "prefix-present floor" applies — i.e. whether the next
- * transform must pin to at least Layer 1 (keeping the distilled prefix present
- * at messages[0]/[1]) because the session has already compressed.
- *
- * Returns true when the session has compressed before (`lastLayer >= 1`) AND
- * this turn is NOT a genuine compaction. A genuine compaction is detected when
- * the last-known window size is known (> 0) and the incoming conversation has
- * shrunk below it — that is the one case where dropping back to Layer 0 is
- * correct (the host shrank the conversation, so the prefix is no longer needed).
- *
- * Notes:
- *  - Covers `lastLayer === 4` (the strong sticky guard's `<= 3` excludes it).
- *  - When `lastKnownMessageCount === 0` (fresh process, not yet set), this never
- *    treats the turn as a compaction — it relies on the DB-restored `lastLayer`
- *    to hold the floor until the live count is established.
- *  - Pure function of its inputs — unit-testable without driving a full transform.
- */
-export function prefixPresentFloorApplies(
-  lastLayer: number,
-  messagesLength: number,
-  lastKnownMessageCount: number,
-): boolean {
-  const hasCompressed = lastLayer >= 1;
-  const genuineCompaction =
-    lastKnownMessageCount > 0 && messagesLength < lastKnownMessageCount;
-  return hasCompressed && !genuineCompaction;
 }
 
 /**
@@ -3487,66 +3493,31 @@ function transformInner(input: {
     );
   }
 
-  // --- Sticky layer guard (Option C) ---
-  // After a compressed turn (layer >= N), don't allow re-entry below N until
-  // the session genuinely shrinks (e.g. after compaction deletes messages).
-  // Prevents calibration oscillation AND layer-transition cache busts:
-  //   - 0→1→0: compressed turn stores lastKnownInput=100K for a 50-message
-  //     window, next turn's 300 raw messages produce an undercounted
-  //     expectedInput that "fits" in layer 0 but actually overflows.
-  //   - 1→2→1: layer 2 strips tool outputs (different bytes), bouncing back
-  //     to layer 1 restores them (different bytes again) → two busts.
-  // Pinning to the *actual* last layer prevents all downward oscillation.
-  // Only applied when calibrated (same session, per-session state) to avoid
-  // affecting other sessions including worker sessions.
-  // Layer 4 (emergency) already blows the cache — stickiness there just traps
-  // the session at emergency permanently. Only apply stickiness for layers 1-3
-  // where dropping back would bust a warm cache.
-  if (
-    calibrated &&
-    sessState.lastLayer >= 1 &&
-    sessState.lastLayer <= 3 &&
-    input.messages.length >= sessState.lastKnownMessageCount
-  ) {
+  // --- Monotonic compression-layer ratchet ---
+  // Once a session compresses to layer L (1-3), NEVER select a lower layer for
+  // the rest of the session. Every downgrade re-renders the distilled prefix at
+  // messages[0/1] with a different budget/strip level and front-busts the whole
+  // prompt cache; the next turn re-compresses and busts again (0<->N / 2<->1
+  // thrash). Reclaiming window by decompressing is a false economy — the reclaim
+  // is itself a full cache write.
+  //
+  // This is unconditional: it does NOT release when the host shrinks the
+  // conversation ("genuine compaction"). The earlier design released the floor on
+  // a shrink, but decompressing to exploit the reclaimed room just trades a
+  // cache-read-cheap compressed prefix for a full re-write — the opposite of what
+  // we want. A truly fresh conversation is a new session (new cache) anyway.
+  //
+  // `maxSustainedLayer` only ever holds 1-3 (see the update site after
+  // transform); layer 4 (emergency overflow) is excluded, so a one-shot overflow
+  // bust never latches the session at emergency — after recovery it settles back
+  // to this sustained floor. `forceMinLayer` (the emergency escalation) is
+  // applied separately via the initial `effectiveMinLayer` and can still push
+  // ABOVE this floor for the recovery turn.
+  if (sessState.maxSustainedLayer >= 1) {
     effectiveMinLayer = Math.max(
       effectiveMinLayer,
-      sessState.lastLayer,
+      sessState.maxSustainedLayer,
     ) as SafetyLayer;
-  }
-
-  // --- Prefix-present floor (no Layer-0 re-entry once compressed) ---
-  // Once a session has compressed (reached Layer >= 1), the distilled prefix is
-  // injected at messages[0]/[1]. Dropping back to Layer 0 omits the prefix —
-  // messages[0] changes → full prompt-cache front-bust; the reverse re-injects
-  // it → bust again (0<->N thrash). The strong sticky guard above pins to the
-  // FULL lastLayer, but only for lastLayer 1-3 AND only while `calibrated`.
-  //
-  // For a CALIBRATED 1-3 session this floor's condition equals the sticky
-  // guard's (both gate on `messages.length >= lastKnownMessageCount`), so here
-  // it is pure defense-in-depth. Its GENUINELY NEW coverage is the two gaps the
-  // sticky guard leaves open — exactly where the production front-busts occur:
-  //   (1) lastLayer === 4 (genuine emergency overflow) — excluded by `<= 3`.
-  //   (2) a compressed-but-UNCALIBRATED session (lastKnownInput == 0, so
-  //       `calibrated` is false): the API call hasn't established a token count
-  //       yet (first compressed turn whose call failed before calibrate, or a
-  //       resume/restart before the first calibrate of this process). The sticky
-  //       guard is skipped entirely; without this floor the layer-0 fit and the
-  //       tier-based bust-vs-continue gate (both gated on effectiveMinLayer===0)
-  //       pass the session through at Layer 0 and vanish the prefix.
-  // The floor pins to >= Layer 1 ONLY (prefix PRESENT) — NEVER higher, so it
-  // never traps the session at an emergency layer. It is released only on a
-  // GENUINE compaction: the host shrank the conversation below the last-known
-  // window (and that window is known, i.e. > 0 — so a fresh process with
-  // lastKnownMessageCount=0 does not spuriously release; it relies on the
-  // DB-restored lastLayer to hold the floor until the live count is set).
-  if (
-    prefixPresentFloorApplies(
-      sessState.lastLayer,
-      input.messages.length,
-      sessState.lastKnownMessageCount,
-    )
-  ) {
-    effectiveMinLayer = Math.max(effectiveMinLayer, 1) as SafetyLayer;
   }
 
   // --- Post-idle compact layer ---
@@ -4112,6 +4083,16 @@ export function transform(input: {
     state.lastTransformedCount = result.messages.length;
     state.lastTransformEstimate = result.totalTokens;
     state.lastLayer = result.layer;
+    // Ratchet the high-water compression layer (1-3 only). Layer 0 never lowers
+    // it; layer 4 (emergency) is excluded so a one-shot overflow bust never traps
+    // the session at emergency — after recovery it settles back to this floor.
+    if (
+      result.layer >= 1 &&
+      result.layer <= 3 &&
+      result.layer > state.maxSustainedLayer
+    ) {
+      state.maxSustainedLayer = result.layer;
+    }
     state.lastWindowMessageIDs = new Set(result.messages.map((m) => m.info.id));
 
     // Source the shared cache-economics compressed size from the ACTUAL rebuilt

--- a/packages/core/test/gradient.test.ts
+++ b/packages/core/test/gradient.test.ts
@@ -29,7 +29,6 @@ import {
   setLastTurnAtForTest,
   setTransformCountForTest,
   setBustSpiralHook,
-  prefixPresentFloorApplies,
   recordCacheUsage,
   getPrefixChurnRate,
   PREFIX_CHURN_ALPHA,
@@ -753,16 +752,17 @@ describe("gradient — force escalation (reactive error recovery)", () => {
     // Despite tiny messages, force min layer should push to at least layer 2
     expect(result.layer).toBeGreaterThanOrEqual(2);
     // After one use, the forceMinLayer flag is consumed (proven directly below).
-    // The resulting layer drops from the forced 2 to 1 — NOT back to 0 — because
-    // the prefix-present floor holds a once-compressed session at Layer >= 1
-    // (prefixPresentFloorApplies). The 2→1 drop proves the flag was consumed.
+    // The session sustained layer 2 on turn 1, so the monotonic layer ratchet
+    // (maxSustainedLayer) now holds it at 2 — it must NOT drop back to 1 (or 0),
+    // because decompressing re-renders the prefix and busts the cache. This is
+    // the ratchet: once compressed to L, never select below L (except emergency).
     expect(loadForceMinLayer("force-sess")).toBe(0);
     const result2 = transform({
       messages,
       projectPath: PROJECT,
       sessionID: "force-sess",
     });
-    expect(result2.layer).toBe(1);
+    expect(result2.layer).toBe(2);
   });
 
   test("forceMinLayer is one-shot — cleared after single use", () => {
@@ -780,15 +780,15 @@ describe("gradient — force escalation (reactive error recovery)", () => {
     expect(r1.layer).toBeGreaterThanOrEqual(2);
     // Flag is consumed (one-shot) — proven directly.
     expect(loadForceMinLayer("oneshot-sess")).toBe(0);
-    // Second call — no flag. The layer drops from 2, but the prefix-present
-    // floor holds it at 1 (a once-compressed session never re-enters Layer 0
-    // absent a genuine compaction). The 2→1 drop confirms the flag was consumed.
+    // Second call — no flag. The session sustained layer 2 on turn 1, so the
+    // monotonic ratchet holds it at 2 (never drops to 1/0). Consumption of the
+    // one-shot flag is proven by loadForceMinLayer===0 above, not by a layer drop.
     const r2 = transform({
       messages,
       projectPath: PROJECT,
       sessionID: "oneshot-sess",
     });
-    expect(r2.layer).toBe(1);
+    expect(r2.layer).toBe(2);
   });
 
   test("resetCalibration clears forceMinLayer", () => {
@@ -846,15 +846,16 @@ describe("gradient — forceMinLayer persistence (restart survival)", () => {
     // One-shot: consumed — DB should be cleared
     expect(loadForceMinLayer(SID)).toBe(0);
 
-    // Next call: the forced flag is gone, but the prefix-present floor holds a
-    // once-compressed session at Layer 1 (no re-entry to Layer 0 absent a
-    // genuine compaction). The 2→1 drop confirms the flag was consumed.
+    // Next call: the forced flag is gone, but the session sustained layer 2 on
+    // the prior turn, so the monotonic ratchet holds it at 2 (never drops to
+    // 1/0). Consumption of the one-shot flag is proven by loadForceMinLayer===0
+    // above, not by a layer drop.
     const result2 = transform({
       messages,
       projectPath: PROJECT,
       sessionID: SID,
     });
-    expect(result2.layer).toBe(1);
+    expect(result2.layer).toBe(2);
   });
 
   test("setForceMinLayer writes to DB and transform consumes it", () => {
@@ -880,6 +881,44 @@ describe("gradient — forceMinLayer persistence (restart survival)", () => {
 
     // DB row should be deleted after consumption
     expect(loadForceMinLayer(SID)).toBe(0);
+  });
+
+  test("restart after an emergency (lastLayer=4) re-seeds the ratchet to >= 1 (no Layer-0 front-bust)", () => {
+    // Regression for the cold-start reseed gap: a session whose last persisted
+    // turn was an emergency overflow (lastLayer=4) was compressed before the
+    // emergency, so on resume it must hold the prefix (layer >= 1) — NOT re-enter
+    // layer 0 and front-bust. Layer 4 itself never latches the ratchet, but the
+    // reseed treats a restored 4 as "was compressed, hold >= 1".
+    const SID = "persist-emergency-restart-sess";
+    // Ensure no in-memory state — force a cold start that reads from the DB.
+    resetCalibration(SID);
+    calibrate(0);
+
+    // Persist an emergency turn: lastLayer=4, a known (non-zero) prior window,
+    // lastTurnAt>0 so the atomic restore fires. force_min_layer stays 0 (the
+    // proactive emergency tail does not set it), so there is no forceMinLayer
+    // fallback — the ratchet reseed is the ONLY thing that can hold the floor.
+    db()
+      .query(
+        `INSERT OR REPLACE INTO session_state
+           (session_id, force_min_layer, last_layer, last_known_input,
+            last_known_message_count, last_turn_at, updated_at)
+         VALUES (?, 0, 4, 500, 20, ?, ?)`,
+      )
+      .run(SID, Date.now(), Date.now());
+
+    // Resume with a small conversation that would trivially fit at layer 0.
+    const messages = [
+      makeMsg("er-1", "user", "resume", SID),
+      makeMsg("er-2", "assistant", "ok", SID),
+    ];
+    const result = transform({
+      messages,
+      projectPath: PROJECT,
+      sessionID: SID,
+    });
+    // Ratchet held from the restored emergency state — NOT layer 0.
+    expect(result.layer).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -1806,7 +1845,7 @@ describe("gradient — calibration oscillation fix", () => {
     expect(getLastLayer(SESSION)).toBeGreaterThanOrEqual(1);
   });
 
-  test("sticky layer: allows layer 0 re-entry after compaction shrinks message count", () => {
+  test("monotonic ratchet: does NOT re-enter layer 0 after a host-side compaction shrinks message count", () => {
     // Same setup: force gradient mode (60 × 600 chars ≈ 9000 tokens > maxInput 8000)
     const msgs = Array.from({ length: 60 }, (_, i) =>
       makeMsg(
@@ -1829,21 +1868,24 @@ describe("gradient — calibration oscillation fix", () => {
     const compressedCount = r1.messages.length;
     calibrate(estimateMessages(r1.messages), SESSION, compressedCount);
 
-    // Simulate compaction: session now has only 3 messages (much smaller than lastKnownMessageCount)
+    // Simulate host-side compaction: session now has only 3 tiny messages (far
+    // fewer than lastKnownMessageCount). The OLD design released the floor here
+    // and re-entered layer 0. That is a false economy: re-expanding the prefix to
+    // raw is itself a full cache write. The monotonic ratchet now HOLDS the
+    // session at its sustained layer (>= 1) — a genuine shrink does not release.
     const postCompaction = [
       makeMsg("post-1", "user", "fresh start", SESSION),
       makeMsg("post-2", "assistant", "ready", SESSION),
       makeMsg("post-3", "user", "go", SESSION),
     ];
 
-    // With fewer messages than lastKnownMessageCount, sticky guard is bypassed
     const r2 = transform({
       messages: postCompaction,
       projectPath: PROJECT,
       sessionID: SESSION,
     });
-    // Should be layer 0 — 3 tiny messages easily fit
-    expect(r2.layer).toBe(0);
+    // Ratchet holds — NOT layer 0, despite 3 tiny messages that would otherwise fit.
+    expect(r2.layer).toBeGreaterThanOrEqual(1);
   });
 
   test("ID-based delta: accurately counts new messages after compression", () => {
@@ -2161,13 +2203,16 @@ describe("gradient — distilled-prefix front-bust (spurious Layer 4 + thrash)",
     expect(prefix2).toBe(prefix1);
   });
 
-  test("RELEASES to Layer 0 after a genuine compaction (prefix-floor must not trap a small session)", () => {
+  test("HOLDS its sustained layer after a genuine compaction (monotonic ratchet — no decompress)", () => {
     seedLargeDistillations(40, 12000);
     const r1 = transformPostIdle(largeRawConversation());
     expect(r1.layer).toBeGreaterThanOrEqual(1);
     calibrate(estimateMessages(r1.messages), SID, r1.messages.length);
 
-    // Genuine compaction: tiny conversation + tiny prefix → must sit at Layer 0.
+    // Genuine compaction: tiny conversation + tiny prefix. The OLD design
+    // released to Layer 0 here; the monotonic ratchet now HOLDS at the sustained
+    // layer. Re-expanding the prefix to raw would be a full cache write — a false
+    // economy — so a once-compressed session never decompresses.
     db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
     seedLargeDistillations(1, 200);
     const r2 = transform({
@@ -2179,7 +2224,7 @@ describe("gradient — distilled-prefix front-bust (spurious Layer 4 + thrash)",
       projectPath: `/test/${PID_KEY}`,
       sessionID: SID,
     });
-    expect(r2.layer).toBe(0);
+    expect(r2.layer).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -2457,57 +2502,23 @@ describe("gradient — overhead/body scale decoupling (usable-collapse fix)", ()
 });
 
 // ---------------------------------------------------------------------------
-// No Layer-0 re-entry once compressed (prefix-present floor)
+// Monotonic compression-layer ratchet (no decompression once compressed)
 // ---------------------------------------------------------------------------
-// Once a session has compressed (reached Layer >= 1, injecting the distilled
-// prefix at messages[0]/[1]), it must NOT drop back to Layer 0 on a later turn —
-// that vanishes the prefix and front-busts the cache. The existing sticky guard
-// only covers lastLayer 1-3 while calibrated; this floor also covers a prior
-// Layer-4 turn and survives a process restart (calibrated=false). It still
-// RELEASES on a genuine compaction (the host shrank the conversation).
+// Once a session compresses to layer L (1-3), it must NEVER select a lower layer
+// on a later turn — that re-renders the distilled prefix at messages[0]/[1] and
+// front-busts the cache; the next turn re-compresses and busts again. The
+// ratchet (maxSustainedLayer) holds the session at its high-water layer
+// unconditionally, including through a host-side conversation shrink ("genuine
+// compaction") — decompressing to reclaim window is a false economy (the reclaim
+// is itself a full cache write). Layer 4 (emergency overflow) is excluded so a
+// one-shot overflow bust never latches the session at emergency.
 //
-// The floor decision is `prefixPresentFloorApplies`, a pure predicate. We test
-// it directly (a full truth table — discriminating: any revert of the predicate
-// flips at least one case). The predicate's WIRING into transform() (pinning the
-// layer UP to >= 1) is proven by the repurposed `forceMinLayer` tests below,
-// which now assert a once-compressed session holds at Layer 1 (2->1) instead of
-// returning to Layer 0. The two transform-level guards here cover the other
-// direction — that the floor does NOT over-apply: a genuine compaction still
-// releases to Layer 0, and a never-compressed small session stays at Layer 0.
-describe("gradient — prefixPresentFloorApplies (no Layer-0 re-entry predicate)", () => {
-  test("never compressed (lastLayer 0) → floor does NOT apply", () => {
-    expect(prefixPresentFloorApplies(0, 100, 0)).toBe(false);
-    expect(prefixPresentFloorApplies(0, 5, 100)).toBe(false);
-    expect(prefixPresentFloorApplies(0, 100, 50)).toBe(false);
-  });
-
-  test("compressed (lastLayer 1-4) + growing/steady conversation → floor applies", () => {
-    for (const layer of [1, 2, 3, 4]) {
-      // count unknown yet (fresh process)
-      expect(prefixPresentFloorApplies(layer, 500, 0)).toBe(true);
-      // conversation grew
-      expect(prefixPresentFloorApplies(layer, 600, 500)).toBe(true);
-      // conversation steady (equal — NOT a shrink)
-      expect(prefixPresentFloorApplies(layer, 500, 500)).toBe(true);
-    }
-  });
-
-  test("covers lastLayer === 4 (the strong sticky guard's `<= 3` excludes it)", () => {
-    expect(prefixPresentFloorApplies(4, 500, 400)).toBe(true);
-  });
-
-  test("genuine compaction (messages shrank below the known window) → floor RELEASES", () => {
-    expect(prefixPresentFloorApplies(1, 3, 500)).toBe(false);
-    expect(prefixPresentFloorApplies(4, 10, 760)).toBe(false);
-  });
-
-  test("shrink is ignored when the window size is not yet known (count 0)", () => {
-    // Fresh process: lastKnownMessageCount=0 must NOT be read as a compaction —
-    // rely on the DB-restored lastLayer to hold the floor until the live count is set.
-    expect(prefixPresentFloorApplies(1, 1, 0)).toBe(true);
-  });
-});
-
+// The WIRING into transform() (pinning the layer UP to maxSustainedLayer) is
+// proven by the repurposed `forceMinLayer` tests above (a once-compressed
+// session holds at its layer, 2->2, instead of dropping to 1/0) and by the
+// transform-level "HOLDS ... after a genuine compaction" tests below. The
+// guards here cover the other direction — that the ratchet does NOT over-apply:
+// a never-compressed small session stays at Layer 0.
 describe("gradient — prefix-present floor: transform-level guards", () => {
   const SID = "prefix-floor-guard-sess";
   const PID_KEY = "prefix-floor-guard-project";
@@ -2574,7 +2585,7 @@ describe("gradient — prefix-present floor: transform-level guards", () => {
     db().query("DELETE FROM session_state WHERE session_id = ?").run(SID);
   });
 
-  test("the floor does NOT trap a genuinely compacted session (releases to Layer 0)", () => {
+  test("the ratchet HOLDS a genuinely compacted session at its sustained layer (no decompress to Layer 0)", () => {
     // Compress once (post-idle forces Layer >= 1, setting lastKnownMessageCount).
     seedDistillations(3, 1500);
     const conv = largeRawConversation();
@@ -2588,7 +2599,9 @@ describe("gradient — prefix-present floor: transform-level guards", () => {
     expect(r1.layer).toBeGreaterThanOrEqual(1);
     calibrate(estimateMessages(r1.messages), SID, r1.messages.length);
 
-    // Genuine compaction: 3 tiny messages, far below the known window.
+    // Genuine compaction: 3 tiny messages, far below the known window. The OLD
+    // design released to Layer 0; the monotonic ratchet now HOLDS at the
+    // sustained layer — decompressing would re-write the whole prefix.
     db().query("DELETE FROM distillations WHERE project_id = ?").run(projectId);
     seedDistillations(1, 150);
     const r2 = transform({
@@ -2600,7 +2613,7 @@ describe("gradient — prefix-present floor: transform-level guards", () => {
       projectPath: `/test/${PID_KEY}`,
       sessionID: SID,
     });
-    expect(r2.layer).toBe(0);
+    expect(r2.layer).toBeGreaterThanOrEqual(1);
   });
 
   test("a never-compressed small session sits at Layer 0 (floor does not over-apply)", () => {


### PR DESCRIPTION
## Problem

While measuring cross-session cache cost (#961), the gateway cache logs showed avoidable full prefix busts from the compression **layer** oscillating turn-to-turn. `transformInner` picks the lowest layer that fits **each turn independently** (`effectiveMinLayer` resets to 0 every turn), so a session could:

- **Drop 2→1** when transient token pressure eased (layer 2 strips tool outputs, layer 1 restores them → different prefix bytes → front-bust, then re-compress next turn → bust again).
- **Re-enter layer 0** on a host-side conversation shrink (the `genuineCompaction` release in `prefixPresentFloorApplies`): the distilled prefix vanishes from `messages[0/1]` → full front-bust; next turn re-injects it → bust again (0↔N thrash).

Two partial guards existed (a `calibrated`-only sticky guard pinning to full `lastLayer`, and a `≥1` prefix-present floor), but both **released on a genuine shrink** and the floor only guaranteed `≥1` — leaving the 2→1 and shrink-to-0 gaps open.

Reclaiming window by decompressing is a **false economy**: the reclaim is itself a full cache write. A cheap cache-read on a compressed prefix beats a full re-write every time.

## Fix

Make the compression layer a **strict monotonic ratchet** on layers 1–3. A new per-session `maxSustainedLayer` high-water is floored into `effectiveMinLayer` every turn, **unconditionally** (no release on genuine compaction). Once a session compresses to layer L, it never selects below L again.

- **Layer 4 (emergency overflow) is excluded** from the high-water — it is a deliberate one-shot bust to recover from "prompt too long", not a sustained level, so it never latches the session at emergency. After recovery the session settles back to its sustained 1–3 floor. `forceMinLayer` can still push *above* the ratchet for the recovery turn.
- Replaces both the calibrated sticky guard and the `prefixPresentFloorApplies` floor (removed as now-dead) with the single high-water floor.
- `maxSustainedLayer` is re-seeded from the DB-restored `lastLayer` on cold start (no new migration): a session restored at layer L (1–3) had sustained ≥L, a safe lower bound; the ratchet re-establishes within a turn if the true high-water was higher.

## Tests

Updated the affected gradient tests to the ratchet contract (a once-compressed session holds at its layer 2→2 instead of dropping to 1/0; a genuine host-side compaction HOLDS instead of releasing to layer 0). **Mutation-verified**: disabling the ratchet floor turns 6 ratchet tests red. 228 gradient tests + 124 gateway cache/compaction tests pass; core + gateway typecheck clean.