### PR TITLE
fix(worker): fall back to a backup model when the preferred one is unavailable

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -73,7 +73,7 @@ import {
   recordEmptyWorkerResponse,
   clearEmptyWorkerStreak,
 } from "./worker-health";
-import { getModelEntrySync } from "./worker-model";
+import { getModelEntrySync, workerModelCandidates } from "./worker-model";
 
 // ---------------------------------------------------------------------------
 // Worker call tracking
@@ -254,6 +254,28 @@ export function isDataPolicyBlocked404(status: number, body: string): boolean {
     /data\s+policy/i.test(body) ||
     /guardrail/i.test(body) ||
     /settings\/privacy/i.test(body)
+  );
+}
+
+/**
+ * True when a 400 body says the requested MODEL is unavailable on this
+ * account/plan (as opposed to a bad request about params). Copilot returns
+ * `code:"model_not_supported"` / `"unsupported_api_for_model"`; other providers
+ * phrase it as "model not found/supported/does not exist". Kept to model-scoped
+ * markers so a generic 400 (bad param, quota, etc.) does NOT trigger a model
+ * swap. Used by the worker retry loop to fall back to a same-provider backup
+ * model (see {@link workerModelCandidates}).
+ */
+export function isModelUnsupported400(status: number, body: string): boolean {
+  if (status !== 400) return false;
+  return (
+    /model_not_supported/i.test(body) ||
+    /unsupported_api_for_model/i.test(body) ||
+    /model_not_found/i.test(body) ||
+    /\bmodel\b[^"]{0,40}?(?:is\s+)?not\s+(?:supported|found|available)\b/i.test(
+      body,
+    ) ||
+    /\bmodel\b[^"]{0,40}?does\s+not\s+exist\b/i.test(body)
   );
 }
 
@@ -1735,14 +1757,39 @@ export function createGatewayLLMClient(
   const factoryVertexProject = opts?.vertexProject;
   return {
     async prompt(system, user, opts) {
-      const model = opts?.model ?? defaultModel;
+      // `model` is mutable: on a 400 model-not-supported the retry loop swaps
+      // in a same-provider backup (workerModelCandidates). Backups never change
+      // provider, so target/protocol/credential stay valid — only the body's
+      // model id changes.
+      let model = opts?.model ?? defaultModel;
 
-      // Skip models already known to produce no usable worker output for THIS
-      // worker kind. This is a capability verdict (not an outage): the call
-      // would just waste a round trip and re-fail. The failing worker defers;
-      // data stays recallable. Scoped per worker so a model that can distill
-      // but not curate is still used for distillation.
-      if (isWorkerIncapable(model.providerID, model.modelID, opts?.workerID)) {
+      // Skip models already known to produce no usable worker output. Two
+      // kinds of "incapable" verdict apply:
+      //   - per-worker capability (a model that can distill but not curate) —
+      //     scoped to opts.workerID;
+      //   - account-wide model-not-supported (a 400 from the fallback path
+      //     below, marked with the default ANY_WORKER scope) — the model is
+      //     unavailable on this plan for EVERY worker kind.
+      // A candidate is unusable if EITHER verdict is set.
+      const candidateBlocked = (c: { providerID: string; modelID: string }) =>
+        isWorkerIncapable(c.providerID, c.modelID, opts?.workerID) ||
+        isWorkerIncapable(c.providerID, c.modelID);
+
+      // Advance PAST any blocklisted candidate to the first usable same-provider
+      // backup: once one chunk's model-not-supported 400 has blocklisted the
+      // preferred model (markWorkerIncapable below), every later chunk re-enters
+      // here with that same preferred model. Without this hop it would be
+      // skipped outright and the whole backlog would produce nothing, even
+      // though a working backup exists — so pick up where the fallback left off
+      // instead of re-failing the swap every chunk. Data stays recallable if
+      // none is usable.
+      for (const cand of workerModelCandidates(model)) {
+        if (!candidateBlocked(cand)) {
+          model = cand;
+          break;
+        }
+      }
+      if (candidateBlocked(model)) {
         return null;
       }
 
@@ -1992,6 +2039,16 @@ export function createGatewayLLMClient(
             // its whole allowance on hidden reasoning). See the empty-response
             // block below.
             let lengthRetried = false;
+            // Same-provider backup models to try when the current one is
+            // unavailable on the account/plan (400 model-not-supported). Seeded
+            // from workerModelCandidates minus the active model and any already
+            // blocklisted (incapable) candidate; each unsupported-model 400 pops
+            // the next one.
+            const modelFallbacks = workerModelCandidates(model)
+              .slice(1)
+              .filter(
+                (c) => c.modelID !== model.modelID && !candidateBlocked(c),
+              );
             // Resolve the retry budget once per call (not per attempt) — the
             // value can't change mid-loop and re-reading the env each iteration
             // is wasteful.
@@ -2675,6 +2732,58 @@ export function createGatewayLLMClient(
                   // Do NOT markWorkerPaused: the fix is re-resolution to a
                   // different model, not pausing the session's workers.
                   return null;
+                }
+
+                // 400 model-not-supported: the requested model is unavailable
+                // on this account/plan (Copilot subscription tiers serve
+                // different catalogs). This is a per-account capability fact,
+                // not an outage — retrying the SAME model is futile. Blocklist
+                // it and, if a same-provider backup remains, swap it in and
+                // retry (rebuild via buildWorkerRequest so the OAuth billing
+                // signature is recomputed over the new body). Bounded by the
+                // finite candidate list. Only when NO backup remains do we fall
+                // through to the generic failure below.
+                if (
+                  isModelUnsupported400(response.status, text) &&
+                  modelFallbacks.length > 0
+                ) {
+                  markWorkerIncapable(model.providerID, model.modelID);
+                  // length-checked above, so a value is guaranteed.
+                  const next = modelFallbacks.shift() ?? model;
+                  log.warn(
+                    `worker model ${model.providerID}/${model.modelID} not supported on this account (400) — ` +
+                      `falling back to ${next.providerID}/${next.modelID} ` +
+                      `(worker=${opts?.workerID ?? "unknown"}, ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}): ${text.slice(0, 160)}`,
+                  );
+                  model = next;
+                  req = await buildWorkerRequest(
+                    target,
+                    activeCred,
+                    model,
+                    system,
+                    user,
+                    maxTokens,
+                    opts?.sessionID,
+                    effectiveTemperature,
+                    factoryVertexProject,
+                    effectiveDisableThinking,
+                    reasoningEffort,
+                  );
+                  // Preserve any runtime beta strip across the rebuild (same
+                  // reasoning as the temperature/thinking rebuilds above).
+                  if (betaStripped) {
+                    req = { ...req, headers: stripBetaHeaders(req.headers) };
+                  }
+                  retryCount++;
+                  // A model swap is NOT a transient retry — it's a one-way walk
+                  // down a finite candidate list (bounded by modelFallbacks
+                  // shrinking). Don't let it consume the transient-error budget
+                  // (`attempt < maxRetries`): decrement to cancel the `attempt++`
+                  // the loop applies on `continue`, so the working backup keeps
+                  // its full 429/5xx retry allowance.
+                  attempt--;
+                  continue;
                 }
 
                 log.error(

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -1124,6 +1124,52 @@ function resolveGitHubCopilotWorker(sessionModelID: string): {
 }
 
 /**
+ * Per-provider ordered backup worker models, tried (in order) when the
+ * preferred model is unavailable on the user's account/plan (a 400
+ * `model_not_supported` / "model not supported"). The FIRST entry a provider
+ * actually serves wins. Only providers whose per-account model access varies
+ * need an entry here; everything else just uses its preferred/default model.
+ *
+ * GitHub Copilot is the motivating case: Copilot's model catalog differs by
+ * subscription tier, so the built-in default (gpt-5-mini) is unavailable on
+ * plans that only serve, e.g., claude. All entries below are Copilot models
+ * confirmed to exist on /chat/completions (the worker path); the order runs
+ * cheap-first, spanning both the OpenAI and Claude families so at least one is
+ * reachable on any plan. (gpt-5.4-mini is deliberately absent — Copilot serves
+ * it only via /responses and it 400s on the worker's Chat Completions path.)
+ */
+const WORKER_MODEL_FALLBACKS: Record<string, string[]> = {
+  "github-copilot": [
+    "gpt-5-mini",
+    "gpt-4o-mini",
+    "claude-sonnet-4.6",
+    "claude-haiku-4.5",
+  ],
+};
+
+/**
+ * Ordered, deduped list of worker models to try for `preferred`, starting with
+ * `preferred` itself and followed by same-provider backups (see
+ * {@link WORKER_MODEL_FALLBACKS}). Used by the worker adapter to fall back to a
+ * reachable model when the preferred one is unavailable on the user's plan
+ * (400 model-not-supported), instead of failing every chunk. Backups are always
+ * same-provider — a worker must never switch providers (wrong credential/wire).
+ */
+export function workerModelCandidates(preferred: {
+  providerID: string;
+  modelID: string;
+}): { providerID: string; modelID: string }[] {
+  const out: { providerID: string; modelID: string }[] = [preferred];
+  const seen = new Set([preferred.modelID]);
+  for (const modelID of WORKER_MODEL_FALLBACKS[preferred.providerID] ?? []) {
+    if (seen.has(modelID)) continue;
+    seen.add(modelID);
+    out.push({ providerID: preferred.providerID, modelID });
+  }
+  return out;
+}
+
+/**
  * Parse the `LORE_WORKER_MODEL` env-var override into a `{providerID, modelID}`.
  *
  * Format: `"providerID/modelID"` (e.g. `openai/gpt-5.4-mini`) or a bare

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -27,6 +27,7 @@ import {
   isTemperatureUnsupportedModel,
   isAnthropicClaudeModel,
   isDataPolicyBlocked404,
+  isModelUnsupported400,
   isThinkingUnsupportedModel,
   markThinkingUnsupported,
   workerThinkingOnByDefault,
@@ -36,6 +37,7 @@ import {
   _resetThinkingUnsupportedModels,
 } from "../src/llm-adapter";
 import { _setModelDataForTest, clearModelDataCache } from "../src/worker-model";
+import { workerModelCandidates } from "../src/worker-model";
 import {
   getConsecutiveTrips,
   resetBackgroundLimiter,
@@ -1013,10 +1015,15 @@ describe("worker data-policy 404: blocklist + re-resolve, not an outage", () => 
     mockMarkPaused.mockClear();
     mockMarkIncapable.mockClear();
     mockMarkFreeBlocked.mockClear();
+    // Reset the shared worker-health blocklist so a model marked incapable by
+    // one test (ANY_WORKER-scoped, e.g. the data-policy 404 case) does not leak
+    // into the next and short-circuit its prompt() at the incapable guard.
+    _resetWorkerHealthForTest();
   });
 
   afterEach(() => {
     mockFetch.mockReset();
+    _resetWorkerHealthForTest();
   });
 
   test("a :free model data-policy 404 blocklists the model + provider :free tier, records data-policy (NOT upstream-error), and does NOT credit-pause", async () => {
@@ -3148,5 +3155,320 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
       (bodyOf(0)?.generationConfig as { maxOutputTokens?: number } | undefined)
         ?.maxOutputTokens,
     ).toBe(24576);
+  });
+});
+
+describe("isModelUnsupported400 detector", () => {
+  test("true for Copilot model_not_supported / unsupported_api_for_model", () => {
+    expect(
+      isModelUnsupported400(
+        400,
+        JSON.stringify({
+          error: {
+            message: "The requested model is not supported.",
+            code: "model_not_supported",
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isModelUnsupported400(
+        400,
+        JSON.stringify({ error: { code: "unsupported_api_for_model" } }),
+      ),
+    ).toBe(true);
+  });
+
+  test("true for prose 'model X is not available/found/does not exist'", () => {
+    expect(
+      isModelUnsupported400(400, "The model gpt-5-mini is not available"),
+    ).toBe(true);
+    expect(isModelUnsupported400(400, "model not found")).toBe(true);
+    expect(
+      isModelUnsupported400(400, "That model does not exist for this account"),
+    ).toBe(true);
+  });
+
+  test("false for a generic 400 (bad param / quota) — must not swap the model", () => {
+    expect(isModelUnsupported400(400, "temperature is not supported")).toBe(
+      false,
+    );
+    expect(isModelUnsupported400(400, "invalid request: bad max_tokens")).toBe(
+      false,
+    );
+  });
+
+  test("false for non-400 statuses", () => {
+    expect(
+      isModelUnsupported400(404, JSON.stringify({ code: "model_not_found" })),
+    ).toBe(false);
+    expect(
+      isModelUnsupported400(
+        429,
+        JSON.stringify({ code: "model_not_supported" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("workerModelCandidates", () => {
+  test("github-copilot: preferred first, then same-provider backups (deduped)", () => {
+    const out = workerModelCandidates({
+      providerID: "github-copilot",
+      modelID: "gpt-5-mini",
+    });
+    expect(out[0]).toEqual({
+      providerID: "github-copilot",
+      modelID: "gpt-5-mini",
+    });
+    const ids = out.map((c) => c.modelID);
+    // Preferred appears exactly once (dedup), and Claude backups are present.
+    expect(ids.filter((m) => m === "gpt-5-mini")).toHaveLength(1);
+    expect(ids).toContain("claude-sonnet-4.6");
+    // Every candidate stays on the same provider — a worker must never switch.
+    expect(out.every((c) => c.providerID === "github-copilot")).toBe(true);
+  });
+
+  test("a non-preferred copilot model still yields the full provider backup set", () => {
+    const ids = workerModelCandidates({
+      providerID: "github-copilot",
+      modelID: "gpt-4o-mini",
+    }).map((c) => c.modelID);
+    expect(ids[0]).toBe("gpt-4o-mini");
+    expect(ids).toContain("gpt-5-mini");
+    expect(ids).toContain("claude-sonnet-4.6");
+    expect(ids.filter((m) => m === "gpt-4o-mini")).toHaveLength(1);
+  });
+
+  test("a provider with no fallback list → just the preferred model", () => {
+    expect(
+      workerModelCandidates({
+        providerID: "anthropic",
+        modelID: "claude-sonnet-5",
+      }),
+    ).toEqual([{ providerID: "anthropic", modelID: "claude-sonnet-5" }]);
+  });
+});
+
+describe("worker 400 model-not-supported: fall back to a same-provider backup", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const mockMarkIncapable = vi.mocked(markWorkerIncapable);
+  const mockMarkPaused = vi.mocked(markWorkerPaused);
+
+  const UNSUPPORTED_400 = JSON.stringify({
+    error: {
+      message: 'The requested model "gpt-5-mini" is not supported.',
+      code: "model_not_supported",
+    },
+  });
+  const OK_200 = JSON.stringify({
+    choices: [{ message: { content: "worked on the backup" } }],
+    usage: { prompt_tokens: 5, completion_tokens: 3 },
+  });
+
+  beforeEach(() => {
+    mockMarkIncapable.mockClear();
+    mockMarkPaused.mockClear();
+    _resetWorkerHealthForTest();
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    _resetWorkerHealthForTest();
+  });
+
+  test("preferred model 400s model_not_supported → blocklist it, retry with the next candidate, succeed", async () => {
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      return call === 1
+        ? new Response(UNSUPPORTED_400, {
+            status: 400,
+            statusText: "Bad Request",
+          })
+        : new Response(OK_200, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+    });
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.githubcopilot.com",
+        openai: "https://api.githubcopilot.com",
+      },
+      () => ({ scheme: "bearer", value: "gho_test" }),
+      { providerID: "github-copilot", modelID: "gpt-5-mini" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      workerID: "lore-import",
+      sessionID: "sess-fallback",
+      protocol: "openai",
+      upstreamProviderID: "github-copilot",
+      upstreamUrl: "https://api.githubcopilot.com",
+    });
+
+    // Recovered on the backup model.
+    expect(text).toBe("worked on the backup");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // The preferred model was blocklisted for this worker kind.
+    expect(mockMarkIncapable).toHaveBeenCalledWith(
+      "github-copilot",
+      "gpt-5-mini",
+    );
+    // Second request used a DIFFERENT (backup) model id.
+    const [, secondInit] = mockFetch.mock.calls[1];
+    const secondBody = JSON.parse(secondInit?.body as string) as {
+      model?: string;
+    };
+    expect(secondBody.model).toBeDefined();
+    expect(secondBody.model).not.toBe("gpt-5-mini");
+    // Not a session credit-pause — the fix is a model swap, not a pause.
+    expect(mockMarkPaused).not.toHaveBeenCalled();
+  });
+
+  test("a provider with NO backup list surfaces the 400 (no swap, one call)", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { message: "model not found", code: "model_not_supported" },
+        }),
+        { status: 400, statusText: "Bad Request" },
+      ),
+    );
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      workerID: "lore-import",
+      sessionID: "sess-nobackup",
+    });
+
+    expect(text).toBeNull();
+    // No backup to try → exactly one attempt, no model blocklisted via this path.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockMarkIncapable).not.toHaveBeenCalled();
+  });
+
+  test("after one chunk blocklists the preferred model, the NEXT call starts directly on the backup (no repeated 400)", async () => {
+    // Call 1: preferred 400s, backup 200s (blocklists preferred).
+    // Call 2: the top-of-prompt candidate advance must skip the now-incapable
+    // preferred and go straight to the backup — otherwise every later chunk
+    // would either re-400 or be skipped outright.
+    let call = 0;
+    mockFetch.mockImplementation(async (_url, init) => {
+      call++;
+      const body = JSON.parse(init?.body as string) as { model?: string };
+      // Only the preferred model 400s; any backup succeeds.
+      return body.model === "gpt-5-mini"
+        ? new Response(UNSUPPORTED_400, {
+            status: 400,
+            statusText: "Bad Request",
+          })
+        : new Response(OK_200, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+    });
+
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.githubcopilot.com",
+        openai: "https://api.githubcopilot.com",
+      },
+      () => ({ scheme: "bearer", value: "gho_test" }),
+      { providerID: "github-copilot", modelID: "gpt-5-mini" },
+    );
+
+    const opts = {
+      workerID: "lore-import",
+      sessionID: "sess-advance",
+      protocol: "openai" as const,
+      upstreamProviderID: "github-copilot",
+      upstreamUrl: "https://api.githubcopilot.com",
+    };
+
+    const first = await client.prompt("system", "user", opts);
+    expect(first).toBe("worked on the backup");
+    const callsAfterFirst = call; // 2 (preferred 400 + backup 200)
+    expect(callsAfterFirst).toBe(2);
+
+    const second = await client.prompt("system", "user", opts);
+    expect(second).toBe("worked on the backup");
+    // The second call made exactly ONE fetch — it started on the backup and
+    // never re-tried the blocklisted preferred model.
+    expect(call - callsAfterFirst).toBe(1);
+    const [, secondCallInit] = mockFetch.mock.calls[2];
+    const secondCallBody = JSON.parse(secondCallInit?.body as string) as {
+      model?: string;
+    };
+    expect(secondCallBody.model).not.toBe("gpt-5-mini");
+  });
+
+  test("a model swap does NOT consume the transient-error retry budget", async () => {
+    // Seer #15455762: a model fallback must not spend the `maxRetries` budget
+    // meant for 429/5xx. With maxRetries=1: preferred 400s (swap), then the
+    // BACKUP hits one transient 429 before 200. If the swap consumed the single
+    // retry, the 429 would exhaust the budget and the call would fail. It must
+    // succeed — the backup keeps its full transient allowance.
+    const prev = process.env.LORE_MAX_RETRIES;
+    process.env.LORE_MAX_RETRIES = "1";
+    resetBackgroundLimiter();
+    try {
+      let call = 0;
+      mockFetch.mockImplementation(async (_url, init) => {
+        call++;
+        const body = JSON.parse(init?.body as string) as { model?: string };
+        if (body.model === "gpt-5-mini") {
+          // Preferred → model_not_supported (triggers the swap).
+          return new Response(UNSUPPORTED_400, {
+            status: 400,
+            statusText: "Bad Request",
+          });
+        }
+        // Backup: one transient 429 (retry-after 0 → instant), then success.
+        if (call === 2) {
+          return new Response(
+            JSON.stringify({ error: { message: "rate limited" } }),
+            { status: 429, headers: { "retry-after": "0" } },
+          );
+        }
+        return new Response(OK_200, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      });
+
+      const client = createGatewayLLMClient(
+        {
+          anthropic: "https://api.githubcopilot.com",
+          openai: "https://api.githubcopilot.com",
+        },
+        () => ({ scheme: "bearer", value: "gho_test" }),
+        { providerID: "github-copilot", modelID: "gpt-5-mini" },
+      );
+
+      const text = await client.prompt("system", "user", {
+        workerID: "lore-import",
+        sessionID: "sess-budget",
+        protocol: "openai",
+        upstreamProviderID: "github-copilot",
+        upstreamUrl: "https://api.githubcopilot.com",
+      });
+
+      // preferred 400 (swap) → backup 429 (transient retry) → backup 200.
+      expect(text).toBe("worked on the backup");
+      expect(call).toBe(3);
+    } finally {
+      if (prev === undefined) delete process.env.LORE_MAX_RETRIES;
+      else process.env.LORE_MAX_RETRIES = prev;
+    }
   });
 });


### PR DESCRIPTION
## Problem

When a worker's preferred model isn't available on the user's account/plan, the call 400s (`model_not_supported` / `unsupported_api_for_model`) and **every** chunk fails — the whole distillation / curation / `lore import` backlog produces nothing, with no recovery short of the user manually setting `LORE_WORKER_MODEL`.

This is the GitHub Copilot case from #1398: Copilot's model catalog varies by subscription tier, so the built-in default (`gpt-5-mini`) 400s on plans that only serve, e.g., claude. Kjaer hit exactly this.

## Fix (adapter-level, all worker kinds)

- **`WORKER_MODEL_FALLBACKS` + `workerModelCandidates(preferred)`** (`worker-model.ts`): an ordered, deduped, **same-provider** candidate list (preferred first). GitHub Copilot ships a real list — `gpt-5-mini`, `gpt-4o-mini`, `claude-sonnet-4.6`, `claude-haiku-4.5` — spanning the OpenAI + Claude families so at least one is reachable on any plan. Other providers just get `[preferred]` (no behavior change). Backups never switch provider (a cross-provider worker call is always doomed — wrong credential/wire).
- **`isModelUnsupported400(status, body)`** (`llm-adapter.ts`): detects a model-scoped 400. Deliberately narrow so a generic 400 (bad param, quota) never swaps the model.
- **Worker retry loop**: on such a 400, `markWorkerIncapable(provider, model)` (account-wide) and retry with the next candidate, rebuilding via `buildWorkerRequest` so the OAuth billing signature is recomputed. Mirrors the existing data-policy-404 blocklist+re-resolve pattern. Bounded by the finite candidate list.
- **Top-of-prompt advance**: skip PAST any already-blocklisted candidate to the first usable backup, so once one chunk blocklists the preferred model, every later chunk starts directly on the working backup instead of re-failing the swap (or being skipped).

This complements #1466 (honor `LORE_WORKER_MODEL`): that lets a user pick a model explicitly; this makes the default path self-heal when the preferred model isn't on their plan, without any config.

## Tests

`isModelUnsupported400` detector (positive/negative/non-400), `workerModelCandidates` (ordering/dedup/same-provider), and adapter behavior: recover on backup after a 400; a no-backup provider surfaces the 400 (one call); a second call after a blocklist starts on the backup with no repeated 400. Mutation-verified (disable the fallback retry, disable the advance loop → tests red). Also fixed a latent test-isolation leak in the data-policy suite that the new account-wide incapable check surfaced. Full gate green: typecheck, lint, 290 tests, format.