### PR TITLE
fix(gateway): use /contributors in discover; intuitive invite from linked cwd

### DIFF
--- a/packages/gateway/src/cli/login.ts
+++ b/packages/gateway/src/cli/login.ts
@@ -34,8 +34,9 @@ import {
 
 /** GitHub OAuth scopes needed:
  *  - `read:org` — org/team membership mirroring (E-5-a, #827)
- *  - `repo` — list collaborators on private repos (E-5-d, #630)
- *  Collaborator API requires `repo` for private org repos (e.g. getsentry/*).
+ *  - `repo` — list per-repo collaborators/contributors on private repos (E-5-d, #630).
+ *  The /collaborators and /contributors endpoints both require `repo` for non-public repos —
+ *  e.g. anything under getsentry/*.
  */
 const OAUTH_SCOPES = "read:org repo";
 

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -151,7 +151,7 @@ const OPTIONS = {
   email: { type: "string" as const },
   role: { type: "string" as const },
   offline: { type: "boolean" as const },
-  // `lore team discover --invite <scope>` (E-5-d-2): mint invites for discovered collaborators.
+  // `lore team discover --invite <team>` (E-5-d-2): mint invites for discovered contributors.
   invite: { type: "string" as const },
   verify: { type: "boolean" as const },
   "no-browser": { type: "boolean" as const },

--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -26,8 +26,8 @@ import {
   claimOrgDomain,
   createTeam,
   createTeamInvite,
-  discoverGitHubCollaborators,
-  distinctCollaborators,
+  discoverGitHubContributors,
+  distinctContributors,
   isEmailAddress,
   listDomainJoinRequests,
   listTeams,
@@ -40,7 +40,7 @@ import {
 } from "../team";
 
 const USAGE =
-  "Usage: lore team [list | members <scope> | discover [repo...] [--invite <scope>] [--role editor|viewer] | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite <scope> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>] | domain <claim <org> <domain> [--role member] | request <org> <domain> | requests <org> | approve <request-id> | reject <request-id>>]";
+  "Usage: lore team [list | members <scope> | discover [repo...] [--invite <team>] [--role editor|viewer] | create <name> | add <scope> <userId> [role] | remove <scope> <userId> | set-role <scope> <userId> <role> | invite [<scope>] <invitee> [--role editor|viewer] [--email <hint>] [--offline] | accept <token> | link <team> [--project <path>] | unlink [--project <path>] | review [--project <path>] | approve <id> | reject <id> | policy <manual|auto> [--project <path>] | domain <claim <org> <domain> [--role member] | request <org> <domain> | requests <org> | approve <request-id> | reject <request-id>>]";
 
 export async function commandTeam(
   positionals: string[],
@@ -101,9 +101,14 @@ export async function commandTeam(
         break;
       }
       case "discover": {
-        // E-5-d (#630): find which of the caller's GitHub repo collaborators are already on Lore.
+        // E-5-d (#630): find which of the caller's GitHub repo contributors are already on Lore.
         // Auto-detects the git remote when no repo arguments given, passes it to the Edge Function
         // so private org repos are scanned (not just the caller's own repos first-page).
+        //
+        // Uses the CONTRIBUTORS endpoint (default-branch commit attribution), NOT collaborators:
+        // /collaborators returns "everyone with at least triage access" — which on a private org
+        // repo is effectively the org roster. /contributors returns "who actually committed" which
+        // matches the admin's intent when scanning for teammates.
         const explicitRepos = positionals
           .slice(1)
           .filter((p) => !p.startsWith("--"));
@@ -118,7 +123,7 @@ export async function commandTeam(
           }
         }
         console.log(
-          `Discovering collaborators for ${repos ? repos.join(", ") : "your repos"}…`,
+          `Discovering contributors for ${repos ? repos.join(", ") : "your repos"}…`,
         );
         let providerToken: string;
         // Use the FRESH client bound to the just-refreshed session — the outer `client` from
@@ -135,21 +140,21 @@ export async function commandTeam(
           process.exitCode = 1;
           return;
         }
-        const found = await discoverGitHubCollaborators(
+        const found = await discoverGitHubContributors(
           freshClient,
           providerToken,
           repos,
         );
         if (!found || found.length === 0) {
-          console.log("No accessible repos with collaborators found.");
+          console.log("No accessible repos with contributors found.");
           break;
         }
         let onLoreTotal = 0;
         let offLoreTotal = 0;
         for (const r of found) {
-          if (r.collaborators.length === 0) continue;
+          if (r.contributors.length === 0) continue;
           console.log(`\n${r.repo}`);
-          for (const c of r.collaborators) {
+          for (const c of r.contributors) {
             if (c.onLore) onLoreTotal++;
             else offLoreTotal++;
             console.log(
@@ -158,10 +163,10 @@ export async function commandTeam(
           }
         }
 
-        // E-5-d-2: --invite <scope> mints an invite per DISTINCT collaborator so the admin can hand
+        // E-5-d-2: --invite <team> mints an invite per DISTINCT contributor so the admin can hand
         // out join links. Invite-only for everyone (on-Lore or not) — we never expose Lore user_ids,
         // so there is no direct auto-add; an on-Lore invitee just gets a frictionless `accept`.
-        // GitHub's API returns no collaborator emails, so links are printed rather than auto-emailed.
+        // GitHub's API returns no contributor emails, so links are printed rather than auto-emailed.
         const inviteRef = values.invite as string | undefined;
         if (inviteRef !== undefined) {
           // A trailing `--invite` with no value parses as `true` under strict:false — reject it
@@ -194,7 +199,7 @@ export async function commandTeam(
             return;
           }
           // Only admins may mint invites (server enforces this too). Pre-check the local mirror so an
-          // editor gets ONE clear message instead of N identical per-collaborator RPC rejections.
+          // editor gets ONE clear message instead of N identical per-contributor RPC rejections.
           if (scopeMemberRole(scope.id, user.user_id) !== "admin") {
             console.error(
               `\nYou must be an admin of "${scope.name ?? scope.id}" to invite members.`,
@@ -204,15 +209,15 @@ export async function commandTeam(
           }
           const inviteRole =
             (values.role as string) === "viewer" ? "viewer" : "editor";
-          const people = distinctCollaborators(found);
+          const people = distinctContributors(found);
           if (people.length === 0) {
             console.log(
-              "\nNo collaborators to invite (the accessible repos have none). Nothing minted.",
+              "\nNo contributors to invite (the accessible repos have none). Nothing minted.",
             );
             break;
           }
           console.log(
-            `\nMinting ${inviteRole} invites to "${scope.name ?? scope.id}" for ${people.length} collaborator${people.length === 1 ? "" : "s"}:`,
+            `\nMinting ${inviteRole} invites to "${scope.name ?? scope.id}" for ${people.length} contributor${people.length === 1 ? "" : "s"}:`,
           );
           for (const c of people) {
             try {
@@ -231,16 +236,16 @@ export async function commandTeam(
             }
           }
           console.log(
-            "\nShare each link with the matching collaborator (GitHub doesn't expose their email). " +
+            "\nShare each link with the matching contributor (GitHub doesn't expose their email). " +
               "To email an address directly, use `lore team invite <scope> --email <addr>`.",
           );
           break;
         }
 
         console.log(
-          `\n${onLoreTotal} collaborator${onLoreTotal === 1 ? "" : "s"} already on Lore, ` +
-            `${offLoreTotal} not yet. Invite them with \`lore team discover --invite <scope>\` ` +
-            "or `lore team invite <scope> --email <addr>`.",
+          `\n${onLoreTotal} contributor${onLoreTotal === 1 ? "" : "s"} already on Lore, ` +
+            `${offLoreTotal} not yet. Invite them with \`lore team discover --invite <team>\` ` +
+            "or `lore team invite <invitee>` from a project linked to a team.",
         );
         break;
       }
@@ -291,17 +296,85 @@ export async function commandTeam(
         break;
       }
       case "invite": {
-        const scope = positionals[1];
-        if (!scope) return usage();
+        if (!positionals[1]) return usage();
         const role = (values.role as string) ?? "editor";
         if (role !== "editor" && role !== "viewer") return usage();
-        const hint = values.email as string | undefined;
+        const user = await getCurrentUser();
+        if (!user) {
+          console.error("Not logged in — run `lore login` first.");
+          process.exitCode = 1;
+          return;
+        }
+        const p1 = positionals[1];
+        const p2 = positionals[2];
+        // Resolve scope: positional[1] wins if it's a UUID OR a writable team name (existing
+        // behavior). If positional[2] is also present, treat positional[1] strictly as scope and
+        // positional[2] as the invitee hint (the unambiguous two-positional form). Otherwise, when
+        // positional[1] doesn't resolve as a scope AND the cwd (or --project path) is linked to a
+        // team, use the linked team with positional[1] recorded as the invitee hint — the intuitive
+        // case of `lore team invite <someone>` from a linked cwd.
+        let scopeRef: string | null;
+        let inviteeHint: string | undefined;
+        if (p2) {
+          scopeRef = p1;
+          inviteeHint = p2;
+        } else {
+          const direct = resolveWritableScope(p1, user.user_id);
+          if (direct) {
+            scopeRef = p1;
+          } else {
+            const projectPath = resolve(
+              (values.project as string) ?? process.cwd(),
+            );
+            const pid = projectId(projectPath);
+            const linked = pid ? projectScope(pid) : null;
+            const linkedScope = linked
+              ? resolveWritableScope(linked, user.user_id)
+              : null;
+            if (linkedScope) {
+              scopeRef = linked;
+              inviteeHint = p1;
+            } else {
+              scopeRef = null;
+            }
+          }
+        }
+        if (!scopeRef) {
+          console.error(
+            `\nNo team to invite to. Either:\n` +
+              `  - link this project first: lore team link <team>  (then lore team invite <invitee>)\n` +
+              `  - or pass the team explicitly: lore team invite <team> [<invitee>]\n` +
+              `See lore team list for teams you admin.`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        const scope = resolveWritableScope(scopeRef, user.user_id);
+        if (!scope) {
+          console.error(
+            `\nNo team "${scopeRef}" you can write to. See \`lore team list\`.`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        // Only admins may mint invites (server enforces this too). Pre-check the local mirror so an
+        // editor gets ONE clear message instead of an opaque RPC rejection.
+        if (scopeMemberRole(scope.id, user.user_id) !== "admin") {
+          console.error(
+            `\nYou must be an admin of "${scope.name ?? scope.id}" to invite members.`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        const email = values.email as string | undefined;
+        // --email takes precedence as the hint label; otherwise the invitee positional hint.
+        const hint = email ?? inviteeHint;
         const offline = values.offline === true;
-        const token = await createTeamInvite(client, scope, role, hint, {
+        const token = await createTeamInvite(client, scope.id, role, hint, {
           offline,
         });
-        // E-5-e: if --email is a real address, email the join link. A send failure NEVER loses the
-        // invite — the token/link is always still printed.
+        // E-5-e: if the resolved hint is a real email, email the join link. A send failure NEVER
+        // loses the invite — the token/link is always still printed.
         const willEmail = !!hint && isEmailAddress(hint);
         const emailed = willEmail
           ? await sendInviteEmail(client, token, hint)

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -27,29 +27,34 @@ export interface MemberSummary {
   role: string;
 }
 
-/** A repo's collaborator roster with a Lore-membership flag per collaborator (E-5-d, #630). */
-export interface DiscoveredCollaborator {
+/** A repo's contributor roster with a Lore-membership flag per contributor (E-5-d, #630). */
+export interface DiscoveredContributor {
   login: string;
   githubId: number;
   onLore: boolean;
 }
 export interface DiscoveredRepo {
   repo: string; // "owner/name"
-  collaborators: DiscoveredCollaborator[];
+  contributors: DiscoveredContributor[];
 }
 
 /**
- * E-5-d (#630, Slice 1): discover which of the caller's GitHub repo collaborators already have a Lore
+ * E-5-d (#630, Slice 1): discover which of the caller's GitHub repo contributors already have a Lore
  * account, so the caller can invite the rest to a team they admin. Server-side-verified via the
  * `github-discover` Edge Function using the caller's OWN `provider_token` (a fresh one from GitHub
- * OAuth) — the client never asserts collaborators or membership. Returns null when there is no
- * `read:org`/repo grant (e.g. an email-only login).
+ * OAuth) — the client never asserts membership. Returns null when there is no `read:org`/repo
+ * grant (e.g. an email-only login).
  *
  * `repos` is an optional explicit list ("owner/name" or a GitHub URL); when omitted the Edge Function
- * scans the caller's own repos (first page). Membership is disclosed only for collaborators of repos
+ * scans the caller's own repos (first page). Membership is disclosed only for contributors of repos
  * the caller can actually read on GitHub, and only as an `onLore` boolean (never a Lore user id).
+ *
+ * Contributors, NOT collaborators: GitHub's `/repos/{owner}/{name}/collaborators` returns
+ * "everyone with at least triage access" — which for a private org repo is effectively the entire
+ * org roster (everyone typically gets triage via org rules). `/contributors` returns the commit-
+ * attribution roster instead, which is what admins actually want when scanning "who worked here".
  */
-export async function discoverGitHubCollaborators(
+export async function discoverGitHubContributors(
   client: SupabaseClient,
   providerToken: string | null | undefined,
   repos?: string[],
@@ -62,7 +67,7 @@ export async function discoverGitHubCollaborators(
   const payload = data as {
     repos?: Array<{
       repo: string;
-      collaborators: Array<{
+      contributors: Array<{
         login: string;
         github_id: number;
         on_lore: boolean;
@@ -71,7 +76,7 @@ export async function discoverGitHubCollaborators(
   };
   return (payload.repos ?? []).map((r) => ({
     repo: r.repo,
-    collaborators: r.collaborators.map((c) => ({
+    contributors: r.contributors.map((c) => ({
       login: c.login,
       githubId: c.github_id,
       onLore: c.on_lore,
@@ -80,16 +85,16 @@ export async function discoverGitHubCollaborators(
 }
 
 /**
- * The DISTINCT collaborators across all discovered repos, deduped by GitHub login (a person on
+ * The DISTINCT contributors across all discovered repos, deduped by GitHub login (a person on
  * several repos should get one invite, not one per repo). Sorted for stable output. Used by
  * `lore team discover --invite` to mint one invite per person (E-5-d-2).
  */
-export function distinctCollaborators(
+export function distinctContributors(
   repos: DiscoveredRepo[],
-): DiscoveredCollaborator[] {
-  const byLogin = new Map<string, DiscoveredCollaborator>();
+): DiscoveredContributor[] {
+  const byLogin = new Map<string, DiscoveredContributor>();
   for (const r of repos)
-    for (const c of r.collaborators)
+    for (const c of r.contributors)
       if (!byLogin.has(c.login)) byLogin.set(c.login, c);
   return Array.from(byLogin.values()).sort((a, b) =>
     a.login.localeCompare(b.login),

--- a/packages/gateway/test/github-discover.test.ts
+++ b/packages/gateway/test/github-discover.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the github-discover Edge Function's pure core (E-5-d, #630) — repo/collaborator
+ * Unit tests for the github-discover Edge Function's pure core (E-5-d, #630) — repo/contributor
  * fetch + parsing + Lore-membership annotation. Mirrors github-provision.test.ts: imports the
  * Deno-free `discover.ts` and drives it with a URL-routed fetch mock.
  */
@@ -7,14 +7,14 @@ import { describe, expect, it } from "vitest";
 import {
   annotateOnLore,
   collectGithubIds,
-  fetchRepoCollaborators,
+  fetchRepoContributors,
   fetchUserRepos,
   parseRepoRef,
-  type RepoCollaborators,
+  type RepoContributors,
 } from "../../../supabase/functions/github-discover/discover";
 
 function mockFetch(
-  routes: Record<string, { status?: number; body: unknown }>,
+  routes: Record<string, { status?: number; body: unknown; link?: string }>,
 ): typeof fetch {
   return (async (input: string | URL | Request) => {
     const url =
@@ -29,11 +29,19 @@ function mockFetch(
         return {
           ok: status >= 200 && status < 300,
           status,
+          headers: new Map(
+            resp.link ? [["link", resp.link]] : [],
+          ) as unknown as Headers,
           json: async () => resp.body,
         } as Response;
       }
     }
-    return { ok: false, status: 404, json: async () => ({}) } as Response;
+    return {
+      ok: false,
+      status: 404,
+      headers: new Map() as unknown as Headers,
+      json: async () => ({}),
+    } as Response;
   }) as typeof fetch;
 }
 
@@ -97,10 +105,10 @@ describe("fetchUserRepos", () => {
   });
 });
 
-describe("fetchRepoCollaborators", () => {
-  it("returns collaborators excluding the caller (by github id)", async () => {
+describe("fetchRepoContributors", () => {
+  it("returns contributors excluding the caller (by github id)", async () => {
     const f = mockFetch({
-      "/collaborators": {
+      "/contributors": {
         body: [
           { login: "alice", id: 1 },
           { login: "self", id: 99 }, // the caller — excluded
@@ -108,7 +116,7 @@ describe("fetchRepoCollaborators", () => {
         ],
       },
     });
-    const cols = await fetchRepoCollaborators(
+    const cols = await fetchRepoContributors(
       "tok",
       { owner: "o", name: "r" },
       99,
@@ -119,10 +127,29 @@ describe("fetchRepoCollaborators", () => {
       { login: "bob", github_id: 2 },
     ]);
   });
+  it("asks for anon contributors and per_page=100 (cheap pagination window)", async () => {
+    let seen = "";
+    const f = (async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string" ? input : ((input as URL).href ?? "");
+      seen = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map() as unknown as Headers,
+        json: async () => [{ login: "alice", id: 1 }],
+      } as Response;
+    }) as typeof fetch;
+    await fetchRepoContributors("tok", { owner: "o", name: "r" }, 99, {
+      fetchImpl: f,
+    });
+    expect(seen).toMatch(/anon=true/);
+    expect(seen).toMatch(/per_page=100/);
+  });
   it("returns null (skip, not throw) on 403 / 404 — inaccessible repo", async () => {
     for (const status of [403, 404]) {
-      const f = mockFetch({ "/collaborators": { status, body: {} } });
-      const cols = await fetchRepoCollaborators(
+      const f = mockFetch({ "/contributors": { status, body: {} } });
+      const cols = await fetchRepoContributors(
         "tok",
         { owner: "o", name: "r" },
         99,
@@ -131,26 +158,133 @@ describe("fetchRepoCollaborators", () => {
       expect(cols).toBeNull();
     }
   });
+  it("returns [] (empty roster, NOT skip) on 202 — stats still computing", async () => {
+    const f = mockFetch({ "/contributors": { status: 202, body: "" } });
+    const cols = await fetchRepoContributors(
+      "tok",
+      { owner: "o", name: "r" },
+      99,
+      { fetchImpl: f },
+    );
+    expect(cols).toEqual([]);
+  });
+  it("follows Link: rel='next' up to MAX_PAGES and dedupes cross-page via Set<id>", async () => {
+    const page2Link =
+      '<https://api.github.com/repos/o/r/contributors?page=2&anon=true&per_page=100>; rel="next"';
+    const page1Body = [
+      { login: "alice", id: 1 },
+      { login: "bob", id: 2 },
+    ];
+    const page2Body = [
+      { login: "bob", id: 2 }, // cross-page dup — must dedupe (first wins)
+      { login: "carol", id: 3 },
+    ];
+    const calls: string[] = [];
+    const f = (async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      calls.push(url);
+      const isPage2 = url.includes("page=2");
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map(
+          isPage2 ? [] : [["link", page2Link]],
+        ) as unknown as Headers,
+        json: async () => (isPage2 ? page2Body : page1Body),
+      } as Response;
+    }) as typeof fetch;
+    const cols = await fetchRepoContributors(
+      "tok",
+      { owner: "o", name: "r" },
+      99,
+      { fetchImpl: f },
+    );
+    expect(calls.length).toBe(2);
+    expect(cols).toEqual([
+      { login: "alice", github_id: 1 },
+      { login: "bob", github_id: 2 },
+      { login: "carol", github_id: 3 },
+    ]);
+  });
+
+  it("stops at MAX_PAGES even when the server keeps sending rel='next'", async () => {
+    const link =
+      '<https://api.github.com/repos/o/r/contributors?page=N&anon=true&per_page=100>; rel="next"';
+    let calls = 0;
+    const f = (async (_input: string | URL | Request) => {
+      calls++;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map([["link", link]]) as unknown as Headers,
+        json: async () => [{ login: `u${calls}`, id: calls }],
+      } as Response;
+    }) as typeof fetch;
+    const cols = await fetchRepoContributors(
+      "tok",
+      { owner: "o", name: "r" },
+      999_999, // self id that won't match anything
+      { fetchImpl: f },
+    );
+    // MAX_PAGES is set to 5 in discover.ts — exactly 5 calls regardless of the next-link loop.
+    expect(calls).toBe(5);
+    expect(cols?.length).toBe(5);
+  });
+
+  it("rewrites a non-apiUrl Link next href onto apiUrl (defense against leaked host)", async () => {
+    // Some test proxies / misconfigs may inject a different host into the next URL. We rewrite
+    // anything that doesn't match apiUrl's origin back onto apiUrl.
+    const leakLink =
+      '<https://attacker.example.com/repos/o/r/contributors?page=2>; rel="next"';
+    let seen = "";
+    const f = (async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      seen = url;
+      return {
+        ok: true,
+        status: 200,
+        headers: new Map([["link", leakLink]]) as unknown as Headers,
+        json: async () => [{ login: "alice", id: 1 }],
+      } as Response;
+    }) as typeof fetch;
+    await fetchRepoContributors("tok", { owner: "o", name: "r" }, 99, {
+      fetchImpl: f,
+      apiUrl: "https://api.github.com",
+    });
+    expect(seen.startsWith("https://api.github.com/")).toBe(true);
+    expect(seen).not.toContain("attacker.example.com");
+  });
   it("throws on other non-ok statuses (e.g. 500)", async () => {
-    const f = mockFetch({ "/collaborators": { status: 500, body: {} } });
+    const f = mockFetch({ "/contributors": { status: 500, body: {} } });
     await expect(
-      fetchRepoCollaborators("tok", { owner: "o", name: "r" }, 99, {
+      fetchRepoContributors("tok", { owner: "o", name: "r" }, 99, {
         fetchImpl: f,
       }),
-    ).rejects.toThrow(/collaborators: 500/);
+    ).rejects.toThrow(/contributors: 500/);
   });
-  it("drops rows with a missing id or login", async () => {
+  it("drops rows with a missing id or login (including anonymous contributors)", async () => {
     const f = mockFetch({
-      "/collaborators": {
+      "/contributors": {
         body: [
           { login: "alice", id: 1 },
-          { login: "noid" }, // no id → dropped
-          { id: 3 }, // no login → dropped
+          { login: "noid" }, // no id → dropped (can't link to Lore)
+          { id: 3 }, // no login → dropped (anonymous contributor)
           { login: "", id: 4 }, // empty login → dropped
+          { login: null, id: 5 }, // null login → dropped
         ],
       },
     });
-    const cols = await fetchRepoCollaborators(
+    const cols = await fetchRepoContributors(
       "tok",
       { owner: "o", name: "r" },
       99,
@@ -161,17 +295,17 @@ describe("fetchRepoCollaborators", () => {
 });
 
 describe("collectGithubIds + annotateOnLore", () => {
-  const rosters: RepoCollaborators[] = [
+  const rosters: RepoContributors[] = [
     {
       repo: "o/r1",
-      collaborators: [
+      contributors: [
         { login: "alice", github_id: 1 },
         { login: "bob", github_id: 2 },
       ],
     },
     {
       repo: "o/r2",
-      collaborators: [
+      contributors: [
         { login: "bob", github_id: 2 }, // duplicate across repos
         { login: "carol", github_id: 3 },
       ],
@@ -184,11 +318,11 @@ describe("collectGithubIds + annotateOnLore", () => {
 
   it("annotates on_lore from the known-Lore id set", () => {
     const out = annotateOnLore(rosters, new Set([2, 3]));
-    expect(out[0].collaborators).toEqual([
+    expect(out[0].contributors).toEqual([
       { login: "alice", github_id: 1, on_lore: false },
       { login: "bob", github_id: 2, on_lore: true },
     ]);
-    expect(out[1].collaborators).toEqual([
+    expect(out[1].contributors).toEqual([
       { login: "bob", github_id: 2, on_lore: true },
       { login: "carol", github_id: 3, on_lore: true },
     ]);
@@ -196,7 +330,7 @@ describe("collectGithubIds + annotateOnLore", () => {
 
   it("annotates all false when no ids are on Lore", () => {
     const out = annotateOnLore(rosters, new Set());
-    expect(out.every((r) => r.collaborators.every((c) => !c.on_lore))).toBe(
+    expect(out.every((r) => r.contributors.every((c) => !c.on_lore))).toBe(
       true,
     );
   });

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -24,17 +24,17 @@ vi.mock("../src/team", () => ({
   listDomainJoinRequests: vi.fn(),
   approveDomainJoin: vi.fn(),
   rejectDomainJoin: vi.fn(),
-  discoverGitHubCollaborators: vi.fn(),
+  discoverGitHubContributors: vi.fn(),
   sendInviteEmail: vi.fn(),
   // Pure predicate — use the real implementation so --email routing behaves in tests.
   isEmailAddress: (s: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.trim()),
   // Pure dedupe helper — real impl so the discover --invite path yields the expected people.
-  distinctCollaborators: (
-    repos: Array<{ collaborators: Array<{ login: string }> }>,
+  distinctContributors: (
+    repos: Array<{ contributors: Array<{ login: string }> }>,
   ) => {
     const seen = new Map<string, { login: string }>();
     for (const r of repos)
-      for (const c of r.collaborators)
+      for (const c of r.contributors)
         if (!seen.has(c.login)) seen.set(c.login, c);
     return Array.from(seen.values()).sort((a, b) =>
       a.login.localeCompare(b.login),
@@ -281,14 +281,43 @@ describe("set-role", () => {
 });
 
 describe("invite (E-5-c)", () => {
-  it("requires a scope", async () => {
+  const PROJECT = "/test/invite/proj";
+
+  beforeEach(() => {
+    db().exec("DELETE FROM scopes");
+    db().exec("DELETE FROM scope_members");
+    // Two teams the caller (u1) admins — s-1 by id, "Rockets" by name (case-insensitive).
+    db()
+      .query(
+        "INSERT INTO scopes (id, org_id, kind, name, promotion_policy, created_at, updated_at) VALUES ('s-1','o','team','Rockets','manual',0,0)",
+      )
+      .run();
+    db()
+      .query(
+        "INSERT INTO scopes (id, org_id, kind, name, promotion_policy, created_at, updated_at) VALUES ('s-2','o','team','Docs','manual',0,0)",
+      )
+      .run();
+    db()
+      .query(
+        "INSERT INTO scope_members (scope_id, user_id, role, created_at, updated_at) VALUES ('s-1','u1','admin',0,0)",
+      )
+      .run();
+    db()
+      .query(
+        "INSERT INTO scope_members (scope_id, user_id, role, created_at, updated_at) VALUES ('s-2','u1','admin',0,0)",
+      )
+      .run();
+    vi.mocked(getCurrentUser).mockResolvedValue({ user_id: "u1" } as never);
+  });
+
+  it("requires a positional", async () => {
     await run("invite");
     expect(errs.join("\n")).toMatch(/Usage: lore team/);
     expect(process.exitCode).toBe(1);
   });
 
   it("rejects an invalid role", async () => {
-    await commandTeam(["invite", "s"], { role: "admin" });
+    await commandTeam(["invite", "s-1"], { role: "admin" });
     expect(errs.join("\n")).toMatch(/Usage: lore team/);
     expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
   });
@@ -306,6 +335,30 @@ describe("invite (E-5-c)", () => {
     expect(logs.join("\n")).toContain("lore team accept tok-abc");
   });
 
+  it("resolves a team NAME (the UUID-bug fix)", async () => {
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-abc");
+    await commandTeam(["invite", "Rockets"], {});
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-1",
+      "editor",
+      undefined,
+      { offline: false },
+    );
+  });
+
+  it("resolves case-insensitively", async () => {
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-abc");
+    await commandTeam(["invite", "rockets"], {});
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-1",
+      "editor",
+      undefined,
+      { offline: false },
+    );
+  });
+
   it("passes --role and --email through to the client", async () => {
     vi.mocked(team.createTeamInvite).mockResolvedValue("tok-xyz");
     await commandTeam(["invite", "s-2"], { role: "viewer", email: "a@b.dev" });
@@ -321,16 +374,95 @@ describe("invite (E-5-c)", () => {
 
   it("passes --offline through and warns the token carries a key", async () => {
     vi.mocked(team.createTeamInvite).mockResolvedValue("tok-abc.SECRET");
-    await commandTeam(["invite", "s-3"], { offline: true });
+    await commandTeam(["invite", "s-3-not-real"], { offline: true });
+    // No linked cwd, no matching scope → falls through to the helpful error, but we also verify
+    // --offline doesn't accidentally short-circuit resolution. Use a real team here:
+    vi.mocked(team.createTeamInvite).mockClear();
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-xyz.SECRET");
+    await commandTeam(["invite", "s-1"], { offline: true });
     expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
       FAKE_CLIENT,
-      "s-3",
+      "s-1",
       "editor",
       undefined,
       { offline: true },
     );
     expect(logs.join("\n")).toMatch(/one-time decryption key/i);
-    expect(logs.join("\n")).toContain("lore team accept tok-abc.SECRET");
+    expect(logs.join("\n")).toContain("lore team accept tok-xyz.SECRET");
+  });
+
+  it("linked-cwd fallback: `invite <githublogin>` from a linked cwd uses linked team + login as hint", async () => {
+    const pid = ensureProject(PROJECT);
+    setProjectScope(pid, "s-1");
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-friend");
+    await commandTeam(["invite", "MathurAditya724"], { project: PROJECT });
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-1",
+      "editor",
+      "MathurAditya724",
+      { offline: false },
+    );
+    expect(logs.join("\n")).toContain("for MathurAditya724");
+    // The printup walks the regular non-email path — admin manually shares the link.
+    expect(logs.join("\n")).toContain("lore team accept tok-friend");
+  });
+
+  it("linked-cwd fallback + --email: --email wins as the hint and we email the link", async () => {
+    const pid = ensureProject(PROJECT);
+    setProjectScope(pid, "s-1");
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-link");
+    vi.mocked(team.sendInviteEmail).mockResolvedValue(true);
+    await commandTeam(["invite", "MathurAditya724"], {
+      project: PROJECT,
+      email: "mathur@example.com",
+    });
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-1",
+      "editor",
+      "mathur@example.com",
+      { offline: false },
+    );
+    expect(logs.join("\n")).toMatch(
+      /Emailed the join link to mathur@example.com/,
+    );
+  });
+
+  it("explicit two-positional: `invite <team> <who>` uses both, no linked-cwd fallback", async () => {
+    const pid = ensureProject(PROJECT);
+    // Project is linked to Docs (s-2); the explicit s-1 + invitee pair MUST bypass the fallback.
+    setProjectScope(pid, "s-2");
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-exp");
+    await commandTeam(["invite", "s-1", "MathurAditya724"], {
+      project: PROJECT,
+    });
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-1",
+      "editor",
+      "MathurAditya724",
+      { offline: false },
+    );
+  });
+
+  it("no scope match + no linked cwd → helpful error directing user to link or pass explicitly", async () => {
+    await commandTeam(["invite", "MathurAditya724"], {});
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+    expect(errs.join("\n")).toMatch(/No team to invite to/);
+    expect(errs.join("\n")).toMatch(/link this project first/);
+    expect(errs.join("\n")).toMatch(/See lore team list/);
+  });
+
+  it("non-admin on the resolved scope → refused before any RPC fires", async () => {
+    db()
+      .query("UPDATE scope_members SET role='editor' WHERE scope_id='s-1'")
+      .run();
+    await commandTeam(["invite", "Rockets"], {});
+    expect(process.exitCode).toBe(1);
+    expect(errs.join("\n")).toMatch(/must be an admin/);
+    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
   });
 });
 
@@ -625,22 +757,22 @@ describe("discover --invite (E-5-d-2)", () => {
       client: FAKE_CLIENT,
       providerToken: "gho_x",
     });
-    vi.mocked(team.discoverGitHubCollaborators).mockResolvedValue([
+    vi.mocked(team.discoverGitHubContributors).mockResolvedValue([
       {
         repo: "o/a",
-        collaborators: [
+        contributors: [
           { login: "alice", githubId: 1, onLore: true },
           { login: "bob", githubId: 2, onLore: false },
         ],
       },
       {
         repo: "o/b",
-        collaborators: [{ login: "bob", githubId: 2, onLore: false }],
+        contributors: [{ login: "bob", githubId: 2, onLore: false }],
       },
     ] as never);
   });
 
-  it("mints ONE invite per distinct collaborator and prints accept links", async () => {
+  it("mints ONE invite per distinct contributor and prints accept links", async () => {
     vi.mocked(team.createTeamInvite)
       .mockResolvedValueOnce("tok-alice")
       .mockResolvedValueOnce("tok-bob");
@@ -701,16 +833,16 @@ describe("discover --invite (E-5-d-2)", () => {
     expect(logs.join("\n")).toMatch(/already on Lore/);
   });
 
-  it("with --invite but repos have no collaborators: mints nothing, says so (no confusing '0 collaborators')", async () => {
-    vi.mocked(team.discoverGitHubCollaborators).mockResolvedValue([
-      { repo: "o/empty", collaborators: [] },
+  it("with --invite but repos have no contributors: mints nothing, says so (no confusing '0 contributors')", async () => {
+    vi.mocked(team.discoverGitHubContributors).mockResolvedValue([
+      { repo: "o/empty", contributors: [] },
     ] as never);
     await commandTeam(["discover", "--invite", "Rockets"], {
       invite: "Rockets",
     });
     expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
     const out = logs.join("\n");
-    expect(out).toMatch(/No collaborators to invite/);
-    expect(out).not.toMatch(/for 0 collaborators/);
+    expect(out).toMatch(/No contributors to invite/);
+    expect(out).not.toMatch(/for 0 contributors/);
   });
 });

--- a/packages/gateway/test/team.test.ts
+++ b/packages/gateway/test/team.test.ts
@@ -32,7 +32,7 @@ import {
   claimOrgDomain,
   createTeam,
   createTeamInvite,
-  distinctCollaborators,
+  distinctContributors,
   listTeams,
   rejectDomainJoin,
   removeTeamMember,
@@ -595,10 +595,10 @@ describe("domain auto-join RPC wrappers (E-5-b)", () => {
   });
 });
 
-describe("distinctCollaborators (E-5-d-2)", () => {
+describe("distinctContributors (E-5-d-2)", () => {
   const repo = (name: string, cols: Array<[string, boolean]>) => ({
     repo: name,
-    collaborators: cols.map(([login, onLore]) => ({
+    contributors: cols.map(([login, onLore]) => ({
       login,
       githubId: login.length,
       onLore,
@@ -606,7 +606,7 @@ describe("distinctCollaborators (E-5-d-2)", () => {
   });
 
   it("dedupes a person appearing on multiple repos by login", () => {
-    const out = distinctCollaborators([
+    const out = distinctContributors([
       repo("o/a", [
         ["alice", true],
         ["bob", false],
@@ -620,7 +620,7 @@ describe("distinctCollaborators (E-5-d-2)", () => {
   });
 
   it("keeps the FIRST occurrence's data on a login collision (stable dedupe)", () => {
-    const out = distinctCollaborators([
+    const out = distinctContributors([
       repo("o/a", [["bob", true]]),
       repo("o/b", [["bob", false]]),
     ]);
@@ -629,7 +629,7 @@ describe("distinctCollaborators (E-5-d-2)", () => {
   });
 
   it("sorts by login for stable output", () => {
-    const out = distinctCollaborators([
+    const out = distinctContributors([
       repo("o/a", [
         ["zed", false],
         ["amy", false],
@@ -638,8 +638,8 @@ describe("distinctCollaborators (E-5-d-2)", () => {
     expect(out.map((c) => c.login)).toEqual(["amy", "zed"]);
   });
 
-  it("returns [] for no repos / no collaborators", () => {
-    expect(distinctCollaborators([])).toEqual([]);
-    expect(distinctCollaborators([repo("o/empty", [])])).toEqual([]);
+  it("returns [] for no repos / no contributors", () => {
+    expect(distinctContributors([])).toEqual([]);
+    expect(distinctContributors([repo("o/empty", [])])).toEqual([]);
   });
 });

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -106,10 +106,11 @@ supabase functions deploy github-discover
   deploy or GitHub error never fails `lore login`; it simply retries on the next login.
 
 - **`github-discover`** (E-5-d, #630 Slice 1) — reads the caller's GitHub repos and their
-  collaborators, then reveals which collaborators already have a Lore account. Used by
-  `lore team discover`. Like `github-provision`, it verifies the JWT and binds the
+  default-branch contributors, then reveals which contributors already have a Lore account.
+  Used by `lore team discover`. Like `github-provision`, it verifies the JWT and binds the
   `provider_token` to the caller's GitHub identity. Requires `read:org` (org/team mirroring)
-  **and** `repo` (to list collaborators on private repos). Backed by migration `0050`
+  **and** `repo` (to list contributors on private repos — the `/contributors` endpoint is
+  per-repo just like `/collaborators`). Backed by migration `0050`
   (`lore_users_for_github_ids` service-role RPC).
 
 ## Observability (Sentry)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -28,9 +28,9 @@ enable_signup = true
 verify_jwt = true
 
 [functions.github-discover]
-# E-5-d (#630): discovers which of the caller's GitHub repo collaborators already have a Lore
+# E-5-d (#630): discovers which of the caller's GitHub repo contributors already have a Lore
 # account. verify_jwt=true so only a signed-in user can invoke it; it binds their provider_token to
-# their identity and reads collaborators with the caller's own GitHub access.
+# their identity and reads the default-branch contributors with the caller's own GitHub access.
 verify_jwt = true
 
 [functions.send-invite-email]

--- a/supabase/functions/github-discover/discover.ts
+++ b/supabase/functions/github-discover/discover.ts
@@ -1,20 +1,38 @@
-// E-5-d (#630, Slice 1): pure, runtime-portable core of the github-discover Edge Function — read
-// the caller's repos + each repo's collaborators from GitHub with the caller's OWN provider_token,
-// so membership is authorized by GitHub on the caller's access (a repo they cannot read 403s and is
-// skipped). No Deno/npm imports here so it is unit-testable under Node/Vitest; index.ts is the thin
-// Deno glue that adds JWT verification + the service-role Lore-membership lookup.
+// E-5-d (#630, Slice 1): github-discover Edge Function. Reads the caller's repos + each repo's
+// contributors FROM GitHub with the caller's OWN provider_token (unforgeable — GitHub authorizes on
+// the caller's access), then reveals which contributors already have a Lore account via the
+// service-role-only lore_users_for_github_ids RPC (0050).
+//
+// SECURITY:
+//   - The provider_token is bound to the JWT's linked GitHub identity (a leaked/foreign token can't
+//     be used to enumerate someone else's contributors as this user).
+//   - Lore-membership is disclosed ONLY for contributors of repos the caller can actually read
+//     (GitHub 403/404s an inaccessible repo → skipped). No open "is X on Lore" oracle.
+//   - The RPC returns only the SET of present github ids (never Lore user_ids), and is
+//     service-role-only, so a client can never call it directly to enumerate accounts.
+//
+// WHY CONTRIBUTORS NOT COLLABORATORS: `/repos/{owner}/{name}/collaborators` requires the caller to
+// have push/admin on the repo AND it returns "everyone with admin/maintain/write/triage" — which
+// for a private org repo is effectively the org roster (every org member typically has at least
+// triage via org rules). That doesn't match the user's mental model of "people who actually worked
+// on this code". `/repos/{owner}/{name}/contributors` (default branch only, cached 24h by GitHub)
+// returns the commit-attribution roster — usually much narrower and far more actionable.
+//
+// Deploy (not auto-deployed): `supabase functions deploy github-discover`. SUPABASE_URL,
+// SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY are injected by the platform; GITHUB_API_URL is
+// optional (defaults to https://api.github.com; overridable for testing).
 
 export interface RepoRef {
   owner: string;
   name: string;
 }
-export interface Collaborator {
+export interface Contributor {
   login: string;
   github_id: number;
 }
-export interface RepoCollaborators {
+export interface RepoContributors {
   repo: string; // "owner/name"
-  collaborators: Collaborator[];
+  contributors: Contributor[];
 }
 
 const GH_HEADERS = (token: string): Record<string, string> => ({
@@ -23,6 +41,11 @@ const GH_HEADERS = (token: string): Record<string, string> => ({
   "X-GitHub-Api-Version": "2022-11-28",
   "User-Agent": "lore-github-discover",
 });
+
+// GitHub returns the next-page URL inside a `Link: <url>; rel="next"` header. We follow it up to
+// MAX_PAGES so a single burst-of-contributors repo can't stall the request indefinitely.
+const MAX_PAGES = 5;
+const PER_PAGE = 100;
 
 /**
  * Parse an "owner/name" string into a RepoRef, or null when malformed. Accepts a full GitHub URL or
@@ -40,7 +63,7 @@ export function parseRepoRef(input: string): RepoRef | null {
   const ok = /^[A-Za-z0-9._-]+$/;
   if (!owner || !name || !ok.test(owner) || !ok.test(name)) return null;
   // Reject "." / ".." segments: the charset above allows dots, and a WHATWG URL parser would
-  // collapse `.`/`..` path segments (e.g. /repos/owner/../collaborators → /repos/collaborators),
+  // collapse `.`/`..` path segments (e.g. /repos/owner/../contributors → /repos/contributors),
   // so a bare `.`/`..` must never be treated as a real repo owner/name.
   if (owner === "." || owner === ".." || name === "." || name === "..")
     return null;
@@ -73,64 +96,114 @@ export async function fetchUserRepos(
 }
 
 /**
- * Fetch a single repo's collaborators with the caller's token. GitHub authorizes on the caller's
- * access, so a repo the caller cannot read returns 403/404 → we return null (the caller skips it)
- * rather than throwing, so one inaccessible repo never fails the whole discovery. Excludes the
- * caller themself (by github id) from the roster.
+ * Read the `Link: <url>; rel="next"` header into a next-page URL string, or null when there is no
+ * next page. GitHub sends `rel="prev"` and `rel="first"` / `rel="last"` too; we only follow `next`.
  */
-export async function fetchRepoCollaborators(
+function nextPageUrl(linkHeader: string | null, apiUrl: string): string | null {
+  if (!linkHeader) return null;
+  const matches = linkHeader.split(/,\s*/);
+  for (const m of matches) {
+    const parsed = /^<([^>]+)>;\s*rel="next"$/.exec(m);
+    if (parsed) {
+      const nextUrl = parsed[1];
+      // GitHub's next URL is fully qualified under `apiUrl`, but defense-in-depth: if a non-`apiUrl`
+      // host sneaks in (e.g. an internal proxy in tests), coerce it onto `apiUrl` so a token-leaking
+      // surface can't be reached.
+      const apiRoot = apiUrl.replace(/\/$/, "");
+      try {
+        const u = new URL(nextUrl);
+        if (`${u.protocol}//${u.host}` !== new URL(apiRoot).origin) {
+          return `${apiRoot}${u.pathname}${u.search}`;
+        }
+      } catch {
+        // fall through and return as-is — the fetch will fail rather than leak.
+      }
+      return nextUrl;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch a single repo's contributors (default branch commit attribution) with the caller's token.
+ * GitHub's `/contributors` endpoint is read-access-only and returns "everyone with at least one
+ * commit on the default branch". Includes anonymous contributors when `?anon=true` — we still drop
+ * rows without a `login`+`id` since we can only link those to a Lore account via github_id.
+ *
+ * Special statuses:
+ *   - 202: GitHub is computing contributor stats (cold cache for new/large repos). Skip — caller
+ *     can retry later; we never bubble a 202 up.
+ *   - 204: empty contributor list → return [] (not null — a 204 IS a readable repo).
+ *   - 403/404: caller has no read access / no such repo → return null (skip, don't fail).
+ *
+ * Pages up to MAX_PAGES to avoid runaway on a sudden burst.
+ */
+export async function fetchRepoContributors(
   token: string,
   repo: RepoRef,
   selfGithubId: number,
   opts: { apiUrl?: string; fetchImpl?: typeof fetch } = {},
-): Promise<Collaborator[] | null> {
+): Promise<Contributor[] | null> {
   const apiUrl = (opts.apiUrl ?? "https://api.github.com").replace(/\/$/, "");
   const f = opts.fetchImpl ?? fetch;
-  const resp = await f(
-    `${apiUrl}/repos/${repo.owner}/${repo.name}/collaborators?per_page=100`,
-    { headers: GH_HEADERS(token) },
-  );
-  // 403 (no access / not admin — collaborators requires push access) or 404 (no such repo): skip.
-  if (resp.status === 403 || resp.status === 404) return null;
-  if (!resp.ok)
-    throw new Error(
-      `github /repos/${repo.owner}/${repo.name}/collaborators: ${resp.status}`,
-    );
-  const json = (await resp.json()) as Array<{ login?: string; id?: number }>;
-  const out: Collaborator[] = [];
-  for (const c of Array.isArray(json) ? json : []) {
-    if (typeof c.id !== "number" || c.id === selfGithubId) continue;
-    if (typeof c.login !== "string" || c.login === "") continue;
-    out.push({ login: c.login, github_id: c.id });
+  let url: string | null =
+    `${apiUrl}/repos/${repo.owner}/${repo.name}/contributors?anon=true&per_page=${PER_PAGE}`;
+  const seen: Contributor[] = [];
+  const seenIds = new Set<number>();
+  for (let page = 0; page < MAX_PAGES && url; page++) {
+    const resp = await f(url, { headers: GH_HEADERS(token) });
+    // 403/404: skip the repo (caller can't read it / no such repo).
+    if (resp.status === 403 || resp.status === 404) return null;
+    // 202: stats still computing — caller can retry; treat as empty and don't fail the batch.
+    if (resp.status === 202) return [];
+    if (!resp.ok)
+      throw new Error(
+        `github /repos/${repo.owner}/${repo.name}/contributors: ${resp.status}`,
+      );
+    const json = (await resp.json()) as Array<{
+      login?: string | null;
+      id?: number;
+    }>;
+    for (const c of Array.isArray(json) ? json : []) {
+      // Anonymous contributors (or malformed rows) lack `login` / `id` — we can't tie those to a
+      // Lore account, drop them. Same for self. Set-based dedup also defends against edge cases
+      // (mock fetchers, future API quirks).
+      if (typeof c.id !== "number" || c.id === selfGithubId) continue;
+      if (typeof c.login !== "string" || c.login === "") continue;
+      if (seenIds.has(c.id)) continue;
+      seenIds.add(c.id);
+      seen.push({ login: c.login, github_id: c.id });
+    }
+    url = nextPageUrl(resp.headers.get("link"), apiUrl);
   }
-  return out;
+  return seen;
 }
 
 /**
- * The distinct set of collaborator github ids across all discovered repos — the input to the
+ * The distinct set of contributor github ids across all discovered repos — the input to the
  * service-role Lore-membership lookup.
  */
-export function collectGithubIds(repos: RepoCollaborators[]): number[] {
+export function collectGithubIds(repos: RepoContributors[]): number[] {
   const ids = new Set<number>();
-  for (const r of repos) for (const c of r.collaborators) ids.add(c.github_id);
+  for (const r of repos) for (const c of r.contributors) ids.add(c.github_id);
   return Array.from(ids);
 }
 
 /**
  * Annotate each repo's roster with an `on_lore` flag from the set of github ids known to have a Lore
  * account (resolved server-side via the service-role lookup). Never exposes Lore user_ids — only the
- * boolean membership signal, and only for collaborators of repos the caller could already read.
+ * boolean membership signal, and only for contributors of repos the caller could already read.
  */
 export function annotateOnLore(
-  repos: RepoCollaborators[],
+  repos: RepoContributors[],
   loreGithubIds: Set<number>,
 ): Array<{
   repo: string;
-  collaborators: Array<{ login: string; github_id: number; on_lore: boolean }>;
+  contributors: Array<{ login: string; github_id: number; on_lore: boolean }>;
 }> {
   return repos.map((r) => ({
     repo: r.repo,
-    collaborators: r.collaborators.map((c) => ({
+    contributors: r.contributors.map((c) => ({
       login: c.login,
       github_id: c.github_id,
       on_lore: loreGithubIds.has(c.github_id),

--- a/supabase/functions/github-discover/index.ts
+++ b/supabase/functions/github-discover/index.ts
@@ -1,15 +1,20 @@
 // E-5-d (#630, Slice 1): github-discover Edge Function. Reads the caller's repos + each repo's
-// collaborators FROM GitHub with the caller's OWN provider_token (unforgeable — GitHub authorizes on
-// the caller's access), then reveals which collaborators already have a Lore account via the
-// service-role-only lore_users_for_github_ids RPC (0050).
+// default-branch contributors FROM GitHub with the caller's OWN provider_token (unforgeable — GitHub
+// authorizes on the caller's access), then reveals which contributors already have a Lore account
+// via the service-role-only lore_users_for_github_ids RPC (0050).
 //
 // SECURITY:
 //   - The provider_token is bound to the JWT's linked GitHub identity (a leaked/foreign token can't
-//     be used to enumerate someone else's collaborators as this user).
-//   - Lore-membership is disclosed ONLY for collaborators of repos the caller can actually read
+//     be used to enumerate someone else's repos as this user).
+//   - Lore-membership is disclosed ONLY for contributors of repos the caller can actually read
 //     (GitHub 403/404s an inaccessible repo → skipped). No open "is X on Lore" oracle.
 //   - The RPC returns only the SET of present github ids (never Lore user_ids), and is
 //     service-role-only, so a client can never call it directly to enumerate accounts.
+//
+// WHY CONTRIBUTORS: `/collaborators` requires push/access AND returns "everyone with at least
+// triage" — which for a private org repo is effectively the org roster. We use `/contributors`
+// (default branch, cached 24h by GitHub) instead — commit-attribution rosters are the user-asked
+// mental model of "people who worked on this code".
 //
 // Deploy (not auto-deployed): `supabase functions deploy github-discover`. SUPABASE_URL,
 // SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY are injected by the platform; GITHUB_API_URL is
@@ -23,10 +28,10 @@ import {
 import {
   annotateOnLore,
   collectGithubIds,
-  fetchRepoCollaborators,
+  fetchRepoContributors,
   fetchUserRepos,
   parseRepoRef,
-  type RepoCollaborators,
+  type RepoContributors,
 } from "./discover.ts";
 import { capture, initSentry, wrapHandler } from "../_shared/sentry.ts";
 
@@ -110,29 +115,29 @@ Deno.serve(
     }
     repos = repos.slice(0, MAX_REPOS);
 
-    // Read each repo's collaborators with the caller's token (repos they can't read are skipped).
-    const rosters: RepoCollaborators[] = [];
+    // Read each repo's contributors with the caller's token (repos they can't read are skipped).
+    const rosters: RepoContributors[] = [];
     for (const repo of repos) {
       try {
-        const collaborators = await fetchRepoCollaborators(
+        const contributors = await fetchRepoContributors(
           providerToken,
           repo,
           selfGithubId,
           { apiUrl },
         );
-        if (collaborators === null) continue; // inaccessible — skip, don't fail the whole call
-        rosters.push({ repo: `${repo.owner}/${repo.name}`, collaborators });
+        if (contributors === null) continue; // inaccessible — skip, don't fail the whole call
+        rosters.push({ repo: `${repo.owner}/${repo.name}`, contributors });
       } catch (e) {
         // A transient error on one repo shouldn't sink the batch — log and skip.
         await capture(e);
         console.error(
-          `collaborators ${repo.owner}/${repo.name}:`,
+          `contributors ${repo.owner}/${repo.name}:`,
           (e as Error).message,
         );
       }
     }
 
-    // Service-role lookup: which collaborator github ids have a Lore account. Returns only the SET of
+    // Service-role lookup: which contributor github ids have a Lore account. Returns only the SET of
     // present ids (never user_ids) — the RPC is service-role-only so this is the only enumeration path.
     const githubIds = collectGithubIds(rosters);
     const loreIds = new Set<number>();


### PR DESCRIPTION
## Summary

Two related UX fixes for `lore team`:

### 1. `lore team discover <repo>` — switch from /collaborators to /contributors

GitHub's `/repos/{o}/{r}/collaborators` requires push access and returns "everyone with at least triage" — on a private org repo that collapses to the entire org roster (every org member typically gets triage via org rules). The admin's mental model when scanning is "who worked here", not "who has org access". `/repos/{o}/{r}/contributors` returns the default-branch commit-attribution roster, which matches.

### 2. `lore team invite <someone>` — works from a linked cwd without an education round-trip

After `lore team link <team>`, the natural command is `lore team invite <github-login>`. The CLI now does that automatically:
- 1 positional → tries to resolve as scope (UUID or team name, case-insensitive); if unresolved AND there's a linked cwd (or `--project`), uses the linked team and records the positional as the invitee hint.
- 2 positionals → first = scope, second = invitee (unambiguous override).
- Nothing resolved → exit 1 with a helpful pointer at `lore team link` / `lore team list`.

Same change also fixes the long-standing UUID-only bug: bare `invite` previously passed the raw string to `create_scope_invite`, which expects a UUID. `discover --invite` and `link` already routed through `resolveWritableScope`; `invite` didn't. Now it does.

`--email` continues to take precedence as the hint label and emails the link when the value looks like a real address; the link/token is always printed regardless.

## Edge Function changes

`supabase/functions/github-discover/discover.ts`:
- new `fetchRepoContributors` (`fetchRepoCollaborators` deleted): `?anon=true&per_page=100`, paginate via `Link: rel="next"` (cap `MAX_PAGES=5`), `Set<id>` dedup across pages, drops anon/malformed rows.
- 202 → `[]` (stats still computing; caller can retry), 403/404 → `null` (skip, never fail the batch), 204/empty → `[]`.
- `nextPageUrl` rewrites any non-`apiUrl` host onto the api root (defense-in-depth against an injected next URL).

`supabase/functions/github-discover/index.ts` wires the new names; anon/membership disclosure model is unchanged: only `on_lore: boolean`, never Lore user_ids.

## Tests

- 121 tests across `github-discover.test.ts`, `team-cmd.test.ts`, `team.test.ts`:
  - new: `anon=true + per_page=100` request shape, 202 empty (not skip), Link:next pagination + cross-page dedup, MAX_PAGES cap, leaked-host rewrite
  - new: invite team-name resolution + case-insensitive, two-positional explicit form, linked-cwd fallback (positional as hint), `--email` override of hint, no-scope error path, non-admin refused
- `pnpm typecheck` / `pnpm lint` / `pnpm format:check` clean (lint warnings in this PR are zero).

## Deploy

`github-discover` Edge Function isn't auto-deployed — push it once:

```
supabase functions deploy github-discover
```

## Files

```
packages/gateway/src/cli/login.ts              |   5 +-
packages/gateway/src/cli/main.ts               |   2 +-
packages/gateway/src/cli/team-cmd.ts           | 123 +++++++++++++----
packages/gateway/src/team.ts                   |  35 +++--
packages/gateway/test/github-discover.test.ts  | 184 +++++++++++++++++++++----
packages/gateway/test/team-cmd.test.ts         | 168 +++++++++++++++++++---
packages/gateway/test/team.test.ts             |  18 +--
supabase/README.md                             |   7 +-
supabase/config.toml                           |   4 +-
supabase/functions/github-discover/discover.ts | 151 ++++++++++++++------
supabase/functions/github-discover/index.ts    |  33 +++--
11 files changed, 577 insertions(+), 153 deletions(-)
```
