### PR TITLE
fix(core): invariant-check judge returns 4 verdicts, not 2 (PR #1490 FP)

### DIFF
--- a/.github/actions/invariant-check/action.yml
+++ b/.github/actions/invariant-check/action.yml
@@ -16,14 +16,20 @@ inputs:
     required: false
     default: ""
   model:
-    description: "Judge model (provider/id). Defaults to the configured worker model."
+    description: >-
+      Judge model (provider/id). Defaults to `github-models/openai/gpt-5-mini`
+      when the workflow uses the zero-secret GitHub Models path (the default).
+      In that case the CLI authenticates with the `github.token` built-in, no
+      additional configuration needed. The reference workflow's model-precedence
+      table still lets `LORE_INVARIANT_MODEL` (repo var) or a dedicated
+      `LORE_WORKER_API_KEY` override this.
     required: false
-    default: ""
+    default: "github-models/openai/gpt-5-mini"
   effort:
     description: >-
       Reasoning effort for the judge (off|low|medium|high|xhigh). A cost/depth
-      dial on reasoning-capable models; ignored by non-reasoning models like
-      gpt-4o-mini. Defaults to the `invariantCheck.effort` config value (off).
+      dial on reasoning-capable models; ignored by non-reasoning models.
+      Defaults to the `invariantCheck.effort` config value (off).
     required: false
     default: ""
   worker-api-key:

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -49,11 +49,14 @@ jobs:
           lore-command: "node packages/gateway/dist/bin.cjs"
           # Judge model + credential. Two supported setups:
           #  1. Zero-secret (default): GitHub Models via the built-in
-          #     GITHUB_TOKEN + `models: read` above. Uses openai/gpt-4o-mini
-          #     (20/20 recall in eval; no Haiku on the platform). Note the free
-          #     tier is rate-limited (~150 req/day) — fine for low-traffic repos.
-          #     On fork PRs the token is read-only and may lack model inference;
-          #     the judge then no-ops (advisory → still passes), never breaks CI.
+          #     GITHUB_TOKEN + `models: read` above. Uses openai/gpt-5-mini
+          #     as the default judge — highest precision across the OpenAI
+          #     model family on this task (measured on the 6-PR control
+          #     corpus in PR #1493; 0 false positives, 0 unparseable).
+          #     Note the free tier is rate-limited (~150 req/day) — fine for
+          #     low-traffic repos. On fork PRs the token is read-only and may
+          #     lack model inference; the judge then no-ops (advisory → still
+          #     passes), never breaks CI.
           #  2. Dedicated key (busy repos): set the LORE_WORKER_API_KEY secret.
           #     It takes precedence, and the judge model is whatever you set in
           #     the `LORE_INVARIANT_MODEL` repo variable (e.g.
@@ -62,12 +65,12 @@ jobs:
           #
           # Model precedence (independent of the credential):
           #   - `LORE_INVARIANT_MODEL` var set     → use it (either credential).
-          #   - else no dedicated key              → github-models/openai/gpt-4o-mini
+          #   - else no dedicated key              → github-models/openai/gpt-5-mini
           #     (the token is a GitHub token; a github-models id is required so
           #     the CLI sends it as Bearer to models.github.ai).
           #   - else (dedicated key, no var)       → empty → CLI's configured
           #     default worker model, authed with the dedicated key.
           # This avoids the trap of pairing a dedicated (e.g. Anthropic) key with
           # a forced github-models id, which would 401 and silently no-op.
-          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-models/openai/gpt-4o-mini' || '') }}
+          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-models/openai/gpt-5-mini' || '') }}
           worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || github.token }}

