### PR TITLE
feat(pi): cancel compaction when raw context fits — keep buried facts end-to-end

### DIFF
--- a/packages/pi/src/internal.ts
+++ b/packages/pi/src/internal.ts
@@ -265,6 +265,71 @@ export function buildProviderRegistrations(opts: {
 }
 
 /**
+ * Default cancel threshold (tokens). Above this, we let Pi compact —
+ * below it, we cancel so Lore manages the window via raw context + recall.
+ * Mirrors OpenCode's `--cap-context` mechanism (Lore caps the layer-0 budget
+ * so OpenCode never natively compacts; on Pi we cap at the same threshold
+ * and cancel the native compaction so the raw context carries the buried
+ * facts into the next turn, with recall as the backup).
+ *
+ * Configurable via `LORE_PI_CANCEL_THRESHOLD` env var so tests + power users
+ * can tune it. The default 200_000 matches the eval cap and Anthropic's
+ * 200K usable window for Sonnet 5 / Sonnet 4 / Opus 4 — large enough to
+ * hold a long session's worth of raw context, small enough to never silently
+ * exceed the model's effective window.
+ */
+export const DEFAULT_PI_CANCEL_THRESHOLD = 200_000;
+
+/**
+ * Resolve the cancel threshold from env, falling back to the constant.
+ * Treats empty / non-numeric / non-positive values as "not set".
+ */
+export function resolveCancelThreshold(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.LORE_PI_CANCEL_THRESHOLD;
+  if (typeof raw !== "string" || raw.trim() === "") return DEFAULT_PI_CANCEL_THRESHOLD;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_PI_CANCEL_THRESHOLD;
+  return n;
+}
+
+/**
+ * Cancel-vs-summary policy: should Pi's upcoming compaction be cancelled so
+ * Lore keeps the raw context (the OpenCode `--cap-context` analog)?
+ *
+ * Returns `true` when:
+ *  - the would-be tokensBefore is below the configured threshold (raw context
+ *    fits), AND
+ *  - Lore is "active" for this session (we'd otherwise lose the chance to
+ *    recall on the next turn).
+ *
+ * Returning `true` causes the extension to return `{ cancel: true }` from the
+ * `session_before_compact` hook, which Pi honors (manual + auto paths, per
+ * `@mariozechner/pi-coding-agent/dist/core/agent-session.js:1275` and `:1498`).
+ *
+ * Returning `false` causes the extension to fall through to the existing POST
+ * /v1/compact summary path. Above the threshold we *must* compact — raw
+ * context would otherwise exceed the model's effective window on the next
+ * turn — so the policy is automatically false-positive-safe.
+ *
+ * Pure: no side effects, no I/O. Easy to unit-test.
+ */
+export function shouldCancelCompaction(
+  tokensBefore: number,
+  opts: { cancelThreshold: number; loreActive: boolean } = {
+    cancelThreshold: DEFAULT_PI_CANCEL_THRESHOLD,
+    loreActive: true,
+  },
+): boolean {
+  if (!opts.loreActive) return false;
+  if (!Number.isFinite(tokensBefore) || tokensBefore <= 0) {
+    // Unknown size — fall through to the gateway summary path. The gateway
+    // can still bail with a 404, in which case we fall back to Pi native.
+    return false;
+  }
+  return tokensBefore < opts.cancelThreshold;
+}
+
+/**
  * Call the gateway's `POST /v1/compact` endpoint and shape the result for Pi's
  * `session_before_compact` hook.
  *
@@ -286,7 +351,12 @@ export async function runCompaction(opts: {
   previousSummary: string | undefined;
   firstKeptEntryId: string;
   tokensBefore: number;
+  /** Override for the cancel-above-token threshold (default 200_000). */
+  cancelThreshold?: number;
+  /** Inject for tests; defaults to `loreActive=true` (the runtime case). */
+  loreActive?: boolean;
   fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
 }): Promise<SessionBeforeCompactResult | undefined> {
   const {
     gatewayBase,
@@ -295,8 +365,26 @@ export async function runCompaction(opts: {
     previousSummary,
     firstKeptEntryId,
     tokensBefore,
+    cancelThreshold,
+    loreActive = true,
     fetchImpl = fetch,
+    env = process.env,
   } = opts;
+
+  // Cancel-when-small policy: if the would-be compacted context fits in our
+  // budget, let Lore keep the raw context (cancel Pi's native compaction).
+  // This is the on-Pi analog of OpenCode's `--cap-context` mechanism that
+  // gives Lore-OpenCode a 0-compaction 100%-retention guarantee. On Pi
+  // there's no provider limit to flip, so we use the hook's cancel + the
+  // `keepRecentTokens` budget to keep the raw context bounded.
+  const threshold = cancelThreshold ?? resolveCancelThreshold(env);
+  if (shouldCancelCompaction(tokensBefore, { cancelThreshold: threshold, loreActive })) {
+    log.info(
+      `pi: cancel compaction — tokensBefore=${tokensBefore} < threshold=${threshold}; ` +
+        `keeping raw context (Lore manages the window via recall).`,
+    );
+    return { cancel: true };
+  }
 
   try {
     const res = await fetchImpl(`${gatewayBase}/v1/compact`, {

--- a/packages/pi/test/extension.e2e.test.ts
+++ b/packages/pi/test/extension.e2e.test.ts
@@ -184,7 +184,9 @@ describe("pi extension — e2e against a real gateway", () => {
         preparation: {
           previousSummary: "",
           firstKeptEntryId: "e1",
-          tokensBefore: 100,
+          // tokensBefore above the default cancel threshold so the policy
+          // doesn't short-circuit and the request actually reaches /v1/compact.
+          tokensBefore: 250_000,
         },
       },
       {},

--- a/packages/pi/test/internal.test.ts
+++ b/packages/pi/test/internal.test.ts
@@ -109,6 +109,9 @@ describe("runCompaction", () => {
     previousSummary: "prev",
     firstKeptEntryId: "entry-7",
     tokensBefore: 4242,
+    // These tests are about the gateway fetch path itself; disable the
+    // cancel-when-small policy which is tested separately below.
+    cancelThreshold: 0,
   };
 
   test("POSTs to /v1/compact with session header + body, returns shaped result", async () => {
@@ -169,5 +172,219 @@ describe("runCompaction", () => {
         new Response(JSON.stringify({ summary: "" }), { status: 200 }),
     );
     expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cancel-when-small policy (Lore manages the window via raw context + recall).
+  // This is the on-Pi analog of OpenCode's --cap-context mechanism.
+  // ---------------------------------------------------------------------------
+  describe("cancel-when-small policy", () => {
+    test("returns { cancel: true } when tokensBefore is below threshold", async () => {
+      const fetchImpl = vi.fn(async () => {
+        throw new Error("fetch should not be called when we cancel");
+      });
+      const result = await runCompaction({
+        gatewayBase: GW,
+        sessionID: "sess-c",
+        projectPath: "/proj",
+        previousSummary: undefined,
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 50_000,
+        cancelThreshold: 200_000,
+        fetchImpl,
+      });
+      expect(result).toEqual({ cancel: true });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    test("returns { cancel: true } at tokensBefore == threshold - 1 (boundary)", async () => {
+      const fetchImpl = vi.fn(async () => {
+        throw new Error("fetch should not be called when we cancel");
+      });
+      const result = await runCompaction({
+        gatewayBase: GW,
+        sessionID: "sess-c",
+        projectPath: "/proj",
+        previousSummary: undefined,
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 199_999,
+        cancelThreshold: 200_000,
+        fetchImpl,
+      });
+      expect(result).toEqual({ cancel: true });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    test("falls through to /v1/compact when tokensBefore is at threshold (raw context would not fit)", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ summary: "ok" }), { status: 200 }),
+      );
+      const result = await runCompaction({
+        gatewayBase: GW,
+        sessionID: "sess-c",
+        projectPath: "/proj",
+        previousSummary: undefined,
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 200_000,
+        cancelThreshold: 200_000,
+        fetchImpl,
+      });
+      expect(fetchImpl).toHaveBeenCalledOnce();
+      expect(result).toEqual({
+        compaction: {
+          summary: "ok",
+          firstKeptEntryId: "entry-7",
+          tokensBefore: 200_000,
+        },
+      });
+    });
+
+    test("returns { cancel: true } for any tokensBefore < threshold (sub-threshold fast path)", async () => {
+      const fetchImpl = vi.fn(async () => {
+        throw new Error("fetch should not be called when we cancel");
+      });
+      for (const tokensBefore of [1, 100, 5_000, 50_000, 199_999]) {
+        const result = await runCompaction({
+          gatewayBase: GW,
+          sessionID: "sess-c",
+          projectPath: "/proj",
+          previousSummary: undefined,
+          firstKeptEntryId: "entry-7",
+          tokensBefore,
+          cancelThreshold: 200_000,
+          fetchImpl,
+        });
+        expect(result).toEqual({ cancel: true });
+      }
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    test("falls through to /v1/compact when tokensBefore >= threshold (must compact)", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ summary: "ok" }), { status: 200 }),
+      );
+      for (const tokensBefore of [200_000, 250_000, 1_000_000]) {
+        vi.mocked(fetchImpl).mockClear();
+        const result = await runCompaction({
+          gatewayBase: GW,
+          sessionID: "sess-c",
+          projectPath: "/proj",
+          previousSummary: undefined,
+          firstKeptEntryId: "entry-7",
+          tokensBefore,
+          cancelThreshold: 200_000,
+          fetchImpl,
+        });
+        expect(fetchImpl).toHaveBeenCalledOnce();
+        expect(result).toEqual({
+          compaction: {
+            summary: "ok",
+            firstKeptEntryId: "entry-7",
+            tokensBefore,
+          },
+        });
+      }
+    });
+
+    test("does NOT cancel when loreActive is false (fall through to /v1/compact)", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ summary: "ok" }), { status: 200 }),
+      );
+      const result = await runCompaction({
+        gatewayBase: GW,
+        sessionID: "sess-c",
+        projectPath: "/proj",
+        previousSummary: undefined,
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 50_000,
+        cancelThreshold: 200_000,
+        loreActive: false,
+        fetchImpl,
+      });
+      expect(fetchImpl).toHaveBeenCalledOnce();
+      expect(result).toEqual({
+        compaction: {
+          summary: "ok",
+          firstKeptEntryId: "entry-7",
+          tokensBefore: 50_000,
+        },
+      });
+    });
+
+    test("does NOT cancel when tokensBefore is 0 / NaN (unknown size — fall through)", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ summary: "ok" }), { status: 200 }),
+      );
+      for (const tokensBefore of [0, NaN, -1]) {
+        vi.mocked(fetchImpl).mockClear();
+        const result = await runCompaction({
+          gatewayBase: GW,
+          sessionID: "sess-c",
+          projectPath: "/proj",
+          previousSummary: undefined,
+          firstKeptEntryId: "entry-7",
+          tokensBefore,
+          cancelThreshold: 200_000,
+          fetchImpl,
+        });
+        expect(fetchImpl).toHaveBeenCalledOnce();
+        expect(result).toEqual({
+          compaction: {
+            summary: "ok",
+            firstKeptEntryId: "entry-7",
+            tokensBefore,
+          },
+        });
+      }
+    });
+
+    test("resolves threshold from LORE_PI_CANCEL_THRESHOLD env var", async () => {
+      const fetchImpl = vi.fn(async () => {
+        throw new Error("fetch should not be called when we cancel");
+      });
+      const result = await runCompaction({
+        gatewayBase: GW,
+        sessionID: "sess-c",
+        projectPath: "/proj",
+        previousSummary: undefined,
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 50_000,
+        env: { LORE_PI_CANCEL_THRESHOLD: "100000" } as NodeJS.ProcessEnv,
+        fetchImpl,
+      });
+      expect(result).toEqual({ cancel: true });
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    test("rejects invalid LORE_PI_CANCEL_THRESHOLD env values (falls back to default)", async () => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ summary: "ok" }), { status: 200 }),
+      );
+      for (const bad of ["", "abc", "0", "-5", "not-a-number"]) {
+        const env = {
+          LORE_PI_CANCEL_THRESHOLD: bad,
+        } as unknown as NodeJS.ProcessEnv;
+        vi.mocked(fetchImpl).mockClear();
+        const result = await runCompaction({
+          gatewayBase: GW,
+          sessionID: "sess-c",
+          projectPath: "/proj",
+          previousSummary: undefined,
+          firstKeptEntryId: "entry-7",
+          tokensBefore: 50_000,
+          env,
+          fetchImpl,
+        });
+        // Default 200K → 50K < 200K → cancel. Both path result and fetch
+        // call behavior confirm the env override was rejected.
+        expect(fetchImpl).not.toHaveBeenCalled();
+        expect(result).toEqual({ cancel: true });
+      }
+    });
   });
 });

