### PR TITLE
fix(ci): isolate delta patches in .delta-patches + guard non-binary patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1026,7 +1026,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: nightly-patches
-          path: patches/*.patch
+          path: .delta-patches/*.patch
+          # .delta-patches is a dotted dir; upload-artifact skips hidden paths
+          # by default, so opt in explicitly.
+          include-hidden-files: true
 
   publish-nightly:
     name: Publish Nightly to GHCR
@@ -1069,7 +1072,7 @@ jobs:
         id: download-patches
         with:
           name: nightly-patches
-          path: patches
+          path: .delta-patches
 
       - name: Publish nightly + patches to GHCR
         uses: ./packages/binpatch/action
@@ -1079,7 +1082,7 @@ jobs:
           repo: byk/loreai
           artifacts-dir: artifacts
           binaries-dir: binaries
-          patches-dir: patches
+          patches-dir: .delta-patches
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------
@@ -1122,7 +1125,7 @@ jobs:
 
       - name: Ensure patches directory exists
         if: startsWith(github.ref, 'refs/heads/release/')
-        run: mkdir -p patches && touch patches/empty
+        run: mkdir -p .delta-patches && touch .delta-patches/empty
 
       - name: Upload release patches
         if: startsWith(github.ref, 'refs/heads/release/')
@@ -1132,8 +1135,10 @@ jobs:
           # Always upload so Craft's artifact provider finds the artifact.
           # When no previous release has binaries, the directory is empty;
           # the placeholder ensures upload-artifact creates the artifact.
-          # (upload-artifact ignores hidden files by default)
-          path: patches/
+          # .delta-patches is a dotted dir AND the placeholder is a hidden
+          # file, so opt in to hidden-file upload explicitly.
+          path: .delta-patches/
+          include-hidden-files: true
 
   # ---------------------------------------------------------------------------
   # CI status: single required check for branch protection.

--- a/packages/binpatch/action/README.md
+++ b/packages/binpatch/action/README.md
@@ -18,9 +18,9 @@ generate/publish job graph without reshaping it.
 
 | `mode` | What it does |
 |---|---|
-| `generate-ghcr` | Diff freshly built binaries against the previous **GHCR nightly**, size-gate the patches, leave them in `patches/` for a later publish step. |
-| `publish-ghcr` | Push the compressed binaries to the registry (`:<nightly-tag>`), create the immutable `<nightly-tag-prefix><version>` tag, and push the patch manifest (`:<patch-tag-prefix><version>`) with the integrity annotations the client reads. |
-| `generate-release` | Diff freshly built binaries against the previous stable **GitHub Release**, size-gate, leave them in `patches/` for a release-artifact upload (e.g. consumed by Craft). |
+| `generate-ghcr` | Diff freshly built binaries against the previous **GHCR nightly**, size-gate the patches, leave them in `.delta-patches/` for a later publish step. |
+| `publish-ghcr` | Push the compressed binaries to the registry (`:<nightly-tag>`), create the immutable `<nightly-tag-prefix><version>` tag, and push the patch manifest (`:<patch-tag-prefix><version>`) with the integrity annotations the client reads. Only patches with a matching binary in `binaries-dir` are pushed. |
+| `generate-release` | Diff freshly built binaries against the previous stable **GitHub Release**, size-gate, leave them in `.delta-patches/` for a release-artifact upload (e.g. consumed by Craft). |
 
 ## Wire contract (defaults)
 

--- a/packages/binpatch/action/action.yml
+++ b/packages/binpatch/action/action.yml
@@ -71,9 +71,13 @@ inputs:
     required: false
     default: artifacts
   patches-dir:
-    description: "Directory where patches are written / read."
+    description: >-
+      Directory where patches are written / read. Defaults to a dotted dir
+      (".delta-patches") so it can never collide with a repo's own "patches/"
+      directory (e.g. pnpm/patch-package dependency patches) that a preceding
+      checkout may have placed in the workspace.
     required: false
-    default: patches
+    default: .delta-patches
   binary-glob:
     description: >-
       Glob (relative to new-binaries-dir) selecting binaries to diff, e.g.
@@ -433,10 +437,18 @@ runs:
           for patch_file in "${PATCHES_DIR}"/*.patch; do
             basename_patch=$(basename "$patch_file" .patch)
             new_binary="${BINARIES_DIR}/${basename_patch}"
-            if [ -f "$new_binary" ]; then
-              sha256=$(sha256sum "$new_binary" | cut -d' ' -f1)
-              ANNOTATIONS="${ANNOTATIONS} --annotation sha256-${basename_patch}=${sha256}"
+            # Only publish a patch that corresponds to a real published binary.
+            # A patch with no matching binary is not a delta patch (e.g. an
+            # unrelated source/dependency patch that leaked into the dir); its
+            # SHA-256 anchor is unknowable, so the client could never verify it.
+            # Skip it rather than push an unusable layer that would poison the
+            # whole chain for every consumer spanning this version.
+            if [ ! -f "$new_binary" ]; then
+              echo "::warning::Skipping ${basename_patch}.patch -- no matching binary in ${BINARIES_DIR}/ (not a delta patch)"
+              continue
             fi
+            sha256=$(sha256sum "$new_binary" | cut -d' ' -f1)
+            ANNOTATIONS="${ANNOTATIONS} --annotation sha256-${basename_patch}=${sha256}"
             PATCH_FILES="${PATCH_FILES} $(basename "$patch_file")"
           done
 


### PR DESCRIPTION
## Problem

Nightly `lore upgrade` keeps falling back to the full 287 MB download instead of applying delta patches.

## Root cause

The delta patch directory (`patches/`) **collided with the repo's own pnpm dependency-patch dir**. `package.json` has:

```json
"patchedDependencies": { "@sentry/node@10.56.0": "patches/@sentry__node@10.56.0.patch" }
```

On the `main` build that produced `0.39.0-dev.1784820552`:
1. The **Generate Delta Patches** job hit a transient GHCR blob-download reset (`connection reset by peer` fetching the previous `lore-linux-x64.gz`) and produced **no** `lore-*.patch` files.
2. `publish-nightly` checked out the repo (bringing `patches/@sentry__node@10.56.0.patch` into `patches/`), the empty patch-artifact download left it in place, and the publish step globbed `patches/*.patch` — finding only the pnpm patch — and **pushed `@sentry__node@10.56.0.patch` as the delta manifest** (`continue-on-error` masked the empty download).

That poisoned tag `patch-0.39.0-dev.1784820552` has **no `lore-<platform>.patch` layer**, so every multi-hop chain spanning that version fails client-side validation → full download. (Single-hop upgrades skipping it still worked, hence the intermittent look.)

## Fix (two independent guards)

1. **Dedicated `.delta-patches` dir** for delta generate/download/publish — a dotted dir can never collide with a source `patches/`. `upload-artifact` needs `include-hidden-files: true` for the dotted path.
2. **Matching-binary guard** in `publish-ghcr`: only push `<name>.patch` when `binaries-dir/<name>` exists; skip (with a `::warning::`) any patch with no matching binary. Its SHA-256 anchor is unknowable, so the client could never verify it anyway.

## Verification

- `actionlint` clean; `action.yml` valid YAML (12 composite steps).
- Mutation-verified the guard against the exact scenario: a stray `@sentry__node@10.56.0.patch` (no matching binary) is **skipped**, real `lore-*.patch` files are pushed with SHA annotations. Reverting the guard pushes the stray patch (reproduces the bug) — non-vacuous.

## Follow-ups (separate)

- **B:** harden `binpatch` client so one malformed/missing-layer patch tag can't disable all upgrades across it (route around it).
- **C:** remove/republish the already-poisoned `patch-0.39.0-dev.1784820552` tag.