### PR TITLE
fix(import): pass sinceMs to api.ts auth probe (Seer HIGH-severity)

### DIFF
--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -508,6 +508,14 @@ async function handleImportExtract(
   req: Request,
   config: GatewayConfig,
 ): Promise<Response> {
+  // Stamp the start of THIS extract request so the auth-rejected probe ignores
+  // failures recorded by a PRIOR request in the same gateway process — see
+  // `hasRecentAuthRejectedFailure` for the cross-run leak rationale. Without
+  // this, a user who corrected their credential and retried within 60 seconds
+  // would be immediately aborted on the first chunk by a stale failure
+  // attributed to the previous attempt.
+  const runStartedAt = Date.now();
+
   const body = await parseBody<{
     git_remote?: string;
     path?: string;
@@ -564,8 +572,15 @@ async function handleImportExtract(
     // Remote extract runs session-less under workerID "lore-import". Inject
     // the same fail-fast-on-auth-rejected probe as the local CLI path so a
     // broken credential doesn't burn every chunk before the response returns.
+    // `runStartedAt` bounds the probe to this request's failures only — see
+    // the rationale at the top of `handleImportExtract`.
     wasRecentChunkAuthRejected: () =>
-      hasRecentAuthRejectedFailure("_unknown", "lore-import"),
+      hasRecentAuthRejectedFailure(
+        "_unknown",
+        "lore-import",
+        60_000,
+        runStartedAt,
+      ),
   });
 
   return jsonResponse(result);


### PR DESCRIPTION
## What

Captures `runStartedAt = Date.now()` at the start of `handleImportExtract` and threads it through the `hasRecentAuthRejectedFailure` call as the `sinceMs` argument — bounds the auth-rejected probe to this request's failures only.

## Why

Seer flagged (finding `15561645/0`, HIGH severity) that the remote `/api/v1/import/extract` endpoint's probe was missing the `sinceMs` parameter, causing cross-request contamination: a failure recorded by a prior request in the same gateway process would falsely abort the next request on its first chunk. A user who corrected their credential and retried within 60 seconds would be immediately aborted by a stale failure attributed to the previous attempt — making the remote import feature unreliable for retry scenarios.

## How

`packages/gateway/src/api.ts`:
- `handleImportExtract` captures `runStartedAt = Date.now()` at handler entry.
- The `wasRecentChunkAuthRejected` callback now passes `60_000` (withinMs) and `runStartedAt` (sinceMs) to `hasRecentAuthRejectedFailure`.

Mirrors the pattern already used by `commandImport` and `import-auto.ts` in the previous PR (#1525) — same probe, same argument shape.

## Follow-up to #1525

PR #1525 (which closed before this finding landed) had the `sinceMs` wiring in `commandImport` and `import-auto.ts` but missed the third call site in `api.ts`. This PR closes the gap. The diff is small (16 insertions / 1 deletion) because the fix is just plumbing the same `sinceMs` argument through the third caller.

## Tests

- `worker-health.test.ts` already exercises the `sinceMs` cross-run leak guard (added in #1525).
- Wiring follows the exact pattern as `commandImport` and `import-auto.ts` — both have regression coverage.
- A dedicated test for the remote endpoint would require `vi.mock` of the LLM client and import chain (heavy mocking) — left for a future PR if the same call site regresses.

## Verification

- `tsc --noEmit` clean in `@loreai/gateway`.
- Full gateway test suite re-run: **3,428 / 3,428 passing**.
- Lint clean on the changed file.