### PR TITLE
feat(upgrade): surface malformed_chain as a delta telemetry reason

### DIFF
--- a/packages/binpatch/src/discover.ts
+++ b/packages/binpatch/src/discover.ts
@@ -17,22 +17,62 @@ import { type ProgressHandler, safeProgress } from "./events";
  * A source of patch chains. Given the current and target versions, resolve the
  * ordered chain of patches (oldest hop first) plus the expected final SHA-256,
  * or `null` when no usable chain exists (caller falls back to a full download).
+ *
+ * A source may optionally classify *why* it returned `null` by invoking the
+ * `report` callback with a {@link DeltaUnavailableReason}. This is telemetry
+ * only — it never changes control flow (a `null` return is always a full-
+ * download fallback). It lets a consumer distinguish a benign "no patches
+ * published yet" from a `malformed_chain` (a published-but-broken manifest in
+ * the range), so a poisoned publish can be alerted on immediately instead of
+ * silently degrading every spanning upgrade to a full download.
  */
 export type SourceStrategy = {
   resolveChain(
     currentVersion: string,
     targetVersion: string,
     signal?: AbortSignal,
+    report?: UnavailableReporter,
   ): Promise<PatchChain | null>;
 };
 
 /** Where a resolved chain came from, for telemetry. */
 export type DeltaSource = "cache" | "network" | "offline_miss";
 
