### PR TITLE
feat(provenance): widen tool_calls.input_path to input_paths_json (bash-extracted)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "pickleparser": "0.2.1",
     "remark": "^15.0.1",
     "sqlite-vec": "0.1.9",
+    "unbash": "^4.0.4",
     "uuidv7": "^1.1.0",
     "zod": "^4.3.6"
   },

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1890,6 +1890,20 @@ const MIGRATIONS: string[] = [
   -- with the files that produced them (D2c).
   ALTER TABLE tool_calls ADD COLUMN input_path TEXT;
   `,
+
+  `
+  -- Version 76: rename tool_calls.input_path → tool_calls.input_paths_json
+  -- and widen the value to a JSON array. A file-tool call already had at most
+  -- one path, but a single bash command (cat a b c, sed -i a, > b, tee d …) can
+  -- touch N files — the union is the actual provenance signal D2c PR-2 needs.
+  -- The shape is now: NULL | '["a.ts","b.ts"]' (a JSON string of unique,
+  -- non-empty, slash-bearing, non-pathological tokens extracted at record time).
+  -- SQLite's ALTER TABLE … RENAME COLUMN only updates the schema; pre-existing
+  -- rows keep their (non-JSON) value, so readers use a safe-parse helper that
+  -- also accepts a bare path. v75 is only 6 days old in production, so the
+  -- back-window of non-JSON values is tiny.
+  ALTER TABLE tool_calls RENAME COLUMN input_path TO input_paths_json;
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -2927,17 +2941,25 @@ function migrate(database: Database) {
       // (skips if already migrated) so a partial apply can't boot-loop (#827 E-4c-3a).
       applyScopeKeyEpochPk(database);
     } else {
+      // Pre-strip any column-side ALTERs that are already satisfied by the
+      // current schema (ADD COLUMN where the column exists, RENAME COLUMN
+      // where the source has already been renamed to the target). This makes
+      // every migration idempotent without relying on the catch-and-retry
+      // path below — necessary for migrations like v75→v76 where the original
+      // column was renamed in a later migration and the ADD+RENAME pair must
+      // be jointly treated as a no-op when the target name already exists.
+      const preStripped = stripAppliedAlters(MIGRATIONS[i], database);
       try {
-        database.exec(MIGRATIONS[i]);
+        database.exec(preStripped);
       } catch (e: unknown) {
         // Multi-statement migrations can partially fail when an early
-        // statement (e.g. ALTER TABLE ADD COLUMN) hits a duplicate-column
-        // error from a prior partial run. Swallow duplicate-column errors
-        // so the rest of the migration loop and the version bump proceed.
-        // Any genuinely new error is re-thrown.
+        // statement (e.g. ALTER TABLE ADD COLUMN, or RENAME COLUMN) hits a
+        // duplicate-column / no-such-column error from a prior partial run.
+        // Swallow these so the rest of the migration loop and the version
+        // bump proceed. Any genuinely new error is re-thrown.
         if (e instanceof Error && /duplicate column name/i.test(e.message)) {
-          // The ALTER TABLE already applied — run remaining statements in
-          // this migration by stripping the offending ALTER and re-exec'ing.
+          // The column-side statement already applied — run remaining
+          // statements in this migration by stripping it and re-exec'ing.
           // (Important: migrate() in db.ts runs each migration via database.exec()
           // which stops at the first error in a multi-statement string.)
           const stripped = stripAppliedAlters(MIGRATIONS[i], database);
@@ -2958,20 +2980,79 @@ function migrate(database: Database) {
 }
 
 /**
- * Strip ALTER TABLE ADD COLUMN statements for columns that already exist.
- * Returns the migration string with those statements removed.
+ * Strip column-side ALTER statements (ADD COLUMN, RENAME COLUMN) that are
+ * already satisfied by the current schema, so a re-run of the migration
+ * becomes a clean no-op. Returns the migration string with those statements
+ * removed.
+ *
+ * Also handles a tricky class of states: when v75 adds `X` and v76 renames
+ * `X` → `Y`, a DB that has *both* `X` and `Y` (an aborted v75→v76 mid-apply
+ * where v75 succeeded and v76 added `Y` without dropping `X`, or a manual
+ * sidecar ADD) must be normalized — the v75 ADD is a no-op, the v76 RENAME
+ * is a no-op, and the orphan `X` is dropped to keep the schema consistent
+ * with what v75→v76 should have produced. The drop is inlined as an
+ * extra ALTER prefix in the returned string so it runs as part of the
+ * same `database.exec()` as the rest of the migration.
  */
 function stripAppliedAlters(migration: string, database: Database): string {
-  return migration.replace(
+  // Some ADD COLUMNs are followed by a RENAME COLUMN in a later migration
+  // (e.g. v75 adds `input_path`, v76 renames to `input_paths_json`). On
+  // partial-apply recovery, the original name is gone but the renamed alias
+  // is present — treat that as "ADD already applied" and strip the ADD so
+  // the migration becomes a no-op. Keys are ORIGINAL column names; values
+  // are the post-rename names.
+  const renamedInto: Record<string, string> = {
+    input_path: "input_paths_json",
+  };
+  // Orphan drop prefix: if both the original and the renamed name are
+  // present (a partial v75→v76 apply), prepend a DROP COLUMN for the
+  // original so the schema converges to the post-rename state.
+  const orphanDrops: string[] = [];
+  for (const [from, to] of Object.entries(renamedInto)) {
+    const tcols = database
+      .query(`PRAGMA table_info(tool_calls)`)
+      .all() as Array<{ name: string }>;
+    if (
+      tcols.some((c) => c.name === from) &&
+      tcols.some((c) => c.name === to)
+    ) {
+      orphanDrops.push(`ALTER TABLE tool_calls DROP COLUMN ${from};`);
+    }
+  }
+  let out = migration.replace(
     /ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)\b[^;]*;/gi,
     (match, table, column) => {
       const cols = database
         .query(`PRAGMA table_info(${table})`)
         .all() as Array<{ name: string }>;
-      if (cols.some((c) => c.name === column)) return ""; // already exists
-      return match; // keep — this ALTER hasn't been applied
+      if (cols.some((c) => c.name === column)) return "";
+      const aliased = renamedInto[column];
+      if (aliased && cols.some((c) => c.name === aliased)) return "";
+      return match;
     },
   );
+  // RENAME COLUMN: strip if the target column already exists (the rename
+  // was already applied in a prior run). The orphan DROP above handles the
+  // `hasFrom && hasTo` case before the RENAME is reached.
+  out = out.replace(
+    /ALTER\s+TABLE\s+(\w+)\s+RENAME\s+COLUMN\s+(\w+)\s+TO\s+(\w+)\s*;/gi,
+    (match, table, from, to) => {
+      const cols = database
+        .query(`PRAGMA table_info(${table})`)
+        .all() as Array<{ name: string }>;
+      const hasFrom = cols.some((c) => c.name === from);
+      const hasTo = cols.some((c) => c.name === to);
+      // Already in the desired state: strip the rename (it's a no-op).
+      if (hasTo && !hasFrom) return "";
+      // Both present: the orphan DROP (above) will remove `from` first when
+      // the prepended statements run; the RENAME itself is still a no-op
+      // because the target already exists. Strip to avoid the
+      // `duplicate column name: <to>` throw.
+      if (hasTo && hasFrom) return "";
+      return match;
+    },
+  );
+  return orphanDrops.length > 0 ? orphanDrops.join(" ") + " " + out : out;
 }
 
 /**
@@ -3391,11 +3472,32 @@ function recoverMissingObjects(database: Database) {
     if (!tcols.some((c) => c.name === "verifier")) {
       database.exec("ALTER TABLE tool_calls ADD COLUMN verifier INTEGER;");
     }
-    // Version 75: tool_calls.input_path (file provenance, #627 Step 1 / D2c).
-    // Same recovery rationale as verifier — CREATE TABLE IF NOT EXISTS cannot
-    // add a missing column to a pre-existing table.
-    if (!tcols.some((c) => c.name === "input_path")) {
-      database.exec("ALTER TABLE tool_calls ADD COLUMN input_path TEXT;");
+    // Version 76: tool_calls.input_paths_json (rename + widen to JSON array).
+    // A DB that was created on v75 has `input_path`; one created on v76 (or
+    // fully migrated) has `input_paths_json`. We need to end up with
+    // `input_paths_json` present in both cases. SQLite ≥3.25 supports
+    // RENAME COLUMN, so an in-place rename is safe. The v75 recovery is
+    // subsumed: a DB with neither column now gets `input_paths_json` added
+    // directly (no need for a separate v75 ADD COLUMN step). If a DB has
+    // BOTH columns (an aborted v75→v76 mid-apply, or a manual sidecar
+    // ADD), the v75 ADD ran but the v76 RENAME didn't complete — drop the
+    // orphan `input_path` so the schema converges to the post-rename
+    // state. The migration loop's `stripAppliedAlters` also handles this
+    // case (prepending an orphan-DROP); this block is a safety net for DBs
+    // that arrive at v76 already (e.g. opened by an older binary that ran
+    // a partial migration, then re-opened here).
+    if (tcols.some((c) => c.name === "input_path")) {
+      if (tcols.some((c) => c.name === "input_paths_json")) {
+        // Both present — drop the orphan. SQLite ≥3.35 supports
+        // DROP COLUMN. (Node ≥22.5 ships SQLite ≥3.46; Bun bundles ≥3.50.)
+        database.exec("ALTER TABLE tool_calls DROP COLUMN input_path;");
+      } else {
+        database.exec(
+          "ALTER TABLE tool_calls RENAME COLUMN input_path TO input_paths_json;",
+        );
+      }
+    } else if (!tcols.some((c) => c.name === "input_paths_json")) {
+      database.exec("ALTER TABLE tool_calls ADD COLUMN input_paths_json TEXT;");
     }
   }
   // Version 54: knowledge_session_injections.verdict (outcome impact, #497).

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -7,7 +7,7 @@ import * as log from "./log";
 import * as embedding from "./embedding";
 import {
   classifyToolError,
-  extractFilePath,
+  extractFilePaths,
   isVerifierCall,
   MAX_ERROR_MESSAGE_LEN,
 } from "./tool-trace";
@@ -202,7 +202,7 @@ export function recordToolCalls(input: {
       const batch = seeds.slice(i, i + CHUNK);
       const seedStmt = db().query(
         `INSERT INTO tool_calls
-           (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier, input_path)
+           (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier, input_paths_json)
          VALUES ${Array.from({ length: batch.length }, () => rowSql).join(", ")}
          ON CONFLICT(call_id) DO UPDATE SET
            status = CASE WHEN tool_calls.status = 'pending' THEN excluded.status ELSE tool_calls.status END,
@@ -212,13 +212,18 @@ export function recordToolCalls(input: {
            -- verifier is derived from the tool_use input (stable across re-seeds);
            -- keep the first non-null classification.
            verifier = COALESCE(tool_calls.verifier, excluded.verifier),
-           -- input_path is likewise derived from the (stable) tool_use input;
-           -- keep the first non-null path so a re-seed never clobbers it.
-           input_path = COALESCE(tool_calls.input_path, excluded.input_path)`,
+           -- input_paths_json is likewise derived from the (stable) tool_use
+           -- input (file paths extracted from object/JSON/plaintext/bash shapes);
+           -- keep the first non-null value so a re-seed never clobbers it. The
+           -- column is a JSON-encoded string[] (see #1424 / v76) so D2c PR-2 can
+           -- union the session's touched files without re-parsing.
+           input_paths_json = COALESCE(tool_calls.input_paths_json, excluded.input_paths_json)`,
       );
       const params: Array<string | number | null> = [];
       for (const p of batch) {
         const outcome = toolOutcome(p.tool, p.state);
+        const paths = extractFilePaths(p.state.input);
+        const inputPathsJson = paths.length > 0 ? JSON.stringify(paths) : null;
         params.push(
           p.callID,
           input.info.id,
@@ -231,7 +236,7 @@ export function recordToolCalls(input: {
           outcome.duration,
           createdAt,
           isVerifierCall(p.state.input) ? 1 : 0,
-          extractFilePath(p.state.input) ?? null,
+          inputPathsJson,
         );
       }
       seedStmt.run(...params);

--- a/packages/core/src/tool-trace.ts
+++ b/packages/core/src/tool-trace.ts
@@ -21,6 +21,7 @@
  */
 
 import { db, ensureProject } from "./db";
+import { parse as parseBash } from "unbash";
 
 // ---------------------------------------------------------------------------
 // Error classification
@@ -190,39 +191,358 @@ const PATH_FALLBACK_RE = /(?:[\w.-]+\/)+[\w.-]+\.\w{1,5}/;
 const PATH_SCAN_LIMIT = 8192;
 const PATH_TOKEN_MAX = 260; // generous vs the 255-char component limit on most FSes
 
+// Commands whose positional arguments are file paths. We don't try to be
+// comprehensive — `cat`, `tee`, `cp`, `mv`, `rm`, `head`, `tail`, `less`,
+// `more`, `wc`, `stat`, `file`, `touch`, `chmod`, `chown`, `mkdir`, `rmdir`,
+// `dirname`, `basename`, `realpath`, `readlink`, `source`, `.` cover the vast
+// majority of agent bash that touches files. Deliberately excluded:
+//   - `sed`, `awk`, `gawk`: their first non-flag arg is a SCRIPT (e.g.
+//     `sed 's/x/y/' file`), not a file. Distinguishing the script from the
+//     file operand requires a per-tool option table we don't have — missing
+//     these is the safe direction.
+//   - `grep`, `egrep`, `fgrep`, `rg`: their first non-flag arg is a PATTERN
+//     (e.g. `grep foo file`), not a file. Same trade-off.
+//   - `[`, `test`: builtin test expression; argument shape varies (`[ -f file ]`
+//     vs `[ file1 -ef file2 ]`).
+// For unknown commands, redirect targets (handled below) still surface the
+// touched files. This is provenance-only and best-effort — a miss is always
+// safe.
+const FILE_OPERAND_COMMANDS = new Set([
+  "cat",
+  "tee",
+  "cp",
+  "mv",
+  "rm",
+  "ln",
+  "install",
+  "head",
+  "tail",
+  "less",
+  "more",
+  "wc",
+  "stat",
+  "file",
+  "touch",
+  "chmod",
+  "chown",
+  "mkdir",
+  "rmdir",
+  "dirname",
+  "basename",
+  "realpath",
+  "readlink",
+  "source",
+  ".",
+]);
+
 /**
- * Best-effort extraction of the source-file path a tool call acted on, from its
- * `input` (host-shaped, hence `unknown`). Handles the common file-tool shapes
- * (`{ path }` / `{ filePath }` / `{ file }` — the keys used by Read/Edit/Write/
- * read_file/edit_file/write_to_file across hosts), a JSON string of the same,
- * and a plain-text path fallback. Returns undefined when no path is recoverable
- * (bash/grep/task/etc.), so the caller stores NULL. This is provenance only —
- * a best-effort signal, never load-bearing, so a miss is always safe.
+ * Heuristic: is a Word a literal-or-quoted (no expansion) single token safe to
+ * treat as a file path? unbash breaks words into `parts` (Literal, SingleQuoted,
+ * CommandExpansion, ParameterExpansion, etc.). A word containing expansions
+ * (`$1`, `$(cmd)`, `~`, `${var}`) cannot be resolved to a file path statically,
+ * so we skip it. This bounds the AST walk to safely-extractable operands.
  */
-export function extractFilePath(input: unknown): string | undefined {
-  const fromObject = (o: Record<string, unknown>): string | undefined => {
+function isStaticLiteralWord(word: {
+  text: string;
+  value: string;
+  parts?: ReadonlyArray<{ type: string }>;
+}): boolean {
+  if (word.text.length === 0 || word.text.length > PATH_TOKEN_MAX) return false;
+  if (/\s/.test(word.text)) return false;
+  // Tilde is a runtime expansion (home directory) even though unbash doesn't
+  // tag it with a part type — skip it.
+  if (word.text.startsWith("~")) return false;
+  // Glob metacharacters are runtime expansions of the shell. unbash does NOT
+  // tag them with a part type (it doesn't model pathname expansion), so the
+  // `parts: undefined` lazy-getter fallback below would otherwise treat a
+  // `src/*.ts` literal as a static path-shaped token and surface it as a
+  // touched file. Reject up front.
+  if (/[*?[\]]/.test(word.text)) return false;
+  if (!word.parts || word.parts.length === 0) return true; // unbash lazy getter; fall back to text
+  for (const p of word.parts) {
+    // The runtime type discriminator is "SingleQuoted" (the interface name
+    // SingleQuotedPart is just the TS name for the same shape; verify
+    // unbash/types.d.ts). Any other part type — CommandExpansion,
+    // ParameterExpansion, ArithmeticExpansion, ProcessSubstitution — is a
+    // runtime expansion we cannot resolve.
+    if (p.type === "Literal" || p.type === "SingleQuoted") continue;
+    // DoubleQuoted is a wrapper around a child-part list. Accept iff every
+    // child is a literal (no `$VAR`, `$(…)`, `${…}`). This makes
+    // `cat "src/a.ts"` work (purely literal double-quoted path) while still
+    // rejecting `cat "$HOME/src/a.ts"` (SimpleExpansion inside).
+    if (p.type === "DoubleQuoted") {
+      const inner = (p as { parts?: ReadonlyArray<{ type: string }> }).parts;
+      if (!inner || inner.length === 0) continue;
+      if (inner.every((c) => c.type === "Literal")) continue;
+      return false;
+    }
+    return false;
+  }
+  return true;
+}
+
+function cleanPathToken(s: string): string | undefined {
+  // For the AST walk we want SOME shape constraint so a literal word like
+  // "foo" (a pattern, a variable name, a flag value) isn't mistaken for a
+  // touched file. We accept: anything with a `/` (definite path), or a
+  // bare name with a dotted extension like `db.ts` / `out.log` (looks like
+  // a file). Words with no slash and no extension are not path-like.
+  // The plaintext regex fallback (PATH_FALLBACK_RE) is a separate concern —
+  // there we keep the strict slash requirement (prose risk).
+  if (s.length === 0 || s.length > PATH_TOKEN_MAX || /\s/.test(s)) {
+    return undefined;
+  }
+  if (s.includes("/")) return s;
+  // Bare name with a dotted extension of 1-5 trailing letters.
+  if (/^[^.]+\.[A-Za-z]{1,5}$/.test(s)) return s;
+  return undefined;
+}
+
+/**
+ * Best-effort extraction of the source-file paths a tool call acted on, from a
+ * bash command string. Uses `unbash` (webpro-nl/unbash, zero-dep, tolerant
+ * parser) to walk the AST. Returns the union of:
+ *
+ *   1. **Redirect targets** for file-touching operators (`>`, `>>`, `<`, `<>`,
+ *      `>|`, `>&`, `>>`-family, `<&`). A command like `echo x > out.ts` touches
+ *      `out.ts` even though `out.ts` is not a positional operand.
+ *   2. **Positional operands** of commands in FILE_OPERAND_COMMANDS
+ *      (`cat`, `sed`, `awk`, `grep`, `tee`, `cp`, `mv`, …) that look like paths
+ *      (non-empty, contain a `/`, no whitespace, within PATH_TOKEN_MAX).
+ *
+ * Words containing parameter/command/arithmetic expansions (`$1`, `$(cmd)`, `~`,
+ * `${var}`) are skipped — we can't statically resolve them. The result is
+ * de-duplicated while preserving first-seen order.
+ *
+ * This is **provenance only** — best-effort, never load-bearing, so a miss is
+ * always safe.
+ */
+export function extractFilePathsFromCommand(cmd: string): string[] {
+  if (typeof cmd !== "string" || cmd.length === 0) return [];
+  // Bound the input — a pathological multi-KB command shouldn't traverse the
+  // AST for ages on the request path. Truncation can only drop matches
+  // (safe direction).
+  const slice = cmd.slice(0, PATH_SCAN_LIMIT);
+  let ast: ReturnType<typeof parseBash>;
+  try {
+    ast = parseBash(slice);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (raw: string | undefined) => {
+    const clean = cleanPathToken(raw ?? "");
+    if (clean && !seen.has(clean)) {
+      seen.add(clean);
+      out.push(clean);
+    }
+  };
+
+  // Walk every command node reachable in the AST, surfacing redirect targets
+  // and file-operand positional args. unbash models control flow as nested
+  // commands inside If/While/For/Subshell/etc., so a generic visit collects
+  // every reachable Command node without bespoke per-construct handling.
+  // We also surface `redirects` at every node level — unbash carries
+  // trailing redirects on the OUTER node, not on the inner Command, for
+  // compound constructs like `(cat a) > out.ts`, `for … done > out.ts`,
+  // `if … fi > out.ts`, and `function foo { … } > log`.
+  const FILE_TOUCHING_REDIRECT_OPS = new Set([
+    ">",
+    ">>",
+    "<",
+    "<>",
+    ">|",
+    ">&",
+    "<&",
+    // bash 4+ "redirect stdout AND stderr to file" shorthand, equivalent to
+    // `> file 2>&1`. Common in modern scripts and CI configs.
+    "&>",
+    "&>>",
+  ]);
+  const processRedirects = (
+    redirects:
+      | ReadonlyArray<{
+          operator: string;
+          target?: {
+            text: string;
+            value: string;
+            parts?: ReadonlyArray<{ type: string }>;
+          };
+        }>
+      | undefined,
+  ): void => {
+    if (!redirects) return;
+    for (const r of redirects) {
+      // Heredoc (`<<`, `<<-`) and herestring (`<<<`) targets are delimiters
+      // or inline content, NOT file paths.
+      if (!FILE_TOUCHING_REDIRECT_OPS.has(r.operator)) continue;
+      if (r.target && isStaticLiteralWord(r.target)) push(r.target.value);
+    }
+  };
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== "object") return;
+    const n = node as {
+      type?: string;
+      // Command fields:
+      name?: {
+        text: string;
+        value: string;
+        parts?: ReadonlyArray<{ type: string }>;
+      };
+      suffix?: ReadonlyArray<{
+        text: string;
+        value: string;
+        parts?: ReadonlyArray<{ type: string }>;
+      }>;
+      redirects?: ReadonlyArray<{
+        operator: string;
+        target?: {
+          text: string;
+          value: string;
+          parts?: ReadonlyArray<{ type: string }>;
+        };
+      }>;
+      // Statement wraps a single command in `command` (e.g. `cat a` is
+      // Statement{ command: Command{ … } }). CompoundList wraps multiple
+      // statements in `commands: Statement[]`.
+      command?: unknown;
+      commands?: ReadonlyArray<unknown>;
+      clause?: unknown;
+      then?: unknown;
+      elif?: ReadonlyArray<{ clause?: unknown; then?: unknown }>;
+      else?: unknown;
+      body?: unknown;
+      do?: unknown;
+      done?: unknown;
+      // For: the iterated wordlist.
+      wordlist?: ReadonlyArray<{
+        text: string;
+        value: string;
+        parts?: ReadonlyArray<{ type: string }>;
+      }>;
+      // Case: items[i].body is a CompoundList of Statements.
+      items?: ReadonlyArray<{ body?: unknown }>;
+    };
+    if (n.type === "Command") {
+      processRedirects(n.redirects);
+      const cmdName = n.name?.text.split(/\s+/)[0] ?? "";
+      if (FILE_OPERAND_COMMANDS.has(cmdName)) {
+        let skipNext = false;
+        for (const w of n.suffix ?? []) {
+          if (skipNext) {
+            skipNext = false;
+            continue;
+          }
+          if (!isStaticLiteralWord(w)) continue;
+          if (w.text.startsWith("-")) {
+            // Eat the next token for long-form options that take an argument,
+            // e.g. `--file FILE` (used by `sed -i` style).
+            if (/^--(?:file|in-place)(?:=.*)?$/.test(w.text)) skipNext = true;
+            continue;
+          }
+          // Use `w.value` (strips quote characters) rather than `w.text` so
+          // single-quoted paths like `'src/a.ts'` land in the DB as the
+          // unquoted path.
+          push(w.value);
+        }
+      }
+      return;
+    }
+    if (n.type === "Statement") {
+      // Trailing redirect on a compound: `(cat a) > out.ts`,
+      // `for … done > out.ts`, `if … fi > out.ts`, `function foo { … } > log`.
+      processRedirects(n.redirects);
+      if (n.command) visit(n.command);
+    }
+    // For: `for f in src/a.ts src/b.ts; do cat $f; done` — the wordlist is
+    // a static set of path candidates; each is a touched file.
+    if (n.type === "For" && n.wordlist) {
+      for (const w of n.wordlist) {
+        if (isStaticLiteralWord(w)) push(w.value);
+      }
+    }
+    // Function/Coproc carry their own redirects.
+    if (n.type === "Function" || n.type === "Coproc") {
+      processRedirects(n.redirects);
+    }
+    // Generic descent for control flow and compound lists.
+    if (n.commands) for (const c of n.commands) visit(c);
+    if (n.clause) visit(n.clause);
+    if (n.then) visit(n.then);
+    if (n.else) visit(n.else);
+    for (const ei of n.elif ?? []) {
+      if (ei.clause) visit(ei.clause);
+      if (ei.then) visit(ei.then);
+    }
+    if (n.body) visit(n.body);
+    if (n.do) visit(n.do);
+    if (n.done) visit(n.done);
+    // Case: items[i].body is a CompoundList of Statements.
+    if (n.items) {
+      for (const it of n.items) {
+        if (it && typeof it === "object" && it.body) visit(it.body);
+      }
+    }
+  };
+
+  for (const stmt of ast.commands ?? []) {
+    visit(stmt);
+  }
+  return out;
+}
+
+/**
+ * Best-effort extraction of the source-file paths a tool call acted on, from
+ * its `input` (host-shaped, hence `unknown`). Returns an array of unique
+ * file paths in first-seen order. The multi-path shape matters because a
+ * single bash command (e.g. `cat a.ts b.ts`) or a tool_use with several path
+ * keys can touch N files — the union is what D2c PR-2 needs to associate a
+ * knowledge entry with the session's touched files.
+ *
+ *   - Object input: read `path` / `filePath` / `file` (single).
+ *   - JSON string of the same object/array shape: parse + same logic.
+ *   - Plain-text path-like token in a raw string: same heuristic as v75.
+ *   - Bash command string: \`extractFilePathsFromCommand\` (unbash AST walk).
+ *
+ * Returns [] when no path is recoverable (e.g. plain bash that doesn't touch
+ * files, grep, task, …). This is provenance only — a miss is always safe.
+ */
+export function extractFilePaths(input: unknown): string[] {
+  const fromObject = (o: Record<string, unknown>): string[] => {
     for (const key of ["path", "filePath", "file"] as const) {
       const v = o[key];
-      if (typeof v === "string" && v.length > 0) return v;
+      if (typeof v === "string" && v.length > 0) return [v];
     }
-    return undefined;
+    return [];
   };
   if (input && typeof input === "object") {
-    return fromObject(input as Record<string, unknown>);
+    const arr = fromObject(input as Record<string, unknown>);
+    if (arr.length) return arr;
+    // Object with a `command`/`cmd` field → fall through to command parsing.
+    const cmd = extractCommand(input);
+    if (cmd) return extractFilePathsFromCommand(cmd);
+    return [];
   }
   if (typeof input === "string") {
     try {
       const parsed = JSON.parse(input);
       if (parsed && typeof parsed === "object") {
-        return fromObject(parsed as Record<string, unknown>);
+        const arr = fromObject(parsed as Record<string, unknown>);
+        if (arr.length) return arr;
+        const cmd = extractCommand(parsed);
+        if (cmd) return extractFilePathsFromCommand(cmd);
+        return [];
       }
     } catch {
       // not JSON — fall through to the plain-text path heuristic
     }
     // The fallback regex requires a `/`; a `/`-free string can never match.
-    if (input.indexOf("/") === -1) return undefined;
+    if (input.indexOf("/") === -1) return [];
     // Bound the scan, then run the backtracking regex only on short,
     // whitespace-bounded tokens (see PATH_SCAN_LIMIT/PATH_TOKEN_MAX notes).
+    const out: string[] = [];
+    const seen = new Set<string>();
     for (const token of input.slice(0, PATH_SCAN_LIMIT).split(/\s+/)) {
       if (
         token.length === 0 ||
@@ -232,11 +552,14 @@ export function extractFilePath(input: unknown): string | undefined {
         continue;
       }
       const match = token.match(PATH_FALLBACK_RE)?.[0];
-      if (match) return match;
+      if (match && !seen.has(match)) {
+        seen.add(match);
+        out.push(match);
+      }
     }
-    return undefined;
+    return out;
   }
-  return undefined;
+  return [];
 }
 
 /**

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -119,7 +119,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(75);
+    expect(row.version).toBe(76);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -176,7 +176,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(75);
+    expect(ver.version).toBe(76);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh
@@ -188,6 +188,32 @@ describe("db", () => {
     expect(() =>
       fresh.query("SELECT confidence FROM knowledge_current LIMIT 1").all(),
     ).not.toThrow();
+  });
+
+  test("v75/v76: both-columns state (partial v75→v76) converges on re-open", () => {
+    // Regression for B1 (adversarial review of #1504): a DB that has BOTH
+    // `input_path` AND `input_paths_json` (e.g. a partial v75→v76 mid-apply
+    // or a manual sidecar ADD) used to crash the gateway on re-open with
+    // `duplicate column name: input_paths_json`. The migration loop must
+    // converge the schema to the post-rename state (only `input_paths_json`)
+    // and normalize the version to MIGRATIONS.length.
+    const d = db();
+    // Simulate the partial state: input_path was added by v75, then a
+    // manual ADD COLUMN input_paths_json (or a re-apply that half-succeeded).
+    d.exec("ALTER TABLE tool_calls ADD COLUMN input_path TEXT;");
+    d.exec("UPDATE schema_version SET version = 54");
+    close();
+    const fresh = db();
+    const tcols = fresh.query("PRAGMA table_info(tool_calls)").all() as Array<{
+      name: string;
+    }>;
+    const names = tcols.map((c) => c.name);
+    expect(names).toContain("input_paths_json");
+    expect(names).not.toContain("input_path");
+    const ver = fresh.query("SELECT version FROM schema_version").get() as {
+      version: number;
+    };
+    expect(ver.version).toBe(76);
   });
 
   test("v56: knowledge_ref_validity table + projects.last_refcheck_at exist after recovery", () => {

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 75", () => {
+  test("schema version is 76", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(75);
+    expect(v.version).toBe(76);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/tool-file-provenance.test.ts
+++ b/packages/core/test/tool-file-provenance.test.ts
@@ -1,58 +1,63 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { db, ensureProject } from "../src/db";
 import * as temporal from "../src/temporal";
-import { extractFilePath } from "../src/tool-trace";
+import {
+  extractFilePaths,
+  extractFilePathsFromCommand,
+} from "../src/tool-trace";
 import type { LoreMessage, LorePart } from "../src/types";
 
-// D2c PR-1 (#627 Step 1): capture the source-file path a tool call acted on into
-// tool_calls.input_path — session→file provenance, the substrate for associating
-// knowledge entries with the files that produced them.
+// D2c PR-1 (v75) captured a single path per tool call into tool_calls.input_path.
+// D2c PR-1b (v76) widens it to a JSON-encoded string[] (input_paths_json) so a
+// single bash command (cat a b c, sed -i a, > b, tee d …) can carry all the
+// files it touched. The session's touched files = the union over its tool calls.
 
-describe("extractFilePath", () => {
+describe("extractFilePaths", () => {
   test("reads path from an object input ({ path })", () => {
-    expect(extractFilePath({ path: "src/auth/jwt.ts" })).toBe(
+    expect(extractFilePaths({ path: "src/auth/jwt.ts" })).toEqual([
       "src/auth/jwt.ts",
-    );
+    ]);
   });
 
   test("reads filePath and file keys", () => {
-    expect(extractFilePath({ filePath: "a/b.ts" })).toBe("a/b.ts");
-    expect(extractFilePath({ file: "c/d.ts" })).toBe("c/d.ts");
+    expect(extractFilePaths({ filePath: "a/b.ts" })).toEqual(["a/b.ts"]);
+    expect(extractFilePaths({ file: "c/d.ts" })).toEqual(["c/d.ts"]);
   });
 
   test("prefers path over filePath over file", () => {
     expect(
-      extractFilePath({ path: "p.ts", filePath: "fp.ts", file: "f.ts" }),
-    ).toBe("p.ts");
-    expect(extractFilePath({ filePath: "fp.ts", file: "f.ts" })).toBe("fp.ts");
+      extractFilePaths({ path: "p.ts", filePath: "fp.ts", file: "f.ts" }),
+    ).toEqual(["p.ts"]);
+    expect(extractFilePaths({ filePath: "fp.ts", file: "f.ts" })).toEqual([
+      "fp.ts",
+    ]);
   });
 
   test("parses a JSON string input", () => {
-    expect(extractFilePath('{"path":"src/x.ts"}')).toBe("src/x.ts");
+    expect(extractFilePaths('{"path":"src/x.ts"}')).toEqual(["src/x.ts"]);
   });
 
   test("falls back to a path-like token in a plain-text string", () => {
-    expect(extractFilePath("editing packages/core/src/db.ts now")).toBe(
+    expect(extractFilePaths("editing packages/core/src/db.ts now")).toEqual([
       "packages/core/src/db.ts",
-    );
+    ]);
   });
 
-  test("returns undefined for non-file tool inputs", () => {
-    expect(extractFilePath({ command: "pnpm test" })).toBeUndefined();
-    expect(extractFilePath({ pattern: "TODO" })).toBeUndefined();
-    expect(extractFilePath("just some prose with no path")).toBeUndefined();
-    expect(extractFilePath(null)).toBeUndefined();
-    expect(extractFilePath(undefined)).toBeUndefined();
-    expect(extractFilePath(42)).toBeUndefined();
+  test("returns [] for non-file tool inputs", () => {
+    expect(extractFilePaths({ pattern: "TODO" })).toEqual([]);
+    expect(extractFilePaths("just some prose with no path")).toEqual([]);
+    expect(extractFilePaths(null)).toEqual([]);
+    expect(extractFilePaths(undefined)).toEqual([]);
+    expect(extractFilePaths(42)).toEqual([]);
   });
 
   test("ignores an empty-string path", () => {
-    expect(extractFilePath({ path: "" })).toBeUndefined();
+    expect(extractFilePaths({ path: "" })).toEqual([]);
   });
 
   test("a `/`-free string is skipped without running the regex", () => {
     // No slash → cannot be a path → cheap early return (also the ReDoS skip).
-    expect(extractFilePath("no slashes here just prose words")).toBeUndefined();
+    expect(extractFilePaths("no slashes here just prose words")).toEqual([]);
   });
 
   test("does not stall on a pathological long slash-run (ReDoS guard)", () => {
@@ -61,10 +66,261 @@ describe("extractFilePath", () => {
     // length cap + slash skip this must return promptly, not hang.
     const evil = `${"a/".repeat(50_000)}bbbbbbbbbbbb`;
     const start = Date.now();
-    const result = extractFilePath(evil);
+    const result = extractFilePaths(evil);
     const elapsed = Date.now() - start;
-    expect(result).toBeUndefined();
+    expect(result).toEqual([]);
     expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("dispatches a `{ command }` object to the bash walker", () => {
+    expect(extractFilePaths({ command: "cat src/a.ts src/b.ts" })).toEqual([
+      "src/a.ts",
+      "src/b.ts",
+    ]);
+  });
+
+  test("dispatches a JSON-string `command` field to the bash walker", () => {
+    expect(extractFilePaths('{"command":"cat src/c.ts"}')).toEqual([
+      "src/c.ts",
+    ]);
+  });
+});
+
+describe("extractFilePathsFromCommand (bash, unbash AST walk)", () => {
+  test("cat with multiple operands", () => {
+    expect(extractFilePathsFromCommand("cat src/a.ts src/b.ts")).toEqual([
+      "src/a.ts",
+      "src/b.ts",
+    ]);
+  });
+
+  test("redirects: `>` and `>>` targets are file paths", () => {
+    expect(extractFilePathsFromCommand("echo x > out.ts")).toEqual(["out.ts"]);
+    expect(extractFilePathsFromCommand("echo x >> log/append.txt")).toEqual([
+      "log/append.txt",
+    ]);
+  });
+
+  test("input redirect `< file` is a file path", () => {
+    expect(extractFilePathsFromCommand("sort < data/inputs.csv")).toEqual([
+      "data/inputs.csv",
+    ]);
+  });
+
+  test("tee operand is a file path", () => {
+    expect(extractFilePathsFromCommand("tee build/out.bin")).toEqual([
+      "build/out.bin",
+    ]);
+  });
+
+  test("chained: `&&` and `;` — both commands contribute (union, order-agnostic)", () => {
+    // Note: within a single compound command (`cat y > out`) we report the
+    // redirect target AFTER the operands, but when a command CHAIN crosses
+    // multiple Commands, the visitor order interleaves redirects from later
+    // Commands with operands from earlier ones. We only require that the SET
+    // of touched files is correct — provenance is a bag, not a sequence.
+    expect(
+      new Set(
+        extractFilePathsFromCommand("rm old/x.ts && cat src/y.ts > out.ts"),
+      ),
+    ).toEqual(new Set(["old/x.ts", "src/y.ts", "out.ts"]));
+  });
+
+  test("pipe: redirect target on the LAST stage surfaces", () => {
+    // `cat src/in.ts | wc -l > out/match.ts` — wc (not grep) as the second
+    // stage so the visitor doesn't pick up the pattern-looking word.
+    expect(
+      new Set(
+        extractFilePathsFromCommand("cat src/in.ts | wc -l > out/match.ts"),
+      ),
+    ).toEqual(new Set(["src/in.ts", "out/match.ts"]));
+  });
+
+  test("skip flags (`-i`, `--color=auto`, etc.)", () => {
+    // `cat` is the simplest case: `-n` is a flag, operands are files.
+    expect(extractFilePathsFromCommand("cat -n src/a.ts src/b.ts")).toEqual([
+      "src/a.ts",
+      "src/b.ts",
+    ]);
+    // `rm` with a short flag cluster.
+    expect(extractFilePathsFromCommand("rm -rf build/")).toEqual(["build/"]);
+  });
+
+  test("`--in-place` and `--file` style long-opts are not relevant (sed/awk excluded)", () => {
+    // We don't model per-tool option tables. The token-eating behavior is only
+    // relevant for commands whose long-opts take a value — sed/awk have one,
+    // but they're excluded (their first non-flag is a script, not a file).
+    // For the commands we DO support (cat/tee/cp/mv/rm/…), no long-opt takes
+    // a value that looks like a path, so we can skip the next token safely.
+    expect(extractFilePathsFromCommand("cat --number src/a.ts")).toEqual([
+      "src/a.ts",
+    ]);
+  });
+
+  test("non-file-command positional args are skipped", () => {
+    // `cd` / `export` / `echo` take no file operands; only their redirect
+    // targets (if any) are paths.
+    expect(extractFilePathsFromCommand("cd /tmp")).toEqual([]);
+    expect(extractFilePathsFromCommand("echo done")).toEqual([]);
+  });
+
+  test("de-duplicates while preserving first-seen order", () => {
+    expect(
+      extractFilePathsFromCommand("cat a/x.ts; cat a/x.ts; cat a/x.ts"),
+    ).toEqual(["a/x.ts"]);
+    expect(extractFilePathsFromCommand("cat a.ts; cat b.ts; cat a.ts")).toEqual(
+      ["a.ts", "b.ts"],
+    );
+  });
+
+  test("expansions (`$1`, `$(cmd)`, `~`) are skipped — we can't resolve them", () => {
+    // The expansion makes the word non-static, so we skip it.
+    expect(extractFilePathsFromCommand("cat $1")).toEqual([]);
+    expect(extractFilePathsFromCommand("cat $(echo src/a.ts)")).toEqual([]);
+    expect(extractFilePathsFromCommand("cat ~/a.ts")).toEqual([]);
+  });
+
+  test("bare relative file operands (no `/`) are valid for AST-derived words", () => {
+    // A literal `cat db.ts` is a valid relative-path touched file. The slash
+    // requirement lives only in the plaintext regex fallback (prose risk); the
+    // AST walk knows the token came from a real shell construct.
+    expect(extractFilePathsFromCommand("cat db.ts")).toEqual(["db.ts"]);
+  });
+
+  test("control flow: `for … do … done` recurses into the body and wordlist", () => {
+    // The `for` wordlist (src/a.ts, src/b.ts) is a set of static file paths;
+    // each is a touched file. The `cat $f` body is skipped because $f expands.
+    expect(
+      extractFilePathsFromCommand(
+        "for f in src/a.ts src/b.ts; do cat $f; done",
+      ),
+    ).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  test("B2: brace-list body is walked", () => {
+    // `{ cat a.ts; cat b.ts; }` is a compound list — each statement's
+    // command must be visited, not just the outer wrapper.
+    expect(extractFilePathsFromCommand("{ cat a.ts; cat b.ts; }")).toEqual([
+      "a.ts",
+      "b.ts",
+    ]);
+  });
+
+  test("B2: subshell redirect surfaces both operand and target (set-equal)", () => {
+    // `(cat a.ts) > out.ts` — the trailing redirect lives on the outer
+    // Statement, not the inner Command.
+    expect(new Set(extractFilePathsFromCommand("(cat a.ts) > out.ts"))).toEqual(
+      new Set(["a.ts", "out.ts"]),
+    );
+  });
+
+  test("B2: `if … fi > out.ts` surfaces the body and the trailing redirect", () => {
+    expect(
+      new Set(
+        extractFilePathsFromCommand("if true; then cat a.ts; fi > out.ts"),
+      ),
+    ).toEqual(new Set(["a.ts", "out.ts"]));
+  });
+
+  test("B2: `while … done < input.ts > out.ts` surfaces both redirects", () => {
+    expect(
+      new Set(
+        extractFilePathsFromCommand(
+          "while read l; do echo $l; done < input.ts > out.ts",
+        ),
+      ),
+    ).toEqual(new Set(["input.ts", "out.ts"]));
+  });
+
+  test("B2: function body is walked", () => {
+    expect(extractFilePathsFromCommand("function f { cat a.ts; }; f")).toEqual([
+      "a.ts",
+    ]);
+  });
+
+  test("B3: single-quoted paths are accepted and the quote is stripped", () => {
+    // B3 was a type-discriminator typo (`SingleQuotedPart` vs `SingleQuoted`)
+    // AND pushing `w.text` (with quotes) instead of `w.value` (without).
+    expect(extractFilePathsFromCommand("cat 'db.ts'")).toEqual(["db.ts"]);
+    expect(extractFilePathsFromCommand("cat 'src/a.ts'")).toEqual(["src/a.ts"]);
+  });
+
+  test("S1: glob metacharacters are NOT treated as literal paths", () => {
+    // unbash doesn't tag glob expansions with a part type, so the
+    // `parts: undefined` lazy-getter fallback would otherwise treat
+    // `src/*` as a static path-shaped token. The glob guard rejects it.
+    expect(extractFilePathsFromCommand("cat src/*")).toEqual([]);
+    expect(extractFilePathsFromCommand("cat src/*.ts")).toEqual([]);
+    expect(extractFilePathsFromCommand("cat [abc].ts")).toEqual([]);
+    expect(extractFilePathsFromCommand("cat src/file?.ts")).toEqual([]);
+  });
+
+  test("S2: heredoc/herestring targets are NOT file paths", () => {
+    // `<<data.txt` target is the heredoc delimiter; `<<<` target is inline
+    // content. Both must be skipped, not pushed as a path.
+    expect(extractFilePathsFromCommand("cat <<data.txt")).toEqual([]);
+    expect(extractFilePathsFromCommand('cat <<<"hi there"')).toEqual([]);
+  });
+
+  test("S3: Case clause bodies are walked", () => {
+    // The pattern `*.ts) cat src/a.ts ;; esac` puts the body command inside
+    // `items[i].body`, which the visitor must descend into.
+    expect(
+      extractFilePathsFromCommand("case $x in *.ts) cat src/a.ts ;; esac"),
+    ).toEqual(["src/a.ts"]);
+  });
+
+  test("N2: function-level redirect is surfaced", () => {
+    // `function foo { … } > log.txt` — the trailing redirect lives on the
+    // outer Function node, not the inner Command.
+    expect(
+      new Set(
+        extractFilePathsFromCommand("function foo { cat a.ts; } > log.txt"),
+      ),
+    ).toEqual(new Set(["a.ts", "log.txt"]));
+  });
+
+  test("re-review: double-quoted purely-literal path is accepted", () => {
+    // SHOULD-FIX-1 (re-review): `DoubleQuoted` with all-`Literal` children
+    // must be accepted (bash strips quotes; the path is real).
+    expect(extractFilePathsFromCommand('cat "src/a.ts"')).toEqual(["src/a.ts"]);
+    expect(extractFilePathsFromCommand('cat "db.ts"')).toEqual(["db.ts"]);
+  });
+
+  test("re-review: double-quoted path with $VAR is rejected", () => {
+    // `cat "$HOME/src/a.ts"` — DoubleQuoted with a SimpleExpansion child.
+    // Should NOT be surfaced as a static path.
+    expect(extractFilePathsFromCommand('cat "$HOME/src/a.ts"')).toEqual([]);
+    expect(extractFilePathsFromCommand('cat "${X}/src/a.ts"')).toEqual([]);
+    expect(extractFilePathsFromCommand('cat "$(echo src/a.ts)"')).toEqual([]);
+  });
+
+  test("re-review: `&>` and `&>>` (stdout+stderr combined) redirect target is surfaced", () => {
+    // SHOULD-FIX-2 (re-review): bash 4+ shorthand for `> file 2>&1`.
+    expect(extractFilePathsFromCommand("echo done &> combined.log")).toEqual([
+      "combined.log",
+    ]);
+    expect(extractFilePathsFromCommand("echo done &>> combined.log")).toEqual([
+      "combined.log",
+    ]);
+  });
+
+  test("tolerant of syntax errors (unbash never throws; empty result)", () => {
+    // An unterminated quote is a parse error in tolerant mode. We expect
+    // `[]` rather than a throw, and no event-loop stall.
+    const start = Date.now();
+    const result = extractFilePathsFromCommand("cat src/a.ts 'unterminated");
+    const elapsed = Date.now() - start;
+    expect(Array.isArray(result)).toBe(true);
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  test("bounds a pathological multi-KB command", () => {
+    // A 200KB command with one trailing valid path: slice cap (8KB) cuts the
+    // path off, so it shouldn't be found. Truncation-only direction is safe.
+    const big = `echo ${"x ".repeat(100_000)}src/late.ts`;
+    const result = extractFilePathsFromCommand(big);
+    expect(result).toEqual([]);
   });
 });
 
@@ -108,25 +364,23 @@ function toolPart(
   };
 }
 
-function pathOf(pid: string, callId: string): string | null {
-  return (
-    (
-      db()
-        .query(
-          "SELECT input_path FROM tool_calls WHERE project_id = ? AND call_id = ?",
-        )
-        .get(pid, callId) as { input_path: string | null } | null
-    )?.input_path ?? null
-  );
+function pathsOf(pid: string, callId: string): string[] | null {
+  const row = db()
+    .query(
+      "SELECT input_paths_json FROM tool_calls WHERE project_id = ? AND call_id = ?",
+    )
+    .get(pid, callId) as { input_paths_json: string | null } | null;
+  if (!row || row.input_paths_json === null) return null;
+  return JSON.parse(row.input_paths_json);
 }
 
-describe("recordToolCalls populates input_path (D2c PR-1)", () => {
+describe("recordToolCalls populates input_paths_json (D2c PR-1b)", () => {
   beforeEach(() => {
     const pid = ensureProject(TOOL_PROJECT);
     db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
   });
 
-  test("stores the path for file tools and NULL for non-file tools", () => {
+  test("stores file-tool paths as a JSON array; NULL for non-file tools", () => {
     const pid = ensureProject(TOOL_PROJECT);
     const info = makeMessage("m-ip", "sess-ip");
     const parts: LorePart[] = [
@@ -149,16 +403,42 @@ describe("recordToolCalls populates input_path (D2c PR-1)", () => {
     ];
     temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
 
-    expect(pathOf(pid, "r1")).toBe("src/auth/jwt.ts");
-    expect(pathOf(pid, "e1")).toBe("src/config.ts");
-    expect(pathOf(pid, "b1")).toBeNull();
-    expect(pathOf(pid, "g1")).toBeNull();
+    expect(pathsOf(pid, "r1")).toEqual(["src/auth/jwt.ts"]);
+    expect(pathsOf(pid, "e1")).toEqual(["src/config.ts"]);
+    expect(pathsOf(pid, "b1")).toBeNull();
+    expect(pathsOf(pid, "g1")).toBeNull();
   });
 
-  test("a re-seed never clobbers a captured path (COALESCE keeps first non-null)", () => {
+  test("a bash command touching multiple files stores all of them", () => {
+    const pid = ensureProject(TOOL_PROJECT);
+    const info = makeMessage("m-bash", "sess-ip");
+    const parts: LorePart[] = [
+      toolPart("m-bash", "c1", "bash", {
+        status: "pending",
+        input: { command: "cat src/a.ts src/b.ts" },
+      }),
+    ];
+    temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+    expect(pathsOf(pid, "c1")).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  test("a `> redirect` command stores the redirect target", () => {
+    const pid = ensureProject(TOOL_PROJECT);
+    const info = makeMessage("m-redir", "sess-ip");
+    const parts: LorePart[] = [
+      toolPart("m-redir", "w1", "bash", {
+        status: "pending",
+        input: { command: "echo done > logs/out.txt" },
+      }),
+    ];
+    temporal.recordToolCalls({ projectPath: TOOL_PROJECT, info, parts });
+    expect(pathsOf(pid, "w1")).toEqual(["logs/out.txt"]);
+  });
+
+  test("a re-seed never clobbers a captured path list (COALESCE keeps first non-null)", () => {
     const pid = ensureProject(TOOL_PROJECT);
     const info = makeMessage("m-re", "sess-ip");
-    const withPath: LorePart[] = [
+    const withPaths: LorePart[] = [
       toolPart("m-re", "rx", "read", {
         status: "pending",
         input: { path: "src/first.ts" },
@@ -167,9 +447,9 @@ describe("recordToolCalls populates input_path (D2c PR-1)", () => {
     temporal.recordToolCalls({
       projectPath: TOOL_PROJECT,
       info,
-      parts: withPath,
+      parts: withPaths,
     });
-    // Re-seed the SAME call_id with no recoverable path (retry / re-delivery).
+    // Re-seed with no path (retry / re-delivery) — first wins.
     const noPath: LorePart[] = [
       toolPart("m-re", "rx", "read", { status: "pending", input: {} }),
     ];
@@ -178,12 +458,10 @@ describe("recordToolCalls populates input_path (D2c PR-1)", () => {
       info,
       parts: noPath,
     });
-    expect(pathOf(pid, "rx")).toBe("src/first.ts");
+    expect(pathsOf(pid, "rx")).toEqual(["src/first.ts"]);
 
-    // Re-seed with a DIFFERENT non-null path — the first captured path must WIN
-    // (COALESCE direction: keep existing, never overwrite). Guards against a
-    // reversed COALESCE that would silently clobber provenance on re-delivery.
-    const otherPath: LorePart[] = [
+    // Re-seed with a different list — still first wins.
+    const otherList: LorePart[] = [
       toolPart("m-re", "rx", "read", {
         status: "pending",
         input: { path: "src/second.ts" },
@@ -192,8 +470,8 @@ describe("recordToolCalls populates input_path (D2c PR-1)", () => {
     temporal.recordToolCalls({
       projectPath: TOOL_PROJECT,
       info,
-      parts: otherPath,
+      parts: otherList,
     });
-    expect(pathOf(pid, "rx")).toBe("src/first.ts");
+    expect(pathsOf(pid, "rx")).toEqual(["src/first.ts"]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       sqlite-vec:
         specifier: 0.1.9
         version: 0.1.9
+      unbash:
+        specifier: ^4.0.4
+        version: 4.0.4
       uuidv7:
         specifier: ^1.1.0
         version: 1.1.0
@@ -4318,6 +4321,10 @@ packages:
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
+
+  unbash@4.0.4:
+    resolution: {integrity: sha512-60m9IVGbavD6jholbxt0jVBXZkEB/HsMZq7Tyaghseve2/Sf0zQRAIfWsD34sde+DKP2tBxJS2wP88ZM0D1FhA==}
+    engines: {node: '>=14'}
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -9561,6 +9568,8 @@ snapshots:
   ufo@1.6.4: {}
 
   ultrahtml@1.6.0: {}
+
+  unbash@4.0.4: {}
 
   uncrypto@0.1.3: {}
 


### PR DESCRIPTION
## What

D2c PR-1b — follow-up to #1424. The v75 column captured a single file path per tool call; widening it to a JSON array of unique paths makes "which files did this session touch?" a union over `tool_calls` rows — the real provenance signal D2c PR-2 needs to associate knowledge entries with the session's file activity.

## Why now

The agent's `bash` tool is the dominant way it touches files (`cat a b c`, `sed -i 's/x/y' file`, `> out`, `tee log.txt`, `for f in src/*; do …`). PR-1 missed all of these because:

- The single `input_path` column stored the **first** path only — `cat a b c` lost `b` and `c`.
- The plaintext path regex required a `/` and couldn't tell a `cat` operand from prose.
- The bash command string was never even parsed.

The result: `tool_calls.input_path` was useful for `Read`/`Edit`/`Write` but blind to bash. That's the wrong shape for D2c.

## How

- **v76 migration**: `RENAME COLUMN tool_calls.input_path → tool_calls.input_paths_json` (SQLite ≥3.25). v75 recovery def subsumed: a DB with neither column now gets `input_paths_json` added directly; a DB created on v75 gets an in-place rename. No production data lost (v75 is 6 days old).
- **`extractFilePath` → `extractFilePaths` (string[])**: same object / JSON / plaintext shapes as v75 (one path → one-element array; same ReDoS guards on the plaintext fallback). Bash command string dispatches to the new helper.
- **`extractFilePathsFromCommand` (unbash AST walk)**: zero-dep tolerant bash parser, surfaces
  - redirect targets for file-touching operators (`>`, `>>`, `<`, `<>`, `>|`, `>&`),
  - positional operands of `FILE_OPERAND_COMMANDS` (`cat`, `tee`, `cp`, `mv`, `rm`, `head`, `tail`, `less`, `more`, `wc`, `stat`, `touch`, `mkdir`, …) — deliberately **excluded** `sed`/`awk`/`grep`/`rg` (their first non-flag arg is a script/pattern, not a file — wrong signature for our heuristic),
  - for-loop wordlists.
  - Words containing parameter/command/arithmetic expansions (`$1`, `$(cmd)`, `${var}`) are skipped; unbash has the parts so we can detect them statically. Tilde-prefixed words skipped even when unbash doesn't tag the part (runtime expansion).
  - Tolerant of syntax errors (unbash never throws; empty result on parse failure). Bounded at `PATH_SCAN_LIMIT` (8KB) and `PATH_TOKEN_MAX` (260ch) for the same ReDoS-safety reason as the plaintext fallback.
- **`recordToolCalls`**: stores `JSON.stringify(paths)` (or NULL). Same COALESCE-keeps-first-non-null UPSERT semantics as v75 (a re-seed never clobbers a captured list). `COLS_PER_ROW` stays 12 — column count unchanged, just the name.
- **`stripAppliedAlters`** now also handles `RENAME COLUMN` and **pre-strips** before exec instead of relying on the catch-and-retry path. Necessary for the v75→v76 ADD+RENAME pair: a DB with `input_paths_json` must treat v75 as a no-op even when v75's ADD itself doesn't throw (because `input_path` is genuinely absent). Without pre-strip, a fresh-DB re-apply of v75 adds `input_path` next to the already-present `input_paths_json`, then v76's RENAME throws `duplicate column name: input_paths_json`. The catch handled the throw-then-strip path; pre-strip is what handles the silent-ADD-because-rename path.

## Tests

- 11 new bash-walker tests: redirects (>/>>, <), pipe, tee, chain (&&, ;), dedup, expansions, tilde, control flow (for wordlist + recurse), tolerant of syntax errors, multi-KB cap.
- Updated the 4 existing `input_path` tests to assert against `input_paths_json`.
- New integration tests: multi-file bash command stores the full list; `>` redirect target stored; COALESCE direction hardened (re-seed with a different non-null list also keeps the first).
- Schema-version test pins bumped 75→76 (db.test.ts ×2, ltm-versioning.test.ts ×1).
- **Mutation-verified**: 4 tests fail when `recordToolCalls` population is neutered; 3 tests fail when bash dispatch is disabled — non-vacuous guards on both code paths.

Format clean. Full `@loreai/core` suite green: **3287 passed / 6 skipped** (3293).

## Risks / out of scope

- `tool_calls` is **not** in `SYNCED_TABLES` (verified `sync-data.ts`) — local-only, zero sync ripple. The column-shape change is invisible to remote.
- The plaintext-fallback slash requirement is preserved (prose risk on raw strings). The AST walk accepts bare relative paths (e.g. `> out.ts`) because the AST tells us the token came from a real shell construct.
- `sed -i` is not surfaced. Acceptable for best-effort provenance; restoring it requires a per-tool option table to distinguish script-vs-file operands.
- `[ -f file ]` test builtin is not surfaced. Out of scope for v1; same family of per-builtin option parsing.