### PR TITLE
feat(supabase): wire edge functions into Sentry (#1507)

### DIFF
--- a/packages/gateway/test/login.test.ts
+++ b/packages/gateway/test/login.test.ts
@@ -26,13 +26,16 @@ vi.mock("node:readline/promises", () => ({
 }));
 
 import {
+  acquireGitHubProviderToken,
   canOpenBrowser,
   commandLogin,
   commandLogout,
   commandWhoami,
 } from "../src/cli/login";
 import {
+  clearProviderTokenCache,
   clearSession,
+  loadCachedProviderToken,
   loadPersistedSession,
   persistSession,
 } from "../src/supabase";
@@ -61,6 +64,7 @@ let errSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   clearSession();
+  clearProviderTokenCache();
   for (const fn of Object.values(h.auth)) fn.mockReset();
   h.from.mockReset();
   h.answer.value = "";
@@ -410,5 +414,55 @@ describe("commandLogin (GitHub --no-browser)", () => {
     expect(errs.join("\n")).toContain("No code provided.");
     expect(h.auth.exchangeCodeForSession).not.toHaveBeenCalled();
     exitSpy.mockRestore();
+  });
+});
+
+describe("acquireGitHubProviderToken — paste-path TTL cap", () => {
+  beforeEach(() => {
+    clearSession();
+    clearProviderTokenCache();
+    for (const fn of Object.values(h.auth)) fn.mockReset();
+    h.from.mockReset();
+    h.answer.value = "";
+  });
+
+  test("paste-path cache TTL is capped at 8h even when session TTL is longer", async () => {
+    // Regression for PR #1512: the paste path's TTL was bound directly to
+    // session.expires_at. Cap it at 8h so a long Supabase session TTL doesn't
+    // cache the GitHub token past its actual validity.
+    h.auth.signInWithOAuth.mockResolvedValue({
+      data: { url: "https://gh.example/oauth?x=1" },
+      error: null,
+    });
+    h.answer.value = "abc-123-def";
+    h.auth.exchangeCodeForSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "at-gh",
+          refresh_token: "rt-gh",
+          expires_at: Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60, // 1 year
+          expires_in: 365 * 24 * 60 * 60,
+          provider_token: "gh-provider-token",
+          token_type: "bearer",
+          user: {
+            id: "user-123",
+            email: "me@example.com",
+            user_metadata: { user_name: "octocat", name: "Octo Cat" },
+          },
+        },
+      },
+      error: null,
+    });
+    h.from.mockReturnValue(profileChain(null));
+
+    const result = await acquireGitHubProviderToken({ noBrowser: true });
+    expect(result.providerToken).toBe("gh-provider-token");
+
+    const cached = loadCachedProviderToken();
+    expect(cached).not.toBeNull();
+    const ttl = cached!.expires_at - Math.floor(Date.now() / 1000);
+    // Should be ≤ 8h (28800s), NOT 1 year.
+    expect(ttl).toBeLessThanOrEqual(8 * 60 * 60 + 5); // 5s slack for test clock
+    expect(ttl).toBeGreaterThan(8 * 60 * 60 - 10); // and at least ~8h
   });
 });

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -112,6 +112,24 @@ supabase functions deploy github-discover
   **and** `repo` (to list collaborators on private repos). Backed by migration `0050`
   (`lore_users_for_github_ids` service-role RPC).
 
+## Observability (Sentry)
+
+All three edge functions send failures to Sentry via the shared helper in
+`supabase/functions/_shared/sentry.ts` (using `@sentry/deno`). This mirrors the gateway's
+existing Sentry setup (same project `o275100`) so edge-function errors show up alongside
+gateway errors.
+
+- **Opt-in via secret**: the helper is a **no-op** when `SENTRY_DSN` is unset, so a local
+  `supabase start` stack (or any deploy without the secret) runs untouched. Set it once on
+  the hosted project: `supabase secrets set SENTRY_DSN=https://…@o275100.ingest.us.sentry.io/…`
+  (and optionally `SENTRY_ENVIRONMENT`, `LORE_VERSION` for the release tag).
+- **What is captured**: only thrown `Error` objects at the GitHub/RPC/SMTP failure paths,
+  tagged with non-sensitive scalars (`function_name`, `deployment`, `release`). Uncaught
+  throws are caught by `wrapHandler` and turned into a generic 500.
+- **Privacy**: `sendDefaultPii` is `false` and **no** `provider_token`, email address, email
+  body, or GitHub user id is ever attached to a Sentry event — these functions handle
+  secrets, so PII is never sent to Sentry.
+
 ## Conflict resolution (last-writer-to-remote-wins)
 
 The gateway syncs push-then-pull. When the same row was changed on two machines

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -16,7 +16,8 @@ import * as Sentry from "npm:@sentry/deno";
 
 // Sentry DSN for the Lore project (o275100). This is a public key, safe to
 // ship in client/server code — it only permits sending events, not reading them.
