### PR TITLE
fix(import): honor env-var + explicit-model credentials for standalone import

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -54,6 +54,18 @@ export interface AgentDef {
    * user's captured upstream (see `upstreamEnvVars`).
    */
   wireProtocol?: "anthropic" | "openai" | "gemini";
+  /**
+   * Env var(s) the agent reads for its API credential, in priority order
+   * (first defined non-empty wins). Paired with `upstreamEnvVars`: a user who
+   * points the agent at a provider purely via shell env (e.g. Claude Code at
+   * OpenRouter via `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`) has a fully
+   * usable credential Lore can reuse for standalone `lore import` — even
+   * though nothing is stored in the agent's on-disk auth file. `scheme` is how
+   * the value is sent upstream: `bearer` (Authorization: Bearer) vs `api-key`
+   * (x-api-key / Anthropic-style). Omit for agents whose credential can't be
+   * read from a static env var (e.g. opencode, github-copilot token exchange).
+   */
+  authTokenEnvVars?: { var: string; scheme: "bearer" | "api-key" }[];
 }
 
 /**
@@ -123,6 +135,73 @@ export function captureUserUpstream(
     return { url: trimmed, wireProtocol: agent.wireProtocol };
   }
   return null;
+}
+
+/**
+ * Sanitize + validate a base-URL env value. Returns a clean http(s) URL string
+ * (control chars stripped, interior whitespace rejected — see the CRLF note in
+ * captureUserUpstream) or null if unusable. Loopback is NOT rejected here:
+ * unlike `lore run`, `lore import` starts no long-lived gateway to point at, so
+ * a loopback base URL (a running gateway the user already has) is a legitimate
+ * extraction upstream.
+ */
+function cleanBaseUrl(raw: string | undefined): string | null {
+  if (!raw) return null;
+  // oxlint-disable-next-line no-control-regex -- intentional control-character sanitization
+  const trimmed = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  if (!trimmed || /\s/.test(trimmed)) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      return null;
+  } catch {
+    return null;
+  }
+  return trimmed;
+}
+
+/**
+ * A credential the user configured for an agent purely through shell env vars:
+ * the agent's base-URL (`upstreamEnvVars`) plus its auth-token
+ * (`authTokenEnvVars`). This is a fully usable extraction credential even when
+ * NOTHING is stored in the agent's on-disk auth file — the common OpenRouter /
+ * corporate-proxy setup (e.g. Claude Code with ANTHROPIC_BASE_URL=openrouter.ai
+ * + ANTHROPIC_AUTH_TOKEN=<key>). Returns the token + scheme + captured upstream
+ * URL, so `lore import` can route extraction to that upstream. Returns null if
+ * the agent has no env-credential mechanism, or the token/base URL is missing.
+ * A base URL is NOT required (some setups set only the token and rely on the
+ * provider default), but a token IS.
+ */
+export function captureUserEnvCredential(
+  agent: AgentDef,
+  env: NodeJS.ProcessEnv = process.env,
+): {
+  token: string;
+  scheme: "bearer" | "api-key";
+  upstreamUrl: string | null;
+} | null {
+  if (!agent.authTokenEnvVars) return null;
+  let picked: { token: string; scheme: "bearer" | "api-key" } | null = null;
+  for (const { var: key, scheme } of agent.authTokenEnvVars) {
+    const raw = env[key];
+    if (!raw) continue;
+    // oxlint-disable-next-line no-control-regex -- intentional control-character sanitization
+    const token = raw.replace(/[\x00-\x1f\x7f]/g, "").trim();
+    if (!token) continue;
+    picked = { token, scheme };
+    break;
+  }
+  if (!picked) return null;
+  // Capture the paired base URL (first defined + valid), if any.
+  let upstreamUrl: string | null = null;
+  for (const key of agent.upstreamEnvVars ?? []) {
+    const clean = cleanBaseUrl(env[key]);
+    if (clean) {
+      upstreamUrl = clean;
+      break;
+    }
+  }
+  return { ...picked, upstreamUrl };
 }
 
 /**
@@ -204,6 +283,14 @@ export const AGENTS: AgentDef[] = [
     detect: () => whichSync("claude"),
     upstreamEnvVars: ["ANTHROPIC_BASE_URL"],
     wireProtocol: "anthropic",
+    // Claude Code: ANTHROPIC_AUTH_TOKEN is a Bearer token (used for
+    // OpenRouter / proxy setups); ANTHROPIC_API_KEY is the first-party
+    // x-api-key. Bearer wins when both are set (matches Claude Code's own
+    // precedence: an explicit auth token overrides the api key).
+    authTokenEnvVars: [
+      { var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" },
+      { var: "ANTHROPIC_API_KEY", scheme: "api-key" },
+    ],
     envVars: (url, cwd) => {
       const env: Record<string, string> = {
         ANTHROPIC_BASE_URL: url,
@@ -251,6 +338,7 @@ export const AGENTS: AgentDef[] = [
     detect: () => whichSync("codex"),
     upstreamEnvVars: ["OPENAI_BASE_URL"],
     wireProtocol: "openai",
+    authTokenEnvVars: [{ var: "OPENAI_API_KEY", scheme: "bearer" }],
     envVars: (_url, cwd) => {
       // Codex CLI is a Rust binary that does NOT read OPENAI_BASE_URL from the
       // environment. Provider routing is done exclusively via config.toml or

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -27,7 +27,8 @@ import {
   type AuthCredential,
 } from "../auth";
 import { defaultModelForProvider, parseWorkerModelEnv } from "../worker-model";
-import { resolveProviderRoute } from "../config";
+import { resolveProviderRoute, providerForUpstreamOrigin } from "../config";
+import { AGENTS, captureUserEnvCredential } from "./agents";
 import { exportLoreFile } from "@loreai/core";
 import { startGateway, type StartOptions } from "./start";
 import {
@@ -62,19 +63,40 @@ type AgentResolvedAuth =
  *      the caller resolves as `workerModel ?? model`).
  *   2. The harness's OWN on-disk auth (routable + unexpired) — the automatic
  *      "use my existing credentials" path.
- *   3. A live session / last-seen credential captured in THIS process (e.g.
+ *   3. The harness's env-based credential: its base-URL + auth-token env vars
+ *      (e.g. Claude Code with ANTHROPIC_BASE_URL=openrouter.ai +
+ *      ANTHROPIC_AUTH_TOKEN=<key>). This is the common OpenRouter / proxy setup
+ *      where nothing is stored on disk but the credential is fully usable.
+ *   4. A live session / last-seen credential captured in THIS process (e.g.
  *      `lore import` invoked after a session, or a warmed global fallback).
- *   4. `cfgModel` explicit override (falls to `resolveAuth`, may be null).
+ *   5. `cfgModel` explicit override (falls to `resolveAuth`, may be null).
  * Returns null when nothing usable is found for this agent.
  */
 export function resolveAgentImportAuth(
   agentName: string,
   workerApiKey: string | undefined,
   cfgModel: { providerID: string; modelID: string } | undefined,
-): {
-  getAuth: (sessionID?: string, providerID?: string) => AuthCredential | null;
-  model: { providerID: string; modelID: string };
-} | null {
+):
+  | {
+      getAuth: (
+        sessionID?: string,
+        providerID?: string,
+      ) => AuthCredential | null;
+      model: { providerID: string; modelID: string };
+      /** Upstream URL to route extraction to, when captured from the agent's env. */
+      upstream?: string;
+    }
+  | {
+      /**
+       * A credential WAS found in the agent's env, but its provider has no
+       * default worker model and the user set no model — so extraction would
+       * send an empty model id and 400. The caller must tell the user to set an
+       * explicit worker model (env override / `.lore.json` model) rather than
+       * silently fail.
+       */
+      needsModel: string;
+    }
+  | null {
   // 1. Explicit dedicated worker key wins. Provider comes from cfg.model when
   //    set, else anthropic (historical default for the raw-key path).
   if (workerApiKey) {
@@ -103,16 +125,76 @@ export function resolveAgentImportAuth(
     (c) => resolveProviderRoute(c.providerID)?.url != null,
   );
   if (usable) {
-    const model = usable.modelID
-      ? { providerID: usable.providerID, modelID: usable.modelID }
-      : defaultModelForProvider(usable.providerID);
+    // Honor an explicit user model (LORE_WORKER_MODEL / .lore.json) when it
+    // targets this credential's provider — the credential authenticates the
+    // provider, the user picks the model. This matters for GitHub Copilot,
+    // whose per-subscription model access varies: the built-in default
+    // (gpt-5-mini) may be unavailable on a Copilot plan that only serves
+    // claude-*, so a user who set LORE_WORKER_MODEL=github-copilot/claude-sonnet-5
+    // must get their model, not the default. Fall back to the credential's own
+    // model hint, then the provider default.
+    const model =
+      cfgModel && cfgModel.providerID === usable.providerID
+        ? cfgModel
+        : usable.modelID
+          ? { providerID: usable.providerID, modelID: usable.modelID }
+          : defaultModelForProvider(usable.providerID);
+    // A routable-but-defaultless provider (openrouter, deepseek, groq, …) has
+    // no WORKER_DEFAULTS entry, so defaultModelForProvider returns an empty
+    // modelID — and an on-disk credential often carries no modelID hint either
+    // (e.g. OpenCode's auth.json stores only the key). Sending model="" would
+    // 400 at the upstream, so signal needsModel instead of returning an
+    // unusable credential (same guard as tier 3). We DO have their key.
+    if (!model.modelID) {
+      return { needsModel: usable.providerID };
+    }
     return {
       getAuth: () => ({ scheme: usable.scheme, value: usable.value }),
       model,
     };
   }
 
-  // 3. Live session / last-seen credential captured in-process. Match the model
+  // 3. Harness ENV credential: the user pointed the agent at a provider purely
+  //    through shell env (base-URL + auth-token env vars), with nothing on disk.
+  //    Very common for OpenRouter / corporate-proxy setups. Resolve the provider
+  //    from the captured base URL (a known host → provider via the reverse map;
+  //    unknown host still works — we route extraction straight at that upstream
+  //    and default the model). Route extraction to the captured upstream.
+  const agentDef = AGENTS.find((a) => a.name === agentName);
+  if (agentDef) {
+    const envCred = captureUserEnvCredential(agentDef);
+    if (envCred) {
+      const providerID = envCred.upstreamUrl
+        ? (providerForUpstreamOrigin(envCred.upstreamUrl) ??
+          agentDef.wireProtocol ??
+          "anthropic")
+        : (agentDef.wireProtocol ?? "anthropic");
+      // Honor an explicit user model ONLY when it targets this credential's
+      // provider (same guard as tier 2) — the env credential authenticates
+      // `providerID`, so a cfgModel for a DIFFERENT provider would route this
+      // key to the wrong upstream/model. Otherwise fall back to the provider
+      // default.
+      const model =
+        cfgModel && cfgModel.providerID === providerID
+          ? cfgModel
+          : defaultModelForProvider(providerID);
+      // An aggregator/proxy provider (openrouter, deepseek, groq, …) has no
+      // WORKER_DEFAULTS entry, so defaultModelForProvider returns an empty
+      // modelID. Sending model="" would 400 at the upstream — so instead of
+      // silently returning an unusable credential, signal that the user must
+      // pick a model (LORE_WORKER_MODEL / .lore.json). We DO have their key.
+      if (!model.modelID) {
+        return { needsModel: providerID };
+      }
+      return {
+        getAuth: () => ({ scheme: envCred.scheme, value: envCred.token }),
+        model,
+        upstream: envCred.upstreamUrl ?? undefined,
+      };
+    }
+  }
+
+  // 4. Live session / last-seen credential captured in-process. Match the model
   //    to that credential's provider (or cfg.model when explicitly set) so the
   //    extraction routes to the provider we actually hold a credential for.
   const lastSeenProvider = getLastSeenAuthProvider() ?? undefined;
@@ -126,8 +208,61 @@ export function resolveAgentImportAuth(
     return { getAuth: resolveAuth, model };
   }
 
-  // 4. cfg.model override with no resolvable credential → nothing usable.
+  // 5. cfg.model override with no resolvable credential → nothing usable.
   return null;
+}
+
+/**
+ * Pick the per-protocol upstreams map for an extraction call. When the
+ * credential was captured from the agent's own env (tier 3, `agentUpstream`
+ * set), route BOTH protocol slots at that captured upstream (e.g.
+ * openrouter.ai) — unless the user configured an explicit dedicated
+ * `LORE_WORKER_UPSTREAM` (`configWorkerUpstream`), which always takes
+ * precedence. Otherwise fall back to the default per-protocol upstreams.
+ */
+export function resolveExtractionUpstreams(
+  agentUpstream: string | undefined,
+  configWorkerUpstream: string | undefined,
+  defaults: { anthropic: string; openai: string },
+): { anthropic: string; openai: string } {
+  if (agentUpstream && !configWorkerUpstream) {
+    return { anthropic: agentUpstream, openai: agentUpstream };
+  }
+  return defaults;
+}
+
+/**
+ * Build the "found your credential but no worker model" guidance shown when one
+ * or more agents resolved a credential for a provider with no default worker
+ * model (and the user set none). Returns null when there's nothing to say.
+ *
+ * Independent of whether OTHER agents authenticated: the per-agent skip lines
+ * promise "(see below)", so this guidance must appear whenever ANY agent hit
+ * the needsModel condition. `anyAuthResolved` only tweaks the wording ("some
+ * agents") — the caller decides whether to also stop the run.
+ */
+export function buildNeedsModelGuidance(
+  providers: string[],
+  anyAuthResolved: boolean,
+): string | null {
+  if (providers.length === 0) return null;
+  const providerList = providers.join(", ");
+  const exportLines = providers
+    .map(
+      (p) =>
+        `[lore]   export LORE_WORKER_MODEL=${p}/<model>   # e.g. ${p}/gpt-5-mini`,
+    )
+    .join("\n");
+  return (
+    `\n[lore] Can't import${anyAuthResolved ? " some agents" : ""}: found your ${providerList} credential(s), but\n` +
+    `[lore] no built-in default worker model exists for ${providers.length > 1 ? "those providers" : providerList}, so Lore\n` +
+    `[lore] doesn't know which model to run extraction on. Pick one and retry:\n` +
+    `[lore]\n` +
+    `${exportLines}\n` +
+    `[lore]   lore import\n` +
+    `[lore]\n` +
+    `[lore] (or set \`model\` / \`workerModel\` in .lore.json).`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -805,6 +940,10 @@ export async function commandImport(
     // Track whether ANY agent had a usable credential, so we can print
     // accurate guidance if the whole run authenticated nothing.
     let anyAuthResolved = false;
+    // Providers for which we found an agent's env credential but no default
+    // model (and the user set none) — collected across ALL agents so the final
+    // guidance names every affected provider, not just the last one seen.
+    const needsModelProviders = new Set<string>();
 
     for (const result of results) {
       const provider = getProvider(result.agentName);
@@ -825,13 +964,36 @@ export async function commandImport(
         );
         continue;
       }
+      if ("needsModel" in auth) {
+        // We HAVE the user's key but not a model to use it with.
+        needsModelProviders.add(auth.needsModel);
+        console.log(
+          `[lore] Skipping ${result.agentDisplayName}: found your ${auth.needsModel} ` +
+            `credential, but no worker model is set for that provider. ` +
+            `Set one and retry (see below).`,
+        );
+        continue;
+      }
       anyAuthResolved = true;
 
-      const llm = createGatewayLLMClient(
+      // When the credential was captured from the agent's own env (tier 3),
+      // route extraction to that captured upstream (e.g. openrouter.ai), not
+      // the default anthropic/openai host. A dedicated worker key
+      // (config.workerUpstream) still takes precedence.
+      const agentUpstreams = resolveExtractionUpstreams(
+        auth.upstream,
+        config.workerUpstream,
         workerUpstreams,
+      );
+
+      const llm = createGatewayLLMClient(
+        agentUpstreams,
         auth.getAuth,
         auth.model,
-        { dedicatedWorkerKey: !!workerApiKey },
+        // A captured env credential is a user-provided key for a specific
+        // upstream — treat it like a dedicated worker key so the in-adapter
+        // protocol-mismatch pre-flight doesn't reject a non-anthropic key.
+        { dedicatedWorkerKey: !!workerApiKey || auth.upstream != null },
       );
 
       const sessionIds = result.sessions.map((s) => s.id);
@@ -897,6 +1059,25 @@ export async function commandImport(
       totalFailed += extractResult.chunksFailed;
     }
 
+    // We found the user's credential but no model to drive it (an aggregator /
+    // proxy provider with no built-in default, and no model configured). Tell
+    // them exactly how to fix it — we're one env var away from working. Name
+    // EVERY affected provider (a multi-agent run can hit more than one). Shown
+    // whenever ANY agent hit this, even if OTHERS authenticated successfully —
+    // the per-agent skip lines promised "(see below)", so the guidance must
+    // always appear when a needsModel failure occurred.
+    const needsModelMsg = buildNeedsModelGuidance(
+      [...needsModelProviders],
+      anyAuthResolved,
+    );
+    if (needsModelMsg) {
+      console.error(needsModelMsg);
+      // Nothing else authenticated → stop here (don't fall through to the
+      // generic "no credential" block or the success summary). If OTHER agents
+      // succeeded, keep going so their import still records + summarizes.
+      if (!anyAuthResolved) return;
+    }
+
     // No agent had a usable credential — explain how to fix it, then stop
     // before claiming a successful (empty) import. Only name a specific
     // provider in the key hint when the user EXPLICITLY configured a model;
@@ -908,15 +1089,22 @@ export async function commandImport(
         : "<key for your provider>";
       console.error(
         "\n[lore] Can't import: no usable credential found for background extraction.\n" +
-          "[lore] `lore import` authenticates using each agent's OWN stored credentials,\n" +
-          "[lore] but none were usable (none found, expired, or the provider needs a\n" +
-          "[lore] runtime token exchange Lore can't do standalone, e.g. GitHub Copilot).\n" +
-          "[lore] Two ways forward:\n" +
+          "[lore] `lore import` authenticates using each agent's OWN credentials —\n" +
+          "[lore] its on-disk auth file OR its base-URL + auth-token env vars (e.g.\n" +
+          "[lore] ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN) — but none were usable\n" +
+          "[lore] (none found, expired, or the provider needs a runtime token exchange\n" +
+          "[lore] Lore can't do standalone, e.g. GitHub Copilot).\n" +
+          "[lore] Ways forward:\n" +
           "[lore]\n" +
-          "[lore]   1. Easiest — run `lore run`, send one message, and the import\n" +
-          "[lore]      happens automatically once your credential is captured.\n" +
+          "[lore]   1. If you launch your agent with base-URL + token env vars set\n" +
+          "[lore]      (OpenRouter / proxy setups), export them in THIS shell and retry:\n" +
+          "[lore]        export ANTHROPIC_BASE_URL=... ANTHROPIC_AUTH_TOKEN=...\n" +
+          "[lore]        lore import\n" +
           "[lore]\n" +
-          "[lore]   2. Give `lore import` a dedicated worker key and retry:\n" +
+          "[lore]   2. Or run `lore run`, send one message, and the import happens\n" +
+          "[lore]      automatically once your credential is captured.\n" +
+          "[lore]\n" +
+          "[lore]   3. Or give `lore import` a dedicated worker key and retry:\n" +
           `[lore]        export LORE_WORKER_API_KEY=${keyHint}\n` +
           "[lore]        lore import",
       );

--- a/packages/gateway/test/import-auth-chain.test.ts
+++ b/packages/gateway/test/import-auth-chain.test.ts
@@ -4,7 +4,24 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { resolveAgentImportAuth } from "../src/cli/import";
+import {
+  resolveExtractionUpstreams,
+  buildNeedsModelGuidance,
+} from "../src/cli/import";
 import { workerKeyScheme } from "../src/auth";
+
+type ImportAuth = NonNullable<ReturnType<typeof resolveAgentImportAuth>>;
+type UsableAuth = Extract<ImportAuth, { getAuth: unknown }>;
+
+/**
+ * Assert the result is a usable auth (not null and not the `needsModel`
+ * signal) and return it narrowed, so tests can access model/getAuth/upstream.
+ */
+function usable(res: ImportAuth | null): UsableAuth {
+  expect(res).not.toBeNull();
+  expect(res).not.toHaveProperty("needsModel");
+  return res as UsableAuth;
+}
 
 let tmp: string;
 const saved: Record<string, string | undefined> = {};
@@ -26,6 +43,13 @@ beforeEach(() => {
   setEnv("HOME", tmp);
   setEnv("XDG_DATA_HOME", join(tmp, ".local", "share"));
   setEnv("XDG_CONFIG_HOME", join(tmp, ".config"));
+  // Clear agent env credentials so each test starts from a known state
+  // (the runner's own shell may have these set).
+  setEnv("ANTHROPIC_BASE_URL", undefined);
+  setEnv("ANTHROPIC_AUTH_TOKEN", undefined);
+  setEnv("ANTHROPIC_API_KEY", undefined);
+  setEnv("OPENAI_BASE_URL", undefined);
+  setEnv("OPENAI_API_KEY", undefined);
 });
 
 afterEach(() => {
@@ -41,12 +65,12 @@ describe("resolveAgentImportAuth", () => {
       providerID: "openai",
       modelID: "gpt-5.6-luna",
     });
-    expect(res).not.toBeNull();
-    expect(res?.model).toEqual({
+    const ok = usable(res);
+    expect(ok.model).toEqual({
       providerID: "openai",
       modelID: "gpt-5.6-luna",
     });
-    const cred = res?.getAuth(undefined, "openai");
+    const cred = ok.getAuth(undefined, "openai");
     expect(cred).toEqual({
       scheme: workerKeyScheme("openai"),
       value: "worker-key-123",
@@ -55,19 +79,49 @@ describe("resolveAgentImportAuth", () => {
 
   test("worker key with no cfg.model defaults provider to anthropic", () => {
     const res = resolveAgentImportAuth("opencode", "wk", undefined);
-    expect(res?.model.providerID).toBe("anthropic");
-    expect(res?.getAuth(undefined, undefined)).toEqual({
+    const ok = usable(res);
+    expect(ok.model.providerID).toBe("anthropic");
+    expect(ok.getAuth(undefined, undefined)).toEqual({
       scheme: "api-key",
       value: "wk",
     });
   });
 
   test("harness on-disk api-key is used when no worker key", () => {
+    // anthropic HAS a WORKER_DEFAULTS entry, so the stored key resolves to a
+    // usable credential with a concrete model even with no cfgModel.
+    writeOpenCodeAuth({ anthropic: { type: "api", key: "sk-ant-xyz" } });
+    const res = resolveAgentImportAuth("opencode", undefined, undefined);
+    const ok = usable(res);
+    expect(ok.model.providerID).toBe("anthropic");
+    expect(ok.model.modelID).toBeTruthy(); // real default, never empty
+    expect(ok.getAuth()).toEqual({ scheme: "api-key", value: "sk-ant-xyz" });
+  });
+
+  test("on-disk key for a routable-but-defaultless provider + no model → needsModel (never an empty-model 400)", () => {
+    // openrouter is routable (has a route URL) but has NO WORKER_DEFAULTS entry,
+    // and OpenCode's auth.json stores only the key (no modelID hint). Tier 2
+    // must signal needsModel rather than return {modelID:""} → silent 400.
     writeOpenCodeAuth({ openrouter: { type: "api", key: "sk-or-xyz" } });
     const res = resolveAgentImportAuth("opencode", undefined, undefined);
-    expect(res).not.toBeNull();
-    expect(res?.model.providerID).toBe("openrouter");
-    expect(res?.getAuth()).toEqual({ scheme: "api-key", value: "sk-or-xyz" });
+    expect(res).toEqual({ needsModel: "openrouter" });
+  });
+
+  test("on-disk key for a defaultless provider IS usable with a same-provider cfgModel", () => {
+    // The escape hatch: a matching LORE_WORKER_MODEL supplies the model tier 2
+    // otherwise lacks, so the openrouter key becomes usable.
+    writeOpenCodeAuth({ openrouter: { type: "api", key: "sk-or-xyz" } });
+    const ok = usable(
+      resolveAgentImportAuth("opencode", undefined, {
+        providerID: "openrouter",
+        modelID: "openrouter/some-model",
+      }),
+    );
+    expect(ok.model).toEqual({
+      providerID: "openrouter",
+      modelID: "openrouter/some-model",
+    });
+    expect(ok.getAuth()).toEqual({ scheme: "api-key", value: "sk-or-xyz" });
   });
 
   test("skips harness credential for a provider Lore does not proxy", () => {
@@ -100,9 +154,9 @@ describe("resolveAgentImportAuth", () => {
       },
     });
     const res = resolveAgentImportAuth("opencode", undefined, undefined);
-    expect(res).not.toBeNull();
-    expect(res?.model.providerID).toBe("github-copilot");
-    expect(res?.getAuth()).toEqual({
+    const ok = usable(res);
+    expect(ok.model.providerID).toBe("github-copilot");
+    expect(ok.getAuth()).toEqual({
       scheme: "bearer",
       value: "gho_refresh",
     });
@@ -111,11 +165,57 @@ describe("resolveAgentImportAuth", () => {
   test("prefers a routable credential over an unroutable earlier one", () => {
     writeOpenCodeAuth({
       "nonexistent-provider": { type: "api", key: "skip-me" },
-      minimax: { type: "api", key: "use-me" },
+      anthropic: { type: "api", key: "use-me" },
     });
     const res = resolveAgentImportAuth("opencode", undefined, undefined);
-    expect(res?.model.providerID).toBe("minimax");
-    expect(res?.getAuth()).toEqual({ scheme: "api-key", value: "use-me" });
+    const ok = usable(res);
+    expect(ok.model.providerID).toBe("anthropic");
+    expect(ok.getAuth()).toEqual({ scheme: "api-key", value: "use-me" });
+  });
+
+  test("on-disk credential honors an explicit same-provider cfgModel (LORE_WORKER_MODEL override) — Kjaer Copilot case", () => {
+    // github-copilot on-disk token, but the user set LORE_WORKER_MODEL to a
+    // model their Copilot plan actually serves (the default gpt-5-mini may be
+    // unavailable). The explicit model must win over the built-in default.
+    writeOpenCodeAuth({
+      "github-copilot": {
+        type: "oauth",
+        access: "gho_access",
+        refresh: "gho_refresh",
+        expires: 0,
+      },
+    });
+    const res = resolveAgentImportAuth("opencode", undefined, {
+      providerID: "github-copilot",
+      modelID: "claude-sonnet-5",
+    });
+    const ok = usable(res);
+    expect(ok.model).toEqual({
+      providerID: "github-copilot",
+      modelID: "claude-sonnet-5",
+    });
+    // Still uses the on-disk credential (tier 2), not a worker key.
+    expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "gho_refresh" });
+  });
+
+  test("on-disk credential ignores a cfgModel for a DIFFERENT provider (keeps its own provider's default)", () => {
+    writeOpenCodeAuth({
+      "github-copilot": {
+        type: "oauth",
+        access: "gho_access",
+        refresh: "gho_refresh",
+        expires: 0,
+      },
+    });
+    // cfgModel targets anthropic, but the credential is github-copilot → the
+    // override must NOT apply (it'd route a copilot token to an anthropic model).
+    const res = resolveAgentImportAuth("opencode", undefined, {
+      providerID: "anthropic",
+      modelID: "claude-sonnet-5",
+    });
+    const ok = usable(res);
+    expect(ok.model.providerID).toBe("github-copilot");
+    expect(ok.model.modelID).toBe("gpt-5-mini"); // copilot default, not the anthropic override
   });
 
   test("returns null when the agent has no on-disk auth and no worker key", () => {
@@ -128,8 +228,220 @@ describe("resolveAgentImportAuth", () => {
     // oauth entry for a routable provider still resolves to the default model.
     writeOpenCodeAuth({ anthropic: { type: "api", key: "sk-ant" } });
     const res = resolveAgentImportAuth("opencode", undefined, undefined);
-    expect(res?.model.providerID).toBe("anthropic");
+    const ok = usable(res);
+    expect(ok.model.providerID).toBe("anthropic");
     // default model for anthropic
-    expect(res?.model.modelID).toBe("claude-sonnet-5");
+    expect(ok.model.modelID).toBe("claude-sonnet-5");
+  });
+});
+
+describe("resolveAgentImportAuth — harness env credential (tier 3)", () => {
+  // OpenRouter has no built-in default worker model, so callers must supply a
+  // model (LORE_WORKER_MODEL / .lore.json). Simulate that with cfgModel.
+  const orModel = {
+    providerID: "openrouter",
+    modelID: "openrouter/gpt-5-mini",
+  };
+
+  test("Claude Code via ANTHROPIC_BASE_URL=openrouter + ANTHROPIC_AUTH_TOKEN (bearer) — the OpenRouter setup", () => {
+    // Fresh tmp HOME → no on-disk claude auth, so the env credential is used.
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "sk-or-live");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", undefined, orModel),
+    );
+    expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "sk-or-live" });
+    // cfgModel is honored for the (defaultless) openrouter provider.
+    expect(ok.model).toEqual(orModel);
+    // Extraction is routed to the captured upstream.
+    expect(ok.upstream).toBe("https://openrouter.ai/api");
+  });
+
+  test("env credential for a provider with NO default model + no cfgModel → needsModel signal (not a silent empty-model 400)", () => {
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "sk-or-live");
+    const res = resolveAgentImportAuth("claude-code", undefined, undefined);
+    expect(res).toEqual({ needsModel: "openrouter" });
+  });
+
+  test("ANTHROPIC_AUTH_TOKEN (bearer) wins over ANTHROPIC_API_KEY (api-key)", () => {
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "sk-or-bearer");
+    setEnv("ANTHROPIC_API_KEY", "sk-apikey");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", undefined, orModel),
+    );
+    expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "sk-or-bearer" });
+  });
+
+  test("ANTHROPIC_API_KEY (api-key) used when no auth token", () => {
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_API_KEY", "sk-apikey");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", undefined, orModel),
+    );
+    expect(ok.getAuth()).toEqual({ scheme: "api-key", value: "sk-apikey" });
+  });
+
+  test("token with no base URL falls back to the agent's wire-protocol provider (anthropic has a default model), no upstream", () => {
+    setEnv("ANTHROPIC_AUTH_TOKEN", "sk-tok");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", undefined, undefined),
+    );
+    expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "sk-tok" });
+    expect(ok.model.providerID).toBe("anthropic"); // wireProtocol fallback
+    expect(ok.model.modelID).toBeTruthy(); // anthropic HAS a default model
+    expect(ok.upstream).toBeUndefined();
+  });
+
+  test("unknown-host base URL routes extraction there; provider defaults to wire protocol (anthropic → has default model)", () => {
+    setEnv("ANTHROPIC_BASE_URL", "https://llm.corp.internal");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "corp-tok");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", undefined, undefined),
+    );
+    expect(ok.upstream).toBe("https://llm.corp.internal");
+    expect(ok.model.providerID).toBe("anthropic");
+    expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "corp-tok" });
+  });
+
+  test("env credential ignores a cfgModel for a DIFFERENT provider (same guard as tier 2) — Seer #15446146", () => {
+    // Env points the agent at OpenRouter, but the user's LORE_WORKER_MODEL names
+    // a github-copilot model. Applying it would route the OpenRouter key to a
+    // copilot model → cross-provider mismatch. The override must be ignored and
+    // fall back to the captured provider's default (openrouter has none →
+    // needsModel), NOT silently used.
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "sk-or-live");
+    const res = resolveAgentImportAuth("claude-code", undefined, {
+      providerID: "github-copilot",
+      modelID: "claude-sonnet-5",
+    });
+    // openrouter has no default model and the mismatched cfgModel is ignored.
+    expect(res).toEqual({ needsModel: "openrouter" });
+  });
+
+  test("env credential honors a cfgModel for the SAME (captured) provider", () => {
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "sk-or-live");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", undefined, {
+        providerID: "openrouter",
+        modelID: "openrouter/some-model",
+      }),
+    );
+    expect(ok.model).toEqual({
+      providerID: "openrouter",
+      modelID: "openrouter/some-model",
+    });
+    expect(ok.upstream).toBe("https://openrouter.ai/api");
+  });
+
+  test("on-disk auth (tier 2) takes precedence over env credential (tier 3)", () => {
+    // opencode has on-disk auth AND we set an env token — but opencode has no
+    // authTokenEnvVars, so only tier 2 applies. Use claude-code with BOTH a
+    // stored credential and env vars to prove ordering.
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmp, ".claude", ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: { accessToken: "disk-oauth", expiresAt: null },
+      }),
+      "utf8",
+    );
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "env-token");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", undefined, undefined),
+    );
+    // Tier 2 (on-disk) wins: provider anthropic, not openrouter; no upstream.
+    expect(ok.model.providerID).toBe("anthropic");
+    expect(ok.getAuth()?.value).toBe("disk-oauth");
+    expect(ok.upstream).toBeUndefined();
+  });
+
+  test("worker key (tier 1) takes precedence over env credential (tier 3)", () => {
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    setEnv("ANTHROPIC_AUTH_TOKEN", "env-token");
+    const ok = usable(
+      resolveAgentImportAuth("claude-code", "sk-ant-worker", undefined),
+    );
+    expect(ok.getAuth(undefined, "anthropic")?.value).toBe("sk-ant-worker");
+    expect(ok.upstream).toBeUndefined();
+  });
+
+  test("no token and no on-disk auth → null (unchanged behavior)", () => {
+    setEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+    const res = resolveAgentImportAuth("claude-code", undefined, undefined);
+    expect(res).toBeNull();
+  });
+});
+
+describe("resolveExtractionUpstreams", () => {
+  const defaults = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  test("captured env upstream routes BOTH protocol slots at it", () => {
+    expect(
+      resolveExtractionUpstreams(
+        "https://openrouter.ai/api",
+        undefined,
+        defaults,
+      ),
+    ).toEqual({
+      anthropic: "https://openrouter.ai/api",
+      openai: "https://openrouter.ai/api",
+    });
+  });
+
+  test("explicit LORE_WORKER_UPSTREAM (configWorkerUpstream) beats the env upstream", () => {
+    // A user-set dedicated worker upstream always wins — we keep the defaults
+    // map (which the caller already pointed at config.workerUpstream).
+    expect(
+      resolveExtractionUpstreams(
+        "https://openrouter.ai/api",
+        "https://proxy.example/v1",
+        defaults,
+      ),
+    ).toEqual(defaults);
+  });
+
+  test("no captured upstream → defaults unchanged", () => {
+    expect(resolveExtractionUpstreams(undefined, undefined, defaults)).toEqual(
+      defaults,
+    );
+  });
+});
+
+describe("buildNeedsModelGuidance", () => {
+  test("no providers → null (nothing to say)", () => {
+    expect(buildNeedsModelGuidance([], false)).toBeNull();
+    expect(buildNeedsModelGuidance([], true)).toBeNull();
+  });
+
+  test("single provider, nothing else authenticated → full guidance, no 'some agents'", () => {
+    const msg = buildNeedsModelGuidance(["openrouter"], false);
+    expect(msg).toContain("Can't import:");
+    expect(msg).not.toContain("some agents");
+    expect(msg).toContain("export LORE_WORKER_MODEL=openrouter/<model>");
+  });
+
+  test("partial success (some agents authed) → guidance STILL produced, worded 'some agents' — Seer #15456784", () => {
+    // The whole point: a needsModel failure must surface guidance even when
+    // OTHER agents succeeded, because the per-agent skip line promised it.
+    const msg = buildNeedsModelGuidance(["openrouter"], true);
+    expect(msg).not.toBeNull();
+    expect(msg).toContain("some agents");
+    expect(msg).toContain("export LORE_WORKER_MODEL=openrouter/<model>");
+  });
+
+  test("multiple providers → one export line each; plural wording", () => {
+    const msg = buildNeedsModelGuidance(["openrouter", "deepseek"], false);
+    expect(msg).toContain("export LORE_WORKER_MODEL=openrouter/<model>");
+    expect(msg).toContain("export LORE_WORKER_MODEL=deepseek/<model>");
+    expect(msg).toContain("those providers");
+    expect(msg).toContain("openrouter, deepseek");
   });
 });


