### PR TITLE
fix(core): preserve temporal KNN partition pushdown before vacuum

### DIFF
--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -462,15 +462,21 @@ export function setStorageMode(
  */
 export function ensureVec0Store(conn: EmbeddingWriteConn, dim: number): void {
   const storedDim = readVecDimension(conn);
-  if (storedDim !== null && storedDim !== dim) {
+  const temporalExisted = Boolean(
+    conn
+      .query("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+      .get(VEC_TABLE.temporal),
+  );
+  const recreating = storedDim !== null && storedDim !== dim;
+  if (recreating) {
     for (const vt of VEC_TABLES) conn.query(`DROP TABLE IF EXISTS ${vt}`).run();
   }
   for (const ddl of vec0Ddl(dim)) conn.query(ddl).run();
   setKv(conn, VEC_DIMENSION_KEY, String(dim));
-  // Fresh installs create the temporal_vec table with project_id as the sole
-  // PARTITION KEY; record the mode so runTemporal knows session_id is an aux
-  // column that KNN WHERE cannot reference.
-  if (readTemporalPartitionMode(conn) === null) {
+  // Only a table we created here is known to use the current project-only DDL.
+  // A same-dimension existing table can be the pre-vacuum compound partition
+  // layout; never mark it converted or a later vacuum would skip its rebuild.
+  if (!temporalExisted || recreating) {
     setKv(conn, TEMPORAL_PARTITION_MODE_KEY, "project_only");
   }
 }

--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -467,6 +467,12 @@ export function ensureVec0Store(conn: EmbeddingWriteConn, dim: number): void {
   }
   for (const ddl of vec0Ddl(dim)) conn.query(ddl).run();
   setKv(conn, VEC_DIMENSION_KEY, String(dim));
+  // Fresh installs create the temporal_vec table with project_id as the sole
+  // PARTITION KEY; record the mode so runTemporal knows session_id is an aux
+  // column that KNN WHERE cannot reference.
+  if (readTemporalPartitionMode(conn) === null) {
+    setKv(conn, TEMPORAL_PARTITION_MODE_KEY, "project_only");
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -32,6 +32,7 @@ import {
   setStorageMode,
   storeEmbedding,
   storeTemporalChunks,
+  TEMPORAL_PARTITION_MODE_KEY,
 } from "./db/vec-store";
 import { config } from "./config";
 import * as log from "./log";
@@ -2102,8 +2103,16 @@ async function poolOrInProcess(
     if (pooled === VECTOR_SEARCH_TIMED_OUT) return [];
     if (pooled !== null) return pooled;
     const readMode = resolveReadMode(readStorageMode(db()), isVecAvailable());
+    const temporalPartitionMode =
+      spec.kind === "temporal" ? getKV(TEMPORAL_PARTITION_MODE_KEY) : null;
     try {
-      return runVectorQuery(db(), readMode, queryEmbedding, spec);
+      return runVectorQuery(
+        db(),
+        readMode,
+        queryEmbedding,
+        spec,
+        temporalPartitionMode,
+      );
     } catch (err) {
       // Safety net for the vec0 read path, which (unlike the blob paths) has no
       // in-line JS fallback: a vec0 `MATCH` can throw transiently — e.g. during a

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -214,6 +214,7 @@ export function runVectorQuery(
   readMode: VecReadMode,
   queryEmbedding: Float32Array,
   spec: VectorQuerySpec,
+  temporalPartitionMode?: string | null,
 ): VectorHit[] | DistillationVectorHit[] {
   switch (spec.kind) {
     case "knowledge":
@@ -231,6 +232,10 @@ export function runVectorQuery(
         spec.limit,
       );
     case "temporal":
+      // Resolve the partition mode from the connection if not passed — session-
+      // scoped queries on a pre-vacuum DB (session IS a partition key) need
+      // WHERE filtering; post-vacuum (`project_only`) it must be JS post-filter.
+      const tpm = temporalPartitionMode ?? readTemporalPartitionMode(conn);
       return runTemporal(
         conn,
         readMode,
@@ -238,6 +243,7 @@ export function runVectorQuery(
         spec.projectId,
         spec.limit,
         spec.sessionId,
+        tpm,
       );
   }
 }
@@ -480,6 +486,18 @@ function runAllDistillations(
   return topK;
 }
 
+function readTemporalPartitionMode(conn: VectorQueryConn): string | null {
+  try {
+    const rows = conn
+      .query("SELECT value FROM kv_meta WHERE key = ?")
+      .all("vec.temporal_partition_mode") as Array<{ value?: string }>;
+    const row = rows[0];
+    return row?.value != null ? row.value : null;
+  } catch {
+    return null;
+  }
+}
+
 function runTemporal(
   conn: VectorQueryConn,
   readMode: VecReadMode,
@@ -487,14 +505,15 @@ function runTemporal(
   projectId: string,
   limit: number,
   sessionId?: string,
+  temporalPartitionMode?: string | null,
 ): VectorHit[] {
   if (readMode === "degraded") return [];
   if (readMode === "vec0") {
-    // project_id is the sole PARTITION KEY → the index scans only the project
-    // shard. session_id is a stored aux column (+session_id, explicitly NOT a
-    // partition key), so KNN WHERE cannot filter on it. When session-scoped,
-    // select session_id and post-filter in JS with widened overfetch to
-    // compensate for attrition.
+    const sessionIsPartitionKey = temporalPartitionMode !== "project_only";
+    // When session_id is a PARTITION KEY (old schema, pre-vacuum), KNN WHERE
+    // can filter on it for a targeted partition scan. After migration to
+    // project-only, session_id is a stored aux column (+session_id) that KNN
+    // WHERE cannot reference — post-filter in JS instead.
     // `temporal_vec` is chunk-keyed and a message may carry MANY chunks
     // (multi-vector part-aware embedding), so a bare `k = limit` could return
     // `limit` *chunks* that collapse to far fewer than `limit` distinct
@@ -509,17 +528,23 @@ function runTemporal(
     // is 1:1.
     const run = (k: number): VectorHit[] => {
       const vsql =
-        "SELECT message_id AS id, session_id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance";
-      const vparams: unknown[] = [toBlob(queryEmbedding), k, projectId];
-      const chunkHits = conn.query(vsql).all(...vparams) as Array<{
+        sessionIsPartitionKey && sessionId
+          ? "SELECT message_id AS id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? AND session_id = ? ORDER BY distance"
+          : "SELECT message_id AS id, session_id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance";
+      const vparams: unknown[] =
+        sessionIsPartitionKey && sessionId
+          ? [toBlob(queryEmbedding), k, projectId, sessionId]
+          : [toBlob(queryEmbedding), k, projectId];
+      const rawHits = conn.query(vsql).all(...vparams) as Array<{
         id: string;
-        session_id: string;
+        session_id?: string;
         similarity: number;
       }>;
-      // Post-filter by session when scoped (aux column, cannot be in KNN WHERE)
-      const scoped = sessionId
-        ? chunkHits.filter((h) => h.session_id === sessionId)
-        : chunkHits;
+      // Post-filter by session when not a partition key (aux column)
+      const scoped =
+        !sessionIsPartitionKey && sessionId
+          ? rawHits.filter((h) => h.session_id === sessionId)
+          : rawHits;
       // Keep each message's best (max) sim. `scoped` is nearest-first, so the
       // first-seen sim for an id is already its best and Map insertion order is
       // best-first; the stable sort then orders messages by similarity with
@@ -536,11 +561,11 @@ function runTemporal(
         .sort((a, b) => b.similarity - a.similarity)
         .slice(0, limit);
     };
-    const k0 = sessionId ? VEC0_MAX_K : vecK(limit * TEMPORAL_CHUNK_OVERFETCH);
+    const needOverfetch = sessionId && !sessionIsPartitionKey;
+    const k0 = needOverfetch
+      ? VEC0_MAX_K
+      : vecK(limit * TEMPORAL_CHUNK_OVERFETCH);
     const hits = run(k0);
-    // Chunk-collapse + session-post-filter attrition can leave < limit
-    // distinct messages even when more exist deeper; widen to the max KNN
-    // window. Session-scoped queries already start at VEC0_MAX_K.
     return hits.length >= limit || k0 >= VEC0_MAX_K ? hits : run(VEC0_MAX_K);
   }
   assertBlobReadMode(readMode);

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -526,13 +526,16 @@ function runTemporal(
     // grouping the bounded result set (≤ k ≤ VEC0_MAX_K rows) in JS sidesteps
     // that entirely. Degenerate-safe: with one chunk per message the collapse
     // is 1:1.
-    const run = (k: number): VectorHit[] => {
+    const run = (
+      k: number,
+      useSessionPartitionKey = sessionIsPartitionKey,
+    ): VectorHit[] => {
       const vsql =
-        sessionIsPartitionKey && sessionId
+        useSessionPartitionKey && sessionId
           ? "SELECT message_id AS id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? AND session_id = ? ORDER BY distance"
           : "SELECT message_id AS id, session_id, 1 - distance AS similarity FROM temporal_vec WHERE embedding MATCH ? AND k = ? AND project_id = ? ORDER BY distance";
       const vparams: unknown[] =
-        sessionIsPartitionKey && sessionId
+        useSessionPartitionKey && sessionId
           ? [toBlob(queryEmbedding), k, projectId, sessionId]
           : [toBlob(queryEmbedding), k, projectId];
       const rawHits = conn.query(vsql).all(...vparams) as Array<{
@@ -542,7 +545,7 @@ function runTemporal(
       }>;
       // Post-filter by session when not a partition key (aux column)
       const scoped =
-        !sessionIsPartitionKey && sessionId
+        !useSessionPartitionKey && sessionId
           ? rawHits.filter((h) => h.session_id === sessionId)
           : rawHits;
       // Keep each message's best (max) sim. `scoped` is nearest-first, so the
@@ -565,8 +568,30 @@ function runTemporal(
     const k0 = needOverfetch
       ? VEC0_MAX_K
       : vecK(limit * TEMPORAL_CHUNK_OVERFETCH);
-    const hits = run(k0);
-    return hits.length >= limit || k0 >= VEC0_MAX_K ? hits : run(VEC0_MAX_K);
+    let useSessionPartitionKey = sessionIsPartitionKey;
+    let hits: VectorHit[];
+    try {
+      hits = run(k0);
+    } catch (error) {
+      // A rebuild can replace the old compound-partition table after we read
+      // its absent mode marker but before this KNN query runs. sqlite-vec then
+      // rejects session_id as an auxiliary-column WHERE constraint. Retry once
+      // with the project-only query shape; never retry unrelated failures.
+      if (
+        sessionIsPartitionKey &&
+        sessionId &&
+        error instanceof Error &&
+        error.message.includes("auxiliary column")
+      ) {
+        useSessionPartitionKey = false;
+        hits = run(VEC0_MAX_K, useSessionPartitionKey);
+      } else {
+        throw error;
+      }
+    }
+    return hits.length >= limit || k0 >= VEC0_MAX_K
+      ? hits
+      : run(VEC0_MAX_K, useSessionPartitionKey);
   }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {

--- a/packages/core/src/vector-worker.ts
+++ b/packages/core/src/vector-worker.ts
@@ -17,7 +17,11 @@
 
 import { parentPort, workerData } from "node:worker_threads";
 import { openReaderConnection, type ReaderConnection } from "./db/reader";
-import { resolveReadMode, readStorageMode } from "./db/vec-store";
+import {
+  resolveReadMode,
+  readStorageMode,
+  TEMPORAL_PARTITION_MODE_KEY,
+} from "./db/vec-store";
 import { runReadJob } from "./read-job";
 import { runVectorQuery } from "./vector-query";
 import type {
@@ -81,7 +85,24 @@ port.on("message", (msg: VectorWorkerInbound) => {
           readStorageMode(conn.db),
           conn.vecAvailable,
         );
-        const hits = runVectorQuery(conn.db, readMode, msg.embedding, msg.spec);
+        const temporalPartitionMode =
+          msg.spec.kind === "temporal"
+            ? ((
+                conn.db
+                  .query("SELECT value FROM kv_meta WHERE key = ?")
+                  .get(TEMPORAL_PARTITION_MODE_KEY) as
+                  | { value?: string }
+                  | null
+                  | undefined
+              )?.value ?? null)
+            : null;
+        const hits = runVectorQuery(
+          conn.db,
+          readMode,
+          msg.embedding,
+          msg.spec,
+          temporalPartitionMode,
+        );
         post({ type: "result", id: msg.id, hits });
       } catch (err) {
         // Per-request failure — reject just this request, keep serving. The

--- a/packages/core/test/data-vacuum.test.ts
+++ b/packages/core/test/data-vacuum.test.ts
@@ -13,6 +13,7 @@ import {
   resetVecStorageModeLatch,
   setStorageMode,
   storeTemporalChunks,
+  TEMPORAL_PARTITION_MODE_KEY,
 } from "../src/db/vec-store";
 
 const PROJECT = "/test/data-vacuum";
@@ -121,6 +122,11 @@ describe("VACUUM / free-page reclaim (#1221)", () => {
       }
     ).n;
     expect(beforeChunks).toBe(1);
+
+    // Simulate a pre-vacuum DB so vacuum's internal vec0Rebuild processes rows.
+    db()
+      .query("DELETE FROM kv_meta WHERE key = ?")
+      .run(TEMPORAL_PARTITION_MODE_KEY);
 
     const r = vacuum();
 

--- a/packages/core/test/vec0-rebuild.test.ts
+++ b/packages/core/test/vec0-rebuild.test.ts
@@ -177,6 +177,41 @@ describeVec("vec0Rebuild", () => {
     expect(msgIds).toEqual(new Set(["m1", "m2", "m3"]));
   });
 
+  test("preserves an unmarked existing compound-partition temporal table", () => {
+    if (!isVecAvailable()) return;
+
+    const conn = db();
+    conn.query("DROP TABLE IF EXISTS temporal_vec").run();
+    conn
+      .query(
+        "CREATE VIRTUAL TABLE temporal_vec USING vec0(chunk_id TEXT PRIMARY KEY, +message_id TEXT, project_id TEXT PARTITION KEY, session_id TEXT PARTITION KEY, embedding float[4] distance_metric=cosine)",
+      )
+      .run();
+    conn
+      .query("DELETE FROM kv_meta WHERE key = ?")
+      .run(TEMPORAL_PARTITION_MODE_KEY);
+
+    ensureVec0Store(conn, DIM);
+    expect(
+      conn
+        .query("SELECT value FROM kv_meta WHERE key = ?")
+        .get(TEMPORAL_PARTITION_MODE_KEY),
+    ).toBeNull();
+
+    conn
+      .query(
+        "INSERT INTO temporal_vec (chunk_id, message_id, project_id, session_id, embedding) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("old#0", "old", pid, "s1", toBlob(v(1, 0, 0, 0)));
+    setStorageMode(conn, "vec0");
+    expect(vec0Rebuild(conn, "temporal").rowsRebuilt).toBe(1);
+    expect(
+      conn
+        .query("SELECT value FROM kv_meta WHERE key = ?")
+        .get(TEMPORAL_PARTITION_MODE_KEY),
+    ).toEqual({ value: "project_only" });
+  });
+
   test("rebuild is atomic: a failure mid-rebuild leaves the original table intact", () => {
     setStorageMode(db(), "vec0");
     ensureVec0Store(db(), DIM);

--- a/packages/core/test/vec0-rebuild.test.ts
+++ b/packages/core/test/vec0-rebuild.test.ts
@@ -15,6 +15,7 @@ import {
   setStorageMode,
   storeEmbedding,
   storeTemporalChunks,
+  TEMPORAL_PARTITION_MODE_KEY,
   vec0Rebuild,
 } from "../src/db/vec-store";
 import { toBlob } from "../src/vector-query";
@@ -155,6 +156,11 @@ describeVec("vec0Rebuild", () => {
     insTemporal("m1", "s1", 4);
     insTemporal("m2", "s2", 4);
     insTemporal("m3", "s3", 4);
+
+    // Simulate a pre-vacuum DB so vec0Rebuild processes these rows.
+    db()
+      .query("DELETE FROM kv_meta WHERE key = ?")
+      .run(TEMPORAL_PARTITION_MODE_KEY);
 
     const r = vec0Rebuild(db(), "temporal");
     expect(r.rowsRebuilt).toBe(12);


### PR DESCRIPTION
## Summary

Preserves session-scoped temporal KNN partition pushdown for databases that still use the pre-vacuum `(project_id, session_id)` partition layout. Databases rebuilt to `project_only` keep the required JavaScript post-filter, because sqlite-vec cannot constrain auxiliary columns in KNN `WHERE` clauses.

## Changes

- Resolve `vec.temporal_partition_mode` in both in-process and worker search paths.
- Use `session_id` in KNN `WHERE` only when it remains a partition key.
- Record `project_only` for fresh vec0 stores so their aux-column layout is unambiguous.
- Cover pre-vacuum rebuild and vacuum scenarios.

## Verification

- `pnpm --filter @loreai/core run typecheck`
- `pnpm test run vec0-cutover.test.ts vec0-rebuild.test.ts data-vacuum.test.ts vec-search.test.ts`
- `pnpm test`
- `pnpm run lint`
- `pnpm run format:check`