### PR TITLE
fix(gateway): paste-path TTL cap + githubOwnerRepo comment

### DIFF
--- a/packages/gateway/src/cli/login.ts
+++ b/packages/gateway/src/cli/login.ts
@@ -368,9 +368,17 @@ async function acquireGitHubProviderTokenPaste(): Promise<{
   await finalizeLogin(client, sessionToPersisted(session));
   const providerToken = session.provider_token;
   if (!providerToken) throw new Error("GitHub did not return an access token.");
-  const ttl = session.expires_at
+  // Same 8h cap as the loopback path: GitHub provider_tokens via Supabase
+  // don't carry an explicit expiry, so bind the cache by whichever runs out
+  // first — the access_token expiry, or the historical 8h GitHub OAuth App
+  // default.
+  const sessionTtl = session.expires_at
     ? session.expires_at - Math.floor(Date.now() / 1000)
     : undefined;
+  const ttl = Math.min(
+    sessionTtl ?? GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
+    GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
+  );
   persistProviderTokenCache(providerToken, ttl);
   return { client, providerToken };
 }

--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -534,9 +534,12 @@ function usage(): void {
  */
 function githubOwnerRepo(remote: string): string | null {
   const normalized = normalizeRemoteUrl(remote);
-  // Match github.com/owner/repo — the normalized output is always lowercased
-  // host/path. If the host isn't github.com, skip (we can't detect via GitHub API).
-  const match = normalized.match(/^github\.com\/([^/]+)\/([^/]+)$/);
+  // Match github.com/owner/repo. `normalizeRemoteUrl` lowercases the host but
+  // preserves the path's case; GitHub itself is case-insensitive on the host
+  // (but the path must match exactly), so we anchor the host case-insensitively
+  // and pass the path through verbatim. Skip non-GitHub remotes (e.g. self-
+  // hosted GitLab) — we can't query them via the GitHub API.
+  const match = normalized.match(/^github\.com\/([^/]+)\/([^/]+)$/i);
   if (!match) return null;
   return `${match[1]}/${match[2]}`;
 }


### PR DESCRIPTION
## Summary

Address 2 post-merge Seer comments on #1510:

1. `packages/gateway/src/cli/login.ts:374` — `acquireGitHubProviderTokenPaste` was calculating the provider_token cache TTL directly from `session.expires_at` without the `Math.min` cap at 8h that the loopback path got in `0ee0a49`. Apply the same cap so a long Supabase session TTL doesn't cache the GitHub token past its actual validity.

2. `packages/gateway/src/cli/team-cmd.ts:541` — `githubOwnerRepo` comment incorrectly said `normalizeRemoteUrl` always lowercases host/path; only the host is lowercased. Fixed the comment and made the regex case-insensitive on the host so the documented behavior matches reality (GitHub is case-insensitive on the host; path must match exactly).

## Tests
112 tests pass; typecheck green for all 5 workspace packages.