### PR TITLE
fix(supabase): flush Sentry events + normalize PostgrestError (#1516 follow-up)

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -123,9 +123,12 @@ gateway errors.
   `supabase start` stack (or any deploy without the secret) runs untouched. Set it once on
   the hosted project: `supabase secrets set SENTRY_DSN=https://…@o275100.ingest.us.sentry.io/…`
   (and optionally `SENTRY_ENVIRONMENT`, `LORE_VERSION` for the release tag).
-- **What is captured**: only thrown `Error` objects at the GitHub/RPC/SMTP failure paths,
-  tagged with non-sensitive scalars (`function_name`, `deployment`, `release`). Uncaught
-  throws are caught by `wrapHandler` and turned into a generic 500.
+- **What is captured**: errors at the GitHub/RPC/SMTP failure paths, tagged with
+  non-sensitive scalars (`function_name`, `deployment`, `release`). Supabase client
+  errors (`PostgrestError`) are normalized to real `Error` objects before capture so
+  Sentry gets a usable stack; no tokens/ids are attached. Uncaught throws are caught by
+  `wrapHandler` and turned into a generic 500. Each `capture()` awaits `Sentry.flush()`
+  so events are sent before the short-lived edge runtime terminates.
 - **Privacy**: `sendDefaultPii` is `false` and **no** `provider_token`, email address, email
   body, or GitHub user id is ever attached to a Sentry event — these functions handle
   secrets, so PII is never sent to Sentry.

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -49,18 +49,43 @@ export function initSentry(functionName: string): void {
 }
 
 /**
- * Capture an exception to Sentry. No-op when Sentry isn't initialized (no DSN).
- * Pass only Error objects — never tokens, emails, or ids.
+ * Normalize a captured value into an Error. Supabase client errors
+ * (e.g. PostgrestError) are plain objects, not Error instances; Sentry produces
+ * weak events (missing/empty stack) for those, so we wrap them. Only scalar
+ * message/hint are extracted — the raw object is NEVER JSON.stringify'd
+ * because it may carry PII (query context, row contents).
  */
-export function capture(err: unknown): void {
+function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  if (typeof err === "string") return new Error(err);
+  const message =
+    (err as { message?: unknown })?.message ??
+    (err as { hint?: unknown })?.hint ??
+    "edge function error";
+  return new Error(
+    typeof message === "string" ? message : "edge function error",
+  );
+}
+
+/**
+ * Capture an exception to Sentry and await the flush so the event is sent even
+ * in a short-lived edge runtime that terminates right after the call. No-op
+ * when Sentry isn't initialized (no DSN). Non-Error values (e.g. Supabase
+ * PostgrestError) are normalized to Error so Sentry gets a real stack — no
+ * tokens/emails/ids are attached.
+ */
+export async function capture(err: unknown): Promise<void> {
   if (!Sentry.isInitialized()) return;
-  Sentry.captureException(err);
+  Sentry.captureException(toError(err));
+  await Sentry.flush(2000);
 }
 
 /**
  * Wrap a Deno.serve handler so any uncaught throw is reported to Sentry and
  * converted into a generic 500 JSON (instead of an opaque edge-platform error),
- * preserving the function's existing response shape for handled cases.
+ * preserving the function's existing response shape for handled cases. The
+ * flush is awaited so the short-lived edge runtime sends the event before the
+ * function returns and the runtime terminates.
  */
 export function wrapHandler(
   functionName: string,
@@ -70,7 +95,7 @@ export function wrapHandler(
     try {
       return await handler(req);
     } catch (err) {
-      capture(err);
+      await capture(err);
       return new Response(JSON.stringify({ error: "internal error" }), {
         status: 500,
         headers: { "content-type": "application/json" },

--- a/supabase/functions/github-discover/index.ts
+++ b/supabase/functions/github-discover/index.ts
@@ -88,7 +88,7 @@ Deno.serve(
       }
       selfGithubId = tokenOwner.id;
     } catch (e) {
-      capture(e);
+      await capture(e);
       return json({ error: `github: ${(e as Error).message}` }, 502);
     }
 
@@ -105,7 +105,7 @@ Deno.serve(
         repos = await fetchUserRepos(providerToken, { apiUrl });
       }
     } catch (e) {
-      capture(e);
+      await capture(e);
       return json({ error: `github: ${(e as Error).message}` }, 502);
     }
     repos = repos.slice(0, MAX_REPOS);
@@ -124,7 +124,7 @@ Deno.serve(
         rosters.push({ repo: `${repo.owner}/${repo.name}`, collaborators });
       } catch (e) {
         // A transient error on one repo shouldn't sink the batch — log and skip.
-        capture(e);
+        await capture(e);
         console.error(
           `collaborators ${repo.owner}/${repo.name}:`,
           (e as Error).message,
@@ -144,7 +144,7 @@ Deno.serve(
         p_github_ids: githubIds,
       });
       if (error) {
-        capture(error);
+        await capture(error);
         console.error("lore_users_for_github_ids failed:", error.message);
         return json({ error: "lookup failed" }, 500);
       }

--- a/supabase/functions/github-provision/index.ts
+++ b/supabase/functions/github-provision/index.ts
@@ -80,7 +80,7 @@ Deno.serve(
       });
       payload = buildProvisionPayload(memberships);
     } catch (e) {
-      capture(e);
+      await capture(e);
       return json({ error: `github: ${(e as Error).message}` }, 502);
     }
 
@@ -94,7 +94,7 @@ Deno.serve(
       p_teams: payload.teams,
     });
     if (rpcErr) {
-      capture(rpcErr);
+      await capture(rpcErr);
       console.error("provision_github_membership failed:", rpcErr.message);
       return json({ error: "provisioning failed" }, 500); // generic — details logged server-side
     }

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -78,7 +78,7 @@ Deno.serve(
       .eq("token", capability)
       .maybeSingle();
     if (invErr) {
-      capture(invErr);
+      await capture(invErr);
       console.error("pending_invites read failed:", invErr.message);
       return json({ error: "lookup failed" }, 500);
     }
@@ -112,7 +112,7 @@ Deno.serve(
     try {
       await sendViaSmtp2go(email, message, { apiKey, sender, apiUrl });
     } catch (e) {
-      capture(e);
+      await capture(e);
       console.error("smtp2go send failed:", (e as Error).message);
       return json({ error: "send failed" }, 502);
     }


### PR DESCRIPTION
## Summary

Follow-up to the already-merged #1516. An adversarial/Seer review (sentry[bot]) flagged two real bugs that were **not** addressed before merge:

1. **Events dropped (MEDIUM, #15530731/0)**: `wrapHandler` returned the `Response` immediately after `captureException`, so the short-lived edge runtime terminated before the async send to Sentry's ingest completed — error reports were silently lost. Fixed by `await Sentry.flush(2000)` in `wrapHandler` and in `capture()`.
2. **PostgrestError not an Error (MEDIUM, #15531255/0)**: `capture()` was called with Supabase `PostgrestError` plain objects (at github-provision:97 and send-invite-email:81), which Sentry renders as weak events with no stack. Fixed by normalizing non-Error values (`toError`) into real `Error` objects before capture — using only the message/hint (never JSON.stringify the whole object, which could carry query/PII context).

All 8 `capture()` call sites now `await` so terminal failures flush. Privacy contract unchanged: no provider_token/email/id reaches Sentry.

## Testing
- `deno check` passes on all three functions (Deno 2.9.4).
- Smoke test: `capture(postgrestErr)` returns without throw; `wrapHandler` returns 500 after flush.
- `pnpm run format:check` clean.

## Note
This is a post-merge fix — the earlier merge gated on the umbrella CI (test/lint green) but did not confirm the Seer review findings were actioned. Apologies for that gap; the findings are now addressed.