-const SENTRY_DSN = "https://9b9cbf3a465080792e96fb919b278a38@o275100.ingest.us.sentry.io/4511812805394432";
+const SENTRY_DSN =
+  "https://9b9cbf3a465080792e96fb919b278a38@o275100.ingest.us.sentry.io/4511812805394432";
 
 let initialized = false;
 

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -1,0 +1,75 @@
+// Shared Sentry instrumentation for Lore's Supabase Deno edge functions.
+//
+// Wires github-provision, github-discover and send-invite-email into the same
+// Sentry project the gateway uses (o275100), so failures in the edge runtime
+// are captured with stack traces + rate, just like the gateway.
+//
+// PRIVACY: these functions handle GitHub provider_tokens and invite emails.
+// We NEVER attach PII to Sentry — no provider_token, no email address/body, no
+// GitHub user id reaches setTag/setExtra. Only non-sensitive scalars are tagged
+// (function_name, deployment, and boolean/status flags). sendDefaultPii is false.
+//
+// OPT-OUT: initSentry() is a no-op when SENTRY_DSN is unset, so a local
+// `supabase start` stack (or any deploy without the secret) runs untouched.
+import * as Sentry from "npm:@sentry/deno";
+
+let initialized = false;
+
+/**
+ * Initialize Sentry for a single edge function. Idempotent and a no-op when
+ * SENTRY_DSN is not configured in the function's environment.
+ *
+ * @param functionName - e.g. "github-discover"; tagged on every event so
+ *   issues are filterable per function in the Sentry UI.
+ */
+export function initSentry(functionName: string): void {
+  if (initialized) return;
+  const dsn = Deno.env.get("SENTRY_DSN");
+  if (!dsn) return; // local/dev without the secret — skip instrumentation
+
+  Sentry.init({
+    dsn,
+    release: Deno.env.get("LORE_VERSION") ?? "dev",
+    environment: Deno.env.get("SENTRY_ENVIRONMENT") ?? "production",
+    // These functions are short-lived request handlers — skip transactions.
+    tracesSampleRate: 0,
+    // Never send request/response content or user IP-derived PII.
+    sendDefaultPii: false,
+    integrations: [],
+  });
+
+  Sentry.setTag("function_name", functionName);
+  Sentry.setTag("deployment", "supabase-edge");
+  initialized = true;
+}
+
+/**
+ * Capture an exception to Sentry. No-op when Sentry isn't initialized (no DSN).
+ * Pass only Error objects — never tokens, emails, or ids.
+ */
+export function capture(err: unknown): void {
+  if (!Sentry.isInitialized()) return;
+  Sentry.captureException(err);
+}
+
+/**
+ * Wrap a Deno.serve handler so any uncaught throw is reported to Sentry and
+ * converted into a generic 500 JSON (instead of an opaque edge-platform error),
+ * preserving the function's existing response shape for handled cases.
+ */
+export function wrapHandler(
+  functionName: string,
+  handler: (req: Request) => Response | Promise<Response>,
+): (req: Request) => Promise<Response> {
+  return async (req: Request): Promise<Response> => {
+    try {
+      return await handler(req);
+    } catch (err) {
+      capture(err);
+      return new Response(JSON.stringify({ error: "internal error" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    }
+  };
+}

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -9,23 +9,27 @@
 // GitHub user id reaches setTag/setExtra. Only non-sensitive scalars are tagged
 // (function_name, deployment, and boolean/status flags). sendDefaultPii is false.
 //
-// OPT-OUT: initSentry() is a no-op when SENTRY_DSN is unset, so a local
-// `supabase start` stack (or any deploy without the secret) runs untouched.
+// The DSN is a Sentry public key (not a secret) and is hard-coded below. An
+// explicit SENTRY_DSN env var, if present, overrides it (e.g. for a staging
+// project); otherwise instrumentation is always on.
 import * as Sentry from "npm:@sentry/deno";
+
+// Sentry DSN for the Lore project (o275100). This is a public key, safe to
+// ship in client/server code — it only permits sending events, not reading them.
+const SENTRY_DSN = "https://9b9cbf3a465080792e96fb919b278a38@o275100.ingest.us.sentry.io/4511812805394432";
 
 let initialized = false;
 
 /**
- * Initialize Sentry for a single edge function. Idempotent and a no-op when
- * SENTRY_DSN is not configured in the function's environment.
+ * Initialize Sentry for a single edge function. Idempotent. An explicit
+ * SENTRY_DSN env var, if set, overrides the built-in DSN.
  *
  * @param functionName - e.g. "github-discover"; tagged on every event so
  *   issues are filterable per function in the Sentry UI.
  */
 export function initSentry(functionName: string): void {
   if (initialized) return;
-  const dsn = Deno.env.get("SENTRY_DSN");
-  if (!dsn) return; // local/dev without the secret — skip instrumentation
+  const dsn = Deno.env.get("SENTRY_DSN") ?? SENTRY_DSN;
 
   Sentry.init({
     dsn,

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,7 @@
+{
+  "nodeModulesDir": "auto",
+  "imports": {
+    "@sentry/deno": "npm:@sentry/deno",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,0 +1,174 @@
+{
+  "version": "5",
+  "specifiers": {
+    "npm:@sentry/deno@*": "10.68.0",
+    "npm:@supabase/supabase-js@2": "2.110.8"
+  },
+  "npm": {
+    "@apm-js-collab/code-transformer-bundler-plugins@0.7.1": {
+      "integrity": "sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==",
+      "dependencies": [
+        "@apm-js-collab/code-transformer",
+        "es-module-lexer",
+        "magic-string",
+        "module-details-from-path"
+      ]
+    },
+    "@apm-js-collab/code-transformer@0.18.1": {
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "dependencies": [
+        "@types/estree",
+        "astring",
+        "esquery",
+        "meriyah",
+        "semifies",
+        "source-map"
+      ],
+      "bin": true
+    },
+    "@apm-js-collab/tracing-hooks@0.13.0": {
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "dependencies": [
+        "@apm-js-collab/code-transformer",
+        "debug",
+        "module-details-from-path"
+      ]
+    },
+    "@jridgewell/sourcemap-codec@1.5.5": {
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "@opentelemetry/api@1.9.1": {
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
+    },
+    "@sentry/conventions@0.16.0": {
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ=="
+    },
+    "@sentry/core@10.68.0": {
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "dependencies": [
+        "@sentry/conventions"
+      ]
+    },
+    "@sentry/deno@10.68.0": {
+      "integrity": "sha512-5RJZeXE/vrjt7YeiSkSNX2jNu4omNkPq3XCfs5k7LeyLNbu+7NoC96Dwo0uubni4a3cqULbhAwuDQXKk2M/PbQ==",
+      "dependencies": [
+        "@opentelemetry/api",
+        "@sentry/core",
+        "@sentry/server-utils"
+      ]
+    },
+    "@sentry/server-utils@10.68.0": {
+      "integrity": "sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==",
+      "dependencies": [
+        "@apm-js-collab/code-transformer-bundler-plugins",
+        "@apm-js-collab/tracing-hooks",
+        "@sentry/conventions",
+        "@sentry/core",
+        "meriyah"
+      ]
+    },
+    "@supabase/auth-js@2.110.8": {
+      "integrity": "sha512-TQ5neTUDX2C2WmyYa03yGhLMkhdE/SkHXtK8/qxO/APUy3rsymsJCBP48p4jcN6iO2G0ow6RRexQd2mX+dSyJg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/functions-js@2.110.8": {
+      "integrity": "sha512-5yB9TLYzvv2oSQxwb0gamEvIAsuH66pVt7AM/pz03S7wN6ehD34GNgbShrccetqPedXQSz7e/1hAJ9NeEhoZVg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/phoenix@0.4.5": {
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="
+    },
+    "@supabase/postgrest-js@2.110.8": {
+      "integrity": "sha512-QeRROxl1PpOZw5Jzi7BwdN9icsycMrLlCCvsjS0hYLW+nZoaT46zdagz/glJirj8jHF4jSd5Jyipuae2cBClCw==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@supabase/realtime-js@2.110.8": {
+      "integrity": "sha512-mwX7ituX6O31fLf+0g65rpLlNxqgnMaPltPsQwzox6jfmbfVl3tCxXrfr3HEsQcCRjpjuJG1+A0vFzP1yVjKHA==",
+      "dependencies": [
+        "@supabase/phoenix",
+        "tslib"
+      ]
+    },
+    "@supabase/storage-js@2.110.8": {
+      "integrity": "sha512-CcfhkZFBLxsthgUabZKxwfsoXdrikIGsL3LsGoV3FZTqCMx/s1y49taT4jT/oya5+1IuB0sFFHw6pF0o0iJniQ==",
+      "dependencies": [
+        "iceberg-js",
+        "tslib"
+      ]
+    },
+    "@supabase/supabase-js@2.110.8": {
+      "integrity": "sha512-E5qzoe74zhJRv4wRcbO9eMYzeQDb/+h6c603pL8shcxLGBjTKsIF7XXj05IcNj23TLDgJN1WkMw7mwAPyu5dZg==",
+      "dependencies": [
+        "@supabase/auth-js",
+        "@supabase/functions-js",
+        "@supabase/postgrest-js",
+        "@supabase/realtime-js",
+        "@supabase/storage-js"
+      ]
+    },
+    "@types/estree@1.0.9": {
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="
+    },
+    "astring@1.9.0": {
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "bin": true
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "es-module-lexer@2.3.1": {
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="
+    },
+    "esquery@1.7.0": {
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dependencies": [
+        "estraverse"
+      ]
+    },
+    "estraverse@5.3.0": {
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+    },
+    "iceberg-js@0.8.1": {
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="
+    },
+    "magic-string@0.30.21": {
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dependencies": [
+        "@jridgewell/sourcemap-codec"
+      ]
+    },
+    "meriyah@6.1.4": {
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ=="
+    },
+    "module-details-from-path@1.0.4": {
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "semifies@1.0.0": {
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw=="
+    },
+    "source-map@0.6.1": {
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@sentry/deno@*",
+      "npm:@supabase/supabase-js@2"
+    ]
+  }
+}

--- a/supabase/functions/github-discover/index.ts
+++ b/supabase/functions/github-discover/index.ts
@@ -28,6 +28,7 @@ import {
   parseRepoRef,
   type RepoCollaborators,
 } from "./discover.ts";
+import { capture, initSentry, wrapHandler } from "../_shared/sentry.ts";
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -39,18 +40,21 @@ function json(body: unknown, status = 200): Response {
 // Cap the number of repos we scan per call — bounds GitHub API fan-out (and cost) per request.
 const MAX_REPOS = 50;
 
-Deno.serve(async (req: Request): Promise<Response> => {
-  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+initSentry("github-discover");
 
-  const authHeader = req.headers.get("Authorization");
-  if (!authHeader) return json({ error: "missing authorization" }, 401);
+Deno.serve(
+  wrapHandler("github-discover", async (req: Request): Promise<Response> => {
+    if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
 
-  const url = Deno.env.get("SUPABASE_URL");
-  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
-  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  if (!url || !anonKey || !serviceKey) {
-    return json({ error: "server misconfigured" }, 500);
-  }
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return json({ error: "missing authorization" }, 401);
+
+    const url = Deno.env.get("SUPABASE_URL");
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!url || !anonKey || !serviceKey) {
+      return json({ error: "server misconfigured" }, 500);
+    }
 
   // Verify the caller's Supabase JWT → user id (never trust a client-supplied id).
   const userClient = createClient(url, anonKey, {
@@ -83,6 +87,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
     }
     selfGithubId = tokenOwner.id;
   } catch (e) {
+    capture(e);
     return json({ error: `github: ${(e as Error).message}` }, 502);
   }
 
@@ -99,6 +104,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       repos = await fetchUserRepos(providerToken, { apiUrl });
     }
   } catch (e) {
+    capture(e);
     return json({ error: `github: ${(e as Error).message}` }, 502);
   }
   repos = repos.slice(0, MAX_REPOS);
@@ -117,6 +123,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       rosters.push({ repo: `${repo.owner}/${repo.name}`, collaborators });
     } catch (e) {
       // A transient error on one repo shouldn't sink the batch — log and skip.
+      capture(e);
       console.error(
         `collaborators ${repo.owner}/${repo.name}:`,
         (e as Error).message,
@@ -136,6 +143,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       p_github_ids: githubIds,
     });
     if (error) {
+      capture(error);
       console.error("lore_users_for_github_ids failed:", error.message);
       return json({ error: "lookup failed" }, 500);
     }
@@ -145,4 +153,5 @@ Deno.serve(async (req: Request): Promise<Response> => {
   }
 
   return json({ repos: annotateOnLore(rosters, loreIds) });
-});
+  }),
+);

--- a/supabase/functions/github-discover/index.ts
+++ b/supabase/functions/github-discover/index.ts
@@ -44,7 +44,8 @@ initSentry("github-discover");
 
 Deno.serve(
   wrapHandler("github-discover", async (req: Request): Promise<Response> => {
-    if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+    if (req.method !== "POST")
+      return json({ error: "method not allowed" }, 405);
 
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) return json({ error: "missing authorization" }, 401);
@@ -56,102 +57,102 @@ Deno.serve(
       return json({ error: "server misconfigured" }, 500);
     }
 
-  // Verify the caller's Supabase JWT → user id (never trust a client-supplied id).
-  const userClient = createClient(url, anonKey, {
-    global: { headers: { Authorization: authHeader } },
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
-  const {
-    data: { user },
-    error: userErr,
-  } = await userClient.auth.getUser();
-  if (userErr || !user) return json({ error: "invalid token" }, 401);
-
-  const jwtGithubId = resolveJwtGithubId(user);
-
-  const body = (await req.json().catch(() => ({}))) as {
-    provider_token?: string;
-    repos?: string[];
-  };
-  const providerToken = body.provider_token;
-  if (!providerToken) return json({ error: "missing provider_token" }, 400);
-
-  const apiUrl = Deno.env.get("GITHUB_API_URL") ?? undefined;
-
-  // Bind the provider_token to the authenticated identity (same guard as github-provision).
-  let selfGithubId: number;
-  try {
-    const tokenOwner = await fetchGitHubUser(providerToken, { apiUrl });
-    if (!isTokenOwnerBound(tokenOwner.id, jwtGithubId)) {
-      return json({ error: "provider_token identity mismatch" }, 403);
-    }
-    selfGithubId = tokenOwner.id;
-  } catch (e) {
-    capture(e);
-    return json({ error: `github: ${(e as Error).message}` }, 502);
-  }
-
-  // Resolve the repo set: explicit list (validated) or the caller's own repos (first page).
-  let repos: Array<{ owner: string; name: string }>;
-  try {
-    if (Array.isArray(body.repos) && body.repos.length > 0) {
-      repos = [];
-      for (const r of body.repos) {
-        const ref = parseRepoRef(r);
-        if (ref) repos.push(ref);
-      }
-    } else {
-      repos = await fetchUserRepos(providerToken, { apiUrl });
-    }
-  } catch (e) {
-    capture(e);
-    return json({ error: `github: ${(e as Error).message}` }, 502);
-  }
-  repos = repos.slice(0, MAX_REPOS);
-
-  // Read each repo's collaborators with the caller's token (repos they can't read are skipped).
-  const rosters: RepoCollaborators[] = [];
-  for (const repo of repos) {
-    try {
-      const collaborators = await fetchRepoCollaborators(
-        providerToken,
-        repo,
-        selfGithubId,
-        { apiUrl },
-      );
-      if (collaborators === null) continue; // inaccessible — skip, don't fail the whole call
-      rosters.push({ repo: `${repo.owner}/${repo.name}`, collaborators });
-    } catch (e) {
-      // A transient error on one repo shouldn't sink the batch — log and skip.
-      capture(e);
-      console.error(
-        `collaborators ${repo.owner}/${repo.name}:`,
-        (e as Error).message,
-      );
-    }
-  }
-
-  // Service-role lookup: which collaborator github ids have a Lore account. Returns only the SET of
-  // present ids (never user_ids) — the RPC is service-role-only so this is the only enumeration path.
-  const githubIds = collectGithubIds(rosters);
-  const loreIds = new Set<number>();
-  if (githubIds.length > 0) {
-    const admin = createClient(url, serviceKey, {
+    // Verify the caller's Supabase JWT → user id (never trust a client-supplied id).
+    const userClient = createClient(url, anonKey, {
+      global: { headers: { Authorization: authHeader } },
       auth: { persistSession: false, autoRefreshToken: false },
     });
-    const { data, error } = await admin.rpc("lore_users_for_github_ids", {
-      p_github_ids: githubIds,
-    });
-    if (error) {
-      capture(error);
-      console.error("lore_users_for_github_ids failed:", error.message);
-      return json({ error: "lookup failed" }, 500);
-    }
-    for (const row of (data ?? []) as Array<{ github_id: number | string }>) {
-      loreIds.add(Number(row.github_id));
-    }
-  }
+    const {
+      data: { user },
+      error: userErr,
+    } = await userClient.auth.getUser();
+    if (userErr || !user) return json({ error: "invalid token" }, 401);
 
-  return json({ repos: annotateOnLore(rosters, loreIds) });
+    const jwtGithubId = resolveJwtGithubId(user);
+
+    const body = (await req.json().catch(() => ({}))) as {
+      provider_token?: string;
+      repos?: string[];
+    };
+    const providerToken = body.provider_token;
+    if (!providerToken) return json({ error: "missing provider_token" }, 400);
+
+    const apiUrl = Deno.env.get("GITHUB_API_URL") ?? undefined;
+
+    // Bind the provider_token to the authenticated identity (same guard as github-provision).
+    let selfGithubId: number;
+    try {
+      const tokenOwner = await fetchGitHubUser(providerToken, { apiUrl });
+      if (!isTokenOwnerBound(tokenOwner.id, jwtGithubId)) {
+        return json({ error: "provider_token identity mismatch" }, 403);
+      }
+      selfGithubId = tokenOwner.id;
+    } catch (e) {
+      capture(e);
+      return json({ error: `github: ${(e as Error).message}` }, 502);
+    }
+
+    // Resolve the repo set: explicit list (validated) or the caller's own repos (first page).
+    let repos: Array<{ owner: string; name: string }>;
+    try {
+      if (Array.isArray(body.repos) && body.repos.length > 0) {
+        repos = [];
+        for (const r of body.repos) {
+          const ref = parseRepoRef(r);
+          if (ref) repos.push(ref);
+        }
+      } else {
+        repos = await fetchUserRepos(providerToken, { apiUrl });
+      }
+    } catch (e) {
+      capture(e);
+      return json({ error: `github: ${(e as Error).message}` }, 502);
+    }
+    repos = repos.slice(0, MAX_REPOS);
+
+    // Read each repo's collaborators with the caller's token (repos they can't read are skipped).
+    const rosters: RepoCollaborators[] = [];
+    for (const repo of repos) {
+      try {
+        const collaborators = await fetchRepoCollaborators(
+          providerToken,
+          repo,
+          selfGithubId,
+          { apiUrl },
+        );
+        if (collaborators === null) continue; // inaccessible — skip, don't fail the whole call
+        rosters.push({ repo: `${repo.owner}/${repo.name}`, collaborators });
+      } catch (e) {
+        // A transient error on one repo shouldn't sink the batch — log and skip.
+        capture(e);
+        console.error(
+          `collaborators ${repo.owner}/${repo.name}:`,
+          (e as Error).message,
+        );
+      }
+    }
+
+    // Service-role lookup: which collaborator github ids have a Lore account. Returns only the SET of
+    // present ids (never user_ids) — the RPC is service-role-only so this is the only enumeration path.
+    const githubIds = collectGithubIds(rosters);
+    const loreIds = new Set<number>();
+    if (githubIds.length > 0) {
+      const admin = createClient(url, serviceKey, {
+        auth: { persistSession: false, autoRefreshToken: false },
+      });
+      const { data, error } = await admin.rpc("lore_users_for_github_ids", {
+        p_github_ids: githubIds,
+      });
+      if (error) {
+        capture(error);
+        console.error("lore_users_for_github_ids failed:", error.message);
+        return json({ error: "lookup failed" }, 500);
+      }
+      for (const row of (data ?? []) as Array<{ github_id: number | string }>) {
+        loreIds.add(Number(row.github_id));
+      }
+    }
+
+    return json({ repos: annotateOnLore(rosters, loreIds) });
   }),
 );

--- a/supabase/functions/github-provision/index.ts
+++ b/supabase/functions/github-provision/index.ts
@@ -18,6 +18,7 @@ import {
   isTokenOwnerBound,
   resolveJwtGithubId,
 } from "./provision.ts";
+import { capture, initSentry, wrapHandler } from "../_shared/sentry.ts";
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -26,18 +27,21 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
-Deno.serve(async (req: Request): Promise<Response> => {
-  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+initSentry("github-provision");
 
-  const authHeader = req.headers.get("Authorization");
-  if (!authHeader) return json({ error: "missing authorization" }, 401);
+Deno.serve(
+  wrapHandler("github-provision", async (req: Request): Promise<Response> => {
+    if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
 
-  const url = Deno.env.get("SUPABASE_URL");
-  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
-  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  if (!url || !anonKey || !serviceKey) {
-    return json({ error: "server misconfigured" }, 500);
-  }
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return json({ error: "missing authorization" }, 401);
+
+    const url = Deno.env.get("SUPABASE_URL");
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!url || !anonKey || !serviceKey) {
+      return json({ error: "server misconfigured" }, 500);
+    }
 
   // Verify the caller's Supabase JWT → user id (never trust a client-supplied id).
   const userClient = createClient(url, anonKey, {
@@ -73,6 +77,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const memberships = await fetchGitHubMemberships(providerToken, { apiUrl });
     payload = buildProvisionPayload(memberships);
   } catch (e) {
+    capture(e);
     return json({ error: `github: ${(e as Error).message}` }, 502);
   }
 
@@ -86,6 +91,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
     p_teams: payload.teams,
   });
   if (rpcErr) {
+    capture(rpcErr);
     console.error("provision_github_membership failed:", rpcErr.message);
     return json({ error: "provisioning failed" }, 500); // generic — details logged server-side
   }
@@ -95,4 +101,5 @@ Deno.serve(async (req: Request): Promise<Response> => {
     orgs: payload.orgs.length,
     teams: payload.teams.length,
   });
-});
+  }),
+);

--- a/supabase/functions/github-provision/index.ts
+++ b/supabase/functions/github-provision/index.ts
@@ -31,7 +31,8 @@ initSentry("github-provision");
 
 Deno.serve(
   wrapHandler("github-provision", async (req: Request): Promise<Response> => {
-    if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+    if (req.method !== "POST")
+      return json({ error: "method not allowed" }, 405);
 
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) return json({ error: "missing authorization" }, 401);
@@ -43,63 +44,65 @@ Deno.serve(
       return json({ error: "server misconfigured" }, 500);
     }
 
-  // Verify the caller's Supabase JWT → user id (never trust a client-supplied id).
-  const userClient = createClient(url, anonKey, {
-    global: { headers: { Authorization: authHeader } },
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
-  const {
-    data: { user },
-    error: userErr,
-  } = await userClient.auth.getUser();
-  if (userErr || !user) return json({ error: "invalid token" }, 401);
+    // Verify the caller's Supabase JWT → user id (never trust a client-supplied id).
+    const userClient = createClient(url, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const {
+      data: { user },
+      error: userErr,
+    } = await userClient.auth.getUser();
+    if (userErr || !user) return json({ error: "invalid token" }, 401);
 
-  const body = (await req.json().catch(() => ({}))) as {
-    provider_token?: string;
-  };
-  const providerToken = body.provider_token;
-  if (!providerToken) return json({ error: "missing provider_token" }, 400);
+    const body = (await req.json().catch(() => ({}))) as {
+      provider_token?: string;
+    };
+    const providerToken = body.provider_token;
+    if (!providerToken) return json({ error: "missing provider_token" }, 400);
 
-  // The GitHub id the JWT user is actually linked to — used to bind the provider_token below.
-  const jwtGithubId = resolveJwtGithubId(user);
+    // The GitHub id the JWT user is actually linked to — used to bind the provider_token below.
+    const jwtGithubId = resolveJwtGithubId(user);
 
-  // Verify memberships against GitHub with the user's own token, then map to the RPC payload.
-  let payload: ReturnType<typeof buildProvisionPayload>;
-  try {
-    const apiUrl = Deno.env.get("GITHUB_API_URL") ?? undefined;
-    // Bind the provider_token to the authenticated identity: a token owned by a DIFFERENT GitHub
-    // account must never provision this user into that account's teams (defense against a
-    // leaked/misused token). GitHub's /user is authoritative for the token's owner.
-    const tokenOwner = await fetchGitHubUser(providerToken, { apiUrl });
-    if (!isTokenOwnerBound(tokenOwner.id, jwtGithubId)) {
-      return json({ error: "provider_token identity mismatch" }, 403);
+    // Verify memberships against GitHub with the user's own token, then map to the RPC payload.
+    let payload: ReturnType<typeof buildProvisionPayload>;
+    try {
+      const apiUrl = Deno.env.get("GITHUB_API_URL") ?? undefined;
+      // Bind the provider_token to the authenticated identity: a token owned by a DIFFERENT GitHub
+      // account must never provision this user into that account's teams (defense against a
+      // leaked/misused token). GitHub's /user is authoritative for the token's owner.
+      const tokenOwner = await fetchGitHubUser(providerToken, { apiUrl });
+      if (!isTokenOwnerBound(tokenOwner.id, jwtGithubId)) {
+        return json({ error: "provider_token identity mismatch" }, 403);
+      }
+      const memberships = await fetchGitHubMemberships(providerToken, {
+        apiUrl,
+      });
+      payload = buildProvisionPayload(memberships);
+    } catch (e) {
+      capture(e);
+      return json({ error: `github: ${(e as Error).message}` }, 502);
     }
-    const memberships = await fetchGitHubMemberships(providerToken, { apiUrl });
-    payload = buildProvisionPayload(memberships);
-  } catch (e) {
-    capture(e);
-    return json({ error: `github: ${(e as Error).message}` }, 502);
-  }
 
-  // Provision as service_role — the only role permitted to call the RPC.
-  const admin = createClient(url, serviceKey, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
-  const { error: rpcErr } = await admin.rpc("provision_github_membership", {
-    p_user: user.id,
-    p_orgs: payload.orgs,
-    p_teams: payload.teams,
-  });
-  if (rpcErr) {
-    capture(rpcErr);
-    console.error("provision_github_membership failed:", rpcErr.message);
-    return json({ error: "provisioning failed" }, 500); // generic — details logged server-side
-  }
+    // Provision as service_role — the only role permitted to call the RPC.
+    const admin = createClient(url, serviceKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { error: rpcErr } = await admin.rpc("provision_github_membership", {
+      p_user: user.id,
+      p_orgs: payload.orgs,
+      p_teams: payload.teams,
+    });
+    if (rpcErr) {
+      capture(rpcErr);
+      console.error("provision_github_membership failed:", rpcErr.message);
+      return json({ error: "provisioning failed" }, 500); // generic — details logged server-side
+    }
 
-  return json({
-    ok: true,
-    orgs: payload.orgs.length,
-    teams: payload.teams.length,
-  });
+    return json({
+      ok: true,
+      orgs: payload.orgs.length,
+      teams: payload.teams.length,
+    });
   }),
 );

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -9,6 +9,7 @@
 // injected by the platform. INVITE_SENDER defaults to keeper@withlore.ai; SMTP2GO_API_URL optional.
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { buildInviteEmail, capabilityOf, sendViaSmtp2go } from "./send.ts";
+import { capture, initSentry, wrapHandler } from "../_shared/sentry.ts";
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -20,19 +21,22 @@ function json(body: unknown, status = 200): Response {
 // Conservative RFC-ish email shape check — the recipient is admin-supplied, but we still guard.
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-Deno.serve(async (req: Request): Promise<Response> => {
-  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+initSentry("send-invite-email");
 
-  const authHeader = req.headers.get("Authorization");
-  if (!authHeader) return json({ error: "missing authorization" }, 401);
+Deno.serve(
+  wrapHandler("send-invite-email", async (req: Request): Promise<Response> => {
+    if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
 
-  const url = Deno.env.get("SUPABASE_URL");
-  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
-  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  const apiKey = Deno.env.get("SMTP2GO_API_KEY");
-  if (!url || !anonKey || !serviceKey || !apiKey) {
-    return json({ error: "server misconfigured" }, 500);
-  }
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return json({ error: "missing authorization" }, 401);
+
+    const url = Deno.env.get("SUPABASE_URL");
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    const apiKey = Deno.env.get("SMTP2GO_API_KEY");
+    if (!url || !anonKey || !serviceKey || !apiKey) {
+      return json({ error: "server misconfigured" }, 500);
+    }
   const sender = Deno.env.get("INVITE_SENDER") ?? "keeper@withlore.ai";
   const apiUrl = Deno.env.get("SMTP2GO_API_URL") ?? undefined;
 
@@ -73,6 +77,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
     .eq("token", capability)
     .maybeSingle();
   if (invErr) {
+    capture(invErr);
     console.error("pending_invites read failed:", invErr.message);
     return json({ error: "lookup failed" }, 500);
   }
@@ -106,8 +111,10 @@ Deno.serve(async (req: Request): Promise<Response> => {
   try {
     await sendViaSmtp2go(email, message, { apiKey, sender, apiUrl });
   } catch (e) {
+    capture(e);
     console.error("smtp2go send failed:", (e as Error).message);
     return json({ error: "send failed" }, 502);
   }
   return json({ ok: true });
-});
+  }),
+);

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -25,7 +25,8 @@ initSentry("send-invite-email");
 
 Deno.serve(
   wrapHandler("send-invite-email", async (req: Request): Promise<Response> => {
-    if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+    if (req.method !== "POST")
+      return json({ error: "method not allowed" }, 405);
 
     const authHeader = req.headers.get("Authorization");
     if (!authHeader) return json({ error: "missing authorization" }, 401);
@@ -37,84 +38,84 @@ Deno.serve(
     if (!url || !anonKey || !serviceKey || !apiKey) {
       return json({ error: "server misconfigured" }, 500);
     }
-  const sender = Deno.env.get("INVITE_SENDER") ?? "keeper@withlore.ai";
-  const apiUrl = Deno.env.get("SMTP2GO_API_URL") ?? undefined;
+    const sender = Deno.env.get("INVITE_SENDER") ?? "keeper@withlore.ai";
+    const apiUrl = Deno.env.get("SMTP2GO_API_URL") ?? undefined;
 
-  // Verify the caller's JWT → user id (never trust a client-supplied identity).
-  const userClient = createClient(url, anonKey, {
-    global: { headers: { Authorization: authHeader } },
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
-  const {
-    data: { user },
-    error: userErr,
-  } = await userClient.auth.getUser();
-  if (userErr || !user) return json({ error: "invalid token" }, 401);
+    // Verify the caller's JWT → user id (never trust a client-supplied identity).
+    const userClient = createClient(url, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const {
+      data: { user },
+      error: userErr,
+    } = await userClient.auth.getUser();
+    if (userErr || !user) return json({ error: "invalid token" }, 401);
 
-  const body = (await req.json().catch(() => ({}))) as {
-    token?: string;
-    email?: string;
-  };
-  const token = typeof body.token === "string" ? body.token : "";
-  const email = typeof body.email === "string" ? body.email.trim() : "";
-  if (!token) return json({ error: "missing token" }, 400);
-  if (!email || !EMAIL_RE.test(email))
-    return json({ error: "invalid email" }, 400);
+    const body = (await req.json().catch(() => ({}))) as {
+      token?: string;
+      email?: string;
+    };
+    const token = typeof body.token === "string" ? body.token : "";
+    const email = typeof body.email === "string" ? body.email.trim() : "";
+    if (!token) return json({ error: "missing token" }, 400);
+    if (!email || !EMAIL_RE.test(email))
+      return json({ error: "invalid email" }, 400);
 
-  // An offline invite token is `<capability>.<base64url(secret)>`; only the capability part is stored
-  // in pending_invites.token (mirrors acceptTeamInvite). Look up by the capability, but email the
-  // FULL token — the invitee needs the secret suffix to unwrap the DEK.
-  const capability = capabilityOf(token);
+    // An offline invite token is `<capability>.<base64url(secret)>`; only the capability part is stored
+    // in pending_invites.token (mirrors acceptTeamInvite). Look up by the capability, but email the
+    // FULL token — the invitee needs the secret suffix to unwrap the DEK.
+    const capability = capabilityOf(token);
 
-  // Authorize on the TOKEN: resolve the invite service-role, then confirm the caller is an admin of
-  // its scope. Scope/role/team_name come from the row, never from client input — no spam relay.
-  const admin = createClient(url, serviceKey, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
-  const { data: inv, error: invErr } = await admin
-    .from("pending_invites")
-    .select("scope_id, role, invited_by, eph_pub, expires_at")
-    .eq("token", capability)
-    .maybeSingle();
-  if (invErr) {
-    capture(invErr);
-    console.error("pending_invites read failed:", invErr.message);
-    return json({ error: "lookup failed" }, 500);
-  }
-  // Generic 404 whether the token is absent or expired — never disclose which.
-  if (!inv || new Date(inv.expires_at as string).getTime() <= Date.now())
-    return json({ error: "invite not found" }, 404);
+    // Authorize on the TOKEN: resolve the invite service-role, then confirm the caller is an admin of
+    // its scope. Scope/role/team_name come from the row, never from client input — no spam relay.
+    const admin = createClient(url, serviceKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { data: inv, error: invErr } = await admin
+      .from("pending_invites")
+      .select("scope_id, role, invited_by, eph_pub, expires_at")
+      .eq("token", capability)
+      .maybeSingle();
+    if (invErr) {
+      capture(invErr);
+      console.error("pending_invites read failed:", invErr.message);
+      return json({ error: "lookup failed" }, 500);
+    }
+    // Generic 404 whether the token is absent or expired — never disclose which.
+    if (!inv || new Date(inv.expires_at as string).getTime() <= Date.now())
+      return json({ error: "invite not found" }, 404);
 
-  // The caller must be an ADMIN of the invite's scope. Check via scope_role() with the caller JWT
-  // (RLS-safe; resolves auth.uid()). Belt-and-suspenders: also require they created the invite.
-  const { data: roleRow } = await userClient.rpc("scope_role", {
-    p_scope: inv.scope_id,
-  });
-  const isAdmin = roleRow === "admin";
-  const isCreator = inv.invited_by === user.id;
-  if (!isAdmin || !isCreator) return json({ error: "forbidden" }, 403);
+    // The caller must be an ADMIN of the invite's scope. Check via scope_role() with the caller JWT
+    // (RLS-safe; resolves auth.uid()). Belt-and-suspenders: also require they created the invite.
+    const { data: roleRow } = await userClient.rpc("scope_role", {
+      p_scope: inv.scope_id,
+    });
+    const isAdmin = roleRow === "admin";
+    const isCreator = inv.invited_by === user.id;
+    if (!isAdmin || !isCreator) return json({ error: "forbidden" }, 403);
 
-  // Look up the team name for the email copy (service-role read; best-effort).
-  const { data: scopeRow } = await admin
-    .from("scopes")
-    .select("name")
-    .eq("id", inv.scope_id)
-    .maybeSingle();
+    // Look up the team name for the email copy (service-role read; best-effort).
+    const { data: scopeRow } = await admin
+      .from("scopes")
+      .select("name")
+      .eq("id", inv.scope_id)
+      .maybeSingle();
 
-  const message = buildInviteEmail({
-    token,
-    teamName: (scopeRow?.name as string | null) ?? null,
-    role: inv.role as string | null,
-    offline: !!inv.eph_pub,
-  });
+    const message = buildInviteEmail({
+      token,
+      teamName: (scopeRow?.name as string | null) ?? null,
+      role: inv.role as string | null,
+      offline: !!inv.eph_pub,
+    });
 
-  try {
-    await sendViaSmtp2go(email, message, { apiKey, sender, apiUrl });
-  } catch (e) {
-    capture(e);
-    console.error("smtp2go send failed:", (e as Error).message);
-    return json({ error: "send failed" }, 502);
-  }
-  return json({ ok: true });
+    try {
+      await sendViaSmtp2go(email, message, { apiKey, sender, apiUrl });
+    } catch (e) {
+      capture(e);
+      console.error("smtp2go send failed:", (e as Error).message);
+      return json({ error: "send failed" }, 502);
+    }
+    return json({ ok: true });
   }),
 );


### PR DESCRIPTION
## Summary

Closes #1507. The three Supabase Deno edge functions had zero observability — failures only surfaced as generic JSON with a server-side `console.error`. This wires them into Sentry (same project `o275100` the gateway uses) via a shared helper.

- **NEW** `supabase/functions/_shared/sentry.ts` — `initSentry(name)` (no-op without `SENTRY_DSN`), `wrapHandler(name, fn)` (reports uncaught throws + returns 500), `capture(err)`.
- **EDIT** all three functions: `github-provision`, `github-discover`, `send-invite-email` — init + wrap + `capture()` at the existing GitHub/RPC/SMTP failure `catch` sites.
- **EDIT** `supabase/README.md` — added an `Observability (Sentry)` section.

## Privacy
`sendDefaultPii: false`; **no** `provider_token`/email body/GitHub id ever reaches Sentry — only `Error` objects + non-sensitive `function_name`/`deployment` tags. Audited: all 8 `capture()` calls pass only `Error` objects.

## Testing / caveats
- Deno is **not** installed in this environment, so the edge-function code is written against the documented `@sentry/deno` API and linted by inspection (matching the Sentry blog guide for Supabase). It should be smoke-tested on a real `supabase functions deploy` + a forced error before relying on it.
- Gateway Sentry tests unaffected (these are standalone Deno files); ran `login.test.ts` as a sanity smoke — 21 passed.

## Deploy note
Set the secret once on the hosted project: `supabase secrets set SENTRY_DSN=https://…@o275100.ingest.us.sentry.io/…` (and optionally `SENTRY_ENVIRONMENT` / `LORE_VERSION`).