+/**
+ * Why a source could not produce a usable chain (telemetry only).
+ *
+ * - `no_patches` — no patch tags/assets exist in the range (benign: the
+ *   channel simply has no deltas published for this hop yet).
+ * - `malformed_chain` — patch tags exist in the range but the chain is broken:
+ *   a manifest is missing the expected `<binaryName>` patch layer, has a bad
+ *   `from-version` back-pointer, is missing its target SHA-256 annotation, or
+ *   otherwise fails validation. A published-but-unusable chain — the signal a
+ *   poisoned publish produces.
+ * - `too_long` — the chain exceeds the max depth (deltas would cost more than a
+ *   full download).
+ * - `over_budget` — the cumulative patch size exceeds the size-ratio gate.
+ * - `network` — a transient network failure prevented resolution.
+ */
+export type DeltaUnavailableReason =
+  | "no_patches"
+  | "malformed_chain"
+  | "too_long"
+  | "over_budget"
+  | "network";
+
+/** Callback a source uses to classify a `null` (no-chain) result. */
+export type UnavailableReporter = (reason: DeltaUnavailableReason) => void;
+
 /** Optional telemetry callback invoked as facts become known. */
 export type DeltaTelemetry = {
   onResolved?: (info: { source: DeltaSource; chain: PatchChain }) => void;
   onOfflineMiss?: () => void;
+  /**
+   * Invoked when the source returns no usable chain, with the source's best
+   * classification of why. Telemetry only — the caller always falls back to a
+   * full download regardless of reason.
+   */
+  onUnavailable?: (reason: DeltaUnavailableReason) => void;
 };
 
 export type ResolveAndApplyOpts = {
@@ -96,12 +136,23 @@ export async function resolveAndApply(
   }
 
   progress({ type: "phase", phase: "resolve" });
+  // Let the source classify a no-chain outcome for telemetry. Default to
+  // `no_patches` (the benign case) unless the source reports something more
+  // specific such as `malformed_chain`.
+  let unavailableReason: DeltaUnavailableReason = "no_patches";
+  const report: UnavailableReporter = (reason) => {
+    unavailableReason = reason;
+  };
   const chain = await source.resolveChain(
     currentVersion,
     targetVersion,
     signal,
+    report,
   );
-  if (!chain) return null;
+  if (!chain) {
+    telemetry?.onUnavailable?.(unavailableReason);
+    return null;
+  }
 
   // Persist for future offline upgrades, then apply.
   if (cache && chain.steps) {

--- a/packages/binpatch/src/index.ts
+++ b/packages/binpatch/src/index.ts
@@ -63,9 +63,11 @@ export {
 export {
   type DeltaSource,
   type DeltaTelemetry,
+  type DeltaUnavailableReason,
   resolveAndApply,
   type ResolveAndApplyOpts,
   type SourceStrategy,
+  type UnavailableReporter,
 } from "./discover";
 
 // Sources.

--- a/packages/binpatch/src/sources/ghcr.ts
+++ b/packages/binpatch/src/sources/ghcr.ts
@@ -21,7 +21,7 @@ import {
   type PatchLink,
   SIZE_THRESHOLD_RATIO,
 } from "../contract";
-import type { SourceStrategy } from "../discover";
+import type { SourceStrategy, UnavailableReporter } from "../discover";
 import { BinpatchError } from "../errors";
 import { OciClient, type OciClientConfig, type OciManifest } from "./oci";
 
@@ -61,9 +61,11 @@ export function filterAndSortChainTags(
   return chainTags.map((t) => t.tag);
 }
 
+type StepFailureReason = "malformed" | "over_budget";
+
 type ChainStepResult =
   | { ok: true; digest: string; size: number }
-  | { ok: false };
+  | { ok: false; reason: StepFailureReason };
 
 export function validateChainStep(
   manifest: OciManifest,
@@ -71,15 +73,17 @@ export function validateChainStep(
 ): ChainStepResult {
   const fromVersion = getPatchFromVersion(manifest);
   if (fromVersion !== opts.expectedFrom) {
-    return { ok: false };
+    return { ok: false, reason: "malformed" };
   }
 
   const layer = manifest.layers.find(
     (l) =>
       l.annotations?.["org.opencontainers.image.title"] === opts.patchLayerName,
   );
-  if (!layer) return { ok: false };
-  if (layer.size > opts.sizeLimit) return { ok: false };
+  // A missing patch layer for this platform is the poisoned-publish signature:
+  // the manifest exists and links correctly, but carries no usable patch.
+  if (!layer) return { ok: false, reason: "malformed" };
+  if (layer.size > opts.sizeLimit) return { ok: false, reason: "over_budget" };
 
   return { ok: true, digest: layer.digest, size: layer.size };
 }
@@ -89,6 +93,15 @@ type NightlyChainValidation = {
   totalSize: number;
   expectedSha256: string;
 };
+
+/** A validation failure, classified for telemetry. */
+type NightlyChainFailure = { failure: "malformed_chain" | "over_budget" };
+
+function isChainFailure(
+  v: NightlyChainValidation | NightlyChainFailure,
+): v is NightlyChainFailure {
+  return "failure" in v;
+}
 
 type ValidateChainOpts = {
   manifests: OciManifest[];
@@ -102,7 +115,7 @@ type ValidateChainOpts = {
 
 function validateNightlyChain(
   opts: ValidateChainOpts,
-): NightlyChainValidation | null {
+): NightlyChainValidation | NightlyChainFailure {
   const {
     manifests,
     chainTags,
@@ -119,7 +132,7 @@ function validateNightlyChain(
   for (let i = 0; i < manifests.length; i++) {
     const manifest = manifests[i];
     const tag = chainTags[i];
-    if (!(manifest && tag)) return null;
+    if (!(manifest && tag)) return { failure: "malformed_chain" };
 
     const remainingBudget = fullGzSize * SIZE_THRESHOLD_RATIO - totalSize;
     const result = validateChainStep(manifest, {
@@ -127,21 +140,26 @@ function validateNightlyChain(
       patchLayerName,
       sizeLimit: remainingBudget,
     });
-    if (!result.ok) return null;
+    if (!result.ok) {
+      return {
+        failure:
+          result.reason === "over_budget" ? "over_budget" : "malformed_chain",
+      };
+    }
 
     digests.push(result.digest);
     totalSize += result.size;
     prevVersion = tag.slice(PATCH_TAG_PREFIX.length);
 
     if (i === manifests.length - 1) {
-      if (prevVersion !== targetVersion) return null;
+      if (prevVersion !== targetVersion) return { failure: "malformed_chain" };
       const sha256 = getPatchTargetSha256(manifest, binaryName) ?? "";
-      if (!sha256) return null;
+      if (!sha256) return { failure: "malformed_chain" };
       return { digests, totalSize, expectedSha256: sha256 };
     }
   }
 
-  return null;
+  return { failure: "malformed_chain" };
 }
 
 /** Configuration for {@link ghcrSource}. */
@@ -173,6 +191,7 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
     fullGzSize: number;
     preloadedTags: string[];
     signal?: AbortSignal;
+    report?: UnavailableReporter;
   }): Promise<PatchChain | null> {
     const {
       token,
@@ -181,6 +200,7 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
       fullGzSize,
       preloadedTags,
       signal,
+      report,
     } = opts;
 
     const chainTags = filterAndSortChainTags(
@@ -189,18 +209,30 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
       targetVersion,
       compareVersions,
     );
-    if (chainTags.length === 0 || chainTags.length > MAX_NIGHTLY_CHAIN_DEPTH) {
+    if (chainTags.length === 0) {
+      report?.("no_patches");
+      return null;
+    }
+    if (chainTags.length > MAX_NIGHTLY_CHAIN_DEPTH) {
+      report?.("too_long");
       return null;
     }
 
     // Fetch manifests for all chain tags in parallel.
     const fetchedManifests = new Map<string, OciManifest>();
+    let fetchFailed = false;
     const results = await Promise.all(
       chainTags.map(async (tag) => {
         try {
           const manifest = await client.fetchManifest(token, tag, signal);
           return { tag, manifest };
         } catch {
+          // A manifest that's listed as a tag but fails to fetch is almost
+          // always transient (5xx / timeout / connection reset), NOT a poison:
+          // a poisoned tag's manifest fetches fine (HTTP 200) and is caught by
+          // validateNightlyChain instead. Classify a fetch failure as network
+          // so it never triggers a false `malformed_chain` poison alert.
+          fetchFailed = true;
           return { tag, manifest: null };
         }
       }),
@@ -210,7 +242,10 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
     }
 
     const manifests = chainTags.map((tag) => fetchedManifests.get(tag));
-    if (manifests.some((m) => !m)) return null;
+    if (manifests.some((m) => !m)) {
+      report?.(fetchFailed ? "network" : "malformed_chain");
+      return null;
+    }
 
     const validation = validateNightlyChain({
       manifests: manifests as OciManifest[],
@@ -221,7 +256,10 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
       binaryName,
       fullGzSize,
     });
-    if (!validation) return null;
+    if (isChainFailure(validation)) {
+      report?.(validation.failure);
+      return null;
+    }
 
     const downloadResults = await Promise.all(
       validation.digests.map((digest) =>
@@ -255,7 +293,7 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
   }
 
   return {
-    async resolveChain(currentVersion, targetVersion, signal) {
+    async resolveChain(currentVersion, targetVersion, signal, report) {
       // A network failure anywhere in resolution (token exchange, manifest /
       // tag listing, or blob download) means "no usable chain" per the
       // SourceStrategy contract — return null so the caller falls back to a
@@ -275,7 +313,12 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
             l.annotations?.["org.opencontainers.image.title"] ===
             `${binaryName}.gz`,
         );
-        if (!gzLayer) return null;
+        // The target's own image manifest is missing this platform's `.gz`
+        // layer — the target publish itself is malformed for this binary.
+        if (!gzLayer) {
+          report?.("malformed_chain");
+          return null;
+        }
 
         return await resolveNightlyChain({
           token,
@@ -284,9 +327,13 @@ export function ghcrSource(config: GhcrSourceConfig): SourceStrategy {
           fullGzSize: gzLayer.size,
           preloadedTags: patchTags,
           signal,
+          report,
         });
       } catch (error) {
-        if (error instanceof BinpatchError) return null;
+        if (error instanceof BinpatchError) {
+          report?.("network");
+          return null;
+        }
         throw error;
       }
     },

--- a/packages/binpatch/src/sources/github-release.ts
+++ b/packages/binpatch/src/sources/github-release.ts
@@ -68,10 +68,6 @@ export type StableChainInfo = {
   steps: { fromVersion: string; toVersion: string }[];
 };
 
-/**
- * Extract the chain of patch URLs from an already-fetched release list.
- * Pure computation — no HTTP.
- */
 /** A stable-chain extraction failure, classified for telemetry. */
 export type StableChainFailure = {
   failure: "no_patches" | "malformed_chain" | "too_long" | "over_budget";
@@ -83,6 +79,10 @@ function isStableChainFailure(
   return "failure" in v;
 }
 
+/**
+ * Extract the chain of patch URLs from an already-fetched release list.
+ * Pure computation — no HTTP.
+ */
 export function extractStableChain(
   opts: ExtractStableChainOpts,
 ): StableChainInfo | StableChainFailure {

--- a/packages/binpatch/src/sources/github-release.ts
+++ b/packages/binpatch/src/sources/github-release.ts
@@ -72,9 +72,20 @@ export type StableChainInfo = {
  * Extract the chain of patch URLs from an already-fetched release list.
  * Pure computation — no HTTP.
  */
+/** A stable-chain extraction failure, classified for telemetry. */
+export type StableChainFailure = {
+  failure: "no_patches" | "malformed_chain" | "too_long" | "over_budget";
+};
+
+function isStableChainFailure(
+  v: StableChainInfo | StableChainFailure,
+): v is StableChainFailure {
+  return "failure" in v;
+}
+
 export function extractStableChain(
   opts: ExtractStableChainOpts,
-): StableChainInfo | null {
+): StableChainInfo | StableChainFailure {
   const { releases, currentVersion, targetVersion, binaryName, fullGzSize } =
     opts;
   const patchAssetName = `${binaryName}.patch`;
@@ -82,28 +93,32 @@ export function extractStableChain(
   const targetIdx = releases.findIndex((r) => r.tag_name === targetVersion);
   const currentIdx = releases.findIndex((r) => r.tag_name === currentVersion);
   if (targetIdx === -1 || currentIdx === -1 || targetIdx >= currentIdx) {
-    return null;
+    // The current or target release isn't in the fetched window (or they're
+    // mis-ordered) — no chain to build, not a broken one.
+    return { failure: "no_patches" };
   }
 
   const chainReleases = releases.slice(targetIdx, currentIdx);
   if (chainReleases.length > MAX_STABLE_CHAIN_DEPTH) {
-    return null;
+    return { failure: "too_long" };
   }
 
   const targetRelease = chainReleases[0];
-  if (!targetRelease) return null;
+  if (!targetRelease) return { failure: "no_patches" };
   const expectedSha256 = getStableTargetSha256(targetRelease, binaryName) ?? "";
-  if (!expectedSha256) return null;
+  if (!expectedSha256) return { failure: "malformed_chain" };
 
   const patchUrls: string[] = [];
   let totalSize = 0;
   for (const release of chainReleases) {
     const patchAsset = release.assets.find((a) => a.name === patchAssetName);
-    if (!patchAsset) return null;
+    // A release in the range with no patch asset for this platform is a
+    // published-but-broken hop — the poisoned-publish signature.
+    if (!patchAsset) return { failure: "malformed_chain" };
     patchUrls.push(patchAsset.browser_download_url);
     totalSize += patchAsset.size;
     if (totalSize > fullGzSize * SIZE_THRESHOLD_RATIO) {
-      return null;
+      return { failure: "over_budget" };
     }
   }
 
@@ -145,7 +160,7 @@ export function githubReleaseSource(
 
   async function fetchRecentReleases(
     signal?: AbortSignal,
-  ): Promise<GitHubRelease[]> {
+  ): Promise<GitHubRelease[] | null> {
     const perPage = MAX_STABLE_CHAIN_DEPTH + 2;
     let response: Response;
     try {
@@ -157,9 +172,10 @@ export function githubReleaseSource(
         signal,
       });
     } catch {
-      return [];
+      // Network failure — distinct from a genuinely empty release list.
+      return null;
     }
-    if (!response.ok) return [];
+    if (!response.ok) return null;
     return (await response.json()) as GitHubRelease[];
   }
 
@@ -181,15 +197,27 @@ export function githubReleaseSource(
   }
 
   return {
-    async resolveChain(currentVersion, targetVersion, signal) {
+    async resolveChain(currentVersion, targetVersion, signal, report) {
       const releases = await fetchRecentReleases(signal);
+      if (releases === null) {
+        report?.("network");
+        return null;
+      }
 
       const targetRelease = releases.find((r) => r.tag_name === targetVersion);
-      if (!targetRelease) return null;
+      if (!targetRelease) {
+        report?.("no_patches");
+        return null;
+      }
       const gzAsset = targetRelease.assets.find(
         (a) => a.name === `${binaryName}.gz`,
       );
-      if (!gzAsset) return null;
+      // The target release exists but has no `.gz` asset for this platform —
+      // the target publish itself is malformed for this binary.
+      if (!gzAsset) {
+        report?.("malformed_chain");
+        return null;
+      }
 
       const chainInfo = extractStableChain({
         releases,
@@ -198,7 +226,10 @@ export function githubReleaseSource(
         binaryName,
         fullGzSize: gzAsset.size,
       });
-      if (!chainInfo) return null;
+      if (isStableChainFailure(chainInfo)) {
+        report?.(chainInfo.failure);
+        return null;
+      }
 
       const downloadResults = await Promise.all(
         chainInfo.patchUrls.map((url) => downloadPatch(url, signal)),
@@ -207,7 +238,12 @@ export function githubReleaseSource(
       const patches: PatchLink[] = [];
       let totalSize = 0;
       for (const data of downloadResults) {
-        if (!data) return null;
+        // A listed patch asset failed to download — transient, not a broken
+        // publish (the asset exists on the release).
+        if (!data) {
+          report?.("network");
+          return null;
+        }
         patches.push({ data, size: data.byteLength });
         totalSize += data.byteLength;
       }

--- a/packages/binpatch/test/discover.test.ts
+++ b/packages/binpatch/test/discover.test.ts
@@ -192,6 +192,49 @@ describe("resolveAndApply", () => {
     expect(result).toBeNull();
   });
 
+  it("fires onUnavailable('malformed_chain') when the source classifies a broken chain", async () => {
+    // A source that finds patch tags in range but a broken/missing-layer
+    // manifest reports `malformed_chain` — the poisoned-publish signal.
+    const source: SourceStrategy = {
+      resolveChain: vi.fn(async (_current, _target, _signal, report) => {
+        report?.("malformed_chain");
+        return null;
+      }),
+    };
+    const onUnavailable = vi.fn();
+    const dest = writeTemp("out-malformed.bin", Buffer.alloc(0));
+
+    const result = await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      telemetry: { onUnavailable },
+    });
+
+    expect(result).toBeNull();
+    expect(onUnavailable).toHaveBeenCalledExactlyOnceWith("malformed_chain");
+  });
+
+  it("defaults onUnavailable to 'no_patches' when the source reports nothing", async () => {
+    const source: SourceStrategy = { resolveChain: vi.fn(async () => null) };
+    const onUnavailable = vi.fn();
+    const dest = writeTemp("out-nopatches.bin", Buffer.alloc(0));
+
+    const result = await resolveAndApply({
+      source,
+      currentVersion: "1.0.0",
+      targetVersion: "1.1.0",
+      oldPath: OLD,
+      destPath: dest,
+      telemetry: { onUnavailable },
+    });
+
+    expect(result).toBeNull();
+    expect(onUnavailable).toHaveBeenCalledExactlyOnceWith("no_patches");
+  });
+
   it("throws on a SHA-256 mismatch (caller falls back to full download)", async () => {
     const chain = makeChain(Buffer.from("real output"));
     // Corrupt the expected hash so the applied result cannot match.

--- a/packages/binpatch/test/sources.test.ts
+++ b/packages/binpatch/test/sources.test.ts
@@ -13,6 +13,14 @@ import {
   validateChainStep,
 } from "../src";
 
+// Build a JSON Response for mocked fetch calls.
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 // A semver-ish comparator matching the gateway's compareVersions contract
 // (returns -1 | 0 | 1) for the nightly tag-ordering tests.
 function cmp(a: string, b: string): -1 | 0 | 1 {
@@ -112,21 +120,22 @@ describe("extractStableChain", () => {
       binaryName: BINARY,
       fullGzSize: 40,
     });
-    expect(info).not.toBeNull();
+    expect(info).not.toHaveProperty("failure");
+    if ("failure" in info) throw new Error("expected a chain, got a failure");
     // Two hops: 1.0.0 -> 1.1.0 -> 1.2.0. Expected sha is the target's.
-    expect(info?.expectedSha256).toBe("aaaa");
-    expect(info?.steps).toEqual([
+    expect(info.expectedSha256).toBe("aaaa");
+    expect(info.steps).toEqual([
       { fromVersion: "1.0.0", toVersion: "1.1.0" },
       { fromVersion: "1.1.0", toVersion: "1.2.0" },
     ]);
     // patchUrls are apply-order: 1.1.0's patch first, then 1.2.0's.
-    expect(info?.patchUrls).toEqual([
+    expect(info.patchUrls).toEqual([
       "https://example.test/1.1.0/tool-linux-x64.patch",
       "https://example.test/1.2.0/tool-linux-x64.patch",
     ]);
   });
 
-  it("returns null when a hop is missing its patch asset", () => {
+  it("reports malformed_chain when a hop is missing its patch asset", () => {
     // 1.0.0 has no patch asset, but it is the current version (not in the
     // chain slice), so drop 1.1.0's patch instead to force a gap.
     const broken = releases.map((r) =>
@@ -142,10 +151,10 @@ describe("extractStableChain", () => {
         binaryName: BINARY,
         fullGzSize: 40,
       }),
-    ).toBeNull();
+    ).toEqual({ failure: "malformed_chain" });
   });
 
-  it("returns null when the chain exceeds the size ratio gate", () => {
+  it("reports over_budget when the chain exceeds the size ratio gate", () => {
     // fullGzSize tiny → 60% ratio easily exceeded by the 5+6 byte patches.
     expect(
       extractStableChain({
@@ -155,10 +164,10 @@ describe("extractStableChain", () => {
         binaryName: BINARY,
         fullGzSize: 1,
       }),
-    ).toBeNull();
+    ).toEqual({ failure: "over_budget" });
   });
 
-  it("returns null when target is not older than current in the list", () => {
+  it("reports no_patches when target is not older than current in the list", () => {
     expect(
       extractStableChain({
         releases,
@@ -167,7 +176,7 @@ describe("extractStableChain", () => {
         binaryName: BINARY,
         fullGzSize: 40,
       }),
-    ).toBeNull();
+    ).toEqual({ failure: "no_patches" });
   });
 });
 
@@ -222,31 +231,31 @@ describe("validateChainStep", () => {
     expect(res).toEqual({ ok: true, digest: "sha256:deadbeef", size: 50 });
   });
 
-  it("rejects a from-version mismatch (broken chain link)", () => {
+  it("rejects a from-version mismatch (broken chain link) as malformed", () => {
     const res = validateChainStep(manifest("9.9.9", 50), {
       expectedFrom: "1.0.0",
       patchLayerName: `${BINARY}.patch`,
       sizeLimit: 100,
     });
-    expect(res.ok).toBe(false);
+    expect(res).toEqual({ ok: false, reason: "malformed" });
   });
 
-  it("rejects a patch layer over the size limit", () => {
+  it("rejects a patch layer over the size limit as over_budget", () => {
     const res = validateChainStep(manifest("1.0.0", 500), {
       expectedFrom: "1.0.0",
       patchLayerName: `${BINARY}.patch`,
       sizeLimit: 100,
     });
-    expect(res.ok).toBe(false);
+    expect(res).toEqual({ ok: false, reason: "over_budget" });
   });
 
-  it("rejects when the named patch layer is absent", () => {
+  it("rejects (as malformed) when the named patch layer is absent", () => {
     const res = validateChainStep(manifest("1.0.0", 50), {
       expectedFrom: "1.0.0",
       patchLayerName: "other.patch",
       sizeLimit: 100,
     });
-    expect(res.ok).toBe(false);
+    expect(res).toEqual({ ok: false, reason: "malformed" });
   });
 });
 
@@ -275,7 +284,7 @@ describe("ghcrSource resolveChain — SourceStrategy contract on network failure
     globalThis.fetch = realFetch;
   });
 
-  it("returns null (not throw) when the registry is unreachable", async () => {
+  it("returns null (not throw) and reports 'network' when the registry is unreachable", async () => {
     // The OCI client uses global fetch; make every call fail like a network
     // outage. Per the SourceStrategy contract a resolution failure must be a
     // null (→ fall back to full download, reported `unavailable`), never a
@@ -293,7 +302,108 @@ describe("ghcrSource resolveChain — SourceStrategy contract on network failure
       compareVersions: cmp,
     });
 
-    await expect(source.resolveChain("1.0.0", "1.1.0")).resolves.toBeNull();
+    const report = vi.fn();
+    await expect(
+      source.resolveChain("1.0.0", "1.1.0", undefined, report),
+    ).resolves.toBeNull();
+    expect(report).toHaveBeenCalledExactlyOnceWith("network");
+  });
+
+  it("reports 'malformed_chain' when a patch tag in range is missing its platform layer", async () => {
+    // The exact poisoned-publish scenario: a patch tag exists in the range
+    // (so it is NOT 'no_patches'), links correctly by from-version, but its
+    // manifest carries a bogus layer instead of `${BINARY}.patch` (e.g. a
+    // dependency patch that leaked into publish). The chain must be rejected
+    // and classified `malformed_chain` so the poison is observable.
+    const token = { token: "t" };
+    const gzLayer = {
+      digest: "sha256:gz",
+      mediaType: "application/gzip",
+      size: 1000,
+      annotations: { "org.opencontainers.image.title": `${BINARY}.gz` },
+    };
+    const targetManifest = { schemaVersion: 2, layers: [gzLayer] };
+    // patch-1.1.0 links from 1.0.0 but has a bogus (non-platform) layer.
+    const poisonedManifest = {
+      schemaVersion: 2,
+      annotations: { "from-version": "1.0.0" },
+      layers: [
+        {
+          digest: "sha256:bogus",
+          mediaType: "application/vnd.oci.image.layer.v1.tar",
+          size: 42,
+          annotations: {
+            "org.opencontainers.image.title": "@dep__thing@1.2.3.patch",
+          },
+        },
+      ],
+    };
+
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes("/token")) return json(token);
+      if (u.includes("/tags/list")) return json({ tags: ["patch-1.1.0"] });
+      if (u.includes("/manifests/nightly-1.1.0")) return json(targetManifest);
+      if (u.includes("/manifests/patch-1.1.0")) return json(poisonedManifest);
+      throw new TypeError(`unexpected fetch: ${u}`);
+    });
+
+    const source = ghcrSource({
+      registry: "https://ghcr.io",
+      repo: "owner/project",
+      userAgent: "test/1.0.0",
+      binaryName: BINARY,
+      targetTag: (v) => `nightly-${v}`,
+      compareVersions: cmp,
+    });
+
+    const report = vi.fn();
+    await expect(
+      source.resolveChain("1.0.0", "1.1.0", undefined, report),
+    ).resolves.toBeNull();
+    expect(report).toHaveBeenCalledExactlyOnceWith("malformed_chain");
+  });
+
+  it("reports 'network' (not 'malformed_chain') when a chain manifest fetch fails transiently", async () => {
+    // A patch tag is in range, but fetching its manifest fails (5xx / reset /
+    // timeout). This is transient, NOT a poisoned publish — it must report
+    // `network`, never a false `malformed_chain` poison alert. (A real poison
+    // fetches HTTP 200 and is caught by validateNightlyChain instead.)
+    const token = { token: "t" };
+    const gzLayer = {
+      digest: "sha256:gz",
+      mediaType: "application/gzip",
+      size: 1000,
+      annotations: { "org.opencontainers.image.title": `${BINARY}.gz` },
+    };
+    const targetManifest = { schemaVersion: 2, layers: [gzLayer] };
+
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes("/token")) return json(token);
+      if (u.includes("/tags/list")) return json({ tags: ["patch-1.1.0"] });
+      if (u.includes("/manifests/nightly-1.1.0")) return json(targetManifest);
+      // The in-range patch manifest 5xxs on every (retried) attempt.
+      if (u.includes("/manifests/patch-1.1.0")) {
+        return new Response("upstream boom", { status: 503 });
+      }
+      throw new TypeError(`unexpected fetch: ${u}`);
+    });
+
+    const source = ghcrSource({
+      registry: "https://ghcr.io",
+      repo: "owner/project",
+      userAgent: "test/1.0.0",
+      binaryName: BINARY,
+      targetTag: (v) => `nightly-${v}`,
+      compareVersions: cmp,
+    });
+
+    const report = vi.fn();
+    await expect(
+      source.resolveChain("1.0.0", "1.1.0", undefined, report),
+    ).resolves.toBeNull();
+    expect(report).toHaveBeenCalledExactlyOnceWith("network");
   });
 });
 

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -127,6 +127,10 @@ export async function attemptDeltaUpgrade(
       // source-less `unavailable` report below — that would overwrite the
       // telemetry outcome and drop the source attribution.
       let reported = false;
+      // Why the source found no usable chain (telemetry classification). Set by
+      // binpatch's `onUnavailable`; folded into the final `unavailable` report
+      // so a `malformed_chain` (a poisoned publish) is alertable, not silent.
+      let unavailableReason: string | undefined;
       // Render the apply-phase byte bar from binpatch's progress events. The
       // bar is created lazily on the first `bytes` event (which carries the
       // total) and fed per-hop deltas (events report cumulative `written`).
@@ -155,6 +159,9 @@ export async function attemptDeltaUpgrade(
                 result: "unavailable",
               });
             },
+            onUnavailable: (reason) => {
+              unavailableReason = reason;
+            },
           },
         });
 
@@ -165,6 +172,7 @@ export async function attemptDeltaUpgrade(
               fromVersion: VERSION,
               toVersion: targetVersion,
               result: "unavailable",
+              reason: unavailableReason,
             });
           }
         } else {

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -902,6 +902,12 @@ export type DeltaUpgradeTelemetry = {
   source?: string;
   /** ok (patches applied) | unavailable (no usable chain) | error. */
   result: "ok" | "unavailable" | "error";
+  /**
+   * When result is "unavailable", why no usable chain was found:
+   * no_patches | malformed_chain | too_long | over_budget | network. A
+   * `malformed_chain` is the poisoned-publish signal worth alerting on.
+   */
+  reason?: string;
   patchBytes?: number;
   chainLength?: number;
   sha256?: string;
@@ -943,6 +949,7 @@ export async function spanDeltaUpgrade<T>(
         outcome = t;
         span.setAttribute("delta.result", t.result);
         if (t.source) span.setAttribute("delta.source", t.source);
+        if (t.reason) span.setAttribute("delta.reason", t.reason);
         if (t.patchBytes !== undefined)
           span.setAttribute("delta.patch_bytes", t.patchBytes);
         if (t.chainLength !== undefined)

--- a/packages/gateway/test/delta-upgrade-telemetry.test.ts
+++ b/packages/gateway/test/delta-upgrade-telemetry.test.ts
@@ -80,18 +80,22 @@ describe("spanDeltaUpgrade", () => {
     expect(cl?.value).toBe(3);
   });
 
-  it("emits NO distributions on unavailable (graceful fallback)", async () => {
-    setupStartSpan();
+  it("emits NO distributions on unavailable (graceful fallback) and records the reason", async () => {
+    const { attrs } = setupStartSpan();
     await spanDeltaUpgrade(BASE, async (report) => {
       report({
         channel: "stable",
         fromVersion: "1.0.0",
         toVersion: "1.1.0",
         result: "unavailable",
+        reason: "malformed_chain",
       });
       return null;
     });
     expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+    expect(attrs["delta.result"]).toBe("unavailable");
+    // The poisoned-publish signal must reach the span so it is alertable.
+    expect(attrs["delta.reason"]).toBe("malformed_chain");
   });
 
   it("emits NO distributions when a non-ok report carries patch metrics (ok-gate is load-bearing)", async () => {


### PR DESCRIPTION
## Why

Fix **B** of the delta-upgrade regression (A = CI collision fix #1470, merged; C = poisoned-tag cleanup, next). Root cause recap: a poisoned patch tag `patch-0.39.0-dev.1784820552` (a manifest missing the platform `lore-linux-x64.patch` layer, from the CI dir-collision + a transient download failure) breaks **every** consecutive chain spanning it, so multi-hop upgrades silently fall back to a full 287 MB download.

Patches are **strictly consecutive** (each links `from-version=prev`), so the client genuinely *cannot* route around a poisoned middle node — no bridging patch exists. The durable client-side mitigation is **observability**: previously a poisoned publish was indistinguishable from a benign 'no patches yet' — both returned `null` → full download with **no signal**, so the outage was silent for ~a day.

## What

Ports [binpatch#1](https://github.com/BYK/binpatch/pull/1) into Lore's vendored `packages/binpatch` and wires it into telemetry:

- **binpatch (vendored):** `SourceStrategy.resolveChain` gains an optional `report(reason)`; `resolveAndApply` adds `telemetry.onUnavailable(reason)`. Reasons: `no_patches | malformed_chain | too_long | over_budget | network`. **Telemetry only — never changes control flow** (a `null` chain is always a full-download fallback). A transient manifest-fetch failure classifies as `network`, not `malformed_chain` (no false poison alerts — caught by the binpatch adversarial review).
- **gateway:** `DeltaUpgradeTelemetry` gains `reason?`; sets a `delta.reason` span attribute; the `delta-upgrade.ts` glue folds `onUnavailable`'s reason into the `unavailable` report.

Now you can **alert on `delta.reason=malformed_chain`** the moment a poisoned publish lands, instead of discovering a multi-day silent full-download regression after the fact.

## Tests

- binpatch: +4 (onUnavailable malformed/default; ghcr e2e missing-layer → malformed_chain; transient fetch → network). `validateChainStep`/`extractStableChain` assert the specific reason.
- gateway: telemetry test asserts `delta.reason=malformed_chain` reaches the span on `unavailable`.
- Full local suite: **344 files / 6609 tests / 0 failed**. typecheck / lint / format:check green. Mutation-verified (missing-layer→malformed and transient→network both go RED when reverted).

## Follow-up

C: remove/republish the poisoned `patch-0.39.0-dev.1784820552` tag to unblock existing users. PR4 later reconciles Lore's vendored copy with the standalone `binpatch` npm package.