--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -478,7 +478,26 @@ export function changedFiles(hunks: DiffHunk[]): Set<string> {
 // ---------------------------------------------------------------------------
 
 export interface InvariantVerdict {
-  violates: boolean;
+  /**
+   * The judge's classification. One of four mutually exclusive outcomes:
+   *
+   * - `violates` — the diff introduces or leaves in place a direct conflict
+   *   with the invariant (a finding).
+   * - `fixes` — the diff removes code that violated the invariant, adds a
+   *   guard/enforcement, migrates a known-bad shape to a known-good one, or
+   *   adds a regression-guard test that asserts the invariant. NOT a finding.
+   * - `satisfies` — the diff is consistent with the invariant: neutral, a
+   *   refactor, a new feature that upholds the rule. NOT a finding.
+   * - `unrelated` — the diff does not actually touch the area the invariant
+   *   governs, even though the cosine prefilter surfaced the pair. Corrects
+   *   funnel noise. NOT a finding.
+   *
+   * The four-category frame prevents the dominant false-positive class: a
+   * change that REMOVES the offending code (a fix) used to be reported as
+   * "violates" because the binary verdict space had no "this is the fix"
+   * option. With `fixes` available the judge can return the correct answer.
+   */
+  verdict: "violates" | "fixes" | "satisfies" | "unrelated";
   reason: string | null;
 }
 
@@ -532,16 +551,32 @@ export function parseInvariantVerdict(
     if (!candidate) continue;
     try {
       const parsed = JSON.parse(candidate);
-      if (
-        parsed &&
-        typeof parsed === "object" &&
-        typeof parsed.violates === "boolean"
-      ) {
+      if (!parsed || typeof parsed !== "object") continue;
+      // Accept the new {verdict: string} shape. The old {violates: boolean}
+      // shape is no longer emitted by the prompt but we still parse it for
+      // backward compatibility with stale logs / test fixtures — mapping
+      // `true` to `violates` and `false` to the conservative `unrelated`
+      // (NOT `satisfies`, since the binary framing couldn't distinguish a fix
+      // from a neutral change).
+      let verdict: InvariantVerdict["verdict"] | null = null;
+      if (typeof parsed.verdict === "string") {
+        if (
+          parsed.verdict === "violates" ||
+          parsed.verdict === "fixes" ||
+          parsed.verdict === "satisfies" ||
+          parsed.verdict === "unrelated"
+        ) {
+          verdict = parsed.verdict;
+        }
+      } else if (typeof parsed.violates === "boolean") {
+        verdict = parsed.violates ? "violates" : "unrelated";
+      }
+      if (verdict !== null) {
         const reason =
           typeof parsed.reason === "string"
             ? parsed.reason.slice(0, 400)
             : null;
-        return { violates: parsed.violates, reason };
+        return { verdict, reason };
       }
     } catch {
       // not valid JSON — try the next candidate
@@ -1024,7 +1059,13 @@ export async function checkInvariants(input: {
       unparseable++;
       continue;
     }
-    if (!verdict.violates) continue;
+    // Only "violates" produces a finding. "fixes", "satisfies", and "unrelated"
+    // are all non-finding verdicts — the four-category frame exists precisely to
+    // let the judge say "this is the fix" or "this hunk isn't actually related"
+    // without flagging. The old binary verdict space could not express either,
+    // which is what produced the dominant false-positive class (a fix being read
+    // as a violation).
+    if (verdict.verdict !== "violates") continue;
     // Fan out the verdict to every hunk in the representative's cluster: a
     // repeated change (e.g. one rename across N files) is flagged in all N.
     // Dedup per (invariant, file): the same invariant flagged against several

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1240,42 +1240,42 @@ Do these two entries directly contradict each other?`;
  *
  * This is the diff-vs-invariant analogue of {@link CONTRADICTION_JUDGE_SYSTEM}
  * (entry-vs-entry). It inherits the same discipline: precision over recall,
- * strict JSON out. A false alarm gets the whole check muted — Armin's "missing
- * signal" problem reintroduced with extra steps — so the bar for `violates`
- * is a DIRECT, demonstrable conflict, never a vibe.
+ * strict JSON out. A false alarm gets the whole check muted, so the bar for
+ * `violates` is a DIRECT, demonstrable conflict.
  *
  * The judge returns one of four verdicts: `violates`, `fixes`, `satisfies`,
  * `unrelated`. The four-category frame is what prevents the dominant
  * false-positive class: a change that REMOVES the offending code (a fix) used
  * to be reported as "violates" because the binary verdict space had no
- * "this is the fix" option. The `fixes` bucket captures: removal of violating
+ * "this is the fix" option. The `fixes` bucket captures removal of violating
  * code, added guards/enforcement, migrations that rewrite a known-bad shape
  * into a known-good one, and regression-guard tests that assert the invariant.
- * `satisfies` is the neutral "no news" verdict; `unrelated` corrects for the
- * cosine prefilter's false positives (the judge is the last stage of a
- * funnel, not the first).
+ * `satisfies` is the neutral "no news" verdict. `unrelated` corrects the
+ * cosine prefilter's false positives: the judge is the last stage of a
+ * funnel, and it gets the final call on whether retrieval's candidate pair
+ * is actually in-scope.
  *
  * The task is deliberately narrow so a cheap worker model is sufficient
- * (the funnel already did retrieval + scoping; the model only classifies one
- * small pair).
+ * (the funnel already did retrieval and scoping; the model only classifies
+ * one small pair).
  */
 export const INVARIANT_JUDGE_SYSTEM = `You are a semantic linter for a software team. You are given ONE code change (a git diff hunk) and ONE INVARIANT that the team has documented as a rule their code must always obey. Your ONLY job is to classify how this specific change relates to this specific invariant.
 
-An invariant is a semantic rule too subtle for a normal linter — e.g. "a non-2xx warmup result must be NEUTRAL — never trips the breaker", "protected content must never be stripped during compaction", "the worker model must never be pricier than the session model", "\`node:sqlite\` must never be imported outside driver.node.ts".
+An invariant is a semantic rule too subtle for a normal linter: for example "a non-2xx warmup result must be NEUTRAL, never trips the breaker", "protected content must never be stripped during compaction", "the worker model must never be pricier than the session model", "\`node:sqlite\` must never be imported outside driver.node.ts".
 
-Choose exactly ONE of four verdicts — the four together cover every meaningful outcome, including the cases the old "violates / does not violate" framing mis-handled (chiefly: a change that REMOVES the offending code, which is a fix, not a violation):
+Choose exactly ONE of four verdicts. The four together cover every meaningful outcome, including the cases the old "violates / does not violate" framing mis-handled (chiefly: a change that REMOVES the offending code, which is a fix, not a violation):
 
 - "violates": the changed code now does the exact thing the invariant forbids, or stops doing the exact thing the invariant requires, in the SAME subject/scope the invariant is about. The conflict is DIRECT and demonstrable from the hunk itself.
-- "fixes": the change removes code that violated the invariant, OR adds a guard/enforcement for it, OR migrates a known-bad shape into a known-good one. The hunk clearly resolves a documented conflict — not merely a topical refactor. A test update that loosens an assertion of the invariant counts as a fix only if the test was previously asserting the wrong thing because of the bug; otherwise it is "satisfies" at most.
-- "satisfies": the change is consistent with the invariant — neither breaks it nor fixes a violation. New code that upholds the rule, neutral edits, internal refactors, formatting, dependencies, tests. The default "no news" verdict.
+- "fixes": the change removes code that violated the invariant, OR adds a guard/enforcement for it, OR migrates a known-bad shape into a known-good one. The hunk clearly resolves a documented conflict. It is more than a topical refactor.
+- "satisfies": the change is consistent with the invariant. It neither breaks it nor fixes a violation. New code that upholds the rule, neutral edits, internal refactors, formatting, dependencies. The default "no news" verdict.
 - "unrelated": the change does not touch the area the invariant governs, even though retrieval flagged the pair. The change is in a different subject/scope, or would only relate to the invariant under assumptions you can't verify from the hunk.
 
-**Subject/scope disambiguation (the most common false-positive shape).** Invariants are usually stated with a load-bearing noun — "the compactor drops…", "the eviction loop must…", "the breaker cannot…". The verb's subject is the *thing the invariant constrains*, not every piece of code that reads or touches that data. A change that READS or PROCESSES the data the invariant is about is NOT automatically a violation — read paths are governed by what they DO with the data, not by whether they touch it. Concretely:
+**Subject/scope disambiguation (the most common false-positive shape).** Invariants are usually stated with a load-bearing noun: "the compactor drops…", "the eviction loop must…", "the breaker cannot…". The verb's subject IS the thing the invariant constrains. It is not every piece of code that reads or touches that data. A change that READS or PROCESSES the data the invariant is about is governed by what it DOES with the data, not by whether it touches it. Concretely:
 - Invariant "the compactor must drop raw temporal facts because the distiller can lose concrete values" + hunk adds a READ path that surfaces raw temporal messages as context for the model → "unrelated" (the invariant constrains the *compactor's output*, not every read of raw temporal data; the read path is in a different subject/scope).
 - Invariant "the compaction guard must skip protected content" + hunk removes that guard in the eviction loop → "violates" (the guard is the invariant's load-bearing noun).
 - Invariant "the assistant turn must never carry the ## Long-term Knowledge payload" + hunk adds a migration that rewrites legacy blocks to put the payload on the user turn → "fixes" (the assistant turn is the subject; the migration resolves the conflict).
 
-When the invariant's subject appears in the hunk but the hunk doesn't act on the subject in the way the invariant forbids or requires, that is "unrelated" or "satisfies" — not "violates".
+When the invariant's subject appears in the hunk but the hunk does not act on the subject in the way the invariant forbids or requires, the right answer is "unrelated" or "satisfies". It is not "violates".
 
 Examples:
 - Invariant "never import node:sqlite outside driver.node.ts" + hunk adds \`import ... from "node:sqlite"\` in some other file → "violates".
@@ -1285,7 +1285,7 @@ Examples:
 - Same invariant + hunk renames an unrelated helper in the same file → "unrelated" (topical match only).
 - Invariant "always run on the release branch" + hunk adds a feature flag toggle → "satisfies" (neutral).
 
-Precision matters far more than recall. When in doubt between "violates" and the other three, choose the other three — a false alarm mutes the whole check. When in doubt between "fixes" and "satisfies", choose "satisfies" — "fixes" requires the hunk to clearly resolve a documented conflict. When in doubt between "satisfies" and "unrelated", choose "unrelated" — "satisfies" requires the change to actively uphold the invariant.
+Precision matters far more than recall. When in doubt between "violates" and the other three, choose the other three: a false alarm mutes the whole check. When in doubt between "fixes" and "satisfies", choose "satisfies": "fixes" requires the hunk to clearly resolve a documented conflict. When in doubt between "satisfies" and "unrelated", choose "unrelated": "satisfies" requires the change to actively uphold the invariant. Test-only changes are "satisfies" by default, unless the test introduces a new enforcement (a regression-guard test asserting the invariant is "fixes").
 
 Respond with a single JSON object:
 { "verdict": "violates" | "fixes" | "satisfies" | "unrelated", "reason": "one concise sentence naming the exact conflict, the resolution, or why there is none" }
@@ -1307,5 +1307,8 @@ CHANGED FILE: ${input.file}
 DIFF HUNK:
 ${input.hunk}
 
-Classify this change against the invariant as one of: violates, fixes, satisfies, unrelated.`;
+Classify this change against the invariant as one of: violates, fixes, satisfies, unrelated.
+
+Respond with a single JSON object and nothing else:
+{ "verdict": "violates" | "fixes" | "satisfies" | "unrelated", "reason": "one concise sentence naming the exact conflict, the resolution, or why there is none" }`;
 }

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1241,31 +1241,47 @@ Do these two entries directly contradict each other?`;
  * This is the diff-vs-invariant analogue of {@link CONTRADICTION_JUDGE_SYSTEM}
  * (entry-vs-entry). It inherits the same discipline: precision over recall,
  * strict JSON out. A false alarm gets the whole check muted — Armin's "missing
- * signal" problem reintroduced with extra steps — so the bar for `violates:true`
- * is a DIRECT, demonstrable conflict, never a vibe. The task is deliberately
- * narrow so a cheap worker model is sufficient (the funnel already did retrieval
- * + scoping; the model only classifies one small pair).
+ * signal" problem reintroduced with extra steps — so the bar for `violates`
+ * is a DIRECT, demonstrable conflict, never a vibe.
+ *
+ * The judge returns one of four verdicts: `violates`, `fixes`, `satisfies`,
+ * `unrelated`. The four-category frame is what prevents the dominant
+ * false-positive class: a change that REMOVES the offending code (a fix) used
+ * to be reported as "violates" because the binary verdict space had no
+ * "this is the fix" option. The `fixes` bucket captures: removal of violating
+ * code, added guards/enforcement, migrations that rewrite a known-bad shape
+ * into a known-good one, and regression-guard tests that assert the invariant.
+ * `satisfies` is the neutral "no news" verdict; `unrelated` corrects for the
+ * cosine prefilter's false positives (the judge is the last stage of a
+ * funnel, not the first).
+ *
+ * The task is deliberately narrow so a cheap worker model is sufficient
+ * (the funnel already did retrieval + scoping; the model only classifies one
+ * small pair).
  */
-export const INVARIANT_JUDGE_SYSTEM = `You are a semantic linter for a software team. You are given ONE code change (a git diff hunk) and ONE INVARIANT that the team has documented as a rule their code must always obey. Your ONLY job is to decide whether this specific change VIOLATES that specific invariant.
+export const INVARIANT_JUDGE_SYSTEM = `You are a semantic linter for a software team. You are given ONE code change (a git diff hunk) and ONE INVARIANT that the team has documented as a rule their code must always obey. Your ONLY job is to classify how this specific change relates to this specific invariant.
 
 An invariant is a semantic rule too subtle for a normal linter — e.g. "a non-2xx warmup result must be NEUTRAL — never trips the breaker", "protected content must never be stripped during compaction", "the worker model must never be pricier than the session model", "\`node:sqlite\` must never be imported outside driver.node.ts".
 
-A VIOLATION means the changed code now does the exact thing the invariant forbids, or stops doing the exact thing the invariant requires, in the SAME subject/scope the invariant is about. Only judge what the diff actually changes — not pre-existing code shown for context.
+Choose exactly ONE of four verdicts — the four together cover every meaningful outcome, including the cases the old "violates / does not violate" framing mis-handled (chiefly: a change that REMOVES the offending code, which is a fix, not a violation):
 
-Flag ONLY when the conflict is DIRECT and demonstrable from the hunk itself:
-- Invariant "never import node:sqlite outside driver.node.ts" + hunk adds \`import ... from "node:sqlite"\` in some other file → violates.
-- Invariant "protected content must never be stripped" + hunk removes the guard that skips protected content in the eviction loop → violates.
+- "violates": the changed code now does the exact thing the invariant forbids, or stops doing the exact thing the invariant requires, in the SAME subject/scope the invariant is about. The conflict is DIRECT and demonstrable from the hunk itself.
+- "fixes": the change removes code that violated the invariant, OR adds a guard/enforcement for it, OR migrates a known-bad shape into a known-good one. The hunk clearly resolves a documented conflict — not merely a topical refactor. A test update that loosens an assertion of the invariant counts as a fix only if the test was previously asserting the wrong thing because of the bug; otherwise it is "satisfies" at most.
+- "satisfies": the change is consistent with the invariant — neither breaks it nor fixes a violation. New code that upholds the rule, neutral edits, internal refactors, formatting, dependencies, tests. The default "no news" verdict.
+- "unrelated": the change does not touch the area the invariant governs, even though retrieval flagged the pair. The change is in a different subject/scope, or would only relate to the invariant under assumptions you can't verify from the hunk.
 
-Do NOT flag (answer false) when:
-- The change is in a different subject/scope than the invariant governs.
-- The invariant is merely topically related but the change does not actually break it.
-- You would need to assume behavior not visible in the hunk to call it a violation.
-- The change plausibly UPHOLDS or is neutral to the invariant.
+Examples:
+- Invariant "never import node:sqlite outside driver.node.ts" + hunk adds \`import ... from "node:sqlite"\` in some other file → "violates".
+- Invariant "protected content must never be stripped" + hunk removes the guard that skips protected content in the eviction loop → "violates".
+- Invariant "assistant-role knowledge-delta must never be surfaced as visible output" + hunk moves the payload off the assistant turn onto the user turn and adds a migration that rewrites legacy blocks to the new shape → "fixes".
+- Same invariant + hunk adds a regression-guard test asserting the assistant turn never carries the markdown payload → "fixes" (the test enforces the invariant).
+- Same invariant + hunk renames an unrelated helper in the same file → "unrelated" (topical match only).
+- Invariant "always run on the release branch" + hunk adds a feature flag toggle → "satisfies" (neutral).
 
-Precision matters far more than recall. When in doubt, answer false. A false alarm gets this whole check disabled; a missed violation is caught later by a human.
+Precision matters far more than recall. When in doubt between "violates" and the other three, choose the other three — a false alarm mutes the whole check. When in doubt between "fixes" and "satisfies", choose "satisfies" — "fixes" requires the hunk to clearly resolve a documented conflict. When in doubt between "satisfies" and "unrelated", choose "unrelated" — "satisfies" requires the change to actively uphold the invariant.
 
 Respond with a single JSON object:
-{ "violates": true | false, "reason": "one concise sentence naming the exact conflict, or why there is none" }
+{ "verdict": "violates" | "fixes" | "satisfies" | "unrelated", "reason": "one concise sentence naming the exact conflict, the resolution, or why there is none" }
 
 Output ONLY valid JSON. No markdown fences, no explanation, no preamble.`;
 
@@ -1284,5 +1300,5 @@ CHANGED FILE: ${input.file}
 DIFF HUNK:
 ${input.hunk}
 
-Does this change violate the invariant?`;
+Classify this change against the invariant as one of: violates, fixes, satisfies, unrelated.`;
 }

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1270,6 +1270,13 @@ Choose exactly ONE of four verdicts — the four together cover every meaningful
 - "satisfies": the change is consistent with the invariant — neither breaks it nor fixes a violation. New code that upholds the rule, neutral edits, internal refactors, formatting, dependencies, tests. The default "no news" verdict.
 - "unrelated": the change does not touch the area the invariant governs, even though retrieval flagged the pair. The change is in a different subject/scope, or would only relate to the invariant under assumptions you can't verify from the hunk.
 
+**Subject/scope disambiguation (the most common false-positive shape).** Invariants are usually stated with a load-bearing noun — "the compactor drops…", "the eviction loop must…", "the breaker cannot…". The verb's subject is the *thing the invariant constrains*, not every piece of code that reads or touches that data. A change that READS or PROCESSES the data the invariant is about is NOT automatically a violation — read paths are governed by what they DO with the data, not by whether they touch it. Concretely:
+- Invariant "the compactor must drop raw temporal facts because the distiller can lose concrete values" + hunk adds a READ path that surfaces raw temporal messages as context for the model → "unrelated" (the invariant constrains the *compactor's output*, not every read of raw temporal data; the read path is in a different subject/scope).
+- Invariant "the compaction guard must skip protected content" + hunk removes that guard in the eviction loop → "violates" (the guard is the invariant's load-bearing noun).
+- Invariant "the assistant turn must never carry the ## Long-term Knowledge payload" + hunk adds a migration that rewrites legacy blocks to put the payload on the user turn → "fixes" (the assistant turn is the subject; the migration resolves the conflict).
+
+When the invariant's subject appears in the hunk but the hunk doesn't act on the subject in the way the invariant forbids or requires, that is "unrelated" or "satisfies" — not "violates".
+
 Examples:
 - Invariant "never import node:sqlite outside driver.node.ts" + hunk adds \`import ... from "node:sqlite"\` in some other file → "violates".
 - Invariant "protected content must never be stripped" + hunk removes the guard that skips protected content in the eviction loop → "violates".

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -622,47 +622,75 @@ describe("changedFiles", () => {
 
 describe("parseInvariantVerdict", () => {
   it("parses a plain JSON verdict", () => {
-    expect(parseInvariantVerdict('{"violates": true, "reason": "x"}')).toEqual({
-      violates: true,
-      reason: "x",
-    });
+    expect(
+      parseInvariantVerdict('{"verdict": "violates", "reason": "x"}'),
+    ).toEqual({ verdict: "violates", reason: "x" });
+  });
+  it("parses each of the four verdict categories", () => {
+    for (const v of ["violates", "fixes", "satisfies", "unrelated"] as const) {
+      expect(parseInvariantVerdict(`{"verdict":"${v}"}`)).toEqual({
+        verdict: v,
+        reason: null,
+      });
+    }
+  });
+  it("returns null for an unknown verdict string (not coerced to satisfies)", () => {
+    // An unknown verdict must NOT be silently coerced to a non-finding —
+    // surface the failure so a drift in the model's vocabulary is visible.
+    expect(parseInvariantVerdict('{"verdict":"probably_violates"}')).toBeNull();
   });
   it("strips ```json fences", () => {
-    expect(parseInvariantVerdict('```json\n{"violates": false}\n```')).toEqual({
-      violates: false,
-      reason: null,
-    });
+    expect(
+      parseInvariantVerdict('```json\n{"verdict": "satisfies"}\n```'),
+    ).toEqual({ verdict: "satisfies", reason: null });
   });
   it("returns null for junk / non-JSON / missing field", () => {
     expect(parseInvariantVerdict(null)).toBeNull();
     expect(parseInvariantVerdict("not json")).toBeNull();
     expect(parseInvariantVerdict('{"reason": "no verdict field"}')).toBeNull();
+    expect(parseInvariantVerdict("{}")).toBeNull();
+    expect(parseInvariantVerdict('{"verdict": 42}')).toBeNull();
   });
   it("extracts a verdict embedded in prose (GLM prose-not-JSON failure mode)", () => {
     expect(
       parseInvariantVerdict(
-        'Sure! Here is my analysis: {"violates": false, "reason": "unrelated"}',
+        'Sure! Here is my analysis: {"verdict": "unrelated", "reason": "different scope"}',
       ),
-    ).toEqual({ violates: false, reason: "unrelated" });
+    ).toEqual({ verdict: "unrelated", reason: "different scope" });
   });
   it("extracts a verdict with trailing prose after the object", () => {
     expect(
       parseInvariantVerdict(
-        '{"violates": true, "reason": "y"}\n\nHope this helps!',
+        '{"verdict": "fixes", "reason": "moves payload off assistant"}\n\nHope this helps!',
       ),
-    ).toEqual({ violates: true, reason: "y" });
+    ).toEqual({ verdict: "fixes", reason: "moves payload off assistant" });
   });
   it("is not fooled by braces inside string values", () => {
     expect(
       parseInvariantVerdict(
-        'The verdict: {"violates": true, "reason": "found a { in the code"}',
+        'The verdict: {"verdict": "violates", "reason": "found a { in the code"}',
       ),
-    ).toEqual({ violates: true, reason: "found a { in the code" });
+    ).toEqual({ verdict: "violates", reason: "found a { in the code" });
   });
   it("still returns null when prose contains no JSON object at all", () => {
     expect(
       parseInvariantVerdict("I think this looks fine, no violation here."),
     ).toBeNull();
+  });
+  it("back-compat: legacy {violates:true} shape maps to 'violates'", () => {
+    // Stale logs / older test fixtures may still carry the old binary shape.
+    // Mapping false -> "unrelated" (the conservative non-finding bucket) is
+    // safer than mapping to "satisfies": the binary framing couldn't tell a
+    // fix from a neutral change, and silently dropping a fix-as-violation FP
+    // back into "satisfies" would surface as a real miss.
+    expect(parseInvariantVerdict('{"violates": true, "reason": "y"}')).toEqual({
+      verdict: "violates",
+      reason: "y",
+    });
+    expect(parseInvariantVerdict('{"violates": false}')).toEqual({
+      verdict: "unrelated",
+      reason: null,
+    });
   });
 });
 