### PR DESCRIPTION
## Problem

The OpenRouter user from #1398 upgraded to the latest nightly (which has the on-disk-auth import + `lore run` adoption fixes) but standalone `lore import` still fails:

```
[lore] Skipping Claude Code: no usable credential found in its on-disk auth
       (none stored, expired, or provider not proxied).
[lore] Can't import: no usable credential found for background extraction.
```

His whole setup authenticates through shell env vars, not Claude Code's on-disk auth:

```zsh
export ANTHROPIC_BASE_URL="https://openrouter.ai/api"
export ANTHROPIC_AUTH_TOKEN="<openrouter key>"
export ANTHROPIC_API_KEY=""
```

That's a fully usable credential — but `resolveAgentImportAuth` never looked at it. It reads the agent's on-disk auth file, `LORE_WORKER_API_KEY`, and last-seen session creds only. So a very common OpenRouter / corporate-proxy setup falls through to "no usable credential" and gets told to run `lore run` or set a worker key, when nothing more was needed.

## Fix

Add a new credential tier (between on-disk auth and last-seen session) that reads the agent's **own base-URL + auth-token env vars**:

- New `AgentDef.authTokenEnvVars` field:
  - Claude Code: `ANTHROPIC_AUTH_TOKEN` (Bearer, wins) / `ANTHROPIC_API_KEY` (x-api-key)
  - Codex: `OPENAI_API_KEY` (Bearer)
- The captured base URL resolves the provider via `providerForUpstreamOrigin` (`openrouter.ai` → `openrouter`), and extraction is routed straight at that upstream (treated like a dedicated worker key so the in-adapter protocol-mismatch pre-flight is skipped).
- Unknown hosts still work — route at the captured upstream, default the model to the agent's wire protocol.
- A token with no base URL falls back to the wire-protocol provider default.

New shared helper `captureUserEnvCredential` reuses the same URL sanitization as `captureUserUpstream` (control-char strip + interior-whitespace reject). Guidance message refreshed to mention the env-var path.

**Precedence (unchanged for existing paths):** worker key (1) > on-disk auth (2) > **env credential (3, new)** > last-seen session (4) > `cfg.model` (5).

## Tests

9 new cases in `import-auth-chain.test.ts`: the OpenRouter setup, bearer>api-key, api-key fallback, no-base-URL fallback, unknown host, tier ordering vs on-disk auth and worker key, null when no token. Mutation-verified (disable tier 3 → 5 tests red). Full gate green (typecheck, lint, 97 tests, format).