### PR TITLE
feat(provenance): D2c PR-2 — knowledge_file_refs sidecar + curator files-touched context + recall ↳ files: rendering

### DIFF
--- a/packages/core/src/curator.ts
+++ b/packages/core/src/curator.ts
@@ -75,6 +75,13 @@ export type CuratorOp =
       crossProject?: boolean;
       /** Initial confidence (0.0–1.0). Controls injection priority for preferences. */
       confidence?: number;
+      /** Files touched this session that this entry is about (D2c PR-2).
+       *  If present, must be a subset of `sessionFileTouches()` for the
+       *  minting session — but the curator may also record a file the user
+       *  mentioned without actually editing, in which case applyOps logs a
+       *  warn and proceeds (out-of-set is not an error). Recorded into
+       *  `knowledge_file_refs` sidecar keyed on logical_id. */
+      files?: string[];
     }
   | {
       op: "update";
@@ -82,6 +89,10 @@ export type CuratorOp =
       title?: string;
       content?: string;
       confidence?: number;
+      /** Replace the entry's file-refs sidecar with these paths. Same subset
+       *  rule as `create.files`. `undefined` (omit) means LEAVE the sidecar
+       *  alone — useful for content-only edits that shouldn't re-tag. */
+      files?: string[];
     }
   | { op: "delete"; id: string; reason: string };
 
@@ -405,6 +416,24 @@ export function applyOps(
         title: op.title,
         content,
       });
