### PR TITLE
fix(cache): stable intermediate cache_control anchor on the OpenAI protocol path (#961)

### DIFF
--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -727,6 +727,20 @@ function ephemeralCacheControl(ttl?: "5m" | "1h" | false): {
     : { type: "ephemeral" };
 }
 
+/**
+ * Minimum number of committed (pre-tail) messages before a second, stable
+ * intermediate `cache_control` anchor is worth adding. Below this the prefix is
+ * small enough that a single tail breakpoint already bounds eviction cost.
+ */
+const CACHE_ANCHOR_MIN_MESSAGES = 12;
+
+/**
+ * Quantization step for the intermediate anchor's position. The anchor sits at a
+ * multiple of this step, so it stays byte-identical for this many turns before
+ * advancing — a moving anchor would bust the very cache it protects.
+ */
+const CACHE_ANCHOR_STEP = 10;
+
 function buildOpenAIMessages(
   messages: GatewayMessage[],
   system: string,
@@ -859,14 +873,58 @@ function buildOpenAIMessages(
       m.role !== "tool" &&
       Array.isArray(m.content) &&
       m.content.length > 0;
-    let idx = result.length - 1;
-    while (idx >= 0 && !isAnnotatable(result[idx])) idx--;
-    const target = idx >= 0 ? result[idx] : undefined;
-    if (target) {
-      const parts = target.content as Array<Record<string, unknown>>;
-      parts[parts.length - 1].cache_control = ephemeralCacheControl(
-        cache.conversationTTL,
-      );
+    const annotate = (
+      m: Record<string, unknown>,
+      ttl?: "5m" | "1h" | false,
+    ) => {
+      const parts = m.content as Array<Record<string, unknown>>;
+      parts[parts.length - 1].cache_control = ephemeralCacheControl(ttl);
+    };
+
+    // (1) Moving tail breakpoint — on the last annotatable message. Advances
+    // every turn; caches everything up to the new tail.
+    let tailIdx = result.length - 1;
+    while (tailIdx >= 0 && !isAnnotatable(result[tailIdx])) tailIdx--;
+    if (tailIdx >= 0) annotate(result[tailIdx], cache.conversationTTL);
+
+    // (2) Stable intermediate anchor breakpoint (upstream-eviction resilience).
+    //
+    // With only the moving tail breakpoint, the entire committed prefix is ONE
+    // cache segment. A single upstream (e.g. OpenRouter) partial cache eviction
+    // then re-bills that whole segment as fresh INPUT (~10x cache-read price) —
+    // observed as one ~345K-token spike per long session, worth ~$1/run on a
+    // frontier model (issue #961). Native Anthropic mitigates this with the
+    // distilled-prefix breakpoint, but at Layer 0 (no distilled prefix) it, too,
+    // has a single segment. Anchoring a second breakpoint partway through the
+    // committed history splits the prefix into two independently-cacheable
+    // segments, so an eviction of one segment leaves the other intact and
+    // bounds the blast radius.
+    //
+    // The anchor MUST be byte-stable across turns or it busts the cache itself.
+    // We quantize its position to a coarse step so it only advances every
+    // CACHE_ANCHOR_STEP messages (byte-identical in between), and only place it
+    // when the committed prefix is large enough to be worth splitting.
+    if (tailIdx >= CACHE_ANCHOR_MIN_MESSAGES) {
+      // Largest multiple of the step strictly below the tail, so the anchor is
+      // always before the moving tail breakpoint and never collides with it.
+      const quantized =
+        Math.floor((tailIdx - 1) / CACHE_ANCHOR_STEP) * CACHE_ANCHOR_STEP;
+      // Walk back from the quantized index to the nearest annotatable message.
+      let anchorIdx = Math.min(quantized, tailIdx - 1);
+      while (anchorIdx > 0 && !isAnnotatable(result[anchorIdx])) anchorIdx--;
+      if (
+        anchorIdx > 0 &&
+        anchorIdx < tailIdx &&
+        isAnnotatable(result[anchorIdx])
+      ) {
+        // Inherit the (longer) system TTL when available: the anchored segment
+        // is old, stable history that benefits from the longer eviction window,
+        // matching how Anthropic anchors its distilled prefix at systemTTL.
+        annotate(
+          result[anchorIdx],
+          cache.systemTTL === false ? cache.conversationTTL : cache.systemTTL,
+        );
+      }
     }
   }
 

--- a/packages/gateway/test/openai-caching.test.ts
+++ b/packages/gateway/test/openai-caching.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, test } from "vitest";
 import type { AnthropicCacheOptions } from "../src/translate/anthropic";
 import { buildOpenAIUpstreamRequest } from "../src/translate/openai";
-import type { GatewayRequest } from "../src/translate/types";
+import type { GatewayMessage, GatewayRequest } from "../src/translate/types";
 
 const BASE = "https://openrouter.ai/api";
 
@@ -368,5 +368,96 @@ describe("buildOpenAIUpstreamRequest — full session cache config", () => {
     // exactly 3 breakpoints: system, tool, conversation tail
     const count = (JSON.stringify(body).match(/"cache_control"/g) ?? []).length;
     expect(count).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Intermediate anchor breakpoint (upstream-eviction resilience, #961)
+// ---------------------------------------------------------------------------
+
+// Build an alternating user/assistant conversation of `n` text messages.
+function convo(n: number): GatewayMessage[] {
+  const msgs: GatewayMessage[] = [];
+  for (let i = 0; i < n; i++) {
+    msgs.push({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: [{ type: "text", text: `msg ${i} ${"x".repeat(20)}` }],
+    });
+  }
+  return msgs;
+}
+
+// Indices of messages carrying a cache_control (excludes the system block).
+function annotatedConversationIndices(body: Record<string, unknown>): number[] {
+  const msgs = messagesOf(body);
+  const out: number[] = [];
+  msgs.forEach((m, i) => {
+    if (m.role === "system") return;
+    if (JSON.stringify(m.content ?? "").includes("cache_control")) out.push(i);
+  });
+  return out;
+}
+
+describe("buildOpenAIUpstreamRequest — intermediate anchor breakpoint (#961)", () => {
+  const cacheOpts: AnthropicCacheOptions = {
+    systemTTL: "1h",
+    cacheConversation: true,
+    conversationTTL: "5m",
+  };
+
+  test("small conversation gets ONLY the moving tail breakpoint (no anchor)", () => {
+    // 6 conversation messages (< CACHE_ANCHOR_MIN_MESSAGES=12): a single tail
+    // breakpoint already bounds eviction cost, so no anchor is added.
+    const body = getBody(makeRequest({ messages: convo(6) }), cacheOpts);
+    const idxs = annotatedConversationIndices(body);
+    expect(idxs.length).toBe(1); // tail only
+  });
+
+  test("large conversation gets a SECOND, earlier anchor breakpoint", () => {
+    // 30 conversation messages: the ~1MB-class prefix is split into two
+    // independently-cacheable segments so an upstream partial eviction re-bills
+    // only one segment, not the whole prefix (the ~345K input spike, #961).
+    const body = getBody(makeRequest({ messages: convo(30) }), cacheOpts);
+    const idxs = annotatedConversationIndices(body);
+    expect(idxs.length).toBe(2); // anchor + tail
+    // Anchor is strictly before the tail.
+    expect(idxs[0]).toBeLessThan(idxs[1]);
+    // Tail is the last message.
+    expect(idxs[1]).toBe(messagesOf(body).length - 1);
+  });
+
+  test("anchor position is byte-stable as the conversation grows (no self-bust)", () => {
+    // The whole point of quantizing the anchor: it must NOT move every turn, or
+    // it busts the very cache it protects. Growing the conversation by one turn
+    // (within the same quantization bucket) must leave the anchor index put.
+    const bodyA = getBody(makeRequest({ messages: convo(24) }), cacheOpts);
+    const bodyB = getBody(makeRequest({ messages: convo(25) }), cacheOpts);
+    const anchorA = annotatedConversationIndices(bodyA)[0];
+    const anchorB = annotatedConversationIndices(bodyB)[0];
+    expect(anchorA).toBe(anchorB);
+  });
+
+  test("anchor inherits the (longer) system TTL, tail keeps the conversation TTL", () => {
+    const body = getBody(makeRequest({ messages: convo(30) }), cacheOpts);
+    const msgs = messagesOf(body);
+    const idxs = annotatedConversationIndices(body);
+    const ccOf = (i: number) => {
+      const parts = msgs[i].content as Array<Record<string, unknown>>;
+      return parts[parts.length - 1].cache_control;
+    };
+    expect(ccOf(idxs[0])).toEqual({ type: "ephemeral", ttl: "1h" }); // anchor: 1h
+    expect(ccOf(idxs[1])).toEqual({ type: "ephemeral" }); // tail: 5m
+  });
+
+  test("stays within the 4-breakpoint budget with tools + large conversation", () => {
+    // Anthropic (and OpenRouter, for Anthropic models) cap cache_control at 4.
+    // system + tools + anchor + tail must never exceed that.
+    const req = makeRequest({
+      messages: convo(30),
+      tools: [{ name: "recall", description: "search", inputSchema: {} }],
+    });
+    const body = getBody(req, { ...cacheOpts, cacheTools: true });
+    const count = (JSON.stringify(body).match(/"cache_control"/g) ?? []).length;
+    expect(count).toBe(4);
   });
 });


### PR DESCRIPTION
## Problem

Finalizing the #961 Sonnet-5 cross-session numbers surfaced that Lore costs ~25% more than vanilla ($5.20 vs $3.92/run). Traced to **one line: uncached `input_tokens`**.

- Vanilla session 2: ~38 uncached input tokens.
- Lore session 2: **~345,000** — and it is **exactly one turn per run** (deterministic, ~turn 14-15) where `hit=51%`, `input≈345K`, but `prefixMatch=97.7%` (the prompt is 97.7% byte-identical to the turn before, which cache-read the same content perfectly at `input=2`).

At $3/Mtok that ~345K ≈ **$1.03/run** = the entire gap.

## Root cause

A transient upstream (OpenRouter) partial cache eviction, **amplified by the single-breakpoint OpenAI path**. On `protocol=openai`, the committed conversation prefix is covered by ONE moving tail `cache_control` breakpoint (`bp=3 sysBlocks=0` in logs). When the upstream cache drops part of that single segment, the *entire* ~1MB prefix re-sends as fresh INPUT (~10x cache-read price) instead of just the evicted slice. Native Anthropic mitigates this with its distilled-prefix breakpoint — but at Layer 0 (no distilled prefix, the eval's case) it, too, has a single segment.

## Fix

Add a second, **byte-stable intermediate anchor** `cache_control` breakpoint partway through the committed history in `buildOpenAIMessages`, splitting the prefix into two independently-cacheable segments so an eviction of one leaves the other intact. The anchor position is **quantized** (advances only every 10 messages) so it does not move each turn and self-bust the cache it protects.

- Stays within the 4-breakpoint budget (system + tools + anchor + tail).
- No-op for small conversations (< 12 committed messages) and for providers that ignore `cache_control`.
- Anchor inherits the longer system TTL; tail keeps the conversation TTL.

## Tests

`openai-caching.test.ts`: small conversation gets no anchor; large gets a 2nd earlier anchor; anchor is byte-stable as the conversation grows; anchor/tail TTLs; 4-breakpoint budget. Mutation-verified (disabling the anchor turns the anchor tests red; the "small conversation → no anchor" test correctly stays green).

Diagnosis + fix for the residual cross-session cost in #961.