### PR TITLE
fix(gateway): emit usage block on OpenAI-completions streaming responses (#1475)

### DIFF
--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -56,6 +56,12 @@ export function parseOpenAIRequest(
   if (typeof raw.top_logprobs === "number") {
     extras.top_logprobs = raw.top_logprobs;
   }
+  if (raw.stream_options && typeof raw.stream_options === "object") {
+    const so = raw.stream_options as Record<string, unknown>;
+    if (typeof so.include_usage === "boolean") {
+      extras.stream_options = { include_usage: so.include_usage };
+    }
+  }
 
   // Parse messages and extract system prompt
   const rawMessages = Array.isArray(raw.messages) ? raw.messages : [];
@@ -352,10 +358,16 @@ function buildOpenAINonStreamResponse(resp: GatewayResponse): Response {
       prompt_tokens: usage.inputTokens,
       completion_tokens: usage.outputTokens,
       total_tokens: usage.inputTokens + usage.outputTokens,
-      ...(usage.cacheReadInputTokens != null
+      ...(usage.cacheReadInputTokens != null ||
+      usage.cacheCreationInputTokens != null
         ? {
             prompt_tokens_details: {
-              cached_tokens: usage.cacheReadInputTokens,
+              ...(usage.cacheReadInputTokens != null
+                ? { cached_tokens: usage.cacheReadInputTokens }
+                : {}),
+              ...(usage.cacheCreationInputTokens != null
+                ? { cache_creation_tokens: usage.cacheCreationInputTokens }
+                : {}),
             },
           }
         : {}),
@@ -395,11 +407,38 @@ function buildOpenAIStreamResponse(resp: GatewayResponse): Response {
         : `chatcmpl-${resp.id}`;
       const created = Math.floor(Date.now() / 1000);
 
+      // Build the terminal usage object from resp.usage (or ZERO_USAGE fallback).
+      // Mirrors the working reference at stream/openai.ts:285-308 so OpenAI
+      // Chat Completions clients that read usage from the final SSE chunk
+      // (e.g. Pi) get the data they asked for via stream_options.include_usage.
+      // Emitted unconditionally, not gated on include_usage — same as the
+      // reference; clients that didn't opt in simply ignore the extra field.
+      const ru = resp.usage ?? ZERO_USAGE;
+      const terminalUsage: Record<string, unknown> = {
+        prompt_tokens: ru.inputTokens,
+        completion_tokens: ru.outputTokens,
+        total_tokens: ru.inputTokens + ru.outputTokens,
+      };
+      if (
+        ru.cacheReadInputTokens != null ||
+        ru.cacheCreationInputTokens != null
+      ) {
+        const details: Record<string, number> = {};
+        if (ru.cacheReadInputTokens != null) {
+          details.cached_tokens = ru.cacheReadInputTokens;
+        }
+        if (ru.cacheCreationInputTokens != null) {
+          details.cache_creation_tokens = ru.cacheCreationInputTokens;
+        }
+        terminalUsage.prompt_tokens_details = details;
+      }
+
       function emitChunk(
         delta: Record<string, unknown>,
         finishReason: string | null,
+        usage?: Record<string, unknown>,
       ) {
-        const chunk = {
+        const chunk: Record<string, unknown> = {
           id: baseId,
           object: "chat.completion.chunk",
           created,
@@ -412,6 +451,9 @@ function buildOpenAIStreamResponse(resp: GatewayResponse): Response {
             },
           ],
         };
+        if (usage) {
+          chunk.usage = usage;
+        }
         controller.enqueue(
           encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`),
         );
@@ -452,8 +494,9 @@ function buildOpenAIStreamResponse(resp: GatewayResponse): Response {
         }
       }
 
-      // Emit final chunk with finish reason
-      emitChunk({}, mapStopReason(resp.stopReason));
+      // Emit final chunk with finish reason AND usage (single chunk, matching
+      // the working reference at stream/openai.ts:285-308).
+      emitChunk({}, mapStopReason(resp.stopReason), terminalUsage);
 
       // Send [DONE] marker
       controller.enqueue(encoder.encode("data: [DONE]\n\n"));
@@ -696,6 +739,9 @@ export function buildOpenAIUpstreamRequest(
     }
     if (req.extras.top_logprobs !== undefined) {
       body.top_logprobs = req.extras.top_logprobs;
+    }
+    if (req.extras.stream_options !== undefined) {
+      body.stream_options = req.extras.stream_options;
     }
   }
 

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -246,6 +246,13 @@ export type GatewayRequest = {
     tool_choice?: unknown;
     parallel_tool_calls?: boolean;
     service_tier?: string;
+    /**
+     * OpenAI Chat Completions: `stream_options` from the incoming request
+     * body. Carried through so the upstream call (`buildOpenAIUpstreamRequest`)
+     * can forward it. Today only `include_usage` is captured — other
+     * sub-fields are ignored to keep the surface narrow.
+     */
+    stream_options?: { include_usage?: boolean };
   };
   /**
    * Set when the request originated from Pi's `openai-codex` provider (ingress

--- a/packages/gateway/test/openai-stream-usage.test.ts
+++ b/packages/gateway/test/openai-stream-usage.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Tests for #1475 — the OpenAI Chat Completions response path must surface
+ * `usage` to clients, both for streaming and non-streaming, including cache
+ * read/write so clients like Pi can derive cache-hit rate.
+ *
+ * Three layers under test:
+ *   1. Egress — `buildOpenAIResponse` (non-stream top-level `usage` and
+ *      stream terminal SSE chunk with `usage`).
+ *   2. Ingress — `parseOpenAIRequest` capturing `stream_options` so the
+ *      upstream can be told to include usage.
+ *   3. Round-trip — `buildOpenAIUpstreamRequest` forwarding
+ *      `stream_options` so the upstream's own usage chunk reaches the
+ *      client on the same-protocol passthrough path.
+ */
+import { describe, test, expect } from "vitest";
+import {
+  buildOpenAIResponse,
+  buildOpenAIUpstreamRequest,
+  parseOpenAIRequest,
+} from "../src/translate/openai";
+import type { GatewayResponse } from "../src/translate/types";
+
+const headers = { authorization: "Bearer sk-test123" };
+
+function baseResp(overrides: Partial<GatewayResponse> = {}): GatewayResponse {
+  return {
+    id: "chatcmpl-test",
+    model: "gpt-4o",
+    content: [{ type: "text", text: "Hello" }],
+    stopReason: "end_turn",
+    usage: { inputTokens: 100, outputTokens: 20 },
+    ...overrides,
+  };
+}
+
+async function readSseChunks(response: Response): Promise<unknown[]> {
+  const text = await response.text();
+  const events = text.split("\n\n").filter((e) => e.startsWith("data: "));
+  const out: unknown[] = [];
+  for (const evt of events) {
+    const payload = evt.slice("data: ".length);
+    if (payload === "[DONE]") {
+      out.push("[DONE]" as const);
+      continue;
+    }
+    out.push(JSON.parse(payload));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Egress — non-stream (buildOpenAIResponse(resp, false))
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIResponse (Chat Completions) — non-stream usage (#1475)", () => {
+  test("emits cache_creation_tokens when cacheCreationInputTokens is set", async () => {
+    const resp = baseResp({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheCreationInputTokens: 50,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, false);
+    const body = (await response.json()) as Record<string, unknown>;
+    const usage = body.usage as Record<string, unknown>;
+    const details = usage.prompt_tokens_details as Record<string, number>;
+    expect(details.cache_creation_tokens).toBe(50);
+  });
+
+  test("emits both cached_tokens and cache_creation_tokens together", async () => {
+    const resp = baseResp({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadInputTokens: 80,
+        cacheCreationInputTokens: 20,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, false);
+    const body = (await response.json()) as Record<string, unknown>;
+    const usage = body.usage as Record<string, unknown>;
+    const details = usage.prompt_tokens_details as Record<string, number>;
+    expect(details.cached_tokens).toBe(80);
+    expect(details.cache_creation_tokens).toBe(20);
+  });
+
+  test("omits prompt_tokens_details when neither cache field is set", async () => {
+    const resp = baseResp({
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const response = buildOpenAIResponse(resp, false);
+    const body = (await response.json()) as Record<string, unknown>;
+    const usage = body.usage as Record<string, unknown>;
+    expect(usage.prompt_tokens_details).toBeUndefined();
+  });
+
+  test("regression: existing cached_tokens emission still works", async () => {
+    const resp = baseResp({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadInputTokens: 80,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, false);
+    const body = (await response.json()) as Record<string, unknown>;
+    const usage = body.usage as Record<string, unknown>;
+    expect(usage.prompt_tokens).toBe(100);
+    expect(usage.completion_tokens).toBe(20);
+    const details = usage.prompt_tokens_details as Record<string, number>;
+    expect(details.cached_tokens).toBe(80);
+  });
+
+  test("regression: total_tokens === prompt_tokens + completion_tokens even with cache fields", async () => {
+    const resp = baseResp({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadInputTokens: 80,
+        cacheCreationInputTokens: 20,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, false);
+    const body = (await response.json()) as Record<string, unknown>;
+    const usage = body.usage as Record<string, unknown>;
+    expect(usage.total_tokens).toBe(120);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Egress — stream (buildOpenAIResponse(resp, true))
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIResponse (Chat Completions) — stream usage (#1475)", () => {
+  test("emits a terminal chunk with usage before [DONE]", async () => {
+    const resp = baseResp({
+      usage: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const response = buildOpenAIResponse(resp, true);
+    const chunks = await readSseChunks(response);
+    const last = chunks[chunks.length - 1];
+    const penultimate = chunks[chunks.length - 2];
+    expect(last).toBe("[DONE]");
+    expect(penultimate).toMatchObject({
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    });
+    const terminalChunk = penultimate as Record<string, unknown>;
+    const usage = terminalChunk.usage as Record<string, unknown>;
+    expect(usage).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+    });
+  });
+
+  test("stream terminal usage includes cached_tokens when cacheReadInputTokens is set", async () => {
+    const resp = baseResp({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadInputTokens: 80,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, true);
+    const chunks = await readSseChunks(response);
+    const penultimate = chunks[chunks.length - 2] as Record<string, unknown>;
+    const usage = penultimate.usage as Record<string, unknown>;
+    const details = usage.prompt_tokens_details as Record<string, number>;
+    expect(details.cached_tokens).toBe(80);
+  });
+
+  test("stream terminal usage includes cache_creation_tokens when cacheCreationInputTokens is set", async () => {
+    const resp = baseResp({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheCreationInputTokens: 50,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, true);
+    const chunks = await readSseChunks(response);
+    const penultimate = chunks[chunks.length - 2] as Record<string, unknown>;
+    const usage = penultimate.usage as Record<string, unknown>;
+    const details = usage.prompt_tokens_details as Record<string, number>;
+    expect(details.cache_creation_tokens).toBe(50);
+  });
+
+  test("stream terminal usage includes both cache fields together", async () => {
+    const resp = baseResp({
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadInputTokens: 80,
+        cacheCreationInputTokens: 20,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, true);
+    const chunks = await readSseChunks(response);
+    const penultimate = chunks[chunks.length - 2] as Record<string, unknown>;
+    const usage = penultimate.usage as Record<string, unknown>;
+    const details = usage.prompt_tokens_details as Record<string, number>;
+    expect(details.cached_tokens).toBe(80);
+    expect(details.cache_creation_tokens).toBe(20);
+  });
+
+  test("stream emits usage chunk even when resp.usage is undefined (ZERO_USAGE fallback)", async () => {
+    const resp = baseResp();
+    delete (resp as { usage?: unknown }).usage;
+
+    const response = buildOpenAIResponse(resp, true);
+    const chunks = await readSseChunks(response);
+    const penultimate = chunks[chunks.length - 2] as Record<string, unknown>;
+    const usage = penultimate.usage as Record<string, unknown>;
+    expect(usage).toEqual({
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    });
+    expect(usage.prompt_tokens_details).toBeUndefined();
+  });
+
+  test("tool-call stream: usage chunk is still emitted and finish_reason is 'tool_calls'", async () => {
+    const resp = baseResp({
+      content: [
+        {
+          type: "tool_use",
+          id: "call_1",
+          name: "get_weather",
+          input: { city: "Paris" },
+        },
+      ],
+      stopReason: "tool_use",
+    });
+
+    const response = buildOpenAIResponse(resp, true);
+    const chunks = await readSseChunks(response);
+    const last = chunks[chunks.length - 1];
+    const penultimate = chunks[chunks.length - 2];
+    expect(last).toBe("[DONE]");
+    expect(penultimate).toMatchObject({
+      choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+    });
+    const terminalChunk = penultimate as Record<string, unknown>;
+    const usage = terminalChunk.usage as Record<string, unknown>;
+    expect(usage).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      total_tokens: 120,
+    });
+  });
+
+  test("usage chunk is the last data chunk before [DONE]", async () => {
+    const resp = baseResp({
+      content: [{ type: "text", text: "Hello world" }],
+      usage: {
+        inputTokens: 50,
+        outputTokens: 10,
+        cacheReadInputTokens: 30,
+      },
+    });
+
+    const response = buildOpenAIResponse(resp, true);
+    const chunks = await readSseChunks(response);
+    expect(chunks[chunks.length - 1]).toBe("[DONE]");
+    const usageChunks = chunks
+      .slice(0, -1)
+      .filter((c) => c !== "[DONE]") as Array<Record<string, unknown>>;
+    const chunksWithUsage = usageChunks.filter((c) => c.usage !== undefined);
+    expect(chunksWithUsage).toHaveLength(1);
+    expect(chunksWithUsage[0]).toBe(chunks[chunks.length - 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ingress — request parsing (stream_options capture)
+// ---------------------------------------------------------------------------
+
+describe("parseOpenAIRequest — stream_options capture (#1475)", () => {
+  test("captures stream_options.include_usage: true into extras", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        stream_options: { include_usage: true },
+      },
+      headers,
+    );
+    expect(req.extras?.stream_options).toEqual({ include_usage: true });
+  });
+
+  test("captures stream_options.include_usage: false (spec opt-out preserved for symmetry)", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        stream_options: { include_usage: false },
+      },
+      headers,
+    );
+    expect(req.extras?.stream_options).toEqual({ include_usage: false });
+  });
+
+  test("ignores stream_options when it is not an object (defensive)", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        stream_options: null,
+      },
+      headers,
+    );
+    expect(req.extras?.stream_options).toBeUndefined();
+  });
+
+  test("ignores stream_options when include_usage is not a boolean", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        stream_options: { include_usage: "yes" },
+      },
+      headers,
+    );
+    expect(req.extras?.stream_options).toBeUndefined();
+  });
+
+  test("omits stream_options from extras when client did not send it", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      },
+      headers,
+    );
+    expect(req.extras?.stream_options).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Egress-to-ingress round-trip (buildOpenAIUpstreamRequest)
+// ---------------------------------------------------------------------------
+
+describe("buildOpenAIUpstreamRequest — stream_options forwarding (#1475)", () => {
+  test("forwards stream_options.include_usage: true when set on extras", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        stream_options: { include_usage: true },
+      },
+      headers,
+    );
+    const result = buildOpenAIUpstreamRequest(req, "https://api.openai.com/v1");
+    const body = result.body as Record<string, unknown>;
+    expect(body.stream_options).toEqual({ include_usage: true });
+  });
+
+  test("forwards stream_options.include_usage: false when set on extras", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        stream_options: { include_usage: false },
+      },
+      headers,
+    );
+    const result = buildOpenAIUpstreamRequest(req, "https://api.openai.com/v1");
+    const body = result.body as Record<string, unknown>;
+    expect(body.stream_options).toEqual({ include_usage: false });
+  });
+
+  test("omits stream_options from upstream body when client did not set it", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      },
+      headers,
+    );
+    const result = buildOpenAIUpstreamRequest(req, "https://api.openai.com/v1");
+    const body = result.body as Record<string, unknown>;
+    expect(body.stream_options).toBeUndefined();
+  });
+
+  test("round-trip: parseOpenAIRequest → buildOpenAIUpstreamRequest preserves stream_options verbatim", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+        stream_options: { include_usage: true },
+        temperature: 0.5,
+      },
+      headers,
+    );
+    const result = buildOpenAIUpstreamRequest(req, "https://api.openai.com/v1");
+    const body = result.body as Record<string, unknown>;
+    expect(body.stream_options).toEqual({ include_usage: true });
+    expect(body.temperature).toBe(0.5);
+    expect(body.stream).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The OpenAI Chat Completions streaming egress dropped the terminal `usage`
chunk that the spec defines, so any client speaking `openai-completions`
that reads token/cost/cache numbers from the stream (e.g. Pi's
`openai-completions` provider via `@loreai/pi`) saw all zeros even when
the gateway had the real numbers in `session_state`.

## Root cause

Two related defects in `packages/gateway/src/translate/openai.ts`:

1. **`buildOpenAIStreamResponse`** never read `resp.usage` — the SSE
   stream ended with a `finish_reason` chunk followed by `[DONE]` and no
   terminal `usage` block. The sibling streaming path
   (`stream/openai.ts:285-308`, the Anthropic-upstream → OpenAI
   translator) does emit a usage chunk; the buffered-replay twin was
   authored without mirroring that emission.

2. **`buildOpenAIUpstreamRequest`** dropped `stream_options` entirely:
   `parseOpenAIRequest` did not capture it into `extras`, and
   `buildOpenAIUpstreamRequest` rebuilt the upstream body from scratch
   without forwarding it. So even on the same-protocol passthrough path
   (`pipeline.ts:6488`) the upstream was never told to include usage,
   and the stream the gateway passed through never carried a usage
   chunk in the first place.

The non-stream egress already emitted `usage` at the top level, but only
the cache-read half (`cached_tokens`) — the cache-write half
(`cache_creation_tokens`) was missing on both paths.

## Fix

- `buildOpenAIStreamResponse` emits a terminal SSE chunk with `usage`
  populated from `resp.usage` (with `ZERO_USAGE` fallback), mirroring
  the working reference. Emission is unconditional — same as the
  reference; clients that did not opt in via `stream_options.include_usage`
  ignore the extra field. `ZERO_USAGE` invariant preserved (cache
  fields only emitted when their source value is `!= null`).
- `buildOpenAINonStreamResponse` surfaces `cache_creation_tokens` in
  `prompt_tokens_details` alongside `cached_tokens`.
- `parseOpenAIRequest` captures `stream_options` from the incoming body
  (defensive: only when it is an object and `include_usage` is a
  boolean).
- `buildOpenAIUpstreamRequest` forwards `stream_options` verbatim to the
  upstream body.

## Tests

`packages/gateway/test/openai-stream-usage.test.ts` (NEW, 21 tests):

- Egress non-stream (5): `cache_creation_tokens` emission, both cache
  fields together, omits when neither set, regression on
  `cached_tokens`, `total_tokens` arithmetic.
- Egress stream (7): terminal usage chunk before `[DONE]`,
  `cached_tokens`/`cache_creation_tokens`/both via stream, `ZERO_USAGE`
  fallback, tool-call stream still emits usage with `finish_reason:
  "tool_calls"`, usage chunk is the last data chunk.
- Ingress (5): `stream_options.include_usage: true/false` capture,
  ignores non-object / non-boolean, omits when client didn't send.
- Round-trip (4): upstream request forwards `stream_options: true/false`,
  omits when not set, full parse → build round-trip preserves
  `stream_options` verbatim.

## Verification

- ✅ `pnpm test` (full gateway suite) — 3274 passed, 0 failed
- ✅ `pnpm run typecheck` — exit 0
- ✅ `pnpm run lint` — exit 0
- ✅ `pnpm run format:check` — exit 0
- ✅ Mutation probes (6/6) — every code change has at least one test
  that fails when the change is reverted:
  - Drop `terminalUsage` from `emitChunk` → 7 stream tests fail
  - Drop `cache_creation_tokens` from non-stream → 2 tests fail
  - Drop `cache_creation_tokens` from stream → 2 tests fail
  - Drop `stream_options` forwarding → 3 tests fail
  - Drop `stream_options` capture → 5 tests fail
  - Flip captured `include_usage` → 5 tests fail with value mismatches

## Closes

Closes #1475