### PR TITLE
test(import): e2e coverage for the commandImport decision matrix + real readers

### DIFF
--- a/packages/core/src/import/providers/claude-code.ts
+++ b/packages/core/src/import/providers/claude-code.ts
@@ -55,7 +55,11 @@ type ContentBlock =
 // Constants
 // ---------------------------------------------------------------------------
 
-const CLAUDE_DIR = join(homedir(), ".claude", "projects");
+// Resolved lazily (not at module load) so `homedir()` is read per call — lets
+// tests redirect it via $HOME and keeps production behavior identical.
+function claudeDir(): string {
+  return join(homedir(), ".claude", "projects");
+}
 const MAX_TOOL_OUTPUT_CHARS = 500;
 const DEFAULT_MAX_TOKENS = 12288;
 
@@ -245,7 +249,7 @@ const claudeCodeProvider: AgentHistoryProvider = {
 
     for (const projectPath of projectPaths) {
       const mangled = manglePath(projectPath);
-      const dir = join(CLAUDE_DIR, mangled);
+      const dir = join(claudeDir(), mangled);
 
       let entries: string[];
       try {

--- a/packages/core/src/import/providers/codex.ts
+++ b/packages/core/src/import/providers/codex.ts
@@ -21,9 +21,17 @@ import { registerProvider } from "./index";
 // Constants
 // ---------------------------------------------------------------------------
 
-const CODEX_DIR = join(homedir(), ".codex");
-const SESSIONS_DIR = join(CODEX_DIR, "sessions");
-const ARCHIVED_DIR = join(CODEX_DIR, "archived_sessions");
+// Resolved lazily (not at module load) so `homedir()` is read per call — lets
+// tests redirect it via $HOME and keeps production behavior identical.
+function codexDir(): string {
+  return join(homedir(), ".codex");
+}
+function sessionsDir(): string {
+  return join(codexDir(), "sessions");
+}
+function archivedDir(): string {
+  return join(codexDir(), "archived_sessions");
+}
 const MAX_TOOL_OUTPUT_CHARS = 500;
 const DEFAULT_MAX_TOKENS = 12288;
 
@@ -252,8 +260,8 @@ const codexProvider: AgentHistoryProvider = {
 
     // Scan both active and archived sessions
     const allFiles = [
-      ...findJsonlFiles(SESSIONS_DIR),
-      ...findJsonlFiles(ARCHIVED_DIR),
+      ...findJsonlFiles(sessionsDir()),
+      ...findJsonlFiles(archivedDir()),
     ];
 
     for (const filePath of allFiles) {

--- a/packages/core/src/import/providers/pi.ts
+++ b/packages/core/src/import/providers/pi.ts
@@ -24,7 +24,11 @@ import { registerProvider } from "./index";
 // Constants
 // ---------------------------------------------------------------------------
 
-const PI_DIR = join(homedir(), ".pi", "agent", "sessions");
+// Resolved lazily (not at module load) so `homedir()` is read per call — lets
+// tests redirect it via $HOME and keeps production behavior identical.
+function piDir(): string {
+  return join(homedir(), ".pi", "agent", "sessions");
+}
 const MAX_TOOL_OUTPUT_CHARS = 500;
 const DEFAULT_MAX_TOKENS = 12288;
 
@@ -217,7 +221,7 @@ const piProvider: AgentHistoryProvider = {
 
     for (const projectPath of projectPaths) {
       const encoded = encodeCwd(projectPath);
-      const dir = join(PI_DIR, encoded);
+      const dir = join(piDir(), encoded);
 
       let entries: string[];
       try {

--- a/packages/core/test/import/readers-e2e.test.ts
+++ b/packages/core/test/import/readers-e2e.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Real-reader e2e: drives the ACTUAL claude-code / codex history readers
+// (detect → readChunks) against on-disk fixtures placed under a tmp HOME. This
+// is possible because the readers now resolve `homedir()` lazily (per call) —
+// so setting $HOME before the call redirects them. Guards against regressions
+// in the load-time-const → lazy-fn refactor and in the readers themselves.
+
+import "../../src/import/providers/claude-code";
+import "../../src/import/providers/codex";
+import { getProvider } from "../../src/import/providers";
+
+const FIXTURES = join(fileURLToPath(new URL(".", import.meta.url)), "fixtures");
+
+/** claude-code detect mangles the project path into a dir name (slashes → dashes). */
+function manglePath(p: string): string {
+  return p.replace(/\//g, "-");
+}
+
+describe("import readers — real on-disk e2e under a redirected HOME", () => {
+  let home: string;
+  let project: string;
+  const prevHome = process.env.HOME;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "lore-reader-home-"));
+    project = mkdtempSync(join(tmpdir(), "lore-reader-proj-"));
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(project, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+  });
+
+  test("claude-code: detect finds a session under ~/.claude/projects/<mangled> and readChunks parses it", () => {
+    const provider = getProvider("claude-code");
+    if (!provider) throw new Error("claude-code not registered");
+
+    // Place the real fixture at the real detect location for THIS project path.
+    const projectsDir = join(home, ".claude", "projects", manglePath(project));
+    mkdirSync(projectsDir, { recursive: true });
+    const fixture = readFileSync(
+      join(FIXTURES, "claude-code-session.jsonl"),
+      "utf-8",
+    );
+    const sessionFile = join(projectsDir, "session-abc.jsonl");
+    writeFileSync(sessionFile, fixture);
+
+    // detect() must resolve the redirected HOME (lazy claudeDir()).
+    const sessions = provider.detect([project]);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].id).toBe(sessionFile);
+    expect(sessions[0].messageCount).toBeGreaterThanOrEqual(3);
+
+    // readChunks() over the detected session id.
+    const chunks = provider.readChunks(
+      project,
+      sessions.map((s) => s.id),
+    );
+    expect(chunks.length).toBeGreaterThan(0);
+    const text = chunks.map((c) => c.text).join("\n");
+    expect(text).toContain("[user]");
+    expect(text).toContain("fix the build error");
+  });
+
+  test("claude-code: detect returns nothing when HOME has no matching project dir", () => {
+    const provider = getProvider("claude-code");
+    if (!provider) throw new Error("claude-code not registered");
+    // Fresh HOME, no fixture written → empty.
+    expect(provider.detect([project])).toEqual([]);
+  });
+
+  test("codex: detect matches a session by cwd under ~/.codex/sessions and readChunks parses it", () => {
+    const provider = getProvider("codex");
+    if (!provider) throw new Error("codex not registered");
+
+    // Codex matches sessions by the recorded `cwd`, so rewrite the fixture's
+    // session_meta cwd to THIS project path, then drop it in the sessions tree.
+    const raw = readFileSync(join(FIXTURES, "codex-session.jsonl"), "utf-8");
+    const lines = raw.split("\n").filter((l) => l.trim());
+    const meta = JSON.parse(lines[0]) as {
+      type: string;
+      payload: { meta: { cwd: string } };
+    };
+    meta.payload.meta.cwd = project;
+    lines[0] = JSON.stringify(meta);
+    const rewritten = lines.join("\n") + "\n";
+
+    const sessionsDir = join(home, ".codex", "sessions", "2026", "07", "24");
+    mkdirSync(sessionsDir, { recursive: true });
+    const sessionFile = join(sessionsDir, "rollout-e2e.jsonl");
+    writeFileSync(sessionFile, rewritten);
+
+    const sessions = provider.detect([project]);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].id).toBe(sessionFile);
+    expect(sessions[0].messageCount).toBeGreaterThanOrEqual(3);
+
+    const chunks = provider.readChunks(
+      project,
+      sessions.map((s) => s.id),
+    );
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.map((c) => c.text).join("\n").length).toBeGreaterThan(0);
+  });
+
+  test("codex: a session recorded in a DIFFERENT cwd is not matched", () => {
+    const provider = getProvider("codex");
+    if (!provider) throw new Error("codex not registered");
+
+    // Fixture cwd left as its original (/test/codex-project), which is not our
+    // tmp project → detect must skip it.
+    const raw = readFileSync(join(FIXTURES, "codex-session.jsonl"), "utf-8");
+    const sessionsDir = join(home, ".codex", "sessions", "2026", "07", "24");
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(join(sessionsDir, "rollout-other.jsonl"), raw);
+
+    expect(provider.detect([project])).toEqual([]);
+  });
+});

--- a/packages/gateway/test/import-command-e2e.test.ts
+++ b/packages/gateway/test/import-command-e2e.test.ts
@@ -1,0 +1,304 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// End-to-end coverage of the REAL `commandImport` decision loop across multiple
+// agents with mixed credential outcomes (success / needsModel / no-cred). Every
+// scenario here maps to a bug Seer or the adversarial review caught on the
+// env-credential feature (PRs #1466), so a regression re-breaks a named test
+// instead of shipping-then-catching in review.
+//
+// Injection seams (no real filesystem/network):
+//  1. registerProvider/clearProviders — fake agents named after real AgentDefs
+//     (claude-code, codex) so the real per-agent auth chain still runs. Restore
+//     the real registry in afterEach so this suite never poisons others.
+//  2. Auth via env vars (ANTHROPIC_AUTH_TOKEN / OPENAI_API_KEY) under a tmp HOME
+//     with no on-disk auth — the auth readers resolve homedir() lazily.
+//  3. createGatewayLLMClient — mocked; captures (upstreams, getAuth, model) and
+//     returns a canned curator answer, so extraction "succeeds" without network.
+
+const shutdownMock = vi.fn(async () => {});
+let startConfig: Record<string, unknown> = {
+  upstreamAnthropic: "https://api.anthropic.com",
+  upstreamOpenAI: "https://api.openai.com",
+};
+vi.mock("../src/cli/start", () => ({
+  startGateway: vi.fn(async () => ({
+    config: startConfig,
+    owned: true,
+    shutdown: shutdownMock,
+  })),
+}));
+
+// Capture every LLM client construction: [upstreams, getAuth, model, opts].
+const llmClientCalls: unknown[][] = [];
+vi.mock("../src/llm-adapter", () => ({
+  createGatewayLLMClient: (...args: unknown[]) => {
+    llmClientCalls.push(args);
+    // "[]" = a valid curator answer with no ops → chunk counts as answered.
+    return { prompt: vi.fn(async () => "[]") };
+  },
+}));
+
+import { commandImport } from "../src/cli/import";
+import { _resetAuthForTest } from "../src/auth";
+import { load as loadConfig } from "@loreai/core";
+import { conversationImport } from "@loreai/core";
+import type { conversationImport as CI } from "@loreai/core";
+
+const { registerProvider, clearProviders, getProviders } = conversationImport;
+
+type FakeSpec = {
+  name: string;
+  displayName: string;
+  messageCount?: number;
+};
+
+/**
+ * A minimal AgentHistoryProvider returning one canned session + chunk for the
+ * project path. `name` must match a real AgentDef when we want the real auth
+ * chain (env creds) to resolve for it.
+ */
+function fakeProvider(spec: FakeSpec): CI.AgentHistoryProvider {
+  const messageCount = spec.messageCount ?? 5;
+  return {
+    name: spec.name,
+    displayName: spec.displayName,
+    detect(): CI.DetectedSession[] {
+      return [
+        {
+          id: `${spec.name}-sess-1`,
+          label: `2026-07-24 (${messageCount} messages)`,
+          startedAt: 1_700_000_000_000,
+          lastActivityAt: 1_700_000_001_000,
+          estimatedTokens: 100,
+          messageCount,
+        } satisfies CI.DetectedSession,
+      ];
+    },
+    readChunks(): CI.ConversationChunk[] {
+      return [
+        {
+          label: `${spec.displayName} session (1 of 1)`,
+          text: "[user] hello\n[assistant] hi there",
+          estimatedTokens: 10,
+          timestamp: 1_700_000_001_000,
+        },
+      ];
+    },
+  };
+}
+
+describe("commandImport (local mode) — multi-agent e2e decision matrix", () => {
+  let project: string;
+  let fakeHome: string;
+  const logs: string[] = [];
+  const errs: string[] = [];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  const prevRemote = process.env.LORE_REMOTE_URL;
+  const prevHome = process.env.HOME;
+  const prevXdgData = process.env.XDG_DATA_HOME;
+  const prevXdgConfig = process.env.XDG_CONFIG_HOME;
+  const prevWorkerModel = process.env.LORE_WORKER_MODEL;
+  const envKeys = [
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+  ];
+  const savedEnv: Record<string, string | undefined> = {};
+  // Snapshot the real provider registry so we can restore it after each test.
+  let realProviders: readonly CI.AgentHistoryProvider[];
+
+  beforeEach(() => {
+    delete process.env.LORE_REMOTE_URL; // force local mode
+    delete process.env.LORE_WORKER_MODEL;
+    for (const k of envKeys) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    _resetAuthForTest();
+    startConfig = {
+      upstreamAnthropic: "https://api.anthropic.com",
+      upstreamOpenAI: "https://api.openai.com",
+    };
+    project = mkdtempSync(join(tmpdir(), "lore-e2e-project-"));
+    // Fresh HOME with no on-disk agent auth → forces the env-credential tier.
+    fakeHome = mkdtempSync(join(tmpdir(), "lore-e2e-home-"));
+    process.env.HOME = fakeHome;
+    process.env.XDG_DATA_HOME = join(fakeHome, ".local", "share");
+    process.env.XDG_CONFIG_HOME = join(fakeHome, ".config");
+
+    // Snapshot + clear the real registry; register fakes per-test.
+    realProviders = [...getProviders()];
+    clearProviders();
+
+    logs.length = 0;
+    errs.length = 0;
+    llmClientCalls.length = 0;
+    logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
+      logs.push(a.join(" "));
+    });
+    errSpy = vi.spyOn(console, "error").mockImplementation((...a) => {
+      errs.push(a.join(" "));
+    });
+    // Swallow the progress \r writes.
+    stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    shutdownMock.mockClear();
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    stderrSpy.mockRestore();
+    vi.restoreAllMocks();
+    rmSync(project, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+    // Restore the real provider registry so sibling suites see the real agents.
+    clearProviders();
+    for (const p of realProviders) registerProvider(p);
+    _resetAuthForTest();
+    // Restore env.
+    if (prevRemote === undefined) delete process.env.LORE_REMOTE_URL;
+    else process.env.LORE_REMOTE_URL = prevRemote;
+    if (prevWorkerModel === undefined) delete process.env.LORE_WORKER_MODEL;
+    else process.env.LORE_WORKER_MODEL = prevWorkerModel;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevXdgData === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = prevXdgData;
+    if (prevXdgConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdgConfig;
+    for (const k of envKeys) {
+      const v = savedEnv[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    // Reset process-global config to a clean dir.
+    await loadConfig(mkdtempSync(join(tmpdir(), "lore-e2e-cfg-")));
+  });
+
+  const out = () => errs.join("\n");
+  const info = () => logs.join("\n");
+
+  test("1. single agent with a real (anthropic) env credential → extraction runs, success, no 'Can't import'", async () => {
+    registerProvider(
+      fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+    );
+    process.env.ANTHROPIC_API_KEY = "sk-ant-real";
+
+    await commandImport([], { project, yes: true });
+
+    expect(out()).not.toContain("Can't import");
+    expect(info()).toContain("Reading Claude Code conversations");
+    // Extraction client built with an anthropic model (anthropic HAS a default).
+    expect(llmClientCalls.length).toBe(1);
+    const model = llmClientCalls[0][2] as {
+      providerID: string;
+      modelID: string;
+    };
+    expect(model.providerID).toBe("anthropic");
+    expect(model.modelID).toBeTruthy();
+  });
+
+  test("2. env credential for a defaultless provider (OpenRouter) WITH a matching LORE_WORKER_MODEL → override honored, correct upstream", async () => {
+    registerProvider(
+      fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+    );
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    process.env.ANTHROPIC_AUTH_TOKEN = "sk-or-live";
+    process.env.LORE_WORKER_MODEL = "openrouter/some-model";
+
+    await commandImport([], { project, yes: true });
+
+    expect(out()).not.toContain("Can't import");
+    expect(llmClientCalls.length).toBe(1);
+    const [upstreams, , model] = llmClientCalls[0] as [
+      { anthropic: string; openai: string },
+      unknown,
+      { providerID: string; modelID: string },
+    ];
+    expect(model).toEqual({ providerID: "openrouter", modelID: "some-model" });
+    // Extraction routed at the captured upstream, not api.anthropic.com.
+    expect(upstreams.anthropic).toBe("https://openrouter.ai/api");
+    expect(upstreams.openai).toBe("https://openrouter.ai/api");
+  });
+
+  test("3. env credential for a defaultless provider (OpenRouter) with NO model → needsModel guidance, extraction never runs", async () => {
+    registerProvider(
+      fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+    );
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    process.env.ANTHROPIC_AUTH_TOKEN = "sk-or-live";
+
+    await commandImport([], { project, yes: true });
+
+    // Never sent an empty model to an upstream.
+    expect(llmClientCalls.length).toBe(0);
+    // Per-agent skip line + consolidated guidance both mention openrouter.
+    expect(info()).toContain("found your openrouter");
+    expect(out()).toContain("export LORE_WORKER_MODEL=openrouter/<model>");
+  });
+
+  test("4. multi-agent: A (anthropic, ok) + B (openrouter, needsModel) → A imports AND B's guidance still prints (the '(see below)' promise)", async () => {
+    registerProvider(
+      fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+    );
+    registerProvider(fakeProvider({ name: "codex", displayName: "Codex" }));
+    // claude-code → real anthropic key (succeeds).
+    process.env.ANTHROPIC_API_KEY = "sk-ant-real";
+    // codex → OpenRouter-style env with no model (needsModel). Codex reads
+    // OPENAI_* env; point it at openrouter via OPENAI_BASE_URL.
+    process.env.OPENAI_BASE_URL = "https://openrouter.ai/api";
+    process.env.OPENAI_API_KEY = "sk-or-codex";
+
+    await commandImport([], { project, yes: true });
+
+    // A's extraction ran (exactly one — codex was skipped pre-extraction).
+    expect(llmClientCalls.length).toBe(1);
+    const model = llmClientCalls[0][2] as { providerID: string };
+    expect(model.providerID).toBe("anthropic");
+    // B's guidance is NOT suppressed even though A succeeded.
+    expect(out()).toContain("export LORE_WORKER_MODEL=openrouter/<model>");
+    expect(out()).toContain("some agents");
+  });
+
+  test("5. multi-agent: two DIFFERENT defaultless providers both needsModel → guidance lists BOTH, one export line each", async () => {
+    registerProvider(
+      fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+    );
+    registerProvider(fakeProvider({ name: "codex", displayName: "Codex" }));
+    process.env.ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+    process.env.ANTHROPIC_AUTH_TOKEN = "sk-or-claude";
+    process.env.OPENAI_BASE_URL = "https://api.deepseek.com";
+    process.env.OPENAI_API_KEY = "sk-deepseek";
+
+    await commandImport([], { project, yes: true });
+
+    expect(llmClientCalls.length).toBe(0);
+    // Both distinct providers appear, each with its own export line (Seer #3:
+    // the summary must not collapse to just the last provider seen).
+    expect(out()).toContain("export LORE_WORKER_MODEL=openrouter/<model>");
+    expect(out()).toContain("export LORE_WORKER_MODEL=deepseek/<model>");
+  });
+
+  test("6. no agent has any usable credential → generic 'Ways forward' guidance, no extraction, gateway shut down", async () => {
+    registerProvider(
+      fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+    );
+    // No env creds, no on-disk auth, no worker key.
+
+    await commandImport([], { project, yes: true });
+
+    expect(llmClientCalls.length).toBe(0);
+    expect(out()).toContain("Can't import");
+    expect(out()).toContain("Ways forward");
+    expect(shutdownMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

The env-credential import feature (#1466) shipped a string of edge-case bugs that only Seer / adversarial review caught *after the fact* — empty-model 400s, cross-provider model misrouting, multi-agent guidance suppression, single-provider-only summaries. Root cause: **no test drove the real `commandImport` loop** across multiple agents with mixed credential outcomes. Everything was unit-tested in isolation (`resolveAgentImportAuth`, pure helpers), but the orchestration — detection → per-agent auth chain → extraction → consolidated guidance/summary — had zero coverage.

This PR adds that coverage so the same class of bug regresses a named test instead of shipping.

## What

**1. Make history-dir resolution lazy (prod behavior unchanged).**
`claude-code` / `codex` / `pi` captured `homedir()` into a module-load `const`, so tests couldn't redirect them via `$HOME`. Converted to lazy `claudeDir()` / `codexDir()` / `piDir()` functions that resolve `homedir()` per call. No production behavior change (same path, just computed on use).

**2. Fake-provider e2e — `packages/gateway/test/import-command-e2e.test.ts`.**
Registers fake `AgentHistoryProvider`s named after real `AgentDef`s (so the *real* per-agent auth chain runs) and drives the full `commandImport` decision matrix with a mocked LLM client. Six scenarios, each mapping to a real Seer/review finding:
1. real anthropic env credential → extraction runs, success
2. defaultless provider (OpenRouter) + matching `LORE_WORKER_MODEL` → override honored, routed at the captured upstream
3. defaultless provider, no model → `needsModel` guidance, extraction never runs (no empty-model 400)
4. multi-agent A(ok)+B(needsModel) → A imports **and** B's guidance still prints (the "(see below)" promise — Seer #15456784)
5. two *different* defaultless providers → guidance lists **both**, one export line each (Seer #15456424)
6. no usable credential anywhere → generic "Ways forward", gateway shut down

**3. Real-reader e2e — `packages/core/test/import/readers-e2e.test.ts`.**
Drives the actual `claude-code` + `codex` `detect`→`readChunks` against on-disk fixtures under a redirected `$HOME`, exercising the lazy-dir change end to end (+ negative cases: no matching project dir, codex cwd mismatch).

## Verification

- Full gate green: typecheck, lint (0 errors), format:check, 50 tests across the 7 affected suites.
- **Mutation-verified non-vacuous:**
  - reintroduce the multi-agent gating bug (`buildNeedsModelGuidance` returns null when `anyAuthResolved`) → scenario 4 RED
  - drop the tier-3 empty-model guard → scenario 3 RED
  - make `claudeDir()` ignore `$HOME` → real-reader detect test RED

Follow-up to #1466 / #1468, per the plan to stop the Seer whack-a-mole with real end-to-end coverage.