### PR TITLE
feat(gateway): delta apply bar shows percentage only (no GB scare)

### DIFF
--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -223,7 +223,12 @@ function makeApplyProgress(): {
     onEvent: (event) => {
       if (event.type === "bytes" && event.phase === "apply") {
         if (!bar) {
-          bar = makeByteProgress("Applying patches", event.total, process.stderr, "pct");
+          bar = makeByteProgress(
+            "Applying patches",
+            event.total,
+            process.stderr,
+            "pct",
+          );
         }
         const delta = event.written - lastWritten;
         lastWritten = event.written;

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -223,7 +223,7 @@ function makeApplyProgress(): {
     onEvent: (event) => {
       if (event.type === "bytes" && event.phase === "apply") {
         if (!bar) {
-          bar = makeByteProgress("Applying patches", event.total);
+          bar = makeByteProgress("Applying patches", event.total, process.stderr, "pct");
         }
         const delta = event.written - lastWritten;
         lastWritten = event.written;

--- a/packages/gateway/src/cli/lib/delta-upgrade.ts
+++ b/packages/gateway/src/cli/lib/delta-upgrade.ts
@@ -223,12 +223,7 @@ function makeApplyProgress(): {
     onEvent: (event) => {
       if (event.type === "bytes" && event.phase === "apply") {
         if (!bar) {
-          bar = makeByteProgress(
-            "Applying patches",
-            event.total,
-            process.stderr,
-            "pct",
-          );
+          bar = makeByteProgress("Applying patches", event.total);
         }
         const delta = event.written - lastWritten;
         lastWritten = event.written;

--- a/packages/gateway/src/cli/lib/progress.ts
+++ b/packages/gateway/src/cli/lib/progress.ts
@@ -50,11 +50,16 @@ function formatBytes(n: number): string {
  * @param totalBytes - Expected total bytes; `null` renders an indeterminate
  *   byte counter instead of a bar.
  * @param out - Output stream (defaults to stderr, the CLI's progress channel).
+ * @param format - `"bytes"` (default) renders the accumulated/total byte
+ *   count. `"pct"` renders only the percentage — useful when the byte total
+ *   is misleading (e.g. a multi-hop chain where intermediate hops inflate the
+ *   displayed size beyond the actual final binary).
  */
 export function makeByteProgress(
   label: string,
   totalBytes: number | null,
   out: ByteProgressOut = process.stderr,
+  format: "bytes" | "pct" = "bytes",
 ): ByteProgress {
   const tty = !!out.isTTY;
   let written = 0;
@@ -66,6 +71,9 @@ export function makeByteProgress(
       return `${label}  ${formatBytes(written)}`;
     }
     const frac = Math.min(written / totalBytes, 1);
+    if (format === "pct") {
+      return `${label} [${renderBar(frac)}] ${(frac * 100).toFixed(0)}%`;
+    }
     return (
       `${label} [${renderBar(frac)}] ` +
       `${formatBytes(written)} / ${formatBytes(totalBytes)}`

--- a/packages/gateway/test/progress.test.ts
+++ b/packages/gateway/test/progress.test.ts
@@ -101,4 +101,30 @@ describe("makeByteProgress", () => {
       p.done();
     }).not.toThrow();
   });
+
+  it("renders percentage only when format='pct' (apply bar suppresses GB scare)", () => {
+    // Multi-hop chains sum newSize across hops, so event.total can far
+    // exceed the final binary size (e.g. 930 MB for a 3-hop 310 MB chain).
+    // The apply bar should show only percentage in that case so users
+    // don't see "applied 1.5 GB / 3.1 GB" for what ends up being a
+    // 310 MB install.
+    const out = fakeOut(true);
+    const p = makeByteProgress(
+      "Applying patches",
+      930 * 1024 * 1024,
+      out,
+      "pct",
+    );
+    p.onProgress(310 * 1024 * 1024); // 33%
+    p.onProgress(310 * 1024 * 1024); // 66%
+    p.onProgress(310 * 1024 * 1024); // 100%
+    p.done();
+
+    const last = out.writes.at(-2);
+    expect(last).toContain("Applying patches");
+    expect(last).toMatch(/\[█+\]\s+100%/);
+    // No byte count in pct mode
+    expect(last).not.toMatch(/\d+\s*(B|KB|MB|GB|TB)/);
+    expect(last).not.toContain("/");
+  });
 });


### PR DESCRIPTION
Multi-hop chains sum newSize across hops, so the apply bar's byte total can far exceed the final binary (e.g. 930 MB shown for a 310 MB install). Switch the apply progress bar to format='pct' so users see only the percentage, not a scary inflated byte count.

- progress.ts: makeByteProgress gains format: 'bytes' | 'pct' (default bytes), adds the percentage-only render branch.
- delta-upgrade.ts: apply bar now passes 'pct'.
- progress.test.ts: regression test for pct-only rendering.

Extracted from the now-obsolete PR #1503 (which also tried to bump binpatch to ^0.3.0 — already superseded by #1515 @ ^0.3.1); this carries only the progress feature. Test: 7 passed.