### PR TITLE
ci: bump lint timeout to 25 min for gpt-5-mini cold-start

### DIFF
--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -25,9 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     # gpt-5-mini is the default judge (PR #1493 cross-model validation:
     # 6/6 control PRs clean, 0 unparseable). Warm cache ~2-4 min; cold
-    # start with GitHub Models can take ~13 min on a PR with many
-    # hunks. 20 min gives ~7 min of headroom for cold-start variation.
-    timeout-minutes: 20
+    # start with GitHub Models can take ~15-20 min on a PR with many
+    # hunks and many invariants. 25 min gives ~5-10 min of headroom for
+    # cold-start variation, and it's the empirical cap we hit on the
+    # first run with the gpt-5-mini default (the 15-min cap and the
+    # 20-min cap were both too tight — see PR #1412).
+    timeout-minutes: 25
     # Advisory: a failure here must never block a PR.
     continue-on-error: true
     steps:

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -46,7 +46,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     continue-on-error: true # advisory: never block a PR
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The 15-min and 20-min caps on the lint job were both too tight — the first run after PR #1412 merged (renamed invariant-check → lint, gpt-5-mini as default) hit the 20-min cap at 20m11s and was cancelled.

gpt-5-mini on GitHub Models takes ~15-20 min cold-start when the PR has many changed files and many invariants. 25 min gives ~5-10 min of headroom while staying well within the GHA free-tier budget per repo.

Files:
- `.github/workflows/semantic-linter.yml`: 20 → 25
- `packages/website/src/content/docs/docs/guides/semantic-linter.md`: 20 → 25 (in the example workflow)