### PR TITLE
docs(readme): simplify to point at docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 > **Lore. The memory that compounds.**
 
-> **Experimental** — Under active development. APIs, storage format, and behavior may change.
+> **Experimental.** Under active development. APIs, storage format, and behavior may change.
 
 **Stop re-explaining your project to your AI.** Your tools change. Your memory doesn't. **Your team's lore, in every session.**
 
-Your AI forgets decisions, loses file paths, and undoes its own work. Lore gives it shared context across projects, tools, and providers — no context files to maintain, no workflow changes. Every new session starts with the relevant facts and gets a fresh injection after the first turn.
+Your AI forgets decisions, loses file paths, and undoes its own work. Lore gives it shared context across projects, tools, and providers. No context files to maintain, no workflow changes. Every new session starts with the relevant facts and gets a fresh injection after the first turn.
 
-Lore is a transparent LLM proxy that gives any AI agent shared context — across tools, projects, and teams. The memory that compounds. Context management and long-term memory aren't separate problems: they're one continuous pipeline. Distillation feeds the gradient context manager, which feeds the knowledge curator, which feeds `.lore.md`, and with Folk Lore *(coming soon)*, your team.
+Lore is a transparent LLM proxy that gives any AI agent shared context across tools, projects, and teams. The memory that compounds. Context management and long-term memory aren't separate problems: they're one continuous pipeline. Distillation feeds the gradient context manager, which feeds the knowledge curator, which feeds `.lore.md`, and with Folk Lore *(coming soon)*, your team.
 
