### PR TITLE
fix(gateway): never place knowledge-delta pair at the true tail (the wedge)

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -1006,7 +1006,11 @@ const KNOWLEDGE_DELTA_FRAMING_NOTE =
 // The inert assistant closer that ends the knowledge-delta exchange (the model
 // must not treat the pair as an open user turn — #1315). Also the canonical
 // assistant text the legacy migration rewrites a payload-carrying assistant to.
-const KNOWLEDGE_DELTA_ASSISTANT_CLOSER = "Understood.";
+// Reads as a system memory-refresh annotation (bracketed, matching the framing
+// note), NOT the agent answering the user — so if a harness ever renders it, it
+// does not look like a stray reply. Inert and non-eliciting (closes the
+// exchange, #1315).
+const KNOWLEDGE_DELTA_ASSISTANT_CLOSER = "[memory refreshed]";
 
 function firstText(m: GatewayMessage | undefined): string | undefined {
   const b = m?.content?.[0];
@@ -1263,7 +1267,16 @@ export function safeDeltaInsertIndex(
   messages: GatewayMessage[],
   desired: number,
 ): number {
-  let idx = Math.max(0, Math.min(desired, messages.length));
+  // The injected delta is a user→assistant PAIR. It must NEVER be placed at the
+  // true tail (idx == messages.length): the pair's trailing assistant would
+  // become the literal last message of the request, so (1) agent harnesses
+  // (Claude Code REPL, OpenCode) render it as a stray turn ("Understood.") and
+  // (2) the model sees the conversation ending on its OWN turn and ends the
+  // agent loop early (the wedge). Cap at messages.length - 1 so at least one
+  // real message (a user turn / tool_result) always follows the pair and closes
+  // the request. (Only reachable when messages.length >= 1; an empty array has
+  // no delta to place.)
+  let idx = Math.max(0, Math.min(desired, Math.max(0, messages.length - 1)));
   // Walk backward while the immediately-preceding message is an assistant
   // carrying a tool_use. This covers both a completed pair (the tool_result is
   // at idx) AND a pending tool call (no tool_result follows yet) — in either
@@ -1795,7 +1808,7 @@ export function buildKnowledgeDeltaMessage(
   // does not react to it.
   //
   // The KNOWLEDGE PAYLOAD rides the USER turn (as ambient context), and the
-  // ASSISTANT turn is a tiny inert closer ("Understood.") that ends the
+  // ASSISTANT turn is a tiny inert closer ("[memory refreshed]") that ends the
   // exchange. Putting the markdown payload on the assistant turn (the pre-fix
   // behavior) had two failure modes observed in production: (1) agent harnesses
   // (Claude Code REPL, OpenCode) RENDER the historical assistant message as a
@@ -1805,10 +1818,12 @@ export function buildKnowledgeDeltaMessage(
   // the payload is incoming user-role context and the assistant message carries
   // no markdown.
   //
-  // Placement is safe for role-alternation + tool-pairing: the block is spliced
-  // before the final message (a user turn / tool_result in an agent request via
-  // safeDeltaInsertIndex against len-1), so the injected assistant closer is
-  // always followed by a user turn. Stacked pairs alternate cleanly
+  // Placement is GUARANTEED never to leave the pair at the true tail:
+  // safeDeltaInsertIndex caps the insert index at messages.length - 1, so at
+  // least one real message (a user turn / tool_result) always follows the pair
+  // and closes the request. Without that cap the pair's trailing assistant could
+  // become the literal last message — a harness renders it as a stray turn and
+  // the model ends the loop early (the wedge). Stacked pairs alternate cleanly
   // (…user,asst,user,asst,final-user). The only same-role adjacency possible is
   // [user][inj-user] at the leading edge — identical to the prior single-user
   // behavior. The pair carries no tool_use/tool_result.

--- a/packages/gateway/test/knowledge-delta-overflow.test.ts
+++ b/packages/gateway/test/knowledge-delta-overflow.test.ts
@@ -315,7 +315,10 @@ describe("parseDeltaMessages — legacy assistant-payload block migration (#1490
         role: "user",
         content: [{ type: "text", text: `${FRAMING}\n\n${PAYLOAD}` }],
       },
-      { role: "assistant", content: [{ type: "text", text: "Understood." }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[memory refreshed]" }],
+      },
     ];
     const out = seedAndReplay(newShape);
     const injUser = out[0];
@@ -323,7 +326,7 @@ describe("parseDeltaMessages — legacy assistant-payload block migration (#1490
     const userText = (injUser.content[0] as { text: string }).text;
     const asstText = (injAsst.content[0] as { text: string }).text;
     expect(userText).toBe(`${FRAMING}\n\n${PAYLOAD}`); // not double-migrated
-    expect(asstText).toBe("Understood.");
+    expect(asstText).toBe("[memory refreshed]");
   });
 
   test("single legacy user message (pre-pair) passes through unmigrated", () => {

--- a/packages/gateway/test/prompt-delta-tools.test.ts
+++ b/packages/gateway/test/prompt-delta-tools.test.ts
@@ -99,12 +99,38 @@ describe("safeDeltaInsertIndex — never splits a tool_use/tool_result pair", ()
     assertNoOrphanedTools(out);
   });
 
-  test("clamps to array bounds", () => {
+  test("clamps to array bounds (never the true tail — leaves one real message)", () => {
     const messages = [user(text("hi"))];
+    // The pair must never end at the tail, so the index is capped at length-1.
     expect(safeDeltaInsertIndex(messages, 99)).toBeLessThanOrEqual(
-      messages.length,
+      messages.length - 1,
     );
     expect(safeDeltaInsertIndex(messages, -5)).toBeGreaterThanOrEqual(0);
+  });
+
+  test("never lets the injected pair end at the true tail (the wedge)", () => {
+    // Regression for the wedge: when insertAt resolves to messages.length, the
+    // pair's trailing assistant became the literal last message — a harness
+    // renders it as a stray turn and the model ends the loop early. The index
+    // must be capped so a real user/tool_result always follows the pair.
+    const convo = [
+      user(text("q1")),
+      assistant(text("r1")),
+      user(text("q2")), // the live final user turn
+    ];
+    const idx = safeDeltaInsertIndex(convo, convo.length); // desired = tail
+    // Splice the [user, assistant] pair at idx; the LAST message must be a real
+    // message (the final user turn), never the injected assistant.
+    const out = convo.slice();
+    out.splice(idx, 0, user(text("delta-u")), assistant(text("delta-a")));
+    expect(out[out.length - 1].role).toBe("user");
+    expect((out[out.length - 1].content[0] as { text: string }).text).toBe(
+      "q2",
+    );
+    // And the injected assistant must not be at the tail.
+    expect(out[out.length - 1]).not.toEqual(
+      expect.objectContaining({ role: "assistant" }),
+    );
   });
 });
 


### PR DESCRIPTION
## Problem (user-reported, root cause confirmed)

After #1490 + #1492, the info dump was gone — but the agent emitted a
random-looking **"Understood"** message out of the blue and the **loop stopped
again**, requiring "continue".

**Root cause is placement, not payload.** The injected knowledge-delta is a
`user→assistant` pair. When its `insertAt` resolved to `messages.length`,
`safeDeltaInsertIndex` clamped **up to the true tail** (`Math.min(desired,
messages.length)`), so the pair's trailing assistant became the **literal last
message** of the request. Agent harnesses render that as a stray turn
("Understood"), and the model sees the conversation ending on its **own** turn
→ ends the agent loop early. On a short/fresh session that's the live tail, so
the frozen index wedges it there every turn.

Evidence: `insertAt` clamp + `safeDeltaInsertIndex` cap-up-to-length; a probe
reproducing `lastTag: "INJ-A"` at the tail; persisted blocks store frozen
absolute `insertAt` (e.g. `207`, `327`) which sit mid-history only on long
sessions — on a fresh session `len-1` is the live tail.

## Fix

Two parts:

1. **Placement** — `safeDeltaInsertIndex` now caps at `messages.length - 1`, so
   at least one real message (a user turn / tool_result) always follows the
   pair and closes the request. The injected assistant can never be the last
   message. Tool-pair guard (walk back before an assistant `tool_use`)
   unchanged.
2. **Closer content** — the inert assistant closer now reads as a system
   annotation, not an agent reply: `"Understood."` → `"[memory refreshed]"`.
   It can still surface until the placement fix is deployed everywhere, so it
   should not look like the agent answering the user.

## Tests

- New regression test: the injected pair never ends at the true tail.
- **Mutation-verified non-vacuous**: reverting the cap turns the wedge test red
  (`expected 'assistant' to be 'user'`).
- Updated: `clamps to array bounds` (now `length - 1`), closer assertions.
- Full gate: 85 tests across the delta/injection surface (incl. cache-stability
  e2e), typecheck, lint, format — all green.

Follow-up to #1490 / #1492.
