### PR TITLE
fix(gateway): inject knowledge-delta payload on user turn, not assistant

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -989,18 +989,73 @@ function isGatewayMessage(v: unknown): v is GatewayMessage {
   );
 }
 
+// The framing note prepended to the knowledge-delta user message. Extracted to
+// a constant so the legacy-block migration (parseDeltaMessages) can recognize
+// the pair it belongs to. Keep the substring "Lore knowledge update" — the
+// cache-stability e2e asserts on it.
+const KNOWLEDGE_DELTA_FRAMING_NOTE =
+  "[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest. Replayed byte-identically on later turns until an intentional cache reset.]";
+
+// The inert assistant closer that ends the knowledge-delta exchange (the model
+// must not treat the pair as an open user turn — #1315). Also the canonical
+// assistant text the legacy migration rewrites a payload-carrying assistant to.
+const KNOWLEDGE_DELTA_ASSISTANT_CLOSER = "Understood.";
+
+function firstText(m: GatewayMessage | undefined): string | undefined {
+  const b = m?.content?.[0];
+  return b && b.type === "text" ? b.text : undefined;
+}
+
 // A delta block's content is now a user→assistant PAIR, stored as a JSON array.
 // Legacy blocks (persisted before the pair change, and single-message test
 // fixtures) stored ONE message object — accept both so already-persisted
 // sessions keep replaying and never crash. Returns [] on anything unparseable.
+//
+// Migration (#1490): blocks persisted before the payload moved off the
+// assistant turn store `[{user: framing}, {assistant: "## Long-term Knowledge…"}]`.
+// Replayed as-is they keep the payload on a visible/completed assistant turn —
+// the exact dump + premature-loop-exit bug this PR fixes — for the life of the
+// session. On load, rewrite that legacy pair to the new shape: payload appended
+// to the framing-note user message, assistant becomes the inert closer. A block
+// already in the new shape (user text already contains the payload) is returned
+// unchanged. Only the exact `[user(framing-only), assistant(payload)]` shape is
+// migrated; anything else (single message, new pair, non-delta) passes through.
 function parseDeltaMessages(raw: string): GatewayMessage[] {
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (Array.isArray(parsed)) return parsed.filter(isGatewayMessage);
-    return isGatewayMessage(parsed) ? [parsed] : [];
+    parsed = JSON.parse(raw);
   } catch {
     return [];
   }