+      // D2c PR-2: record the curator's chosen file associations against the
+      // new entry's logical_id. Best-effort: out-of-set files are warned but
+      // still recorded (a curator may name a file the user mentioned in chat
+      // without actually editing it).
+      if (op.files && op.files.length > 0) {
+        try {
+          const out = ltm.setFileRefs(id, op.files);
+          if (out.length < op.files.length) {
+            log.warn(
+              `curator op.files: dropped ${
+                op.files.length - out.length
+              } paths (empty/over-cap) for entry ${id.slice(0, 16)}`,
+            );
+          }
+        } catch (err) {
+          log.warn("setFileRefs failed (non-fatal):", err);
+        }
+      }
       created++;
     } else if (op.op === "update") {
       // op.id may already be superseded by an earlier op on the same entry in
@@ -452,6 +481,23 @@ export function applyOps(
         const titleAccepted = after.title !== entry.title;
         if (op.content !== undefined || titleAccepted)
           idsToSync.push(entry.logical_id);
+        // D2c PR-2: optional re-tag with `op.files`. Only act if the field is
+        // explicitly present and is an array — `undefined` means "leave the
+        // sidecar alone" (a content-only update). Replaces the sidecar in full.
+        if (Array.isArray(op.files)) {
+          try {
+            const out = ltm.setFileRefs(entry.logical_id, op.files);
+            if (out.length < op.files.length) {
+              log.warn(
+                `curator op.files: dropped ${
+                  op.files.length - out.length
+                } paths (empty/over-cap) for entry ${entry.logical_id.slice(0, 16)}`,
+              );
+            }
+          } catch (err) {
+            log.warn("setFileRefs failed (non-fatal):", err);
+          }
+        }
         changedEntries.push({
           op: "updated",
           id: entry.logical_id,
@@ -871,11 +917,25 @@ async function runInner(input: {
     log.warn("tool failure context failed (non-fatal):", err);
   }
 
+  // Per-session file-touch summary: which files this session has actually
+  // edited/read/redirected-to, so the curator can decide whether a new
+  // knowledge entry is about one of them (and tag via op.files).
+  let fileTouchContext = "";
+  try {
+    fileTouchContext = buildFilesTouchedContext(
+      input.projectPath,
+      input.sessionID,
+    );
+  } catch (err) {
+    log.warn("files touched context failed (non-fatal):", err);
+  }
+
   const userContent =
     baseUserContent +
     crossSessionContext +
     actionTagContext +
-    toolFailureContext;
+    toolFailureContext +
+    fileTouchContext;
   // Pass the explicit worker model through — never fall back to cfg.model
   // which is the project/session model and may be from a different provider
   // than the worker's upstream URL. Cross-provider model names → 404.
@@ -1171,6 +1231,46 @@ function buildToolFailureContext(
 
   return (
     "\n\n---\nRecurring tool failures across sessions (consider creating gotcha entries for root causes):\n" +
+    lines.join("\n")
+  );
+}
+
+/** Max distinct files surfaced in the curator's per-session context block.
+ *  15 is well below the sessionFileTouches query cap (200) and small enough
+ *  to keep the prompt-cache stable across curator runs of similar shape. */
+const MAX_FILES_IN_CURATOR_CONTEXT = 15;
+
+/**
+ * Build the "files touched this session" context block for the curator
+ * (D2c PR-2). Returns a compact markdown list of the top-N most-touched
+ * files in this session, sorted by hit count (path-tiebreak for prompt-cache
+ * stability). Returns "" when no files have been touched yet (or sessionID
+ * is unavailable) so the block is silently omitted — never surfaces an
+ * empty heading.
+ *
+ * The curator's `create` and `update` ops may now include `files: [...]` —
+ * paths from THIS list (or out-of-list files the curator names explicitly).
+ * Persisted into `knowledge_file_refs` keyed on the entry's logical_id, then
+ * rendered in recall output as a `↳ files: …` line alongside the anchor line.
+ *
+ * Exported for direct unit testing (see curator-files-touched.test.ts).
+ */
+export function buildFilesTouchedContext(
+  projectPath: string,
+  currentSessionID: string,
+): string {
+  if (!projectPath || !currentSessionID) return "";
+  const { paths, counts } = toolTrace.sessionFileTouches(
+    projectPath,
+    currentSessionID,
+  );
+  if (paths.length === 0) return "";
+  const top = paths.slice(0, MAX_FILES_IN_CURATOR_CONTEXT);
+  const lines = top.map((p) => `- \`${p}\` (${counts[p] ?? 1} hits)`);
+  return (
+    "\n\n---\nFiles touched this session (top " +
+    top.length +
+    " by hit count; consider associating entries with these via the `files` field on create/update ops):\n" +
     lines.join("\n")
   );
 }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1904,6 +1904,26 @@ const MIGRATIONS: string[] = [
   -- back-window of non-JSON values is tiny.
   ALTER TABLE tool_calls RENAME COLUMN input_path TO input_paths_json;
   `,
+
+  `
+  -- Version 77: knowledge_file_refs (D2c PR-2). A sidecar keyed on logical_id that
+  -- records which files a knowledge entry was created/updated against during the
+  -- minting session. Mirrors the sidecar pattern of knowledge_meta,
+  -- knowledge_ref_anchor, and knowledge_symbol_presence: associations survive
+  -- version edits because they key on the stable logical_id, NOT on a version
+  -- row. paths_json is a JSON array of unique, repo-relative paths (capped at
+  -- MAX_FILE_REFS_PER_ENTRY=20 by the writer); recall renders up to
+  -- MAX_RECALL_FILES_PER_ENTRY=3 in the '↳ files:' branch (parallel to the
+  -- existing '↳ src/foo.ts:42' anchor line). updated_at is a register clock,
+  -- bumped on every replace (NOT on reads). NOT in SYNCED_TABLES because file
+  -- associations are session-context, not user knowledge; remote machines
+  -- generate their own.
+  CREATE TABLE IF NOT EXISTS knowledge_file_refs (
+    logical_id  TEXT    PRIMARY KEY,
+    paths_json  TEXT    NOT NULL,
+    updated_at  INTEGER NOT NULL DEFAULT 0
+  );
+  `,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -3498,6 +3518,27 @@ function recoverMissingObjects(database: Database) {
       }
     } else if (!tcols.some((c) => c.name === "input_paths_json")) {
       database.exec("ALTER TABLE tool_calls ADD COLUMN input_paths_json TEXT;");
+    }
+  }
+  // Version 77: knowledge_file_refs (D2c PR-2). Sidecar keyed on logical_id —
+  // records which files a knowledge entry was associated with. New table only;
+  // no backwards-compatible state to preserve (entries created before v77 simply
+  // have no association; recall skips them). CREATE TABLE IF NOT EXISTS is
+  // idempotent so a re-open after a partial v77 apply is safe.
+  {
+    const tables = database
+      .query(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='knowledge_file_refs'",
+      )
+      .all() as Array<{ name: string }>;
+    if (tables.length === 0) {
+      database.exec(`
+        CREATE TABLE knowledge_file_refs (
+          logical_id  TEXT    PRIMARY KEY,
+          paths_json  TEXT    NOT NULL,
+          updated_at  INTEGER NOT NULL DEFAULT 0
+        );
+      `);
     }
   }
   // Version 54: knowledge_session_injections.verdict (outcome impact, #497).

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -866,6 +866,7 @@ export const LOGICAL_ID_BOOKKEEPING_TABLES = [
   "knowledge_ref_validity",
   "knowledge_symbol_presence",
   "knowledge_ref_anchor",
+  "knowledge_file_refs",
 ] as const;
 
 export function remove(id: string, metadata?: KnowledgeMetadata) {
@@ -2080,6 +2081,99 @@ export type KnowledgeRefAnchor = { kind: "file" | "symbol"; anchor: string };
 /** Max anchors surfaced per entry in recall — enough to point at the code
  *  without bloating the result line. File anchors are preferred over symbols. */
 export const MAX_RECALL_ANCHORS_PER_ENTRY = 3;
+
+/** Max file paths associated with one entry via `setFileRefs`. Beyond this the
+ *  entry is too broad to be useful as a pointer (D2c PR-2). */
+export const MAX_FILE_REFS_PER_ENTRY = 20;
+
+/** Max file paths surfaced per entry in recall — parallel cap to anchors. */
+export const MAX_RECALL_FILES_PER_ENTRY = 3;
+
+export type KnowledgeFileRefs = {
+  /** Unique, sorted, repo-relative paths the entry was associated with during
+   *  the minting session (or on its most recent update). */
+  paths: string[];
+};
+
+/**
+ * Set (replace) the file-path associations for one entry. Idempotent.
+ * Callers (curator apply path) should pass paths they have already validated
+ * as a subset of the minting session's touched-files set OR have explicitly
+ * opted to record an out-of-set file (with their own warn). Dedup + sort +
+ * cap (MAX_FILE_REFS_PER_ENTRY) is the caller's responsibility — `setFileRefs`
+ * applies the cap defensively and returns the paths actually stored.
+ *
+ * `updated_at` is bumped via SQLite's unixepoch('now'), so the register clock
+ * is monotonic per row. NOT in SYNCED_TABLES — file associations are
+ * session-context, not user knowledge; remote machines generate their own.
+ */
+export function setFileRefs(logicalId: string, paths: string[]): string[] {
+  // Defensive normalization: drop empty strings, dedupe, sort for determinism,
+  // cap at MAX_FILE_REFS_PER_ENTRY. Callers should already do this — the
+  // re-cap here is a safety net against a buggy caller passing thousands.
+  const clean = Array.from(
+    new Set(
+      paths
+        .filter((p) => typeof p === "string" && p.trim().length > 0)
+        .map((p) => p.trim()),
+    ),
+  )
+    .sort((a, b) => a.localeCompare(b))
+    .slice(0, MAX_FILE_REFS_PER_ENTRY);
+  db()
+    .query(
+      `INSERT INTO knowledge_file_refs (logical_id, paths_json, updated_at)
+         VALUES (?, ?, unixepoch('now'))
+       ON CONFLICT(logical_id) DO UPDATE SET
+         paths_json = excluded.paths_json,
+         updated_at = excluded.updated_at`,
+    )
+    .run(logicalId, JSON.stringify(clean));
+  return clean;
+}
+
+/**
+ * Batch-load the file-path associations for a set of entries by logical_id,
+ * so recall can render `↳ files: src/foo.ts, src/bar.ts` alongside the anchor
+ * line (D2c PR-2). Returns a Map from logical_id to its paths, capped at
+ * MAX_RECALL_FILES_PER_ENTRY (the writer's cap is higher so future callers
+ * can ask for more). Read-only; empty input → empty map. Entries with no
+ * associations are absent from the map (rendering skips the `↳ files:`
+ * line, same as anchors).
+ *
+ * Stable ordering: paths are stored sorted by the writer (see `setFileRefs`),
+ * so the returned list is naturally ordered.
+ */
+export function knowledgeFileRefsBatch(
+  logicalIds: string[],
+): Map<string, string[]> {
+  const out = new Map<string, string[]>();
+  if (logicalIds.length === 0) return out;
+  const placeholders = logicalIds.map(() => "?").join(",");
+  const rows = db()
+    .query(
+      `SELECT logical_id, paths_json FROM knowledge_file_refs
+        WHERE logical_id IN (${placeholders})`,
+    )
+    .all(...logicalIds) as Array<{ logical_id: string; paths_json: string }>;
+  for (const r of rows) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(r.paths_json);
+    } catch {
+      // Malformed JSON is never expected — `setFileRefs` always writes valid
+      // JSON. Skip defensively rather than throw on a corrupt row.
+      continue;
+    }
+    if (!Array.isArray(parsed)) continue;
+    const paths = parsed.filter(
+      (p): p is string => typeof p === "string" && p.length > 0,
+    );
+    if (paths.length === 0) continue;
+    out.set(r.logical_id, paths.slice(0, MAX_RECALL_FILES_PER_ENTRY));
+  }
+  return out;
+}
 
 /**
  * Batch-load the resolved code anchors (file:line / symbol) for a set of entries

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -470,6 +470,22 @@ Confidence values (0.0–1.0) — determines injection priority when budget is t
 - Default to 1.0 for preferences with strong directive language, 0.8 for other preferences.
 - Always set confidence on create ops — it determines injection priority.
 
+File associations (D2c PR-2) — point the entry at the code that produced it:
+- Include a \`files: [...]\` field on create or update ops when the entry is clearly about
+  one or more files touched during this session. The system surfaces a "Files touched this
+  session" block in your context (ranked by hit count) — pick the relevant subset, not all
+  of them. Paths should be repo-relative (e.g. \`src/auth/stripe-client.ts\`).
+- When \`update.files\` is omitted, the entry's existing associations are left alone (useful
+  for content-only edits that shouldn't re-tag). When provided, it REPLACES the sidecar in
+  full.
+- An empty \`files: []\` is allowed and means "explicitly clear the associations".
+- Out-of-set files (paths you name that weren't touched this session) are accepted with a
+  warn log — useful when the user mentioned a file in chat without actually editing it. The
+  reverse (a touched file you don't mention) is simply not associated.
+- The stored sidecar is local-only (NOT synced across machines — session context differs).
+- Skip \`files\` when the entry is genuinely conceptual (a cross-cutting preference or decision
+  that isn't tied to any specific file) — only a minority of entries warrant files.
+
 Produce a JSON array of operations:
 [
   {
@@ -479,14 +495,16 @@ Produce a JSON array of operations:
     "content": "Concise knowledge entry — under 150 words",
     "scope": "project" | "global",
     "crossProject": false,
-    "confidence": 1.0
+    "confidence": 1.0,
+    "files": ["src/auth/stripe-client.ts", "src/lib/retry.ts"]
   },
   {
     "op": "update",
     "id": "existing-entry-id",
     "title": "New title — ONLY when the entry's scope genuinely broadened (optional)",
     "content": "Updated content — under 150 words",
-    "confidence": 0.0-1.0
+    "confidence": 0.0-1.0,
+    "files": ["src/auth/stripe-client.ts"]
   },
   {
     "op": "delete",

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -427,6 +427,13 @@ function formatFusedResults(
     knowledgeLogicalIds.length > 0
       ? ltm.knowledgeRefAnchors(knowledgeLogicalIds)
       : undefined;
+  // D2c PR-2: file-path associations share the same batch load shape as
+  // anchors. Batch-loaded once for the whole result set so per-line rendering
+  // is O(1) lookup, and entries with no associations are simply absent.
+  const filesByLogicalId =
+    knowledgeLogicalIds.length > 0
+      ? ltm.knowledgeFileRefsBatch(knowledgeLogicalIds)
+      : undefined;
 
   lines.push(`## Recall Results`);
   lines.push(``);
@@ -456,7 +463,12 @@ function formatFusedResults(
         lines.push(`#### ${SOURCE_LABELS[currentSource]}`);
       }
 
-      const line = renderResultLine(r.item, r.charBudget, anchorsByLogicalId);
+      const line = renderResultLine(
+        r.item,
+        r.charBudget,
+        anchorsByLogicalId,
+        filesByLogicalId,
+      );
       lines.push(line);
     }
   }
@@ -577,10 +589,20 @@ function renderAnchors(anchors?: ltm.KnowledgeRefAnchor[]): string {
   return ` \u21b3 ${parts.join(", ")}`;
 }
 
+/** Render an entry's file-path associations as a `↳ files: a, b, c` suffix
+ *  (D2c PR-2). Parallel to renderAnchors: empty/absent → "". Up to
+ *  MAX_RECALL_FILES_PER_ENTRY (already enforced by the batch reader) paths.
+ *  Sorted deterministically by the writer, so output is stable. */
+function renderFiles(paths?: string[]): string {
+  if (!paths || paths.length === 0) return "";
+  return ` \u21b3 files: ${paths.join(", ")}`;
+}
+
 function renderResultLine(
   tagged: TaggedResult,
   charBudget: number,
   anchorsByLogicalId?: Map<string, ltm.KnowledgeRefAnchor[]>,
+  filesByLogicalId?: Map<string, string[]>,
 ): string {
   const id = taggedResultKey(tagged);
 
@@ -590,26 +612,28 @@ function renderResultLine(
       const age = relativeAge(k.updated_at);
       const titlePart = `**${inline(k.title)}** (${age}): `;
       const anchors = renderAnchors(anchorsByLogicalId?.get(k.logical_id));
+      const files = renderFiles(filesByLogicalId?.get(k.logical_id));
       const contentBudget = Math.max(
         40,
-        charBudget - titlePart.length - anchors.length,
+        charBudget - titlePart.length - anchors.length - files.length,
       );
       const content = truncateAtSentence(inline(k.content), contentBudget);
       const wasTruncated = inline(k.content).length > contentBudget;
-      return `- ${titlePart}${content}${anchors}${wasTruncated ? ` (${id})` : ""}`;
+      return `- ${titlePart}${content}${anchors}${files}${wasTruncated ? ` (${id})` : ""}`;
     }
     case "cross-knowledge": {
       const k = tagged.item;
       const age = relativeAge(k.updated_at);
       const titlePart = `**${inline(k.title)}** (${age}, from: ${tagged.projectLabel}): `;
       const anchors = renderAnchors(anchorsByLogicalId?.get(k.logical_id));
+      const files = renderFiles(filesByLogicalId?.get(k.logical_id));
       const contentBudget = Math.max(
         40,
-        charBudget - titlePart.length - anchors.length,
+        charBudget - titlePart.length - anchors.length - files.length,
       );
       const content = truncateAtSentence(inline(k.content), contentBudget);
       const wasTruncated = inline(k.content).length > contentBudget;
-      return `- ${titlePart}${content}${anchors}${wasTruncated ? ` (${id})` : ""}`;
+      return `- ${titlePart}${content}${anchors}${files}${wasTruncated ? ` (${id})` : ""}`;
     }
     case "distillation": {
       const d = tagged.item;
@@ -1486,11 +1510,17 @@ export function recallById(id: string): string {
       const detailAnchors = renderAnchors(
         ltm.knowledgeRefAnchors([entry.logical_id]).get(entry.logical_id),
       );
+      // D2c PR-2: file-path associations, parallel to the anchor line. Same
+      // batch-loader path as the main recall surface — keeps the rendering
+      // semantics consistent (sorted, capped at MAX_RECALL_FILES_PER_ENTRY).
+      const detailFiles = renderFiles(
+        ltm.knowledgeFileRefsBatch([entry.logical_id]).get(entry.logical_id),
+      );
       return [
         `## Recall Detail: ${id}`,
         ``,
         `#### Knowledge`,
-        `- **${inline(entry.title)}** (${entry.category}): ${inline(entry.content)}${detailAnchors}`,
+        `- **${inline(entry.title)}** (${entry.category}): ${inline(entry.content)}${detailAnchors}${detailFiles}`,
       ].join("\n");
     }
     case "d": {

--- a/packages/core/src/tool-trace.ts
+++ b/packages/core/src/tool-trace.ts
@@ -746,3 +746,61 @@ export function formatToolFailureSection(
   );
   return `### Recurring Tool Failures\n${lines.join("\n")}`;
 }
+
+/**
+ * Per-session file-touch summary: distinct files that file-operating tool
+ * calls (Read/Edit/Write/…) and bash commands with file-touching operands or
+ * redirects ACTED ON during this session (D2c PR-2). Walks
+ * `tool_calls.input_paths_json` (the JSON array written by `recordToolCalls`)
+ * via SQLite's `json_each()` so a single multi-path bash command
+ * (`cat a b c > out.ts`) surfaces every path it touched — not just one.
+ *
+ * Returns a stable-sorted, deduped list of paths AND the per-path hit count
+ * so the curator's "files touched this session" context block can rank by
+ * activity. Capped at `limit` (default 200, well above the curator's
+ * MAX_FILES_IN_CURATOR_CONTEXT=15 to leave headroom). Empty input or no
+ * paths → empty arrays (callers check `paths.length === 0`).
+ */
+export function sessionFileTouches(
+  projectPath: string,
+  sessionID: string,
+  opts?: { limit?: number; sinceMs?: number },
+): { paths: string[]; counts: Record<string, number> } {
+  const pid = ensureProject(projectPath);
+  const limit = opts?.limit ?? 200;
+  const since = opts?.sinceMs ?? 0;
+  // ORDER BY hits DESC, path ASC gives deterministic output for the same
+  // (hits, path) tiebreak — critical for prompt-cache stability of the
+  // context block the curator consumes. The CTE materialises the per-row
+  // JSON expansion once; the bare `FROM t, json_each(t.col)` cross-join
+  // form evaluated incorrectly in SQLite (collapsed to a single path per
+  // call_id — see adversarial review #1504 for the analogous LATERAL fix).
+  const rows = db()
+    .query(
+      `WITH expanded(path) AS (
+         SELECT json_each.value
+           FROM tool_calls, json_each(tool_calls.input_paths_json)
+          WHERE tool_calls.project_id = ?
+            AND tool_calls.session_id = ?
+            AND tool_calls.input_paths_json IS NOT NULL
+            AND tool_calls.created_at >= ?
+       )
+       SELECT path, COUNT(*) AS hits
+         FROM expanded
+        GROUP BY path
+        ORDER BY hits DESC, path ASC
+        LIMIT ?`,
+    )
+    .all(pid, sessionID, since, limit) as Array<{
+    path: string;
+    hits: number;
+  }>;
+  const counts: Record<string, number> = {};
+  const paths: string[] = [];
+  for (const r of rows) {
+    if (typeof r.path !== "string" || r.path.length === 0) continue;
+    counts[r.path] = r.hits;
+    paths.push(r.path);
+  }
+  return { paths, counts };
+}

--- a/packages/core/test/curator-file-refs-op.test.ts
+++ b/packages/core/test/curator-file-refs-op.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { applyOps } from "../src/curator";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+
+// D2c PR-2: CuratorOp{create,update}.files — optional file-association
+// field on the curator's JSON ops. Recorded into knowledge_file_refs
+// sidecar keyed on logical_id. Out-of-set files are accepted with a warn
+// log (the curator may name a file the user mentioned without editing it).
+
+const PROJ = "/test/d2c-pr2/curator-files";
+
+describe("curator applyOps with `files` field (D2c PR-2)", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM knowledge WHERE project_id = ?").run(pid);
+    db().query("DELETE FROM knowledge_file_refs").run();
+  });
+
+  test("create op with files records associations on the new entry", () => {
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "decision",
+          title: "Stripe retry uses idempotency key",
+          content: "...",
+          scope: "project",
+          files: ["src/lib/retry.ts", "src/auth/stripe-client.ts"],
+        },
+      ],
+      { projectPath: PROJ, sessionID: "sess-create" },
+    );
+    expect(result.created).toBe(1);
+    const newId = result.changedEntries[0].id;
+    const files = ltm.knowledgeFileRefsBatch([newId]).get(newId);
+    expect(files).toEqual(["src/auth/stripe-client.ts", "src/lib/retry.ts"]);
+  });
+
+  test("create op WITHOUT files does NOT record an empty association", () => {
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "preference",
+          title: "Always write tests",
+          content: "...",
+          scope: "project",
+        },
+      ],
+      { projectPath: PROJ, sessionID: "sess-create" },
+    );
+    const newId = result.changedEntries[0].id;
+    expect(ltm.knowledgeFileRefsBatch([newId]).has(newId)).toBe(false);
+  });
+
+  test("update op with files REPLACES prior associations", () => {
+    const id = ltm.create({
+      projectPath: PROJ,
+      category: "decision",
+      title: "Tagging test",
+      content: "...",
+      scope: "project",
+    });
+    ltm.setFileRefs(id, ["old.ts"]);
+    applyOps(
+      [
+        {
+          op: "update",
+          id,
+          content: "updated content",
+          files: ["new1.ts", "new2.ts"],
+        },
+      ],
+      { projectPath: PROJ, sessionID: "sess-update" },
+    );
+    const files = ltm.knowledgeFileRefsBatch([id]).get(id);
+    expect(files).toEqual(["new1.ts", "new2.ts"]);
+  });
+
+  test("update op WITHOUT files leaves prior associations alone", () => {
+    const id = ltm.create({
+      projectPath: PROJ,
+      category: "decision",
+      title: "Leave alone test",
+      content: "...",
+      scope: "project",
+    });
+    ltm.setFileRefs(id, ["preserve.ts"]);
+    applyOps([{ op: "update", id, content: "content change only" }], {
+      projectPath: PROJ,
+      sessionID: "sess-update",
+    });
+    const files = ltm.knowledgeFileRefsBatch([id]).get(id);
+    expect(files).toEqual(["preserve.ts"]);
+  });
+
+  test("update op with files: [] explicitly CLEARS the associations", () => {
+    const id = ltm.create({
+      projectPath: PROJ,
+      category: "decision",
+      title: "Clear test",
+      content: "...",
+      scope: "project",
+    });
+    ltm.setFileRefs(id, ["x.ts"]);
+    applyOps([{ op: "update", id, content: "now conceptual", files: [] }], {
+      projectPath: PROJ,
+      sessionID: "sess-update",
+    });
+    expect(ltm.knowledgeFileRefsBatch([id]).has(id)).toBe(false);
+  });
+
+  test("out-of-set files are accepted (warned, not rejected)", () => {
+    // Curator may name a file the user mentioned in chat without editing.
+    // applyOps records it (after defensive normalize) and the warn is logged
+    // but does not block the op.
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "gotcha",
+          title: "Out-of-set reference",
+          content: "The user mentioned foo.ts but did not edit it.",
+          scope: "project",
+          files: ["foo.ts"], // never touched this session
+        },
+      ],
+      { projectPath: PROJ, sessionID: "sess-create" },
+    );
+    expect(result.created).toBe(1);
+    const newId = result.changedEntries[0].id;
+    const files = ltm.knowledgeFileRefsBatch([newId]).get(newId);
+    expect(files).toEqual(["foo.ts"]);
+  });
+
+  test("create op with files exceeding MAX_FILE_REFS_PER_ENTRY is defensively capped", () => {
+    const manyFiles = Array.from({ length: 30 }, (_, i) => `src/file-${i}.ts`);
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "decision",
+          title: "Wide entry",
+          content: "...",
+          scope: "project",
+          files: manyFiles,
+        },
+      ],
+      { projectPath: PROJ, sessionID: "sess-create" },
+    );
+    const newId = result.changedEntries[0].id;
+    // Direct DB check: writer capped at MAX_FILE_REFS_PER_ENTRY (20).
+    const raw = db()
+      .query("SELECT paths_json FROM knowledge_file_refs WHERE logical_id = ?")
+      .get(newId) as { paths_json: string };
+    const stored = JSON.parse(raw.paths_json);
+    expect(stored).toHaveLength(ltm.MAX_FILE_REFS_PER_ENTRY);
+    // The batch reader is capped at MAX_RECALL_FILES_PER_ENTRY (3).
+    const files = ltm.knowledgeFileRefsBatch([newId]).get(newId);
+    expect(files).toHaveLength(ltm.MAX_RECALL_FILES_PER_ENTRY);
+  });
+
+  test("update op with a non-array `files` field is silently ignored (defensive guard)", () => {
+    // The curator's `files` field is typed as `string[]`, but a model could
+    // produce a string/number by accident. The apply path's `Array.isArray`
+    // guard must treat a non-array as "don't touch the sidecar" rather than
+    // calling setFileRefs with a non-array (which would character-split it).
+    const id = ltm.create({
+      projectPath: PROJ,
+      category: "decision",
+      title: "Type guard test",
+      content: "...",
+      scope: "project",
+    });
+    ltm.setFileRefs(id, ["preserve.ts"]);
+    applyOps(
+      [
+        // Intentionally bypass the type — simulate a model mistake.
+        {
+          op: "update",
+          id,
+          content: "content",
+          files: "foo.ts" as unknown as string[],
+        },
+      ],
+      { projectPath: PROJ, sessionID: "sess-update" },
+    );
+    // The sidecar must be UNCHANGED (Array.isArray guard prevents the
+    // character-split path inside setFileRefs).
+    expect(ltm.knowledgeFileRefsBatch([id]).get(id)).toEqual(["preserve.ts"]);
+  });
+
+  test("dedup-merged create op (existing entry wins) leaves prior associations unchanged", () => {
+    // When tryCreate merges the new content into an existing entry via
+    // dedup, the create branch continues past the files-handling block. So
+    // an `op.files` on a dedup-merged create does NOT change the existing
+    // entry's associations — the curator must send a separate update op.
+    const id = ltm.create({
+      projectPath: PROJ,
+      category: "decision",
+      title: "Existing tag",
+      content: "existing body",
+      scope: "project",
+    });
+    ltm.setFileRefs(id, ["existing.ts"]);
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "decision",
+          title: "Existing tag", // same title → tryCreate merges via dedup
+          content: "refined body",
+          scope: "project",
+          files: ["new.ts"], // should NOT replace the existing sidecar
+        },
+      ],
+      { projectPath: PROJ, sessionID: "sess-create" },
+    );
+    expect(result.created).toBe(0);
+    expect(result.updated).toBe(1);
+    expect(ltm.knowledgeFileRefsBatch([id]).get(id)).toEqual(["existing.ts"]);
+  });
+});

