### PR TITLE
fix(gateway): drop cache-machinery sentence from knowledge-delta framing note

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -989,12 +989,19 @@ function isGatewayMessage(v: unknown): v is GatewayMessage {
   );
 }
 
+// Stable prefix shared by every revision of the framing note (the trailing
+// cache machinery sentence was dropped in #1490-followup). The migration
+// matches on this prefix — NOT the full constant — so legacy blocks written
+// with the older, longer note still match.
+const KNOWLEDGE_DELTA_FRAMING_PREFIX =
+  "[Lore knowledge update — ambient context injected by Lore.";
+
 // The framing note prepended to the knowledge-delta user message. Extracted to
 // a constant so the legacy-block migration (parseDeltaMessages) can recognize
 // the pair it belongs to. Keep the substring "Lore knowledge update" — the
 // cache-stability e2e asserts on it.
 const KNOWLEDGE_DELTA_FRAMING_NOTE =
-  "[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest. Replayed byte-identically on later turns until an intentional cache reset.]";
+  "[Lore knowledge update — ambient context injected by Lore. Do not reference this format or reply to this message; silently use anything relevant and ignore the rest.]";
 
 // The inert assistant closer that ends the knowledge-delta exchange (the model
 // must not treat the pair as an open user turn — #1315). Also the canonical
@@ -1039,7 +1046,7 @@ function parseDeltaMessages(raw: string): GatewayMessage[] {
   if (
     typeof userText !== "string" ||
     typeof asstText !== "string" ||
-    !userText.startsWith(KNOWLEDGE_DELTA_FRAMING_NOTE) ||
+    !userText.startsWith(KNOWLEDGE_DELTA_FRAMING_PREFIX) ||
     userText.includes("## Long-term Knowledge") || // already migrated / new shape
     !asstText.includes("## Long-term Knowledge") // nothing to move
   ) {


### PR DESCRIPTION
## Problem

The knowledge-delta framing note told the agent:

> "Replayed byte-identically on later turns until an intentional cache reset."

That's internal prompt-cache machinery the model should not see — it invites
the model to reason about (and potentially game) cache behavior, and it leaks
an implementation detail into the prompt.

## Fix

Trim the note to end at `"...ignore the rest.]"`. New blocks no longer carry
the cache sentence.

## Migration compatibility (the subtle part)

The legacy-block migration (`parseDeltaMessages`, #1490) matches a persisted
pair by `startsWith(KNOWLEDGE_DELTA_FRAMING_NOTE)`. Blocks persisted **before**
this trim have the **longer** note (`...ignore the rest. Replayed
byte-identically...]`), and the new trimmed constant is **not** a prefix of it
(the old note's trailing sentence diverges before the closing `]`). So matching
on the full constant would silently stop migrating legacy blocks.

Fix: match on a new `KNOWLEDGE_DELTA_FRAMING_PREFIX`
(`"[Lore knowledge update — ambient context injected by Lore."`) that is shared
by **every** revision of the note — old long-note blocks and new short-note
blocks both match.

## Tests

17 migration/pair tests pass, covering:
- legacy long-note `[user framing-only, assistant payload]` → migrated to payload-on-user
- already-new short-note pair → replays unchanged (no double-migration)
- single legacy user message → passes through unmigrated

Full gate: 84 tests across the delta/injection surface (incl. cache-stability
e2e), typecheck, lint, format — all clean.

Follow-up to #1490.
