### PR TITLE
feat(gateway): OAuth scopes bump, provider_token cache, hybrid OAuth, git-remote auto-detect

### DIFF
--- a/packages/gateway/src/cli/login.ts
+++ b/packages/gateway/src/cli/login.ts
@@ -19,6 +19,7 @@ import { createInterface } from "node:readline/promises";
 import qrcode from "qrcode-terminal";
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import {
+  clearProviderTokenCache,
   clearSession,
   createSupabaseClient,
   getCurrentUser,
@@ -37,6 +38,9 @@ import {
  *  Collaborator API requires `repo` for private org repos (e.g. getsentry/*).
  */
 const OAUTH_SCOPES = "read:org repo";
+
+/** Historical GitHub OAuth App default TTL for read-only tokens (8 hours). */
+const GITHUB_PROVIDER_TOKEN_TTL_SECONDS = 8 * 60 * 60;
 
 // ---------------------------------------------------------------------------
 // lore login
@@ -218,15 +222,26 @@ export async function acquireGitHubProviderToken(opts?: {
   const cached = loadCachedProviderToken();
   if (cached) {
     const client = createSupabaseClient();
-    // Restore the persisted session so the returned client is usable.
+    // Restore the persisted session so the returned client is usable. If the
+    // session can't be restored (e.g. refresh_token expired or revoked), the
+    // EF call would 401 with a confusing error — fall through to OAuth instead
+    // so the user gets a fresh re-auth.
     const persisted = loadPersistedSession();
     if (persisted) {
-      await client.auth.setSession({
+      const { error: setErr } = await client.auth.setSession({
         access_token: persisted.access_token,
         refresh_token: persisted.refresh_token,
       });
+      if (setErr) {
+        // Session unrecoverable — discard the cache and run OAuth.
+        clearProviderTokenCache();
+      } else {
+        return { client, providerToken: cached.provider_token };
+      }
+    } else {
+      // No session to bind the token to — discard the cache.
+      clearProviderTokenCache();
     }
-    return { client, providerToken: cached.provider_token };
   }
 
   // No cached token — run OAuth.
@@ -265,27 +280,47 @@ async function acquireGitHubProviderTokenLoopback(): Promise<{
     "If you authorized from another device, paste the code (or redirect URL) here:\n",
   );
 
-  // Race: loopback callback vs stdin paste.
+  // Race: loopback callback vs stdin paste. Empty stdin input is ignored so a
+  // user reflexively pressing Enter can't win the race with a blank code.
   const rl = createInterface({ input: process.stdin, output: process.stdout });
-  const oauthCode = await Promise.race([
-    cbCode,
-    rl.question("").then((line) => {
-      done.close();
-      rl.close();
-      return extractAuthCode(line.trim());
-    }),
-  ]).finally(() => {
+  const emptyInput = new Error("__skip__");
+  const pastePromise = rl.question("").then(
+    (line) => {
+      const code = extractAuthCode(line.trim());
+      if (!code) throw emptyInput;
+      return code;
+    },
+    () => {
+      // loser-side rejection when Node rejects a pending question on close —
+      // swallow so we don't surface an unhandled rejection.
+      throw emptyInput;
+    },
+  );
+  let oauthCode: string;
+  try {
+    oauthCode = await Promise.race([cbCode, pastePromise]);
+  } catch (e) {
+    if (e === emptyInput) throw new Error("No code provided.");
+    throw e;
+  } finally {
     rl.close();
     done.close();
-  });
+  }
 
   const session = await exchangeOAuthCode(client, oauthCode);
   await finalizeLogin(client, sessionToPersisted(session));
   const providerToken = session.provider_token;
   if (!providerToken) throw new Error("GitHub did not return an access token.");
-  const ttl = session.expires_at
+  // GitHub provider_tokens issued via Supabase don't carry an explicit expiry;
+  // bound the cache by whichever runs out first: the access_token expiry, or
+  // 8h (historical GitHub OAuth App default for read-only flows).
+  const sessionTtl = session.expires_at
     ? session.expires_at - Math.floor(Date.now() / 1000)
     : undefined;
+  const ttl = Math.min(
+    sessionTtl ?? GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
+    GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
+  );
   persistProviderTokenCache(providerToken, ttl);
   return { client, providerToken };
 }

--- a/packages/gateway/src/cli/login.ts
+++ b/packages/gateway/src/cli/login.ts
@@ -17,17 +17,26 @@ import { createServer } from "node:http";
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline/promises";
 import qrcode from "qrcode-terminal";
-import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import {
   clearSession,
   createSupabaseClient,
   getCurrentUser,
   isLoggedIn,
+  loadCachedProviderToken,
   loadPersistedSession,
+  persistProviderTokenCache,
   type PersistedSession,
   persistSession,
   sessionToPersisted,
 } from "../supabase";
+
+/** GitHub OAuth scopes needed:
+ *  - `read:org` — org/team membership mirroring (E-5-a, #827)
+ *  - `repo` — list collaborators on private repos (E-5-d, #630)
+ *  Collaborator API requires `repo` for private org repos (e.g. getsentry/*).
+ */
+const OAUTH_SCOPES = "read:org repo";
 
 // ---------------------------------------------------------------------------
 // lore login
@@ -165,7 +174,7 @@ async function loginWithGitHub(): Promise<void> {
     // read:org lets us mirror the user's GitHub org/team memberships into Lore teams at login
     // (E-5-a, #827). Verified server-side via the github-provision Edge Function using the returned
     // provider_token — the client never asserts memberships.
-    options: { skipBrowserRedirect: true, redirectTo, scopes: "read:org" },
+    options: { skipBrowserRedirect: true, redirectTo, scopes: OAUTH_SCOPES },
   });
   if (error || !data.url) {
     done.close();
@@ -178,55 +187,156 @@ async function loginWithGitHub(): Promise<void> {
   openBrowser(data.url);
 
   const oauthCode = await code; // resolves when the browser hits the callback
-  const { data: sess, error: exchErr } =
-    await client.auth.exchangeCodeForSession(oauthCode);
-  if (exchErr) throw new Error(exchErr.message);
-  if (!sess.session) throw new Error("No session returned after OAuth.");
+  const session = await exchangeOAuthCode(client, oauthCode);
 
-  await finalizeLogin(client, sessionToPersisted(sess.session));
-  await provisionGitHubTeams(client, sess.session.provider_token);
+  await finalizeLogin(client, sessionToPersisted(session));
+  await provisionGitHubTeams(client, session.provider_token);
 }
 
 /**
- * E-5-d (#630): obtain a FRESH GitHub `provider_token` via a one-shot loopback OAuth, for a
- * capability that needs to read from GitHub after login (e.g. `lore team discover`). The
- * `provider_token` is short-lived and NOT persisted/refreshed (see provisionGitHubTeams), so it must
- * be re-acquired on demand. Returns the fresh token plus the authed client bound to the refreshed
- * session. Requires an interactive browser (loopback); throws if the grant yields no provider_token
- * (e.g. an email-only account). Also refreshes the persisted session as a side effect.
+ * E-5-d (#630): obtain a GitHub `provider_token` for a read-from-GitHub capability
+ * (e.g. `lore team discover`). Checks the disk cache first; if the cached token is
+ * still valid, returns it (no browser). Otherwise runs the OAuth flow:
+ *
+ *   - When a local browser is available: loopback callback (127.0.0.1:ephemeral).
+ *     While waiting, also listens on stdin for a paste — hybrid mode covers users
+ *     who opened the URL on another device even when the loopback started.
+ *   - When remote/headless (`--no-browser` or `!canOpenBrowser()`): paste-code flow
+ *     (fixed `http://127.0.0.1/callback`, user copies the code from the redirect URL).
+ *
+ * Returns the fresh token plus the authed client bound to the refreshed session.
+ * Throws if the grant yields no provider_token (e.g. an email-only account).
+ * Also refreshes the persisted session and caches the provider_token as a side effect.
  */
-export async function acquireGitHubProviderToken(): Promise<{
+export async function acquireGitHubProviderToken(opts?: {
+  noBrowser?: boolean;
+}): Promise<{
+  client: SupabaseClient;
+  providerToken: string;
+}> {
+  // Try the disk cache first — avoids re-prompting OAuth within the token TTL.
+  const cached = loadCachedProviderToken();
+  if (cached) {
+    const client = createSupabaseClient();
+    // Restore the persisted session so the returned client is usable.
+    const persisted = loadPersistedSession();
+    if (persisted) {
+      await client.auth.setSession({
+        access_token: persisted.access_token,
+        refresh_token: persisted.refresh_token,
+      });
+    }
+    return { client, providerToken: cached.provider_token };
+  }
+
+  // No cached token — run OAuth.
+  const noBrowser = opts?.noBrowser ?? !canOpenBrowser();
+  if (noBrowser) return acquireGitHubProviderTokenPaste();
+
+  return acquireGitHubProviderTokenLoopback();
+}
+
+/**
+ * Loopback + hybrid-stdin variant: sets up the 127.0.0.1 callback and simultaneously
+ * watches stdin for a paste. This covers the case where a user's browser is on a
+ * different machine — the loopback never fires, but they can paste the code from
+ * the redirect URL on that machine.
+ */
+async function acquireGitHubProviderTokenLoopback(): Promise<{
   client: SupabaseClient;
   providerToken: string;
 }> {
   const client = createSupabaseClient();
-  const { code, redirectTo, done } = await startLoopbackCallback();
+  const { code: cbCode, redirectTo, done } = await startLoopbackCallback();
   const { data, error } = await client.auth.signInWithOAuth({
     provider: "github",
-    options: { skipBrowserRedirect: true, redirectTo, scopes: "read:org" },
+    options: { skipBrowserRedirect: true, redirectTo, scopes: OAUTH_SCOPES },
   });
   if (error || !data.url) {
     done.close();
     throw new Error(error?.message ?? "Could not start GitHub OAuth.");
   }
+
   console.log("Opening your browser to authorize GitHub access…");
   console.log("If it doesn't open, scan this or visit the URL below:\n");
   await showAuthUrl(data.url);
   openBrowser(data.url);
+  console.log(
+    "If you authorized from another device, paste the code (or redirect URL) here:\n",
+  );
 
-  const oauthCode = await code;
-  const { data: sess, error: exchErr } =
-    await client.auth.exchangeCodeForSession(oauthCode);
-  if (exchErr) throw new Error(exchErr.message);
-  if (!sess.session) throw new Error("No session returned after OAuth.");
-  // Keep the persisted session fresh (this OAuth refreshed the access token).
-  await finalizeLogin(client, sessionToPersisted(sess.session));
-  const providerToken = sess.session.provider_token;
-  if (!providerToken) {
-    throw new Error(
-      "GitHub did not return an access token — this account may not be linked to GitHub.",
-    );
+  // Race: loopback callback vs stdin paste.
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const oauthCode = await Promise.race([
+    cbCode,
+    rl.question("").then((line) => {
+      done.close();
+      rl.close();
+      return extractAuthCode(line.trim());
+    }),
+  ]).finally(() => {
+    rl.close();
+    done.close();
+  });
+
+  const session = await exchangeOAuthCode(client, oauthCode);
+  await finalizeLogin(client, sessionToPersisted(session));
+  const providerToken = session.provider_token;
+  if (!providerToken) throw new Error("GitHub did not return an access token.");
+  const ttl = session.expires_at
+    ? session.expires_at - Math.floor(Date.now() / 1000)
+    : undefined;
+  persistProviderTokenCache(providerToken, ttl);
+  return { client, providerToken };
+}
+
+/**
+ * Paste-code variant for remote/headless machines. Same PKCE concept as the
+ * loopback path, but uses the fixed `http://127.0.0.1/callback` redirect (the
+ * browser lands on a dead page — user copies the `code=` from the URL bar).
+ */
+async function acquireGitHubProviderTokenPaste(): Promise<{
+  client: SupabaseClient;
+  providerToken: string;
+}> {
+  const client = createSupabaseClient();
+
+  const redirectTo = "http://127.0.0.1/callback";
+  const { data, error } = await client.auth.signInWithOAuth({
+    provider: "github",
+    options: { skipBrowserRedirect: true, redirectTo, scopes: OAUTH_SCOPES },
+  });
+  if (error || !data.url) {
+    throw new Error(error?.message ?? "Could not start GitHub OAuth.");
   }
+
+  console.log("Scan this with your phone, or open the URL on any device:\n");
+  await showAuthUrl(data.url);
+  console.log(
+    "After authorizing, your browser will try to open " +
+      `${redirectTo}?code=…\n` +
+      "That page won't load — copy the value after `code=` (or paste the " +
+      "whole URL) here.\n",
+  );
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let pasted: string;
+  try {
+    pasted = (await rl.question("Paste the code (or redirect URL): ")).trim();
+  } finally {
+    rl.close();
+  }
+  const oauthCode = extractAuthCode(pasted);
+  if (!oauthCode) throw new Error("No code provided.");
+
+  const session = await exchangeOAuthCode(client, oauthCode);
+  await finalizeLogin(client, sessionToPersisted(session));
+  const providerToken = session.provider_token;
+  if (!providerToken) throw new Error("GitHub did not return an access token.");
+  const ttl = session.expires_at
+    ? session.expires_at - Math.floor(Date.now() / 1000)
+    : undefined;
+  persistProviderTokenCache(providerToken, ttl);
   return { client, providerToken };
 }
 
@@ -248,7 +358,7 @@ async function loginWithGitHubManual(): Promise<void> {
   const redirectTo = "http://127.0.0.1/callback";
   const { data, error } = await client.auth.signInWithOAuth({
     provider: "github",
-    options: { skipBrowserRedirect: true, redirectTo, scopes: "read:org" },
+    options: { skipBrowserRedirect: true, redirectTo, scopes: OAUTH_SCOPES },
   });
   if (error || !data.url) {
     throw new Error(error?.message ?? "Could not start GitHub OAuth.");
@@ -307,6 +417,21 @@ async function provisionGitHubTeams(
   } catch {
     // Best-effort — provisioning retries on next login.
   }
+}
+
+/**
+ * Exchange an OAuth code for a session, returning the full `Session` object.
+ * Shared by all OAuth paths (loopback, paste, hybrid) so the provider_token
+ * extraction and expiry logic is in one place.
+ */
+async function exchangeOAuthCode(
+  client: SupabaseClient,
+  oauthCode: string,
+): Promise<Session> {
+  const { data, error } = await client.auth.exchangeCodeForSession(oauthCode);
+  if (error) throw new Error(error.message);
+  if (!data.session) throw new Error("No session returned after OAuth.");
+  return data.session;
 }
 
 /** Pull the OAuth `code` out of a pasted redirect URL, or return the raw code. */

--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -5,6 +5,7 @@
 import { resolve } from "node:path";
 import {
   effectivePromotionPolicy,
+  getGitRemote,
   keystore,
   ltm,
   projectId,
@@ -14,6 +15,7 @@ import {
   setProjectPromotionPolicy,
   setProjectScope,
   syncData,
+  normalizeRemoteUrl,
 } from "@loreai/core";
 import { getAuthedClient, getCurrentUser } from "../supabase";
 import { acquireGitHubProviderToken } from "./login";
@@ -100,14 +102,32 @@ export async function commandTeam(
       }
       case "discover": {
         // E-5-d (#630): find which of the caller's GitHub repo collaborators are already on Lore.
-        // Needs a FRESH provider_token (short-lived, not persisted) → re-run GitHub OAuth.
-        const repos = positionals.slice(1).filter((p) => !p.startsWith("--"));
+        // Auto-detects the git remote when no repo arguments given, passes it to the Edge Function
+        // so private org repos are scanned (not just the caller's own repos first-page).
+        const explicitRepos = positionals
+          .slice(1)
+          .filter((p) => !p.startsWith("--"));
+        let repos: string[] | undefined;
+        if (explicitRepos.length > 0) {
+          repos = explicitRepos;
+        } else {
+          const remote = getGitRemote(process.cwd());
+          if (remote) {
+            const slug = githubOwnerRepo(remote);
+            if (slug) repos = [slug];
+          }
+        }
+        console.log(
+          `Discovering collaborators for ${repos ? repos.join(", ") : "your repos"}…`,
+        );
         let providerToken: string;
         // Use the FRESH client bound to the just-refreshed session — the outer `client` from
         // getAuthedClient() may hold a token that expired during the interactive OAuth flow.
+        // acquireGitHubProviderToken now caches the provider_token; a cache hit skips OAuth.
+        const noBrowser = !!values["no-browser"];
         let freshClient = client;
         try {
-          const acquired = await acquireGitHubProviderToken();
+          const acquired = await acquireGitHubProviderToken({ noBrowser });
           freshClient = acquired.client;
           providerToken = acquired.providerToken;
         } catch (e) {
@@ -118,7 +138,7 @@ export async function commandTeam(
         const found = await discoverGitHubCollaborators(
           freshClient,
           providerToken,
-          repos.length > 0 ? repos : undefined,
+          repos,
         );
         if (!found || found.length === 0) {
           console.log("No accessible repos with collaborators found.");
@@ -505,4 +525,18 @@ export async function commandTeam(
 function usage(): void {
   console.error(USAGE);
   process.exitCode = 1;
+}
+
+/**
+ * Normalize a remote URL to a GitHub `owner/repo` slug, or null when the
+ * remote is not a GitHub URL (e.g. self-hosted GitLab). Accepts git@, https://,
+ * or `github.com/owner/name` forms, stripping `.git` suffix and path.
+ */
+function githubOwnerRepo(remote: string): string | null {
+  const normalized = normalizeRemoteUrl(remote);
+  // Match github.com/owner/repo — the normalized output is always lowercased
+  // host/path. If the host isn't github.com, skip (we can't detect via GitHub API).
+  const match = normalized.match(/^github\.com\/([^/]+)\/([^/]+)$/);
+  if (!match) return null;
+  return `${match[1]}/${match[2]}`;
 }

--- a/packages/gateway/src/supabase.ts
+++ b/packages/gateway/src/supabase.ts
@@ -80,6 +80,7 @@ export function persistSession(session: PersistedSession): void {
   // the mirror intact.
   if (prev && prev.user_id !== session.user_id) {
     syncData.clearPullOnlyMirrors();
+    clearProviderTokenCache();
   }
   setTeamConfig(SESSION_KEY, JSON.stringify(session));
 }
@@ -91,11 +92,79 @@ export function clearSession(): void {
   // sign-out (otherwise currentTier() would keep reporting the logged-out
   // user's tier until a future login + pull).
   syncData.clearPullOnlyMirrors();
+  clearProviderTokenCache();
 }
 
 /** True when a session is persisted locally. Does NOT verify with the server. */
 export function isLoggedIn(): boolean {
   return loadPersistedSession() !== null;
+}
+
+// ---------------------------------------------------------------------------
+// provider_token disk cache (E-5-d, #630) — short-lived, scoped to session
+// ---------------------------------------------------------------------------
+
+/**
+ * The cached GitHub provider_token shape. The token is short-lived (GitHub
+ * OAuth tokens via Supabase often expire in ~8h) and is persisted alongside the
+ * Supabase access_token so that `lore team discover` within the expiry window
+ * avoids re-prompting the OAuth dance.
+ */
+export interface CachedProviderToken {
+  provider_token: string;
+  expires_at: number; // unix seconds
+}
+
+/** team_config key under which the cached provider_token lives. */
+const CACHED_PROVIDER_TOKEN_KEY = "github.provider_token";
+
+/**
+ * Load a previously cached GitHub provider_token, or null when expired / absent.
+ * The token is scoped to the CURRENT Supabase session (access_token); a session
+ * switch (login/logout/account change) naturally invalidates the cache because
+ * clearSession() / persistSession-on-account-switch clear it.
+ */
+export function loadCachedProviderToken(): CachedProviderToken | null {
+  const raw = getTeamConfig(CACHED_PROVIDER_TOKEN_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as CachedProviderToken;
+    if (!parsed.provider_token || typeof parsed.expires_at !== "number")
+      return null;
+    // Expired — discard.
+    if (Date.now() / 1000 >= parsed.expires_at) {
+      deleteTeamConfig(CACHED_PROVIDER_TOKEN_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the GitHub provider_token and its expiry. The expiry is derived from
+ * `expires_in` (seconds from now) on the OAuth session if available, falling
+ * back to a conservative 50-minute default for GitHub tokens that don't carry
+ * an explicit expiry (the Supabase relay sets one on the provider_token when
+ * the upstream GitHub response includes one; when it doesn't, we assume 1h and
+ * shave 10min for clock skew).
+ */
+export function persistProviderTokenCache(
+  providerToken: string,
+  expiresIn?: number,
+): void {
+  const ttl = typeof expiresIn === "number" && expiresIn > 0 ? expiresIn : 3000; // default 50 min
+  const entry: CachedProviderToken = {
+    provider_token: providerToken,
+    expires_at: Math.floor(Date.now() / 1000) + ttl,
+  };
+  setTeamConfig(CACHED_PROVIDER_TOKEN_KEY, JSON.stringify(entry));
+}
+
+/** Clear the cached provider_token — called on logout and account switch. */
+export function clearProviderTokenCache(): void {
+  deleteTeamConfig(CACHED_PROVIDER_TOKEN_KEY);
 }
 
 /**

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -8,7 +8,11 @@
  * CONTENT under a team scope is a later story; here the scope id is the team's `scopes.id`, and all
  * keystore calls key on it.
  */
-import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  FunctionsHttpError,
+  FunctionsRelayError,
+  type SupabaseClient,
+} from "@supabase/supabase-js";
 import { crypto, keystore } from "@loreai/core";
 import { getCurrentUser } from "./supabase";
 import { publishIdentityPub, pullOnce, pushOnce } from "./sync";
@@ -54,7 +58,7 @@ export async function discoverGitHubCollaborators(
   const { data, error } = await client.functions.invoke("github-discover", {
     body: { provider_token: providerToken, repos },
   });
-  if (error) throw new Error(`github-discover: ${error.message}`);
+  if (error) throw await enrichFunctionsError("github-discover", error);
   const payload = data as {
     repos?: Array<{
       repo: string;
@@ -498,4 +502,41 @@ export async function rejectDomainJoin(
     p_request_id: requestId,
   });
   if (error) throw new Error(`reject_domain_join: ${error.message}`);
+}
+
+/**
+ * Enrich a Supabase Edge Function error with the response body, so the CLI
+ * user sees the real error text (e.g. "invalid token", "lookup failed") instead
+ * of the generic "Edge Function returned a non-2xx status code".
+ *
+ * FunctionsHttpError.context is the Response object — read its body.
+ * FunctionsRelayError.context is also a Response (the relay error response).
+ * FunctionsFetchError.context is the original Fetch error.
+ */
+async function enrichFunctionsError(
+  name: string,
+  error: unknown,
+): Promise<Error> {
+  if (error instanceof FunctionsHttpError) {
+    const resp = error.context as Response;
+    try {
+      let body: string | null = null;
+      if (resp?.body) {
+        // Clone in case the response was already consumed by the SDK.
+        body = await resp.clone().text().catch(() => null);
+      }
+      if (body) return new Error(`${name}: ${body}`);
+      return new Error(
+        `${name}: HTTP ${resp?.status ?? "unknown"}: ${error.message}`,
+      );
+    } catch {
+      return new Error(`${name}: HTTP ${resp?.status}: ${error.message}`);
+    }
+  }
+  if (error instanceof FunctionsRelayError) {
+    return new Error(`${name}: relay error — ${error.message}`);
+  }
+  return new Error(
+    `${name}: ${error instanceof Error ? error.message : String(error)}`,
+  );
 }

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -523,7 +523,10 @@ async function enrichFunctionsError(
       let body: string | null = null;
       if (resp?.body) {
         // Clone in case the response was already consumed by the SDK.
-        body = await resp.clone().text().catch(() => null);
+        body = await resp
+          .clone()
+          .text()
+          .catch(() => null);
       }
       if (body) return new Error(`${name}: ${body}`);
       return new Error(

--- a/packages/gateway/test/login.test.ts
+++ b/packages/gateway/test/login.test.ts
@@ -378,4 +378,37 @@ describe("commandLogin (GitHub --no-browser)", () => {
     expect(loadPersistedSession()?.access_token).toBe("at-gh");
     expect(logs.join("\n")).toContain("https://gh.example/oauth?x=1");
   });
+
+  test("empty paste input is rejected with a clear error (not sent to Supabase)", async () => {
+    // Regression: an empty paste used to flow into exchangeCodeForSession and
+    // produce a confusing Supabase error. Now it must throw early.
+    h.auth.signInWithOAuth.mockResolvedValue({
+      data: { url: "https://gh.example/oauth?x=1" },
+      error: null,
+    });
+    h.answer.value = "   ";
+    h.auth.exchangeCodeForSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    h.from.mockReturnValue(profileChain(null));
+
+    // commandLogin catches and process.exit(1)s — verify the exit code and the
+    // surfaced "No code provided." message instead of the throw.
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number,
+    ) => {
+      throw new Error(`process.exit unexpectedly called with "${code}"`);
+    }) as never);
+    try {
+      await commandLogin([], { "no-browser": true });
+    } catch (e) {
+      // outer catch printed to stderr
+      expect(String(e)).toContain("process.exit");
+    }
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errs.join("\n")).toContain("No code provided.");
+    expect(h.auth.exchangeCodeForSession).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
 });

--- a/packages/gateway/test/login.test.ts
+++ b/packages/gateway/test/login.test.ts
@@ -370,7 +370,7 @@ describe("commandLogin (GitHub --no-browser)", () => {
       options: {
         skipBrowserRedirect: true,
         redirectTo: "http://127.0.0.1/callback",
-        scopes: "read:org",
+        scopes: "read:org repo",
       },
     });
     // The pasted URL's ?code= is extracted before exchange.

--- a/packages/gateway/test/supabase.test.ts
+++ b/packages/gateway/test/supabase.test.ts
@@ -20,11 +20,14 @@ vi.mock("@supabase/supabase-js", () => ({
 
 import { db, syncData } from "@loreai/core";
 import {
+  clearProviderTokenCache,
   clearSession,
   getAuthedClient,
   getCurrentUser,
   isLoggedIn,
+  loadCachedProviderToken,
   loadPersistedSession,
+  persistProviderTokenCache,
   persistSession,
   sessionToPersisted,
   SUPABASE_ANON_KEY,
@@ -249,5 +252,69 @@ describe("profile mirror lifecycle (tier must not leak across sessions)", () => 
 
     persistSession(SAMPLE); // switch back to A
     expect(syncData.currentTier()).toBe("free"); // A's stale pro NOT resurrected
+  });
+});
+
+describe("github provider_token disk cache", () => {
+  beforeEach(() => {
+    clearSession();
+    clearProviderTokenCache();
+  });
+
+  test("round-trips a valid token through the cache", () => {
+    expect(loadCachedProviderToken()).toBeNull();
+    persistProviderTokenCache("gh-token-1", 3600);
+    const cached = loadCachedProviderToken();
+    expect(cached?.provider_token).toBe("gh-token-1");
+  });
+
+  test("default TTL falls back to 50 minutes when expiresIn is missing/zero", () => {
+    persistProviderTokenCache("gh-token-2");
+    const cached = loadCachedProviderToken();
+    // Should be valid for ~3000s, not 0s (which would have expired already).
+    expect(cached).not.toBeNull();
+    expect(cached!.expires_at - Math.floor(Date.now() / 1000)).toBeGreaterThan(
+      2900,
+    );
+  });
+
+  test("expired cache entries are dropped on load", () => {
+    // Manually plant an already-expired entry.
+    db()
+      .query(
+        "INSERT INTO team_config (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      )
+      .run(
+        "github.provider_token",
+        JSON.stringify({
+          provider_token: "stale",
+          expires_at: Math.floor(Date.now() / 1000) - 10,
+        }),
+      );
+    expect(loadCachedProviderToken()).toBeNull();
+  });
+
+  test("clearSession clears the cached provider_token", () => {
+    persistProviderTokenCache("gh-token-3", 3600);
+    expect(loadCachedProviderToken()).not.toBeNull();
+    clearSession();
+    expect(loadCachedProviderToken()).toBeNull();
+  });
+
+  test("account switch (different user_id) clears the cached provider_token", () => {
+    persistSession(SAMPLE);
+    persistProviderTokenCache("gh-token-4", 3600);
+    expect(loadCachedProviderToken()).not.toBeNull();
+    persistSession({ ...SAMPLE, user_id: "user-other" });
+    expect(loadCachedProviderToken()).toBeNull();
+  });
+
+  test("token refresh (same user_id) preserves the cached provider_token", () => {
+    persistSession(SAMPLE);
+    persistProviderTokenCache("gh-token-5", 3600);
+    // Refresh the session for the same user — different tokens, same identity.
+    persistSession({ ...SAMPLE, access_token: "at-refreshed" });
+    const cached = loadCachedProviderToken();
+    expect(cached?.provider_token).toBe("gh-token-5");
   });
 });

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -92,10 +92,11 @@ deploy them separately (they are not auto-deployed by CI):
 
 ```bash
 supabase functions deploy github-provision
+supabase functions deploy github-discover
 ```
 
 - **`github-provision`** (E-5-a, #827) — mirrors a user's GitHub org/team memberships into Lore
-  teams. At login the CLI requests the `read:org` OAuth scope and passes the returned
+  teams. At login the CLI requests the `read:org repo` OAuth scope and passes the returned
   `provider_token` to this function; the function verifies the caller's Supabase JWT, reads the
   user's *own* memberships from the GitHub API (unforgeable — a client can never assert
   memberships), and calls the **service-role-only** `provision_github_membership` RPC (migration
@@ -103,6 +104,13 @@ supabase functions deploy github-provision
   platform; `GITHUB_API_URL` is optional (defaults to `https://api.github.com`). `verify_jwt = true`
   (config.toml) so only a signed-in user can invoke it. Provisioning is best-effort — a missing
   deploy or GitHub error never fails `lore login`; it simply retries on the next login.
+
+- **`github-discover`** (E-5-d, #630 Slice 1) — reads the caller's GitHub repos and their
+  collaborators, then reveals which collaborators already have a Lore account. Used by
+  `lore team discover`. Like `github-provision`, it verifies the JWT and binds the
+  `provider_token` to the caller's GitHub identity. Requires `read:org` (org/team mirroring)
+  **and** `repo` (to list collaborators on private repos). Backed by migration `0050`
+  (`lore_users_for_github_ids` service-role RPC).
 
 ## Conflict resolution (last-writer-to-remote-wins)
 


### PR DESCRIPTION
## Summary

Fixes four issues with `lore team discover` — re-login loop, repo prompt in git checkout, remote callback breakage, and opaque Edge Function errors.

## Changes

- **Bumped OAuth scopes from `read:org` to `read:org repo`** — `repo` scope required to list collaborators on private org repos (e.g. `getsentry/cli`).
- **provider_token disk cache** (`supabase.ts`) — cached in `team_config` key `github.provider_token` with TTL from `expires_at`; cleared on logout/account switch. Cache hit skips OAuth entirely.
- **Hybrid paste+loopback OAuth** (`login.ts`) — races loopback callback vs stdin paste; paste-only path for `--no-browser`/remote.
- **Git-remote auto-detect** (`team-cmd.ts`) — extracts `owner/repo` from cwd's git remote when no repos specified.
- **Real Edge Function errors** (`team.ts`) — `enrichFunctionsError` reads the HTTP response body from `FunctionsHttpError.context` instead of the generic SDK wrapper message.
- **Docs** (`supabase/README.md`) — documents both edge functions, scopes, and migration 0050.

## Testing

90 tests pass, typecheck passes across all 5 workspace packages.