--- a/packages/core/test/curator-files-touched.test.ts
+++ b/packages/core/test/curator-files-touched.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { buildFilesTouchedContext } from "../src/curator";
+import { db, ensureProject } from "../src/db";
+import { recordToolCalls } from "../src/temporal";
+import type { LoreMessage, LorePart } from "../src/types";
+
+// D2c PR-2: buildFilesTouchedContext — the curator's per-session "what files
+// were touched" prompt-context block. Mirrors buildActionTagContext shape:
+// compact markdown, top-N sorted, "" when empty.
+
+const PROJ = "/test/d2c-pr2/files-touched-ctx";
+const SESS = "sess-curator-ctx";
+
+function makeMessage(): LoreMessage {
+  return {
+    id: "m-ctx",
+    sessionID: SESS,
+    role: "assistant",
+    time: { created: 1_700_000_000_000 },
+    parentID: "p",
+    modelID: "x",
+    providerID: "y",
+    mode: "build",
+    path: { cwd: PROJ, root: PROJ },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  };
+}
+
+function toolPart(callID: string, tool: string, input: unknown): LorePart {
+  return {
+    id: `tp-${callID}`,
+    sessionID: SESS,
+    messageID: "m-ctx",
+    type: "tool",
+    tool,
+    callID,
+    state: { status: "pending", input } as Record<string, unknown>,
+  };
+}
+
+describe("buildFilesTouchedContext (D2c PR-2)", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJ);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+  });
+
+  test("returns '' when projectPath is missing (graceful no-op)", () => {
+    expect(buildFilesTouchedContext("", SESS)).toBe("");
+  });
+
+  test("returns '' when sessionID is missing (graceful no-op)", () => {
+    expect(buildFilesTouchedContext(PROJ, "")).toBe("");
+  });
+
+  test("returns '' when no files have been touched this session", () => {
+    expect(buildFilesTouchedContext(PROJ, SESS)).toBe("");
+  });
+
+  test("returns a markdown block sorted by hit count DESC", () => {
+    recordToolCalls({
+      projectPath: PROJ,
+      info: makeMessage(),
+      parts: [
+        toolPart("c1", "Read", { filePath: "src/a.ts" }),
+        toolPart("c2", "Edit", { filePath: "src/a.ts" }),
+        toolPart("c3", "Write", { filePath: "src/a.ts" }),
+        toolPart("c4", "Read", { filePath: "src/b.ts" }),
+      ],
+    });
+    const out = buildFilesTouchedContext(PROJ, SESS);
+    expect(out).toContain("Files touched this session");
+    expect(out).toContain("`src/a.ts` (3 hits)");
+    expect(out).toContain("`src/b.ts` (1 hits)");
+    // a.ts must appear before b.ts (hit-count order).
+    const aIdx = out.indexOf("src/a.ts");
+    const bIdx = out.indexOf("src/b.ts");
+    expect(aIdx).toBeLessThan(bIdx);
+  });
+
+  test("caps at MAX_FILES_IN_CURATOR_CONTEXT (15)", () => {
+    const parts: LorePart[] = [];
+    for (let i = 0; i < 20; i++) {
+      parts.push(toolPart(`c${i}`, "Read", { filePath: `src/file-${i}.ts` }));
+    }
+    recordToolCalls({
+      projectPath: PROJ,
+      info: makeMessage(),
+      parts,
+    });
+    const out = buildFilesTouchedContext(PROJ, SESS);
+    // Count occurrences of "- `src/" — should be exactly 15.
+    const matches = out.match(/- `src\//g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(15);
+  });
+});

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -119,7 +119,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(76);
+    expect(row.version).toBe(77);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -176,7 +176,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(76);
+    expect(ver.version).toBe(77);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh
@@ -213,7 +213,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(76);
+    expect(ver.version).toBe(77);
   });
 
   test("v56: knowledge_ref_validity table + projects.last_refcheck_at exist after recovery", () => {

--- a/packages/core/test/ltm-file-refs.test.ts
+++ b/packages/core/test/ltm-file-refs.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "vitest";
+import { close, db } from "../src/db";
+import * as ltm from "../src/ltm";
+
+// D2c PR-2: knowledge_file_refs sidecar, keyed on logical_id. Associations
+// are project-context (NOT user knowledge), so they live in a per-entry
+// sidecar that survives version edits (keyed on logical_id, not on a
+// version row). setFileRefs replaces; knowledgeFileRefsBatch reads.
+
+const PROJECT = "/test/d2c-pr2/file-refs";
+
+describe("ltm.setFileRefs / knowledgeFileRefsBatch (D2c PR-2)", () => {
+  test("setFileRefs persists, batch reader returns sorted unique paths", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Stripe retry uses idempotency key",
+      content: "...",
+    });
+    const out = ltm.setFileRefs(id, [
+      "src/lib/retry.ts",
+      "src/auth/stripe-client.ts",
+      "src/auth/stripe-client.ts", // duplicate → ignored
+      "  ", // whitespace-only → dropped
+    ]);
+    expect(out).toEqual(["src/auth/stripe-client.ts", "src/lib/retry.ts"]); // sorted + deduped
+    const got = ltm.knowledgeFileRefsBatch([id]).get(id);
+    expect(got).toEqual(["src/auth/stripe-client.ts", "src/lib/retry.ts"]);
+  });
+
+  test("setFileRefs caps at MAX_FILE_REFS_PER_ENTRY (20) defensively", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Wide entry",
+      content: "...",
+    });
+    const paths = Array.from({ length: 50 }, (_, i) => `src/file-${i}.ts`);
+    const out = ltm.setFileRefs(id, paths);
+    expect(out).toHaveLength(ltm.MAX_FILE_REFS_PER_ENTRY);
+    expect(out).toHaveLength(20);
+  });
+
+  test("setFileRefs is idempotent (re-call replaces, not appends)", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Idempotent tag",
+      content: "...",
+    });
+    ltm.setFileRefs(id, ["a.ts", "b.ts"]);
+    ltm.setFileRefs(id, ["c.ts"]);
+    const got = ltm.knowledgeFileRefsBatch([id]).get(id);
+    expect(got).toEqual(["c.ts"]);
+  });
+
+  test("knowledgeFileRefsBatch caps reader output at MAX_RECALL_FILES_PER_ENTRY (3)", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Many files",
+      content: "...",
+    });
+    // Write 10 (under MAX_FILE_REFS_PER_ENTRY=20)
+    const paths = Array.from({ length: 10 }, (_, i) => `src/f-${i}.ts`);
+    ltm.setFileRefs(id, paths);
+    const got = ltm.knowledgeFileRefsBatch([id]).get(id);
+    expect(got).toHaveLength(ltm.MAX_RECALL_FILES_PER_ENTRY);
+    expect(got).toHaveLength(3);
+    // First 3 (alphabetically)
+    expect(got).toEqual(["src/f-0.ts", "src/f-1.ts", "src/f-2.ts"]);
+  });
+
+  test("knowledgeFileRefsBatch: empty input → empty map (no query)", () => {
+    const got = ltm.knowledgeFileRefsBatch([]);
+    expect(got.size).toBe(0);
+  });
+
+  test("knowledgeFileRefsBatch: entry with no associations → absent from map", () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Untagged entry",
+      content: "...",
+    });
+    const got = ltm.knowledgeFileRefsBatch([id]);
+    expect(got.has(id)).toBe(false);
+  });
+
+  test("setFileRefs updates updated_at clock (monotonic per row)", async () => {
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Clock test",
+      content: "...",
+    });
+    ltm.setFileRefs(id, ["a.ts"]);
+    const t1 = (
+      db()
+        .query(
+          "SELECT updated_at AS t FROM knowledge_file_refs WHERE logical_id = ?",
+        )
+        .get(id) as { t: number }
+    ).t;
+    // Tiny pause to guarantee the unixepoch('now') value changes (second-grain
+    // on most platforms — for SQLite ≥3.38 it can be sub-second).
+    await new Promise((r) => setTimeout(r, 1100));
+    ltm.setFileRefs(id, ["b.ts"]);
+    const t2 = (
+      db()
+        .query(
+          "SELECT updated_at AS t FROM knowledge_file_refs WHERE logical_id = ?",
+        )
+        .get(id) as { t: number }
+    ).t;
+    expect(t2).toBeGreaterThan(t1);
+  });
+
+  test("recoverMissingObjects: missing knowledge_file_refs table is recreated", () => {
+    // Simulate the failure mode: drop the table, close, reopen.
+    db().exec("DROP TABLE knowledge_file_refs");
+    close();
+    // Reopen triggers recoverMissingObjects.
+    db();
+    // New entry should work cleanly.
+    const id = ltm.create({
+      projectPath: PROJECT,
+      scope: "project",
+      category: "decision",
+      title: "Post-recovery entry",
+      content: "...",
+    });
+    expect(() => ltm.setFileRefs(id, ["x.ts"])).not.toThrow();
+    expect(ltm.knowledgeFileRefsBatch([id]).get(id)).toEqual(["x.ts"]);
+  });
+});

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 76", () => {
+  test("schema version is 77", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(76);
+    expect(v.version).toBe(77);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/recall-file-refs.test.ts
+++ b/packages/core/test/recall-file-refs.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject } from "../src/db";
+import * as ltm from "../src/ltm";
+import { runRecall } from "../src/recall";
+
+// D2c PR-2: recall renders file-path associations as a `↳ files: …` line
+// alongside the anchor line in the id-detail path. Mirrors the anchor
+// rendering surface, parallel cap (MAX_RECALL_FILES_PER_ENTRY=3).
+
+const PROJECT = "/test/recall-file-refs/project";
+
+function seed(title: string, content: string): string {
+  return ltm.create({
+    projectPath: PROJECT,
+    scope: "project",
+    crossProject: false,
+    category: "gotcha",
+    title,
+    content,
+  });
+}
+
+describe("recall renders file-path associations (D2c PR-2, id-detail path)", () => {
+  beforeEach(() => {
+    ensureProject(PROJECT);
+    db().exec("DELETE FROM knowledge_file_refs");
+  });
+
+  test("a single path renders as `↳ files: path/to/file`", async () => {
+    const id = seed("Tagged entry", "entry content");
+    const lid = ltm.get(id)!.logical_id;
+    ltm.setFileRefs(lid, ["src/auth/retry.ts"]);
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).toContain("\u21b3 files: src/auth/retry.ts");
+  });
+
+  test("multiple paths render comma-separated, sorted", async () => {
+    const id = seed("Tagged entry", "entry content");
+    const lid = ltm.get(id)!.logical_id;
+    ltm.setFileRefs(lid, ["src/lib/retry.ts", "src/auth/stripe-client.ts"]);
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).toContain(
+      "\u21b3 files: src/auth/stripe-client.ts, src/lib/retry.ts",
+    );
+  });
+
+  test("recall caps at MAX_RECALL_FILES_PER_ENTRY (3) for rendering", async () => {
+    const id = seed("Wide tagged entry", "entry content");
+    const lid = ltm.get(id)!.logical_id;
+    // Write 5 — recall should render 3 (alphabetical first 3).
+    ltm.setFileRefs(lid, [
+      "src/a.ts",
+      "src/b.ts",
+      "src/c.ts",
+      "src/d.ts",
+      "src/e.ts",
+    ]);
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).toContain("\u21b3 files: src/a.ts, src/b.ts, src/c.ts");
+    expect(out).not.toContain("src/d.ts");
+    expect(out).not.toContain("src/e.ts");
+  });
+
+  test("entries with no file refs render WITHOUT a `↳ files:` line", async () => {
+    const id = seed("Untagged entry", "entry content");
+    const out = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    expect(out).not.toContain("\u21b3 files:");
+  });
+
+  test("renderFileRefs is order-deterministic across same set", async () => {
+    const id = seed("Determinism test", "entry content");
+    const lid = ltm.get(id)!.logical_id;
+    ltm.setFileRefs(lid, ["x.ts", "y.ts", "z.ts"]);
+    const out1 = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    const out2 = await runRecall({
+      query: "",
+      id: `k:${id}`,
+      projectPath: PROJECT,
+    });
+    // Same input → same output bytes (cache-friendly).
+    expect(out1).toBe(out2);
+  });
+});
+
+describe("recall renders file-path associations (D2c PR-2, cross-knowledge branch)", () => {
+  const ORIGIN = "/test/recall-file-refs/origin";
+  const FOREIGN = "/test/recall-file-refs/foreign";
+
+  beforeEach(() => {
+    ensureProject(ORIGIN);
+    ensureProject(FOREIGN);
+    db().exec("DELETE FROM knowledge_file_refs");
+  });
+
+  test("a cross-knowledge (project-scoped, recalled from another project) entry surfaces its file refs", async () => {
+    // To trigger the cross-knowledge RENDERING branch (recall.ts:629), the
+    // entry must be project-scoped (crossProject=false) in ORIGIN so that
+    // searchScoredOtherProjects (ltm.ts:3561) picks it up when searching
+    // from FOREIGN. crossProject=true entries surface in the regular search
+    // and tag as "knowledge", not "cross-knowledge" — that's a separate code
+    // path with identical renderFiles wiring but different label.
+    const id = ltm.create({
+      projectPath: ORIGIN,
+      scope: "project",
+      crossProject: false,
+      category: "decision",
+      title: "Use Stripe idempotency keys",
+      content: "All charge creation must include Idempotency-Key header.",
+    });
+    const lid = ltm.get(id)!.logical_id;
+    ltm.setFileRefs(lid, ["src/auth/stripe-client.ts", "src/lib/retry.ts"]);
+    // Recall from FOREIGN with a matching query — must surface as
+    // cross-knowledge (project_id = ORIGIN != FOREIGN). The
+    // renderResultLine cross-knowledge branch (recall.ts:629) is exercised.
+    const out = await runRecall({
+      query: "Stripe idempotency",
+      projectPath: FOREIGN,
+    });
+    expect(out).toContain(
+      "\u21b3 files: src/auth/stripe-client.ts, src/lib/retry.ts",
+    );
+    // The cross-knowledge branch adds a `from: <label>` marker.
+    expect(out).toMatch(/from: /);
+  });
+});

--- a/packages/core/test/tool-trace-session-files.test.ts
+++ b/packages/core/test/tool-trace-session-files.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { db, ensureProject, projectId } from "../src/db";
+import { recordToolCalls } from "../src/temporal";
+import * as toolTrace from "../src/tool-trace";
+import type { LoreMessage, LorePart } from "../src/types";
+
+// D2c PR-2: sessionFileTouches — per-session summary of distinct files
+// tool calls acted on. Backed by tool_calls.input_paths_json (the JSON array
+// written by recordToolCalls in PR-1b), walked via SQLite's json_each so a
+// single multi-path bash command surfaces every path it touched.
+
+const PROJECT = "/test/d2c-pr2/session-files";
+const SESSION = "sess-1";
+
+function makeMessage(id: string): LoreMessage {
+  return {
+    id,
+    sessionID: SESSION,
+    role: "assistant",
+    time: { created: 1_700_000_000_000 },
+    parentID: "parent-1",
+    modelID: "claude-sonnet-4-20250514",
+    providerID: "anthropic",
+    mode: "build",
+    path: { cwd: PROJECT, root: PROJECT },
+    cost: 0,
+    tokens: {
+      input: 100,
+      output: 50,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+}
+
+function toolPart(
+  messageID: string,
+  callID: string,
+  tool: string,
+  state: Record<string, unknown>,
+): LorePart {
+  return {
+    id: `tp-${callID}`,
+    sessionID: SESSION,
+    messageID,
+    type: "tool",
+    tool,
+    callID,
+    // Wrap the caller's state in a proper LoreToolState shape (status must be
+    // present so toolOutcome() in temporal.ts can read it without crashing).
+    state: { status: "pending", ...state } as Record<string, unknown>,
+  };
+}
+
+describe("sessionFileTouches (D2c PR-2)", () => {
+  beforeEach(() => {
+    const pid = ensureProject(PROJECT);
+    db().query("DELETE FROM tool_calls WHERE project_id = ?").run(pid);
+  });
+
+  test("returns empty arrays for a session with no tool calls", () => {
+    const got = toolTrace.sessionFileTouches(PROJECT, SESSION);
+    expect(got.paths).toEqual([]);
+    expect(got.counts).toEqual({});
+  });
+
+  test("returns empty arrays for an unknown session_id", () => {
+    recordToolCalls({
+      projectPath: PROJECT,
+      info: makeMessage("m1"),
+      parts: [
+        toolPart("m1", "c1", "Read", {
+          input: { filePath: "src/a.ts" },
+        }),
+      ],
+    });
+    const got = toolTrace.sessionFileTouches(PROJECT, "no-such-session");
+    expect(got.paths).toEqual([]);
+  });
+
+  test("aggregates single-path tool calls (Read/Edit/Write) by file", () => {
+    recordToolCalls({
+      projectPath: PROJECT,
+      info: makeMessage("m1"),
+      parts: [
+        toolPart("m1", "c1", "Read", { input: { filePath: "src/a.ts" } }),
+        toolPart("m1", "c2", "Edit", { input: { filePath: "src/a.ts" } }),
+        toolPart("m1", "c3", "Write", { input: { filePath: "src/b.ts" } }),
+      ],
+    });
+    const got = toolTrace.sessionFileTouches(PROJECT, SESSION);
+    // Sorted by hits DESC, path ASC: a.ts has 2 hits, b.ts has 1.
+    expect(got.paths).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(got.counts).toEqual({ "src/a.ts": 2, "src/b.ts": 1 });
+  });
+
+  test("multi-path bash command (input_paths_json array) expands via json_each", () => {
+    // Manually insert a tool_calls row with a multi-path JSON array to test
+    // the json_each path directly (recordToolCalls always passes through
+    // extractFilePaths which produces an array — so this is the production
+    // shape, not a synthetic edge).
+    recordToolCalls({
+      projectPath: PROJECT,
+      info: makeMessage("m1"),
+      parts: [
+        toolPart("m1", "c1", "bash", {
+          input: { command: "cat a.ts b.ts > out.ts" },
+        }),
+      ],
+    });
+    const got = toolTrace.sessionFileTouches(PROJECT, SESSION);
+    expect(new Set(got.paths)).toEqual(new Set(["a.ts", "b.ts", "out.ts"]));
+    // Each path appears exactly once.
+    for (const p of got.paths) {
+      expect(got.counts[p]).toBe(1);
+    }
+  });
+
+  test("limit caps the returned paths but preserves hit-count ordering", () => {
+    recordToolCalls({
+      projectPath: PROJECT,
+      info: makeMessage("m1"),
+      parts: [
+        toolPart("m1", "c1", "Read", { input: { filePath: "src/a.ts" } }),
+        toolPart("m1", "c2", "Read", { input: { filePath: "src/b.ts" } }),
+        toolPart("m1", "c3", "Read", { input: { filePath: "src/c.ts" } }),
+        toolPart("m1", "c4", "Read", { input: { filePath: "src/d.ts" } }),
+      ],
+    });
+    const got = toolTrace.sessionFileTouches(PROJECT, SESSION, { limit: 2 });
+    expect(got.paths).toHaveLength(2);
+    // All four have 1 hit; tiebreak is alphabetical ASC.
+    expect(got.paths).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  test("scopes to project_id (does not leak other projects)", () => {
+    const OTHER = "/test/d2c-pr2/session-files-other";
+    ensureProject(OTHER);
+    recordToolCalls({
+      projectPath: PROJECT,
+      info: makeMessage("m1"),
+      parts: [
+        toolPart("m1", "c1", "Read", { input: { filePath: "src/our.ts" } }),
+      ],
+    });
+    recordToolCalls({
+      projectPath: OTHER,
+      info: { ...makeMessage("m2"), sessionID: "sess-other" },
+      parts: [
+        {
+          ...toolPart("m2", "c2", "Read", {
+            input: { filePath: "src/their.ts" },
+          }),
+          sessionID: "sess-other",
+        },
+      ],
+    });
+    const ourGot = toolTrace.sessionFileTouches(PROJECT, SESSION);
+    expect(ourGot.paths).toEqual(["src/our.ts"]);
+    expect(ourGot.counts["src/their.ts"]).toBeUndefined();
+  });
+
+  test("ensureProject returns a string id (regression check)", () => {
+    expect(typeof projectId(PROJECT)).toBe("string");
+  });
+});


### PR DESCRIPTION
## D2c PR-2 — knowledge_file_refs sidecar + curator files-touched context + recall ↳ files: rendering

Closes the entry↔file association loop. After **D2c PR-1 (#1424)** captured `tool_calls.input_path` per call and **D2c PR-1b (#1504)** widened it to `input_paths_json` (JSON array of paths via bash AST walk), the curator can now opt to associate a new/updated knowledge entry with the files it touched during the minting session, and recall surfaces that as a `↳ files: a, b, c` line alongside the anchor line.

### Storage — sidecar, keyed on logical_id

- **v77 migration**: `CREATE TABLE knowledge_file_refs (logical_id PRIMARY KEY, paths_json TEXT NOT NULL, updated_at INTEGER)`. Recovery def in `recoverMissingObjects` recreates the table if missing.
- **`ltm.ts`**: `setFileRefs` (idempotent, defensive cap `MAX_FILE_REFS_PER_ENTRY=20`), `knowledgeFileRefsBatch` (cap `MAX_RECALL_FILES_PER_ENTRY=3`), added to `LOGICAL_ID_BOOKKEEPING_TABLES`.
- **NOT in `SYNCED_TABLES`** — session-context, not user knowledge; remote machines generate their own. Same posture as `tool_calls` (proven correct in #1504).

### Curator integration

- **`buildFilesTouchedContext`** (mirrors `buildToolFailureContext` shape): top-15 files by hit-count, sorted by path tiebreak for prompt-cache stability, markdown block appended to `userContent`.
- **`CuratorOp{create,update}.files?: string[]`**. Out-of-set files accepted with warn log (curator may name a file the user mentioned without editing). `update.files=[]` explicitly clears; `update` without `files` leaves the sidecar alone (content-only edits).
- **`prompt.ts`**: new "File associations (D2c PR-2)" section + JSON schema example updated.

### Recall rendering

- **`renderFiles(paths)`**: ` ↳ files: a, b, c` suffix, parallel to anchors.
- Threaded through `renderResultLine` knowledge / cross-knowledge / id-detail branches. `knowledgeFileRefsBatch` loaded once for the whole result set (parallel to anchors).
- `formatKnowledge` (system prompt) NOT updated — that block is byte-stable-sorted; adding volatile file hits would churn the prompt cache. Same decision as anchors.

### Tests — 32 across 5 new files + 2 schema-version pin bumps

| File | Tests | Coverage |
|---|---|---|
| `ltm-file-refs.test.ts` | 8 | `setFileRefs` idempotent + cap + dedup, `knowledgeFileRefsBatch` cap + empty input + missing-table recovery, `updated_at` monotonic |
| `tool-trace-session-files.test.ts` | 7 | empty / unknown session, single-path aggregation, multi-path bash via `json_each` (CTE form for cross-row expansion), limit cap, `project_id` scoping |
| `curator-files-touched.test.ts` | 5 | graceful no-op for missing inputs, sorted hit-count block, `MAX_FILES_IN_CURATOR_CONTEXT=15` |
| `curator-file-refs-op.test.ts` | 7 | create with files, create without files (no-op), update with files replaces, update without files preserves, `files=[]` clears, out-of-set accepted, `MAX_FILE_REFS` cap |
| `recall-file-refs.test.ts` | 5 | single/multi path render, recall cap=3, entries with no refs render without line, determinism |

### Key technical note

`json_each` cross-join (`FROM t, json_each(t.col)`) silently collapses to a single path per call_id in SQLite — wrapping the expansion in a CTE (`WITH expanded(path) AS (...)`) is the correct form. Adversarial review of #1504 surfaced the analogous json_each trap for bash-path extraction; this CTE mirrors that fix.

### Stats

**Full @loreai/core suite: 3333 passed / 6 skipped (3339)**. Format clean, lint clean, build green. Schema-version pin bumped 76 → 77 in `db.test.ts` and `ltm-versioning.test.ts`.

### Open design decisions defended in this PR

1. **Session-scoped (immutable), not re-curated over time** — v1 behavior. PR-3 (staleness) handles file-deleted without re-tagging.
2. **Curator-selected, not heuristic all-touched** — the curator gets the list in its prompt context and emits `files: [...]` per op; no heuristic gate. Validation guard: `files` must be a subset of `sessionFileTouches` OR explicitly opt-out (warn-and-proceed).
3. **Cross-project entries (`project_id=NULL`)** — still allow associations; the "files touched" prompt block is omitted for cross-project calls (curator must name explicitly). Renders identically in recall.
4. **`formatKnowledge` (system prompt) NOT updated** — volatile file refs would churn prompt cache. Same decision as anchors.