-Built on [Sanity's Nuum](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) memory architecture and [Mastra's Observational Memory](https://mastra.ai/research/observational-memory) research. The core idea: coding agents need **distillation, not summarization** — preserving file paths, error messages, and exact decisions rather than narrative summaries that lose the details agents need to keep working.
+Built on [Sanity's Nuum](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem) memory architecture and [Mastra's Observational Memory](https://mastra.ai/research/observational-memory) research. The core idea: coding agents need **distillation, not summarization**, preserving file paths, error messages, and exact decisions rather than narrative summaries that lose the details agents need to keep working.
 
 Published as [`@loreai/gateway`](https://www.npmjs.com/package/@loreai/gateway) (standalone proxy), [`@loreai/opencode`](https://www.npmjs.com/package/@loreai/opencode) (OpenCode plugin), [`@loreai/pi`](https://www.npmjs.com/package/@loreai/pi) (Pi extension), and [`@loreai/core`](https://www.npmjs.com/package/@loreai/core) (shared engine).
+
+Full documentation lives at **[withlore.ai/docs](https://withlore.ai/docs/)**.
 
 ## Why
 
@@ -28,87 +30,83 @@ Recent research on AI self-improvement identifies two fundamental levers: **harn
 
 Lore treats context management and memory as the same problem. Distillation, knowledge curation, cross-session recall, and `.lore.md` export — all in one pipeline. You keep coding. Lore keeps the context.
 
-## What to expect
-
-Once Lore is active, you should notice:
-
-- **No more compactions** — Lore replaces compaction with incremental distillation. Your context never gets wiped and rebuilt from a lossy summary.
-- **Infinite sessions at lower cost** — the gradient context manager keeps sessions running indefinitely without degradation. Background work runs at up to 50% off via batch APIs on supported providers, using cheaper models (A/B tested for quality parity). Predictive cache warming avoids expensive cache rebuilds.
-- **Decisions stick** — the curator preserves the "why" behind every choice. A future session won't "helpfully" refactor your workaround back to the broken approach.
-- **Your AI learns from experience** — patterns, gotchas, and architectural decisions are automatically curated across sessions and exported to `.lore.md`. Five distinct feedback loops — behavioral pattern detection, semantic clustering, instruction capture, LLM-mediated curation, and adaptive calibration — compound across sessions. Project-specific knowledge and global preferences follow you everywhere.
-- **Free on-device vector search** — Nomic Embed v1.5 runs locally with zero API cost. Hybrid architecture fuses vector similarity with BM25 keyword search and LLM-powered query expansion for best-of-both-worlds recall.
-- **Works with any provider** — `lore run` auto-detects Claude Code, OpenCode, Pi, and Codex. Any other Anthropic/OpenAI-compatible tool works by pointing its base URL at the gateway. Switch providers freely; your memory stays.*
-- **Import your history** — Lore imports conversations from Claude Code, Codex, Aider, Cline, Continue, OpenCode, and Pi, extracting knowledge from your existing sessions so your AI starts with context from day one.
-- **Team knowledge with Folk Lore** — shared memory across your team, managed centrally. *(Coming soon.)*
-
-<sub>* Any provider accessible via an OpenAI or Anthropic-compatible API.</sub>
-
 ## Quick start
 
-### Gateway (works with any AI client)
-
 ```bash
-# Install and start
 curl -fsSL https://withlore.ai/install | bash
 lore run
 ```
 
-`lore run` starts the gateway and auto-detects your AI agent (Claude Code, OpenCode, Pi, Codex), configuring everything automatically.
-
-Or run directly: `npx @loreai/gateway`
-
-### OpenCode plugin
-
-Add `@loreai/opencode` to the `plugin` array in your project's `opencode.json`:
-
-```json
-{
-  "plugin": [
-    "@loreai/opencode"
-  ]
-}
-```
-
-Restart OpenCode and the plugin will be installed automatically. The legacy name `opencode-lore` still works if you have an existing setup.
-
-### Pi extension
-
-Pi discovers extensions via your `~/.pi/settings.json`:
-
-```json
-{
-  "packages": [
-    "npm:@loreai/pi@latest"
-  ]
-}
-```
-
-Then run `pi install` once. The extension auto-loads on every Pi session.
-
-All three share the same SQLite database at `~/.local/share/lore/lore.db` — switching between tools on the same project preserves everything.
+`lore run` starts the gateway and auto-detects your AI agent (Claude Code, OpenCode, Pi, Codex, Hermes), configuring everything automatically. Per-harness setup, manual configs, and remote-gateway instructions live at [withlore.ai/docs/install](https://withlore.ai/docs/install/) and the [guides section](https://withlore.ai/docs/guides/).
 
 ## How it works
 
-Lore uses a three-tier memory architecture (following [Nuum's design](https://www.sanity.io/blog/how-we-solved-the-agent-memory-problem)):
+Lore is a transparent HTTP proxy that sits between an AI harness and its upstream LLM provider. Every supported harness already speaks a standard LLM HTTP API (Anthropic's `/v1/messages`, OpenAI's `/v1/chat/completions`, Codex's `/v1/codex/responses`); Lore redirects those requests to its own gateway, where the conversation is parsed, persisted, and transformed before being forwarded to the real upstream.
 
-1. **Temporal storage** — every message is stored in a local SQLite FTS5 database, searchable on demand via the `recall` tool.
+A three-tier memory architecture (temporal storage → distillation → long-term knowledge) and a layered gradient context manager compose every request: stable knowledge caches at the top, distilled context in the middle, raw conversation at the bottom. The full architecture (cost-aware cache layer, recall pipeline, LTM pin invariant) is at [withlore.ai/docs/architecture](https://withlore.ai/docs/architecture/).
 
-2. **Distillation** — messages are incrementally distilled into an observation log (dated, timestamped, priority-tagged entries), following [Mastra's observer/reflector pattern](https://mastra.ai/research/observational-memory). When segments accumulate, older distillations are consolidated into structured context documents optimized for diverse downstream queries (current state, key decisions, technical changes, timeline) — a [context-distillation objective](https://arxiv.org/abs/2501.17390) that generalizes better than flat summarization. Consolidated entries are archived rather than deleted, preserving a searchable detail layer for the `recall` tool.
+## Configuration
 
-3. **Long-term knowledge** — a curated knowledge base of facts, patterns, decisions, and gotchas that matter across sessions and projects, maintained by a background curator agent. Entries are confidence-ranked: unconditional directives (1.0) always surface, mild preferences (0.6) only when budget allows. Project-specific knowledge stays scoped; global preferences (coding style, review habits, tooling choices) follow you across all projects.
+All Lore behavior is tunable through `.lore.json` (in your project root) and `LORE_*` environment variables. The full schema (every field, default, and override) is at [withlore.ai/docs/configuration](https://withlore.ai/docs/configuration/) and [withlore.ai/docs/environment](https://withlore.ai/docs/environment/). The docs are auto-generated from `packages/core/src/config.ts` and stay in sync with the code.
 
-A **gradient context manager** decides how much of each tier to include in each turn, using a 4-layer safety system that calibrates overhead dynamically from real API token counts. When tool outputs are stripped for compression, [loss-annotated metadata](https://arxiv.org/abs/2602.16284) preserves key signals (tool name, size, error presence, file paths) so the model can make informed decisions about whether to recall the full content.
+To turn long-term knowledge off entirely (keeping conversation storage, distillation, and recall), set `"knowledge": { "enabled": false }`. See the [`knowledge` reference](https://withlore.ai/docs/configuration/#knowledge).
 
-### Cost efficiency
+## Team memory
 
-Lore is designed to cost less than the default approach, not more:
+Lore's long-term knowledge is local-first, but project knowledge is most valuable when the whole team shares it. Lore exports curated facts to a `.lore.md` file at your project root: plain Markdown, committed to your repo, designed to be reviewed in pull requests.
 
-- **Up to 50% off background work** — distillation, curation, and query expansion run via batch APIs (Anthropic Messages Batches, OpenAI Batch) at half price when available
-- **Cheaper worker models** — background work automatically uses cheaper models (e.g., Sonnet instead of Opus), A/B tested for quality parity
-- **Predictive cache warming** — survival analysis predicts when you'll return and sends $0.01 keepalive requests to prevent $0.70+ cache rebuilds
-- **3-block system prompt caching** — stable preferences cached for 1 hour at 10x cheaper reads; dynamic context rides the 5-minute conversation cache
-- **No compaction cache busts** — compaction destroys the entire prompt cache on every trigger. Lore's gradient compression eliminates compaction entirely
-- **Content deduplication** — duplicate file reads and tool outputs are detected and deduplicated automatically, saving thousands of tokens per session
+- **Diffable & merge-friendly**: entries are sorted alphabetically by title within each category and carry stable `<!-- lore:UUID -->` markers, so a new fact is a minimal diff, not a reshuffle.
+- **Reviewable**: `git diff` shows what the agent learned; a reviewer can reject a wrong fact before it becomes shared truth. Knowledge history is your git history.
+- **Hand-editable**: fix, delete, or add facts by hand; they're imported on the next run.
+
+This is the team path that works today with your existing git workflow. **Folk Lore** (coming soon) adds live, continuous team sync on top. See [withlore.ai/different/#waitlist](https://withlore.ai/different/#waitlist). Full review workflow and configuration at [withlore.ai/docs/team-memory](https://withlore.ai/docs/team-memory/).
+
+## CLI
+
+Lore ships a CLI for inspecting and managing stored data. These commands work **without the gateway running**; they access the SQLite database directly.
+
+```bash
+# Inspect
+lore data list projects
+lore data list knowledge
+lore data list sessions
+lore data list distillations --project /path/to/project
+
+# Show full detail for an entry (supports partial ID prefix)
+lore data show knowledge abc12345
+lore data show session abc12345-6789
+lore data show distillation abc12345
+
+# Clear data (prompts for confirmation; --yes to skip in scripts)
+lore data clear --project .
+lore data clear --project . --knowledge
+lore data clear --project . --temporal
+lore data clear --project . --distillations
+lore data clear --all
+
+# Delete a single entry
+lore data delete knowledge abc12345
+
+# Search from the terminal
+lore recall "error handling patterns"
+lore recall "auth decision" --scope knowledge --limit 5
+lore recall "migration error" --project /path/to/project --json
+
+# Import conversation history from existing agents
+lore import
+```
+
+All destructive commands prompt for confirmation. Use `--yes` to skip (for scripts). Use `--json` on any `list`/`show` command for machine-readable output.
+
+> **Starting fresh in a project?** Run `lore data clear --project .` to wipe all stored memories for the current directory. This regenerates `.lore.md`. Commit the change to prevent old knowledge from being re-imported from git history.
+
+### Web dashboard
+
+When the gateway is running, visit **http://localhost:3207/ui** for a web-based dashboard that lets you browse all projects, knowledge entries, sessions, and distillations; view full detail for any entry; search across all data sources (using the same recall engine); and delete entries or clear project data. Server-rendered HTML — no external dependencies.
+
+## lat.md compatibility
+
+If your project uses [lat.md](https://github.com/1st1/lat.md) to maintain a knowledge graph, Lore automatically indexes the `lat.md/` directory and includes its sections in recall results. No configuration needed — if the directory exists, Lore parses the markdown files, extracts sections, and ranks them alongside its own knowledge entries using BM25 + RRF fusion. Lore re-scans the directory on session idle, so changes by the agent or by hand are picked up automatically.
 
 ## Benchmarks
 
@@ -153,224 +151,6 @@ Lore's distilled context is smaller and more cacheable than raw tail windows, ma
 | cli-nightly        | 898      | 353K   | ~19K tokens      | 19x         |
 
 The eval is self-contained and reproducible: session transcripts are stored as JSON files with no database dependency.
-
-## The `recall` tool
-
-The assistant gets a `recall` tool that searches across stored messages, distillations, and knowledge using hybrid vector + FTS5 BM25 search with LLM-powered query expansion. It's used automatically when the distilled context doesn't have enough detail:
-
-- "What did we decide about auth last week?"
-- "What was the error from the migration?"
-- "What's my database schema convention?"
-
-Search results are ranked using Reciprocal Rank Fusion across multiple sources: knowledge entries, distillation observations, temporal messages, recency-biased temporal, cross-project knowledge, and lat.md sections.
-
-## Team memory
-
-Lore's long-term knowledge is local-first, but it's most valuable shared. Curated facts are exported to a `.lore.md` file at your project root — plain Markdown, committed to your repo, and designed to be reviewed in pull requests.
-
-- **Diffable & merge-friendly** — entries are sorted alphabetically by title within each category and carry stable `<!-- lore:UUID -->` markers, so a new fact is a minimal diff, not a reshuffle.
-- **Reviewable** — `git diff` shows what the agent learned; a reviewer can reject a wrong fact before it becomes shared truth. Knowledge history is your git history.
-- **Hand-editable** — fix, delete, or add facts by hand; they're imported on the next run.
-
-This is the team path that works today with your existing git workflow. **Folk Lore** (coming soon) adds live, continuous team sync on top — see [withlore.ai](https://withlore.ai/different/#waitlist).
-
-## Configuration
-
-Create a `.lore.json` file in your project root to customize behavior. All fields are optional — defaults are shown below:
-
-```jsonc
-{
-  // Disable long-term knowledge entirely. Temporal storage, distillation,
-  // gradient context management, and the recall tool (for conversation search)
-  // remain active. Only the curator, knowledge injection, and .lore.md sync
-  // are turned off.
-  "knowledge": { "enabled": true },
-
-  // Tune the curator that extracts knowledge from conversations.
-  "curator": {
-    "enabled": true,        // set false to stop extracting knowledge entries
-    "onIdle": true,         // run curation when a session goes idle
-    "afterTurns": 3,        // run curation after N user turns
-    "maxEntries": 25        // consolidate when entries exceed this count
-  },
-
-  // Knowledge file export/import. Defaults to AGENTS.md (the universal format
-  // read by 16+ AI tools). Set path to ".lore.md" for a dedicated Lore file.
-  "agentsFile": {
-    "enabled": true,        // set false to disable knowledge file sync
-    "path": "AGENTS.md"     // or ".lore.md", "CLAUDE.md", ".cursor/rules/lore.md"
-  },
-
-  // Context budget fractions (of usable context window).
-  "budget": {
-    "distilled": 0.25,      // distilled history prefix
-    "raw": 0.4,             // recent raw messages
-    "output": 0.25,         // reserved for model output
-    "ltm": 0.05             // long-term knowledge in system prompt (2-30%)
-  },
-
-  // Distillation thresholds.
-  "distillation": {
-    "minMessages": 5,          // min undistilled messages before distilling
-    "minSegmentTokens": 64,    // min tokens per segment (below = skip/absorb)
-    "maxSegmentTokens": 16384  // max tokens per distillation segment
-  },
-
-  // Temporal message pruning.
-  "pruning": {
-    "retention": 120,       // days to keep distilled messages
-    "maxStorage": 1024      // max storage in MB before emergency pruning
-  },
-
-  // Include cross-project knowledge entries. Default: false.
-  "crossProject": false
-}
-```
-
-### Disabling long-term knowledge
-
-If you prefer to manage context manually and only want conversation search capabilities, set:
-
-```json
-{
-  "knowledge": { "enabled": false }
-}
-```
-
-This disables:
-- **Knowledge extraction** — the curator won't extract patterns, decisions, or gotchas from conversations
-- **Knowledge injection** — no knowledge entries are added to the system prompt
-- **Knowledge file sync** — no import/export of AGENTS.md / .lore.md
-
-This keeps active:
-- **Temporal storage** — all messages are still stored and searchable
-- **Distillation** — conversations are still distilled for context management
-- **Gradient context manager** — context window is still managed automatically
-- **The `recall` tool** — the agent can still search conversation history and distillations (knowledge search is skipped)
-
-## What gets stored
-
-All data lives locally in `~/.local/share/lore/lore.db`:
-
-- **Session observations** — timestamped event log of each conversation: what was asked, what was done, decisions made, errors found
-- **Long-term knowledge** — patterns, gotchas, and architectural decisions curated across sessions and projects. Entries can reference each other with `[[entry-id]]` wiki links, forming a navigable knowledge graph. Dead references are automatically cleaned up when entries are deleted or consolidated.
-- **Raw messages** — full message history in FTS5-indexed SQLite for the `recall` tool
-- **Embeddings** — on-device vector embeddings (Nomic Embed v1.5) for semantic search, stored alongside the entries they represent
-
-## CLI tools
-
-Lore includes a CLI for inspecting and managing stored data. These commands work **without the gateway running** — they access the SQLite database directly.
-
-### `lore data` — Data management
-
-```bash
-# List all tracked projects
-lore data list projects
-
-# List knowledge, sessions, or distillations for the current project
-lore data list knowledge
-lore data list sessions
-lore data list distillations --project /path/to/project
-
-# Show full detail for an entry (supports partial ID prefix)
-lore data show knowledge abc12345
-lore data show session abc12345-6789
-lore data show distillation abc12345
-
-# Clear all data for a project (regenerates .lore.md)
-lore data clear --project .
-
-# Clear specific data types
-lore data clear --project . --knowledge
-lore data clear --project . --temporal
-lore data clear --project . --distillations
-
-# Nuclear option: wipe the entire database
-lore data clear --all
-
-# Delete a single entry
-lore data delete knowledge abc12345
-lore data delete session abc12345-6789
-```
-
-All destructive commands prompt for confirmation. Use `--yes` to skip (for scripts). Use `--json` on any list/show command for machine-readable output.
-
-> **Starting fresh in a project?** Run `lore data clear --project .` to wipe all stored memories for the current directory. This regenerates `.lore.md` — commit the change to prevent old knowledge from being re-imported from git history.
-
-### `lore recall` — Search from the terminal
-
-```bash
-# Search project memory
-lore recall "error handling patterns"
-
-# Search with options
-lore recall "auth decision" --scope knowledge --limit 5
-lore recall "migration error" --project /path/to/project --json
-```
-
-### `lore import` — Import conversation history
-
-```bash
-# Auto-detect prior conversations and pick which agents to import
-lore import
-
-# Import from one agent only (non-interactive)
-lore import --agent claude-code
-
-# Only scan the current directory (skip sibling git worktrees)
-lore import --no-worktrees
-
-# Supported: Claude Code, Codex, Aider, Cline, Continue, OpenCode, Pi
-```
-
-Extracts knowledge from your existing sessions so Lore starts with context from day one. Idempotent — safe to run multiple times.
-
-When more than one agent has history, `lore import` shows a numbered list and lets you select which agents to import (comma-separated numbers, or `a` for all).
-
-**Worktrees & monorepos:** agent history is keyed by the directory the agent ran in, so a repo's conversations are spread across its main checkout and every git worktree. `lore import` finds them all by default (via `git worktree list`) — pass `--no-worktrees` to restrict to the current directory.
-
-### Migrating from another memory system (Engram, mem0)
-
-Already using a dedicated memory tool? `lore import` also migrates **already-curated** memories directly into Lore's knowledge store (no LLM pass — the entries are already structured):
-
-```bash
-# Auto-detect and import Engram memory (runs `engram export` for you)
-lore import --source engram
-
-# Or import from an explicit export file
-engram export engram.json
-lore import --source engram --file engram.json
-
-# Import everything as global (cross-project) knowledge
-lore import --source engram --global
-```
-
-Engram observation types map onto Lore categories (`bugfix`/`discovery` → `gotcha`, `config` → `architecture`, etc.), and each observation's project is recovered from its session directory. Idempotent — re-running dedups by title and only updates entries whose content changed.
-
-**mem0** is imported natively too — `lore import --source mem0` auto-detects your deployment (Qdrant/OpenMemory server, mem0 self-hosted server, or the embedded default store) and reads it with no Python required. Imported memories default to the `pattern` category. Use `--file <dump.json>` or the `--mem0-*` flags to point at a specific store.
-
-### Web dashboard
-
-When the gateway is running, visit **http://localhost:3207/ui** for a web-based dashboard that lets you:
-
-- Browse all projects, their knowledge entries, sessions, and distillations
-- View full detail for any entry
-- Search across all data sources (uses the same recall engine)
-- Delete entries or clear project data
-
-The dashboard is server-rendered HTML with no external dependencies — it works in any browser, including terminal browsers.
-
-## lat.md compatibility
-
-If your project uses [lat.md](https://github.com/1st1/lat.md) to maintain a knowledge graph, Lore automatically indexes the `lat.md/` directory and includes its sections in recall results. No configuration needed — if the directory exists, Lore parses the markdown files, extracts sections, and ranks them alongside its own knowledge entries using BM25 + RRF fusion.
-
-This means the `recall` tool searches both:
-- Lore's LLM-curated memory (distillations, knowledge entries, raw messages)
-- lat.md's human-authored design documentation (architecture, specs, decisions)
-
-lat.md sections also participate in LTM injection — the most relevant sections for the current session are included in the system prompt alongside Lore's own knowledge entries, ranked by session-context relevance.
-
-Lore re-scans the `lat.md/` directory periodically (on session idle), so changes made by the agent or by hand are picked up automatically.
 
 ## Eval results
 
@@ -448,10 +228,7 @@ To use a local clone instead of the published packages:
 - **OpenCode**: `{ "plugin": ["file:///absolute/path/to/lore"] }`
 - **Pi**: symlink the built package into `~/.pi/agent/extensions/`, or add a local path to `~/.pi/settings.json` `packages`
 
-Contributors editing prompts in `packages/core/src/prompt.ts` or the
-user-facing system prompt injection in `packages/opencode/src/index.ts` /
-`packages/pi/src/index.ts` should follow the review bar in
-[`docs/PROMPT_CHANGES.md`](docs/PROMPT_CHANGES.md).
+Contributors editing prompts in `packages/core/src/prompt.ts` or the user-facing system prompt injection in `packages/opencode/src/index.ts` / `packages/pi/src/index.ts` should follow the review bar in [`docs/PROMPT_CHANGES.md`](docs/PROMPT_CHANGES.md).
 
 ## Standing on the shoulders of
 


### PR DESCRIPTION
Collapses README sections fully duplicated on withlore.ai/docs (install, three-tier architecture, cost-aware context, recall pipeline, team memory, full .lore.json schema, the disabling-knowledge walkthrough) into one-paragraph pointers with the docs URL.

Kept verbatim because no docs page covers them: the Why framing with Meta-Harness / SIA citations, the full CLI reference for `lore data` / `lore recall` / `lore import` and the dashboard, the lat.md compatibility section, all benchmark and mega-session eval tables, the v1-v6 history, and the academic citations.

Net: -223 lines. No code or config changes.