### PR TITLE
fix(ci): stop docs preview failing on non-website PRs

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -27,13 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-
       # Check if website files changed. On 'closed' events we always proceed
       # (cleanup). Otherwise we only install/build/deploy when website files
       # changed — non-website PRs skip the whole install + build.
@@ -47,24 +40,46 @@ jobs:
               - 'packages/website/**'
               - '.github/workflows/docs-preview.yml'
 
+      # One place decides whether the expensive path runs. This also gates the
+      # toolchain setup below: setup-node's pnpm cache fails its post-job save
+      # when no install ever ran, which failed the whole job on every
+      # non-website PR.
+      - name: Decide whether to build
+        id: gate
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          THIS_REPO: ${{ github.repository }}
+          ACTION: ${{ github.event.action }}
+          WEBSITE_CHANGED: ${{ steps.filter.outputs.website }}
+        run: |
+          if [[ "$HEAD_REPO" == "$THIS_REPO" ]] &&
+             { [[ "$ACTION" == "closed" ]] || [[ "$WEBSITE_CHANGED" == "true" ]]; }; then
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: pnpm/action-setup@v6
+        if: steps.gate.outputs.run == 'true'
+
+      - uses: actions/setup-node@v6
+        if: steps.gate.outputs.run == 'true'
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
       - name: Install dependencies
-        if: >-
-          (github.event.action == 'closed' || steps.filter.outputs.website == 'true') &&
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.gate.outputs.run == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build website
-        if: >-
-          (github.event.action == 'closed' || steps.filter.outputs.website == 'true') &&
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.gate.outputs.run == 'true'
         run: pnpm --filter '@loreai/website' build
         env:
           PR_NUMBER: ${{ github.event.number }}
 
       - name: Deploy PR Preview
-        if: >-
-          (github.event.action == 'closed' || steps.filter.outputs.website == 'true') &&
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.gate.outputs.run == 'true'
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: packages/website/dist/


### PR DESCRIPTION
Found while waiting on #1522, whose `preview` job failed in 11s despite the PR touching no website files.

## What breaks

#1517 gated the install/build steps behind a paths filter but left `setup-node` with `cache: 'pnpm'` running unconditionally. On a PR that touches no website files nothing ever installs, so there is no pnpm store to save and the post-job cache step errors:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

That fails the job, and with it the PR's merge state. It hits **every** non-website PR — #1522 is just where I noticed it.

## Fix

Move the paths filter ahead of the toolchain setup, collapse the duplicated three-clause `if:` into one gate step, and reuse it for setup as well as install/build/deploy. Non-website PRs now skip the toolchain entirely instead of setting up a cache they never fill.

## Gate semantics unchanged

Verified each branch of the condition against the old expression:

| case | before | after |
|---|---|---|
| website PR, same repo | build | build |
| non-website PR, same repo | skip | skip |
| `closed`, non-website (cleanup) | run | run |
| `closed`, website (cleanup) | run | run |
| fork PR, website changed | skip | skip |
| fork PR closed | skip | skip |
| `workflow_dispatch` (no PR context) | skip | skip |

`actionlint` clean. This PR touches `.github/workflows/docs-preview.yml`, which is in the filter, so its own `preview` job exercises the build path — the non-website path is what #1522 will confirm once this lands.