+  if (!Array.isArray(parsed)) {
+    return isGatewayMessage(parsed) ? [parsed] : [];
+  }
+  const msgs = parsed.filter(isGatewayMessage);
+  if (msgs.length !== 2) return msgs;
+  const [m0, m1] = msgs;
+  if (m0.role !== "user" || m1.role !== "assistant") return msgs;
+  const userText = firstText(m0);
+  const asstText = firstText(m1);
+  if (
+    typeof userText !== "string" ||
+    typeof asstText !== "string" ||
+    !userText.startsWith(KNOWLEDGE_DELTA_FRAMING_NOTE) ||
+    userText.includes("## Long-term Knowledge") || // already migrated / new shape
+    !asstText.includes("## Long-term Knowledge") // nothing to move
+  ) {
+    return msgs;
+  }
+  // Legacy pair: move the assistant payload onto the framing-note user message.
+  return [
+    {
+      role: "user",
+      content: [{ type: "text", text: `${userText}\n\n${asstText}` }],
+    },
+    {
+      role: "assistant",
+      content: [{ type: "text", text: KNOWLEDGE_DELTA_ASSISTANT_CLOSER }],
+    },
+  ];
 }
 
 /**
@@ -1759,7 +1814,7 @@ export function buildKnowledgeDeltaMessage(
       content: [
         {
           type: "text",
-          text: `[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest. Replayed byte-identically on later turns until an intentional cache reset.]\n\n${rendered}${tocRendered}`,
+          text: `${KNOWLEDGE_DELTA_FRAMING_NOTE}\n\n${rendered}${tocRendered}`,
         },
       ],
     },
@@ -1768,7 +1823,7 @@ export function buildKnowledgeDeltaMessage(
       content: [
         {
           type: "text",
-          text: "Understood.",
+          text: KNOWLEDGE_DELTA_ASSISTANT_CLOSER,
         },
       ],
     },

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1729,15 +1729,24 @@ export function buildKnowledgeDeltaMessage(
   // core/gradient.ts `buildPrefixMessages`), NOT a lone user message. A lone
   // user block read as an open user turn, so instruction-literal models (e.g.
   // MiniMax M3) prefaced every turn with "Acknowledged… none of this applies…
-  // I won't reference this knowledge." The pair closes the exchange: the tiny
-  // user note frames it as ambient context (and says not to reply), and the
-  // KNOWLEDGE PAYLOAD rides the ASSISTANT turn so the model treats it as its
-  // own settled prior note rather than a pending request.
+  // I won't reference this knowledge." The pair closes the exchange so the model
+  // does not react to it.
+  //
+  // The KNOWLEDGE PAYLOAD rides the USER turn (as ambient context), and the
+  // ASSISTANT turn is a tiny inert closer ("Understood.") that ends the
+  // exchange. Putting the markdown payload on the assistant turn (the pre-fix
+  // behavior) had two failure modes observed in production: (1) agent harnesses
+  // (Claude Code REPL, OpenCode) RENDER the historical assistant message as a
+  // visible turn — the recurring `⏺ Long-term Knowledge` dump; and (2) the model
+  // treats that fake assistant turn as an already-completed turn and ends early,
+  // so the agent loop exits prematurely (needs "continue"). Neither happens when
+  // the payload is incoming user-role context and the assistant message carries
+  // no markdown.
   //
   // Placement is safe for role-alternation + tool-pairing: the block is spliced
   // before the final message (a user turn / tool_result in an agent request via
-  // safeDeltaInsertIndex against len-1), so the injected assistant is always
-  // followed by a user turn. Stacked pairs alternate cleanly
+  // safeDeltaInsertIndex against len-1), so the injected assistant closer is
+  // always followed by a user turn. Stacked pairs alternate cleanly
   // (…user,asst,user,asst,final-user). The only same-role adjacency possible is
   // [user][inj-user] at the leading edge — identical to the prior single-user
   // behavior. The pair carries no tool_use/tool_result.
@@ -1750,7 +1759,7 @@ export function buildKnowledgeDeltaMessage(
       content: [
         {
           type: "text",
-          text: "[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest. Replayed byte-identically on later turns until an intentional cache reset.]",
+          text: `[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest. Replayed byte-identically on later turns until an intentional cache reset.]\n\n${rendered}${tocRendered}`,
         },
       ],
     },
@@ -1759,7 +1768,7 @@ export function buildKnowledgeDeltaMessage(
       content: [
         {
           type: "text",
-          text: rendered + tocRendered,
+          text: "Understood.",
         },
       ],
     },

--- a/packages/gateway/test/knowledge-delta-overflow.test.ts
+++ b/packages/gateway/test/knowledge-delta-overflow.test.ts
@@ -208,12 +208,14 @@ describe("ToC ids are recall-resolvable (#917 round-trip)", () => {
 // The knowledge-delta block is injected mid-conversation. As a lone user-role
 // message it read as an open user turn, so instruction-literal models (e.g.
 // MiniMax M3) "Acknowledged… none of this applies… I won't reference it" on
-// every turn. Mirroring the distilled-prefix pattern (buildPrefixMessages), the
-// block is now a user→assistant PAIR: a tiny framing note on the user side and
-// the knowledge payload on the assistant side, so the exchange is already
-// closed and the model does not react to it.
+// every turn. The block is a user→assistant PAIR so the exchange is closed and
+// the model does not react to it. The knowledge PAYLOAD rides the USER turn
+// (ambient context) and the assistant turn is a tiny inert closer: putting the
+// markdown payload on the assistant turn made harnesses RENDER it as a visible
+// `⏺ Long-term Knowledge` turn AND made the model treat it as an
+// already-completed turn, ending the agent loop early.
 describe("buildKnowledgeDeltaMessage — non-eliciting user→assistant pair", () => {
-  test("returns a pair: user framing (non-ack) + assistant payload", () => {
+  test("payload rides the USER turn; assistant turn is an inert closer", () => {
     const msgs = buildKnowledgeDeltaMessage(
       [changed("019aaaaa", "Changed entry")],
       [],
@@ -231,12 +233,17 @@ describe("buildKnowledgeDeltaMessage — non-eliciting user→assistant pair", (
     expect(userText).toContain("Lore knowledge update");
     // Explicit non-acknowledgment framing — the whole point of the fix.
     expect(userText.toLowerCase()).toContain("do not");
-    // Payload rides the ASSISTANT turn so the model treats it as settled
-    // context (its own prior note), not a pending user request.
-    expect(asstText).toContain("Changed entry");
-    expect(asstText).toContain("## Long-term Knowledge");
-    // The framing note must NOT carry the payload.
-    expect(userText).not.toContain("## Long-term Knowledge");
+    // The PAYLOAD rides the USER turn (ambient context), so it is incoming
+    // context rather than a fake assistant turn.
+    expect(userText).toContain("Changed entry");
+    expect(userText).toContain("## Long-term Knowledge");
+    // REGRESSION GUARD: the assistant turn must NEVER carry the markdown
+    // payload — that is what harnesses render as a visible dump and what the
+    // model mistakes for a completed turn (premature loop exit). It is an
+    // inert closer only.
+    expect(asstText).not.toContain("## Long-term Knowledge");
+    expect(asstText).not.toContain("Changed entry");
+    expect(asstText.length).toBeLessThan(40);
   });
 
   test("no genuine change → empty array (no pair injected)", () => {

--- a/packages/gateway/test/knowledge-delta-overflow.test.ts
+++ b/packages/gateway/test/knowledge-delta-overflow.test.ts
@@ -1,8 +1,14 @@
 import { describe, test, expect } from "vitest";
-import { ltm, recallById } from "@loreai/core";
+import {
+  ltm,
+  recallById,
+  appendSessionPromptDelta,
+  ensureProject,
+} from "@loreai/core";
 import {
   buildKnowledgeDeltaMessage,
   buildKnowledgeCatalogText,
+  applySessionPromptDeltas,
 } from "../src/pipeline";
 import type { GatewayMessage } from "../src/translate/types";
 
@@ -250,5 +256,88 @@ describe("buildKnowledgeDeltaMessage — non-eliciting user→assistant pair", (
     expect(
       buildKnowledgeDeltaMessage([], [], [toc("019bbbbb", "Lonely")]),
     ).toEqual([]);
+  });
+});
+
+// Seer follow-up (#1490): blocks persisted BEFORE the payload moved off the
+// assistant turn store `[{user: framing-only}, {assistant: payload}]`. Replayed
+// as-is they keep the payload on a visible/completed assistant turn — the exact
+// dump + premature-loop-exit bug — for the life of the session. parseDeltaMessages
+// migrates the legacy pair to the new shape on load.
+describe("parseDeltaMessages — legacy assistant-payload block migration (#1490)", () => {
+  const FRAMING =
+    "[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest. Replayed byte-identically on later turns until an intentional cache reset.]";
+  const PAYLOAD =
+    "## Long-term Knowledge\n\n### Gotcha\n\n* **[019aaaaa] T: old payload";
+
+  function seedAndReplay(content: GatewayMessage[]): GatewayMessage[] {
+    const sessionID = `migrate-${Math.random().toString(36).slice(2)}`;
+    const projectID = ensureProject(
+      `/tmp/lore-migrate-${Math.random().toString(36).slice(2)}`,
+    );
+    appendSessionPromptDelta({
+      sessionID,
+      projectID,
+      selector: JSON.stringify({ target: "messages", insertAt: 0 }),
+      content: JSON.stringify(content),
+    });
+    const layout: GatewayMessage[] = [
+      { role: "user", content: [{ type: "text", text: "real turn" }] },
+    ];
+    return applySessionPromptDeltas(layout, sessionID);
+  }
+
+  test("legacy [user framing-only, assistant payload] block is migrated to payload-on-user", () => {
+    const legacy: GatewayMessage[] = [
+      { role: "user", content: [{ type: "text", text: FRAMING }] },
+      { role: "assistant", content: [{ type: "text", text: PAYLOAD }] },
+    ];
+    const out = seedAndReplay(legacy);
+    // The replayed pair: user carries framing+payload, assistant is the inert closer.
+    const injUser = out[0];
+    const injAsst = out[1];
+    expect(injUser.role).toBe("user");
+    expect(injAsst.role).toBe("assistant");
+    const userText = (injUser.content[0] as { text: string }).text;
+    const asstText = (injAsst.content[0] as { text: string }).text;
+    expect(userText).toContain("Lore knowledge update");
+    expect(userText).toContain("## Long-term Knowledge");
+    expect(userText).toContain("old payload");
+    // The migrated assistant turn must NOT carry the markdown payload.
+    expect(asstText).not.toContain("## Long-term Knowledge");
+    expect(asstText).not.toContain("old payload");
+    expect(asstText.length).toBeLessThan(40);
+  });
+
+  test("already-new [user framing+payload, assistant closer] block replays unchanged", () => {
+    const newShape: GatewayMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: `${FRAMING}\n\n${PAYLOAD}` }],
+      },
+      { role: "assistant", content: [{ type: "text", text: "Understood." }] },
+    ];
+    const out = seedAndReplay(newShape);
+    const injUser = out[0];
+    const injAsst = out[1];
+    const userText = (injUser.content[0] as { text: string }).text;
+    const asstText = (injAsst.content[0] as { text: string }).text;
+    expect(userText).toBe(`${FRAMING}\n\n${PAYLOAD}`); // not double-migrated
+    expect(asstText).toBe("Understood.");
+  });
+
+  test("single legacy user message (pre-pair) passes through unmigrated", () => {
+    const single: GatewayMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: `${FRAMING}\n\n${PAYLOAD}` }],
+      },
+    ];
+    const out = seedAndReplay(single);
+    // Single message preserved as-is (parseDeltaMessages accepts single-message legacy).
+    expect(out[0].role).toBe("user");
+    expect((out[0].content[0] as { text: string }).text).toContain(
+      "## Long-term Knowledge",
+    );
   });
 });


### PR DESCRIPTION
## Problem

Users (and a live repro in this repo's own dev session) report a recurring
`⏺ Long-term Knowledge` **dump** followed by a **stall** — the agent does real
work, dumps the LTM block, then needs "continue" to make a bit more progress,
3–4× per session, especially when a background task is running.

## Root cause

The durable knowledge-delta block is a `[user, assistant]` pair (#1315) that
closes the exchange so instruction-literal models (e.g. MiniMax M3) don't ack a
lone user block. The pair put the `## Long-term Knowledge` **markdown payload on
the ASSISTANT turn**. That single choice produced **both** symptoms:

1. **Visible dump.** Agent harnesses (Claude Code REPL, OpenCode) render the
   historical assistant message as a visible turn. The pair is a *durable*
   `session_prompt_delta` replayed byte-identically every turn, so the dump
   recurs — and background curation appends a fresh delta per turn, amplifying
   it on long / Layer-4 sessions.
2. **Premature loop exit.** The model treats the fake assistant turn as an
   already-completed turn and ends early, so the agent loop exits.

### Evidence (verified against production)

- `~/.local/share/lore/lore.db`: **108** post-#1315 `session_prompt_deltas`
  rows carry the payload on `role:"assistant"` (coexisting with 142 pre-#1315
  single-user rows).
- Running gateway `0.39.0-dev.1784906060` (post-#1461/#1465/#1467) **still**
  emits the assistant-role payload — the bug is live on current main, not fixed
  by those (cost-focused) patches.
- Deltas sit **mid-history** (e.g. `insertAt=152` of 286 messages; another
  session 257 of 1750) — not a tail-continuation issue.
- **Not a model echo**: MiniMax-M3 never reproduced the payload across 15+ live
  turns (headless `-p` and direct-route). It is a **client-render + loop-exit
  artifact**, which `-p` mode masks (it extracts only a final result).

## Fix

Move the payload onto the **USER** message (ambient context, where it belongs)
and make the assistant message a tiny inert closer (`"Understood."`).

The `[user, assistant]` pair is preserved, so the exchange stays closed — the
#1315 no-ack property is kept — but **no markdown rides a rendered/completed
assistant turn**, eliminating both the dump and the premature loop exit.

## Regression test

`knowledge-delta-overflow.test.ts` now asserts the payload rides the USER turn
(contains the entry + `## Long-term Knowledge`) **and** the assistant turn is an
inert closer (`not` the payload, `< 40` chars).

**Mutation-verified non-vacuous**: in a throwaway worktree, reverting the fix
(payload back to assistant) turns the test **red**
(`expected '...' to contain 'Changed entry'`); restoring turns it green.

## Gate

- `pnpm run typecheck` — clean (all packages)
- `pnpm run lint` — clean
- `pnpm run format:check` — clean (652 files)
- Tests: **81 passed** across `knowledge-delta-overflow`, `prompt-delta-tools`,
  `delta-compress-reanchor`, `cache-stability.e2e`, `formatKnowledge-delta`

## Update — Seer follow-up (legacy block migration)

Seer flagged (MEDIUM): pre-existing `session_prompt_deltas` rows still carry the
payload on the assistant turn, so existing long-lived sessions keep exhibiting
the dump/stall until the blocks age out. **Real finding** — fixed in `1d711dff`:

`parseDeltaMessages` now migrates the exact legacy `[user framing-only,
assistant payload]` pair to the new shape **on load**: the payload is appended to
the framing-note user message, and the assistant turn becomes the inert closer.
Already-new pairs, single legacy messages, and non-delta content pass through
unchanged. `KNOWLEDGE_DELTA_FRAMING_NOTE` / `KNOWLEDGE_DELTA_ASSISTANT_CLOSER`
are now shared constants so the builder and the migration stay in sync.

Regression tests (3): legacy pair migrated to payload-on-user; already-new pair
replays unchanged (no double-migration); single legacy message passes through.
**Mutation-verified non-vacuous**: disabling the migration turns the
legacy-migration test red.