--- a/packages/pi/test/no-tui-output.test.ts
+++ b/packages/pi/test/no-tui-output.test.ts
@@ -126,12 +126,14 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
       );
 
       // Compaction → gateway returns 404 session_not_found → graceful fallback.
+      // tokensBefore above the default cancel threshold so the cancel-when-small
+      // policy doesn't short-circuit and the request actually reaches /v1/compact.
       const result = await onCompact?.(
         {
           preparation: {
             previousSummary: "",
             firstKeptEntryId: "entry-1",
-            tokensBefore: 100,
+            tokensBefore: 250_000,
           },
         },
         {},


### PR DESCRIPTION
## What

Add a `shouldCancelCompaction` policy to `@loreai/pi` that returns `{ cancel: true }` from the `session_before_compact` hook when the would-be compacted context fits under a configurable threshold. Pi honors cancel on both manual (agent-session.js:1275) and auto (agent-session.js:1498) paths. Result: Lore keeps the raw context, raw facts survive end-to-end, no need for the summary path to be lossless.

## Why

The current `@loreai/pi` only returns the summary branch from `session_before_compact`, so Pi compacts natively even when Lore could keep the raw context. The summary path can drop buried facts (issue #1478). On OpenCode, `--cap-context` caps the layer-0 budget so OpenCode never natively compacts — that's why lore-OpenCode gets 100% retention with 0 compactions on single-long. This PR brings the same behavior to lore-Pi: instead of relying on a possibly-lossy summary, just **don't compact when the raw context fits**, and let Lore manage the window via recall on the next turn.

## How

- New pure policy `shouldCancelCompaction(tokensBefore, { cancelThreshold, loreActive })` — three guards:
  - `loreActive` must be true (so we don't try to cancel when Lore is disabled for this session)
  - `tokensBefore` must be finite and > 0 (unknown size falls through to the summary path)
  - `tokensBefore < cancelThreshold` (else we *must* compact — raw context would exceed the model's effective window on the next turn)
- `runCompaction` now checks the policy first; if it returns true, returns `{ cancel: true }` and never calls `/v1/compact`.
- New `DEFAULT_PI_CANCEL_THRESHOLD = 200_000` — matches the eval cap and Anthropic's 200K usable window. Configurable via `LORE_PI_CANCEL_THRESHOLD` env var.

## Tests

35 tests pass (was 26). 9 new tests cover the policy: cancel at < threshold, fall-through at >= threshold, boundary at threshold-1 vs threshold, loreActive=false guard, tokensBefore<=0/NaN guard, env var resolution, invalid env values rejected.

**Mutation-verified** all three critical guards are load-bearing:
- M1 (flip `<` to `>` in `tokensBefore < opts.cancelThreshold`): 11 tests failed
- M2 (remove `loreActive=false` guard): 1 test failed
- M3 (remove `tokensBefore <= 0` guard): 1 test failed

Existing fetch-path tests updated to use `tokensBefore: 250_000` (above threshold) so they continue to exercise the path they care about.

## Relationship to #1478

This is the first of two clean fixes for #1478 (offline compaction summary drops captured concrete values). The other fix — widening `assembleOfflineCompaction` to carry salient temporal facts — is still on the table for cases where the session grows past the cancel threshold. With this PR, the threshold becomes the dividing line: below it, cancel; above it, fall through to the summary path (which still needs the #1478 widening for the cases it gets called on).

## Eval

Eval launched at `/home/byk/.local/share/lore-eval-live/PI-XLONG-S5-CANCEL/`. Initial runs hit `403 Budget limit exceeded (monthly limit)` on the OpenRouter coding-plan key — pre-existing infra issue, unrelated to this change. Will re-run on a working key to confirm the policy actually drives retention to 100%.