### PR TITLE
fix(cache): anchor the OpenAI intermediate cache_control breakpoint at the prefix midpoint (#961)

### DIFF
--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -900,15 +900,25 @@ function buildOpenAIMessages(
     // segments, so an eviction of one segment leaves the other intact and
     // bounds the blast radius.
     //
+    // Placement: the anchor targets the MIDPOINT of the committed prefix, not a
+    // point near the tail. The observed eviction sits deep in the early prefix
+    // (the accumulated large user blobs), so an anchor hugging the tail would
+    // leave that whole early region as one unprotected segment — it must split
+    // the LARGE half. A midpoint anchor cuts the prefix into two ~equal halves,
+    // so an eviction of the front half re-sends ~half, not all.
+    //
     // The anchor MUST be byte-stable across turns or it busts the cache itself.
     // We quantize its position to a coarse step so it only advances every
     // CACHE_ANCHOR_STEP messages (byte-identical in between), and only place it
     // when the committed prefix is large enough to be worth splitting.
     if (tailIdx >= CACHE_ANCHOR_MIN_MESSAGES) {
-      // Largest multiple of the step strictly below the tail, so the anchor is
-      // always before the moving tail breakpoint and never collides with it.
+      // Midpoint of the committed prefix, quantized DOWN to a step multiple so
+      // it stays put for many turns (the midpoint advances at ~half the tail's
+      // rate, so it moves even less often than the step alone implies). Quantize
+      // guarantees the anchor is stable and strictly below the moving tail.
+      const midpoint = Math.floor(tailIdx / 2);
       const quantized =
-        Math.floor((tailIdx - 1) / CACHE_ANCHOR_STEP) * CACHE_ANCHOR_STEP;
+        Math.floor(midpoint / CACHE_ANCHOR_STEP) * CACHE_ANCHOR_STEP;
       // Walk back from the quantized index to the nearest annotatable message.
       let anchorIdx = Math.min(quantized, tailIdx - 1);
       while (anchorIdx > 0 && !isAnnotatable(result[anchorIdx])) anchorIdx--;

--- a/packages/gateway/test/openai-caching.test.ts
+++ b/packages/gateway/test/openai-caching.test.ts
@@ -413,28 +413,43 @@ describe("buildOpenAIUpstreamRequest — intermediate anchor breakpoint (#961)",
     expect(idxs.length).toBe(1); // tail only
   });
 
-  test("large conversation gets a SECOND, earlier anchor breakpoint", () => {
-    // 30 conversation messages: the ~1MB-class prefix is split into two
+  test("large conversation gets a SECOND anchor near the prefix MIDPOINT", () => {
+    // 60 conversation messages: the ~1MB-class prefix is split into two
     // independently-cacheable segments so an upstream partial eviction re-bills
     // only one segment, not the whole prefix (the ~345K input spike, #961).
-    const body = getBody(makeRequest({ messages: convo(30) }), cacheOpts);
+    // (Uses 60 rather than 30 so a near-tail anchor is clearly outside the
+    // middle-half band below — the near-tail formula would land at ~50/60.)
+    const body = getBody(makeRequest({ messages: convo(60) }), cacheOpts);
+    const msgs = messagesOf(body);
     const idxs = annotatedConversationIndices(body);
     expect(idxs.length).toBe(2); // anchor + tail
     // Anchor is strictly before the tail.
     expect(idxs[0]).toBeLessThan(idxs[1]);
     // Tail is the last message.
-    expect(idxs[1]).toBe(messagesOf(body).length - 1);
+    expect(idxs[1]).toBe(msgs.length - 1);
+    // CRITICAL (H1): the anchor must sit near the MIDDLE of the committed
+    // prefix, not hugging the tail — otherwise it splits off only a tiny
+    // trailing segment and leaves the large early prefix (where the eviction
+    // actually lands) unprotected. Assert the anchor is in the middle half.
+    const tail = idxs[1];
+    expect(idxs[0]).toBeGreaterThan(tail * 0.25);
+    expect(idxs[0]).toBeLessThan(tail * 0.75);
   });
 
   test("anchor position is byte-stable as the conversation grows (no self-bust)", () => {
     // The whole point of quantizing the anchor: it must NOT move every turn, or
-    // it busts the very cache it protects. Growing the conversation by one turn
-    // (within the same quantization bucket) must leave the anchor index put.
-    const bodyA = getBody(makeRequest({ messages: convo(24) }), cacheOpts);
-    const bodyB = getBody(makeRequest({ messages: convo(25) }), cacheOpts);
-    const anchorA = annotatedConversationIndices(bodyA)[0];
-    const anchorB = annotatedConversationIndices(bodyB)[0];
-    expect(anchorA).toBe(anchorB);
+    // it busts the very cache it protects. Growing the conversation across
+    // several turns (within the same quantization bucket — the midpoint advances
+    // at ~half the tail's rate) must leave the anchor index put.
+    const anchorAt = (n: number) =>
+      annotatedConversationIndices(
+        getBody(makeRequest({ messages: convo(n) }), cacheOpts),
+      )[0];
+    // 24..29 all map to the same quantized midpoint bucket.
+    const a = anchorAt(24);
+    for (const n of [25, 26, 27, 28, 29]) {
+      expect(anchorAt(n)).toBe(a);
+    }
   });
 
   test("anchor inherits the (longer) system TTL, tail keeps the conversation TTL", () => {


### PR DESCRIPTION
## Context

Follow-up to #1467. That PR added a second, "intermediate anchor" `cache_control` breakpoint on the OpenAI/OpenRouter path to shrink the blast radius of a transient upstream cache eviction (the ~345K-token input spike, ~$1/run on Sonnet-5 cross-session — see #961). But empirically it **did not** reduce the spike.

## Root cause

The #1467 anchor quantized to `floor((tailIdx-1)/STEP)*STEP`, which lands the anchor **near the tail** (e.g. msg 40 of 46). That splits off only a tiny trailing segment and leaves the *large early prefix* — exactly where the eviction lands — as one unprotected segment. Validation (VERIFY-ANCHOR-S5XS, N=3) showed the spike fully intact: `input≈345K, hit=51%`, cost ~$4.85/run.

## Fix

Anchor at the **midpoint** of the committed prefix (`floor(tailIdx/2)`, quantized), splitting the large prefix into two ~equal halves so an eviction of the front half re-sends ~half, not all.

## Validation (VERIFY-MIDPOINT-S5XS, Sonnet-5 cross-session)

| | near-tail (#1467) | **midpoint (this PR)** | vanilla |
|---|---|---|---|
| session-2 input tokens | ~345,000 | **26–32** | ~38 |
| spike | present every run | **gone** | n/a |
| cost/run | $4.85 avg | **$3.73** | $3.92 |
| retention (probes) | 4/4 | **4/4** | 0/4 |

The spike is eliminated and cross-session cost drops to **vanilla parity** (slightly below), while retention stays 100%.

## Tests

`openai-caching.test.ts`: anchor sits near the prefix MIDPOINT (uses convo(60) so a near-tail anchor is provably outside the middle-half band); byte-stable across turns within a quantization bucket; stays within the 4-breakpoint budget. Mutation-verified: reverting to the near-tail formula fails the MIDPOINT test; a move-every-turn anchor fails byte-stability.