### PR TITLE
fix(cache): align CACHE_ANCHOR_MIN_MESSAGES with the anchor's real engagement point (#961)

### DIFF
--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -728,18 +728,24 @@ function ephemeralCacheControl(ttl?: "5m" | "1h" | false): {
 }
 
 /**
- * Minimum number of committed (pre-tail) messages before a second, stable
- * intermediate `cache_control` anchor is worth adding. Below this the prefix is
- * small enough that a single tail breakpoint already bounds eviction cost.
- */
-const CACHE_ANCHOR_MIN_MESSAGES = 12;
-
-/**
  * Quantization step for the intermediate anchor's position. The anchor sits at a
  * multiple of this step, so it stays byte-identical for this many turns before
  * advancing — a moving anchor would bust the very cache it protects.
  */
 const CACHE_ANCHOR_STEP = 10;
+
+/**
+ * Minimum number of committed (pre-tail) messages before a second, stable
+ * intermediate `cache_control` anchor is placed. Below this the prefix is small
+ * enough that a single tail breakpoint already bounds eviction cost.
+ *
+ * This is `2 * CACHE_ANCHOR_STEP`, not an independent number: the anchor lands at
+ * `floor((tailIdx / 2) / STEP) * STEP`, which only clears 0 (and so passes the
+ * `anchorIdx > 0` guard) once the midpoint reaches a full step, i.e. once
+ * `tailIdx >= 2 * STEP`. Setting a smaller minimum would advertise an anchor that
+ * silently never fires for `tailIdx` in `[min, 2*STEP)`.
+ */
+const CACHE_ANCHOR_MIN_MESSAGES = 2 * CACHE_ANCHOR_STEP;
 
 function buildOpenAIMessages(
   messages: GatewayMessage[],

--- a/packages/gateway/test/openai-caching.test.ts
+++ b/packages/gateway/test/openai-caching.test.ts
@@ -406,11 +406,29 @@ describe("buildOpenAIUpstreamRequest — intermediate anchor breakpoint (#961)",
   };
 
   test("small conversation gets ONLY the moving tail breakpoint (no anchor)", () => {
-    // 6 conversation messages (< CACHE_ANCHOR_MIN_MESSAGES=12): a single tail
+    // 6 conversation messages (< CACHE_ANCHOR_MIN_MESSAGES): a single tail
     // breakpoint already bounds eviction cost, so no anchor is added.
     const body = getBody(makeRequest({ messages: convo(6) }), cacheOpts);
     const idxs = annotatedConversationIndices(body);
     expect(idxs.length).toBe(1); // tail only
+  });
+
+  test("anchor engagement threshold matches CACHE_ANCHOR_MIN_MESSAGES exactly", () => {
+    // Regression for a stale-constant gap: the anchor lands at
+    // floor((tailIdx/2)/STEP)*STEP, so it only clears the `anchorIdx > 0` guard
+    // once tailIdx reaches 2*STEP (=20). CACHE_ANCHOR_MIN_MESSAGES must equal
+    // that real engagement point — a smaller value would advertise an anchor
+    // that silently never fires just above the threshold.
+    // Just below (tailIdx 19): no anchor.
+    const below = annotatedConversationIndices(
+      getBody(makeRequest({ messages: convo(19) }), cacheOpts),
+    );
+    expect(below.length).toBe(1); // tail only
+    // Exactly at the threshold (tailIdx 20): anchor appears.
+    const at = annotatedConversationIndices(
+      getBody(makeRequest({ messages: convo(20) }), cacheOpts),
+    );
+    expect(at.length).toBe(2); // anchor + tail
   });
 
   test("large conversation gets a SECOND anchor near the prefix MIDPOINT", () => {


### PR DESCRIPTION
## Context

Follow-up to #1469 (midpoint cache anchor). Seer flagged that the intermediate anchor never fires for conversations with `tailIdx` in `[12, 19]`, even though `CACHE_ANCHOR_MIN_MESSAGES` was `12`: https://github.com/BYK/loreai/pull/1469#discussion_r3644527401

## Why it happened

The anchor lands at `floor((tailIdx / 2) / STEP) * STEP` (STEP=10). For `tailIdx` in `[12, 19]` the midpoint is `6..9`, which quantizes to `0`, and the `anchorIdx > 0` guard then skips it. So the anchor only actually engages once `tailIdx >= 2 * STEP = 20`. The `12` constant advertised an anchor that silently never fired in `[12, 20)`.

This never affected the eval (sessions are 40+ messages), so it's a code-honesty fix, not a behavior/correctness bug: the anchor engagement point is unchanged.

## Fix

Set `CACHE_ANCHOR_MIN_MESSAGES = 2 * CACHE_ANCHOR_STEP` (reordered so `STEP` is declared first) and document why the minimum is tied to the step. Now the constant equals the real engagement point, so the outer `tailIdx >= CACHE_ANCHOR_MIN_MESSAGES` guard is the single source of truth for when the anchor turns on.

## Tests

New `openai-caching.test.ts` regression: "anchor engagement threshold matches CACHE_ANCHOR_MIN_MESSAGES exactly" — asserts no anchor at `tailIdx=19`, anchor at `tailIdx=20`. Mutation-verified: raising the constant to `3*STEP` fails the test. 25/25 pass, tsc + oxfmt clean.