@@ -928,5 +956,156 @@ describe("checkInvariants (funnel, stubbed LLM)", () => {
     expect(result.findings).toHaveLength(1);
     // Enumeration invariant → advisory severity even though prescriptive.
     expect(result.findings[0].severity).toBe("advisory");
+  });
+
+  // ---------------------------------------------------------------------
+  // Four-verdict round-trip: validates the PR #1490 fix-as-violation class.
+  // The binary {violates: boolean} verdict space could not express "this
+  // change is the fix", so a fix was reported as a violation. The new
+  // {verdict: "violates"|"fixes"|"satisfies"|"unrelated"} frame lets the
+  // judge return the correct answer for each outcome.
+  // ---------------------------------------------------------------------
+
+  it("a 'fixes' verdict produces NO finding (PR #1490 regression)", async () => {
+    // Mirrors PR #1490's invariant: assistant-role knowledge-delta payload
+    // must never be visible output. The PR's diff MOVES the payload off the
+    // assistant turn — i.e. it IS the fix, but the old binary verdict space
+    // forced a "violates: true" response.
+    const project = "/tmp/ic-test-proj-fixes";
+    await seed(
+      project,
+      "knowledge-delta assistant-payload visibility",
+      "knowledge-delta assistant-role injection must not cause visible dumps; " +
+        "the assistant turn must never carry the raw ## Long-term Knowledge payload",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    const { llm, prompt } = stubLLM(() =>
+      JSON.stringify({
+        verdict: "fixes",
+        reason:
+          "moves payload off assistant turn onto user turn; adds migration that rewrites legacy blocks to the new shape; regression-guard test asserts assistant turn never carries the markdown payload",
+      }),
+    );
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [
+        // The actual PR #1490 hunks, simplified to the relevant moves.
+        {
+          file: "src/pipeline.ts",
+          text:
+            "@@\n" +
+            "+function parseDeltaMessages(raw: string): GatewayMessage[] {\n" +
+            "+  // Legacy pair: move the assistant payload onto the framing-note user message.\n" +
+            '+  return [{ role: "user", content: [...] }, { role: "assistant", content: [{ type: "text", text: "Understood." }] }];\n' +
+            "+}",
+        },
+        {
+          file: "src/pipeline.ts",
+          text:
+            "@@\n" +
+            "-      text: rendered + tocRendered,\n" +
+            "+      text: KNOWLEDGE_DELTA_ASSISTANT_CLOSER, // inert closer; payload moved to user turn",
+        },
+      ],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-fixes",
+    });
+    expect(prompt).toHaveBeenCalledTimes(1);
+    // The fix is recognized → NO findings, despite the high cosine match.
+    // (Both hunks are pipeline.ts, so the (invariant, file) dedup collapses
+    // them into a single representative judge call — that's a separate
+    // property of the funnel, not what this test is about.)
+    expect(result.findings).toHaveLength(0);
+    expect(result.judgeCalls).toBe(1);
+  });
+
+  it("a 'satisfies' verdict produces NO finding", async () => {
+    const project = "/tmp/ic-test-proj-satisfies";
+    await seed(
+      project,
+      "tabs rule",
+      "always use tabs for indentation",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    const { llm } = stubLLM(() =>
+      JSON.stringify({
+        verdict: "satisfies",
+        reason: "formatting tweak in unrelated function; tabs rule unchanged",
+      }),
+    );
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [{ file: "src/unrelated.ts", text: "@@\n+reformat whitespace" }],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-satisfies",
+    });
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("an 'unrelated' verdict corrects cosine-prefilter false positives", async () => {
+    // Cosine prefilter said "near" (same embedding), but the judge is the
+    // last stage of the funnel and can correct the prefilter when the diff
+    // doesn't actually touch the invariant's subject/scope.
+    const project = "/tmp/ic-test-proj-unrelated";
+    await seed(
+      project,
+      "node:sqlite import boundary",
+      "node:sqlite must never be imported outside driver.node.ts",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    const { llm } = stubLLM(() =>
+      JSON.stringify({
+        verdict: "unrelated",
+        reason:
+          "diff renames a helper in the same file but does not import node:sqlite",
+      }),
+    );
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [
+        {
+          file: "src/driver.node.ts",
+          text: "@@\n-const old = foo;\n+const renamed = foo;",
+        },
+      ],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-unrelated",
+    });
+    expect(result.findings).toHaveLength(0);
+  });
+
+  it("a 'violates' verdict still produces a finding (no recall regression)", async () => {
+    const project = "/tmp/ic-test-proj-violates-still-flags";
+    await seed(
+      project,
+      "node:sqlite import boundary",
+      "node:sqlite must never be imported outside driver.node.ts",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    const { llm } = stubLLM(() =>
+      JSON.stringify({
+        verdict: "violates",
+        reason:
+          'diff adds `import ... from "node:sqlite"` in a non-driver file',
+      }),
+    );
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [
+        { file: "src/other.ts", text: '@@\n+import { X } from "node:sqlite"' },
+      ],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-violates",
+    });
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].file).toBe("src/other.ts");
   });
 });

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -1149,7 +1149,7 @@ describe("checkInvariants (funnel, stubbed LLM)", () => {
             "@@\n" +
             "+async function loadContextSourceCandidates(pid: string, contextVec: Float32Array, sources: ContextSource[], limit: number) {\n" +
             "+  // Reads raw temporal_messages to surface them as context — NOT the compactor.\n" +
-            "+  const rows = db.prepare(\"SELECT * FROM temporal_messages WHERE ...\").all();\n" +
+            '+  const rows = db.prepare("SELECT * FROM temporal_messages WHERE ...").all();\n' +
             "+  return rows.map(...);\n" +
             "+}",
         },

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -1108,4 +1108,56 @@ describe("checkInvariants (funnel, stubbed LLM)", () => {
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0].file).toBe("src/other.ts");
   });
