### PR TITLE
chore(gateway): bump binpatch ^0.1.0 → ^0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@types/node": "24.13.1",
     "@types/pg": "^8.11.10",
     "@vitest/coverage-v8": "^4.1.8",
-    "binpatch": "0.1.0",
+    "binpatch": "^0.3.1",
     "esbuild": "^0.28.1",
     "fast-check": "^4.5.3",
     "linkinator": "^7.6.1",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -73,7 +73,7 @@
     "@types/bun": "^1.2.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/semver": "^7.7.1",
-    "binpatch": "^0.1.0",
+    "binpatch": "^0.3.1",
     "fossilize": "^0.10.1",
     "onnxruntime-node": "1.27.0",
     "tar": "^7.5.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
       binpatch:
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: ^0.3.1
+        version: 0.3.1
       esbuild:
         specifier: '>=0.28.1'
         version: 0.28.1
@@ -181,8 +181,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       binpatch:
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.3.1
+        version: 0.3.1
       fossilize:
         specifier: ^0.10.1
         version: 0.10.1
@@ -2435,6 +2435,10 @@ packages:
 
   binpatch@0.1.0:
     resolution: {integrity: sha512-xhD1I3NwmywSGPK4EqQLT+jcDsnboWzHoBh1UrFrLf/68m4Ohy/i7NCdm4jSIzDv7ZHfiDsjgKtztCQyLY1+kw==}
+    engines: {node: '>=22.5'}
+
+  binpatch@0.3.1:
+    resolution: {integrity: sha512-KD1kWfjqXp+SaNxY71QJ16I+6NU/U8MJD1H9A9VDLqrmmslXvRi+7evICcYwftdhu+Yxd6lH1OqypfYbjfFb8g==}
     engines: {node: '>=22.5'}
 
   binpunch@1.0.0:
@@ -7111,6 +7115,8 @@ snapshots:
   bignumber.js@9.3.1: {}
 
   binpatch@0.1.0: {}
+
+  binpatch@0.3.1: {}
 
   binpunch@1.0.0: {}
 


### PR DESCRIPTION
Pick up the published binpatch@0.3.1:

- 0.3.1: semver-guard fix (no longer throws on malformed/incomparable nightly patch tags)
- 0.3.0: per-HTTP `InstrumentHook` for telemetry/tracing
- 0.2.0: injectable `fetch` for custom CA / proxy / test injection

Fully backward-compatible additive surface since 0.1.0 — gateway imports
(`makeCache`, `PatchCache`, `DeltaResult`, `PatchChain`, `ghcrSource`,
`githubReleaseSource`, `resolveAndApply`, `ProgressEvent`, `SourceStrategy`)
are unchanged. No code changes in gateway; only dependency bump.

Verified: gateway typecheck clean, delta-upgrade tests (5) pass, frozen
lockfile install succeeds.

This supersedes the stalled PR #1503 (which also added a pct progress mode +
regression test); this PR keeps scope tight to the dependency bump only.