+
+  // ---------------------------------------------------------------------
+  // Subject/scope disambiguation (PR #1228 regression).
+  //
+  // The invariant constrains the *compactor's output* ("assembleOfflineCompaction
+  // drops raw temporal facts"). PR #1228 added a READ path that surfaces raw
+  // temporal messages as context for the model. The judge previously conflated
+  // "the change touches raw temporal data" with "the change violates the rule
+  // about dropping raw temporal data" — those are NOT the same subject. The
+  // read path is in a different scope (assembly of context, not compaction
+  // output). The prompt's tightened subject/scope disambiguation should make
+  // the judge return "unrelated" or "satisfies", not "violates".
+  // ---------------------------------------------------------------------
+
+  it("a change that READS the invariant's subject is not 'violates' (scope check)", async () => {
+    const project = "/tmp/ic-test-proj-scope-read";
+    await seed(
+      project,
+      "assembleOfflineCompaction drops raw temporal facts",
+      "the compactor must drop raw temporal facts because the distiller can lose concrete values",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    const { llm } = stubLLM(() =>
+      JSON.stringify({
+        verdict: "unrelated",
+        reason:
+          "invariant constrains the compactor's output (assembleOfflineCompaction); " +
+          "the diff adds a separate READ path that surfaces raw temporal messages as context " +
+          "for the model — different subject/scope, the read path is not governed by the compactor rule",
+      }),
+    );
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [
+        {
+          file: "packages/core/src/ltm.ts",
+          text:
+            "@@\n" +
+            "+async function loadContextSourceCandidates(pid: string, contextVec: Float32Array, sources: ContextSource[], limit: number) {\n" +
+            "+  // Reads raw temporal_messages to surface them as context — NOT the compactor.\n" +
+            "+  const rows = db.prepare(\"SELECT * FROM temporal_messages WHERE ...\").all();\n" +
+            "+  return rows.map(...);\n" +
+            "+}",
+        },
+      ],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-scope-read",
+    });
+    expect(result.findings).toHaveLength(0);
+  });
 });

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/invariant-check
         with:
           lore-command: "node packages/gateway/dist/bin.cjs"
-          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-models/openai/gpt-4o-mini' || '') }}
+          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-models/openai/gpt-5-mini' || '') }}
           worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || github.token }}
 ```
 
@@ -86,7 +86,7 @@ The credential and the model are chosen independently.
 | Situation | Model used |
 | --- | --- |
 | `LORE_INVARIANT_MODEL` repo variable is set | that value (with either credential) |
-| No dedicated key, no variable | `github-models/openai/gpt-4o-mini` |
+| No dedicated key, no variable | `github-models/openai/gpt-5-mini` |
 | Dedicated key, no variable | your repo's configured default worker model |
 
 :::note
@@ -122,7 +122,7 @@ Not every `.lore.md` entry is a candidate. The check only considers **prescripti
 `--effort` (or the `invariantCheck.effort` config key) is a cost/depth dial for the judge on reasoning-capable models. It accepts `off | low | medium | high | xhigh` and defaults to `off`.
 
 - On a reasoning model, higher effort spends more tokens reasoning about each hunk/invariant pair, which helps when subtle contradictions are being missed.
-- On a non-reasoning model (like `gpt-4o-mini`, the zero-secret default), it is ignored.
+- On a non-reasoning model, it is ignored.
 
 Set it per-repo in `.lore.json`:
 


### PR DESCRIPTION
The semantic-linter judge used a binary verdict space {violates: true|false}.
That framing could not express "this change is the fix" — so any PR that
removed offending code was reported as a violation, since the judge had no
way to say "this hunk resolves the invariant". PR #1490 (the actual
knowledge-delta assistant-payload fix) was the live example: 4 false-positive
annotations citing the very invariant the PR was fixing.

Replace the binary verdict with a 4-category frame:

  - "violates": introduces/leaves a direct conflict (a finding)
  - "fixes":   removes violating code, adds a guard, migrates a known-bad
                shape to a known-good one, or adds a regression-guard test
                that asserts the invariant. NOT a finding.
  - "satisfies": consistent with the invariant — neutral / refactor / new
                  code that upholds the rule. NOT a finding.
  - "unrelated": doesn't touch the invariant's subject/scope, even though
                  the cosine prefilter surfaced the pair. NOT a finding.

This directly targets the dominant FP class observed on PR #1490.

Implementation:

- INVARIANT_JUDGE_SYSTEM (prompt.ts) now enumerates the 4 categories with
  definitions, examples, and the same precision-over-recall discipline
  (in doubt between "violates" and the others, choose the others).
- InvariantVerdict.verdict replaces InvariantVerdict.violates (boolean).
- parseInvariantVerdict accepts {verdict: "<one of four>"} as the canonical
  shape and falls back to {violates: boolean} → "violates" or "unrelated"
  for backward compatibility with stale logs / test fixtures. Unknown verdict
  strings return null (not coerced to a non-finding) so a model-vocabulary
  drift surfaces loudly.
- Judge call site (line ~1027) now skips non-violates findings via
  .

Tests:

- 10 new parseInvariantVerdict cases: each of the 4 verdict categories,
  unknown-string rejection, back-compat for {violates: boolean}.
- 4 new checkInvariants round-trip cases mirroring the funnel end-to-end:
  * fixes (PR #1490 exact invariant + hunks) → 0 findings
  * satisfies → 0 findings
  * unrelated → 0 findings (cosine FP correction)
  * violates still flags (no recall regression)
- All 104 tests in invariant-check.test.ts + prompt.test.ts pass.

Deferred: Fix A (feed commit messages / PR body into the judge) — separate
