### PR TITLE
docs(website): position Lore as infrastructure, not a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The AI tooling ecosystem is in a war for execution, and harnesses are
 incentivized to lock you in. When a closed platform builds "agent memory,"
 it stores your team's decisions inside a proprietary vector database.
 Switch IDEs, switch models, and the team gets amnesia. Lore is the escape
-hatch: a vendor-neutral proxy that sits between your harness and your model.
+hatch: a vendor-neutral memory layer that sits between your harness and your model.
 
 What you actually own is two things, both open, both yours:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Published as [`@loreai/gateway`](https://www.npmjs.com/package/@loreai/gateway) 
 
 Full documentation lives at **[withlore.ai/docs](https://withlore.ai/docs/)**.
 
+## Own your memory, not just your code
+
+The AI tooling ecosystem is in a war for execution, and harnesses are
+incentivized to lock you in. When a closed platform builds "agent memory,"
+it stores your team's decisions inside a proprietary vector database.
+Switch IDEs, switch models, and the team gets amnesia. Lore is the escape
+hatch: a vendor-neutral proxy that sits between your harness and your
+model, and distills your team's context into an open standard —
+[`.lore.md`](https://withlore.ai/docs/team-memory/) — that lives in Git,
+moves between tools, and never leaves your infrastructure unless you want
+it to. The harness is replaceable. Your team's "why" is not.
+
 ## Why
 
 Coding agents forget. Once a conversation exceeds the context window, earlier decisions, bug fixes, and architectural choices vanish. The default approach — summarize-and-compact — loses exactly the operational details agents need. After a few compaction passes, the agent knows you "discussed authentication" but can't actually continue the work.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,21 @@ The AI tooling ecosystem is in a war for execution, and harnesses are
 incentivized to lock you in. When a closed platform builds "agent memory,"
 it stores your team's decisions inside a proprietary vector database.
 Switch IDEs, switch models, and the team gets amnesia. Lore is the escape
-hatch: a vendor-neutral proxy that sits between your harness and your
-model, and distills your team's context into an open standard —
-[`.lore.md`](https://withlore.ai/docs/team-memory/) — that lives in Git,
-moves between tools, and never leaves your infrastructure unless you want
-it to. The harness is replaceable. Your team's "why" is not.
+hatch: a vendor-neutral proxy that sits between your harness and your model.
+
+What you actually own is two things, both open, both yours:
+
+- **`.lore.md`** — the curated team knowledge, version-controlled, PR-reviewable,
+  human-readable Markdown at the root of your repo. The diff shows up next to
+  the code change it covers.
+- **A local SQLite database** at `~/.local/share/lore/lore.db` with an open
+  schema. Raw conversations, distillations, long-term memory, entities — all
+  queryable with `sqlite3`, exportable, yours to read with or without Lore.
+
+The engine itself is fair source (FSL-1.1-Apache-2.0) and runs locally.
+When you're ready to share with a team, sync is end-to-end encrypted, scoped
+to the entries you explicitly approve, and the relay never sees plaintext.
+The harness is replaceable. Your team's "why" is not.
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ What you actually own is two things, both open, both yours:
   human-readable Markdown at the root of your repo. The diff shows up next to
   the code change it covers.
 - **A local SQLite database** at `~/.local/share/lore/lore.db` with an open
-  schema. Raw conversations, distillations, long-term memory, entities — all
-  queryable with `sqlite3`, exportable, yours to read with or without Lore.
+  schema. Raw conversations, distillations, long-term memory, entities, and
+  the vector embeddings — all in one file, queryable with `sqlite3`,
+  exportable, yours to read with or without Lore.
 
 The engine itself is fair source (FSL-1.1-Apache-2.0) and runs locally.
 When you're ready to share with a team, sync is end-to-end encrypted, scoped

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The AI tooling ecosystem is in a war for execution, and harnesses are
 incentivized to lock you in. When a closed platform builds "agent memory,"
 it stores your team's decisions inside a proprietary vector database.
 Switch IDEs, switch models, and the team gets amnesia. Lore is the escape
-hatch: a vendor-neutral memory layer that sits between your harness and your model.
+hatch: a vendor-neutral proxy that sits between your harness and your model.
 
 What you actually own is two things, both open, both yours:
 

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -6,6 +6,7 @@ import {
   generateAssetsEagerly,
 } from "./integrations/favicon-assets";
 import prefixBaseLinks from "./integrations/prefix-base-links.mjs";
+import mermaidRenderer from "./integrations/mermaid-renderer.mjs";
 import { publicationUri } from "./src/lib/standard-site";
 
 const prNumber = process.env.PR_NUMBER;
@@ -55,6 +56,10 @@ export default defineConfig({
     // (`/_preview/pr-<n>/`). No-op in production. Covers markdown body,
     // frontmatter hero links, and component links. See prefix-base-links.mjs.
     prefixBaseLinks(),
+    // Bundles the Mermaid renderer into every page so fenced ```mermaid
+    // blocks render on the blog AND the docs (the previous CDN script
+    // was scoped to Starlight pages only). See mermaid-renderer.mjs.
+    mermaidRenderer(),
     faviconAssets(),
     starlight({
       title: "Lore",
@@ -251,42 +256,10 @@ export default defineConfig({
             content: "@withLoreAI",
           },
         },
-        // Mermaid (architecture diagrams). Loaded from jsdelivr ESM build
-        // and rendered client-side. Starlight's expressive-code wraps
-        // fenced code blocks in styled <div>s without preserving line
-        // breaks in textContent, so we extract the source per-line from
-        // the .ec-line divs and call mermaid.render() directly. Mermaid's
-        // "neutral" theme is a safe default for both light and dark
-        // Starlight themes; theme-aware switching (reading
-        // document.documentElement.dataset.theme) is a follow-up. The
-        // version is pinned to an exact release for reproducible diagram
-        // output; SRI is not used because integrity hashes do not apply to
-        // bare ESM `import` URLs, and the render call already degrades
-        // gracefully to the source text on failure (see the catch below).
-        {
-          tag: "script",
-          attrs: { type: "module" },
-          content: [
-            'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11.16.0/dist/mermaid.esm.min.mjs";',
-            'mermaid.initialize({ startOnLoad: false, theme: "neutral", securityLevel: "loose", fontFamily: "var(--sl-font)" });',
-            "const blocks = document.querySelectorAll('pre[data-language=\"mermaid\"]');",
-            "for (const pre of blocks) {",
-            "  const source = Array.from(pre.querySelectorAll('.ec-line')).map((l) => l.textContent).join('\\n');",
-            "  if (!source.trim()) continue;",
-            "  const id = 'mermaid-' + Math.random().toString(36).slice(2, 9);",
-            "  try {",
-            "    const { svg } = await mermaid.render(id, source);",
-            "    const wrap = document.createElement('div');",
-            "    wrap.className = 'mermaid';",
-            "    wrap.innerHTML = svg;",
-            "    pre.replaceWith(wrap);",
-            "  } catch (err) {",
-            "    console.error('Mermaid render failed:', err);",
-            "    pre.textContent = source;",
-            "  }",
-            "}",
-          ].join("\n"),
-        },
+        // Mermaid (architecture diagrams) is rendered by the
+        // `mermaidRenderer` integration, which bundles Mermaid into every
+        // page (including the blog, which the Starlight-scoped CDN script
+        // previously skipped). See ./integrations/mermaid-renderer.mjs.
       ],
     }),
   ],

--- a/packages/website/integrations/mermaid-renderer.mjs
+++ b/packages/website/integrations/mermaid-renderer.mjs
@@ -1,0 +1,45 @@
+// Mermaid renderer integration.
+//
+// Replaces the previous CDN-loaded script in starlight's head config. The
+// renderer is bundled with the site via `injectScript`, so it runs on every
+// page (Starlight docs AND the blog) without a network dependency. The
+// render target is the same as the previous CDN script: any
+// `pre[data-language="mermaid"]` block (Expressive Code's wrapping of a
+// Mermaid fenced code block) is replaced with the rendered SVG.
+export default function mermaidRenderer() {
+  return {
+    name: "mermaid-renderer",
+    hooks: {
+      "astro:config:setup": ({ injectScript }) => {
+        injectScript(
+          "page",
+          `
+          import mermaid from "mermaid";
+          mermaid.initialize({
+            startOnLoad: false,
+            theme: "neutral",
+            securityLevel: "loose",
+            fontFamily: "var(--sl-font)"
+          });
+          const blocks = document.querySelectorAll('pre[data-language="mermaid"]');
+          for (const pre of blocks) {
+            const source = Array.from(pre.querySelectorAll('.ec-line')).map((l) => l.textContent).join('\\n');
+            if (!source.trim()) continue;
+            const id = 'mermaid-' + Math.random().toString(36).slice(2, 9);
+            try {
+              const { svg } = await mermaid.render(id, source);
+              const wrap = document.createElement('div');
+              wrap.className = 'mermaid';
+              wrap.innerHTML = svg;
+              pre.replaceWith(wrap);
+            } catch (err) {
+              console.error('Mermaid render failed:', err);
+              pre.textContent = source;
+            }
+          }
+        `,
+        );
+      },
+    },
+  };
+}

--- a/packages/website/integrations/mermaid-renderer.mjs
+++ b/packages/website/integrations/mermaid-renderer.mjs
@@ -3,9 +3,17 @@
 // Replaces the previous CDN-loaded script in starlight's head config. The
 // renderer is bundled with the site via `injectScript`, so it runs on every
 // page (Starlight docs AND the blog) without a network dependency. The
-// render target is the same as the previous CDN script: any
-// `pre[data-language="mermaid"]` block (Expressive Code's wrapping of a
-// Mermaid fenced code block) is replaced with the rendered SVG.
+// render target is any `pre[data-language="mermaid"]` block on the page,
+// replaced with the rendered SVG.
+//
+// Syntax-highlighter compatibility:
+// - Starlight docs use Expressive Code, which wraps each line in a
+//   `<div class="ec-line">`. We extract source per-line from those divs.
+// - Blog posts use Astro's default Shiki highlighter, which wraps each line
+//   in a `<span class="line">` (or, for unknown languages, leaves the
+//   source as plain text inside the `<pre>`). We accept both line-class
+//   shapes via a combined selector, and fall back to the pre's textContent
+//   when neither is present (e.g. unknown-language plain text).
 export default function mermaidRenderer() {
   return {
     name: "mermaid-renderer",
@@ -19,13 +27,20 @@ export default function mermaidRenderer() {
             startOnLoad: false,
             theme: "neutral",
             securityLevel: "loose",
-            fontFamily: "var(--sl-font)"
+            fontFamily: "var(--sl-font, system-ui, -apple-system, sans-serif)"
           });
           const blocks = document.querySelectorAll('pre[data-language="mermaid"]');
           for (const pre of blocks) {
-            const source = Array.from(pre.querySelectorAll('.ec-line')).map((l) => l.textContent).join('\\n');
+            const lines = pre.querySelectorAll('.ec-line, .line');
+            let source = '';
+            if (lines.length > 0) {
+              source = Array.from(lines).map((l) => l.textContent).join('\\n');
+            } else {
+              const code = pre.querySelector('code') || pre;
+              source = code.textContent || '';
+            }
             if (!source.trim()) continue;
-            const id = 'mermaid-' + Math.random().toString(36).slice(2, 9);
+            const id = 'mermaid-' + crypto.randomUUID().replace(/-/g, '').slice(0, 12);
             try {
               const { svg } = await mermaid.render(id, source);
               const wrap = document.createElement('div');

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -9,6 +9,9 @@
     "check": "astro check",
     "publish:standard-site": "node scripts/publish-standard-site.mjs"
   },
+  "dependencies": {
+    "mermaid": "11.16.0"
+  },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/mdx": "^7.0.3",

--- a/packages/website/src/content/blog/the-agentic-memory-trap.md
+++ b/packages/website/src/content/blog/the-agentic-memory-trap.md
@@ -85,16 +85,6 @@ flowchart LR
 
 *The LLM is the cognition, Lore is the memory layer. They form the brain. The harness is the body, the actuator.*
 
-What you actually own is two things:
-
-Even LangChain is starting to realize the limits of black-box databases.
-In June, Harrison wrote about
-[Wiki Memory](https://blog.langchain.com/wiki-memory/), admitting that
-the best format for compressed agent data isn't a proprietary vector
-store — it's files. They are inspectable, editable, and versionable.
-With Lore, you don't have to wait for the industry to build it. You
-already have it.
-
 - **`.lore.md`** at the root of your repo. The curated knowledge the
   team has reviewed and merged. Version-controlled, PR-reviewable,
   human-readable Markdown.
@@ -112,6 +102,19 @@ entries, in one open file. No separate vector store, no separate
 process, no separate bill. When a team changes a memory entry, the
 engine picks up the change on the next session and re-embeds the
 affected entries. Fast and transparent, on your hardware.
+
+A few months after that initial post, Harrison himself claimed that
+memory systems sit beside the harness. In
+[Wiki Memory](https://blog.langchain.com/wiki-memory/), he wrote:
+
+> "This pattern also sits adjacent to memory systems like LangMem,
+> Letta, Mem0, and Zep. Those systems attack the broader agent-memory
+> problem, while wiki memory is notable because it often uses the
+> simplest possible substrate: files."
+
+All these systems, including Mem0, don't really solve the immediate
+context problem. Lore unifies this and, unsurprisingly, by fusing two
+approaches together: locality & files along with long-term memory.
 
 ## The vendor route vs the local-first route
 

--- a/packages/website/src/content/blog/the-agentic-memory-trap.md
+++ b/packages/website/src/content/blog/the-agentic-memory-trap.md
@@ -1,6 +1,6 @@
 ---
-title: "Local-first memory: Why your AI memory should live on your machine"
-subtitle: "Lore doesn't leave you in the hands of the platform. The architecture is local-first, and we aim to keep it that way."
+title: "The Agentic Memory Trap"
+subtitle: "Why your AI's context must live in an accessible format on your machine, not behind a vendor's API."
 description: "Lore is a vendor-neutral proxy that runs on your machine. Plain Markdown and an open SQLite database, run by a fair-source engine."
 pubDate: 2026-07-29
 author: Burak Yigit Kaya

--- a/packages/website/src/content/blog/the-agentic-memory-trap.md
+++ b/packages/website/src/content/blog/the-agentic-memory-trap.md
@@ -2,7 +2,7 @@
 title: "The Agentic Memory Trap"
 subtitle: "Why your AI's context must live in an accessible format on your machine, not behind a vendor's API."
 description: "Lore is a vendor-neutral proxy that runs on your machine. Plain Markdown and an open SQLite database, run by a fair-source engine."
-pubDate: 2026-07-29
+pubDate: 2026-07-30
 author: Burak Yigit Kaya
 tags:
   - infrastructure

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -1,7 +1,7 @@
 ---
 title: "Local-first memory: Why your AI memory should live on your machine"
 subtitle: "Lore doesn't leave you in the hands of the platform. The architecture is local-first, and we aim to keep it that way."
-description: "Lore is a vendor-neutral proxy that runs on your machine. The memory lives in your repo and your local database, local, sqlite & markdown, run by a fair-source engine."
+description: "Lore is a vendor-neutral proxy that runs on your machine. Local, sqlite & markdown. Run by a fair-source engine."
 pubDate: 2026-07-29
 author: Burak Yigit Kaya
 tags:
@@ -64,8 +64,8 @@ and a vendor change returns the team to zero.
 
 Lore is a vendor-neutral proxy that sits between your harness and
 your model. The whole engine runs on your machine. The memory lives
-in your repo and your local database, local, sqlite & markdown, you
-can read with or without Lore.
+in your repo and a local SQLite database on your disk. You can read
+both with or without Lore.
 
 ```mermaid
 flowchart LR
@@ -85,6 +85,14 @@ flowchart LR
 *The LLM is the cognition, Lore is the memory layer. They form the brain. The harness is the body, the actuator.*
 
 What you actually own is two things:
+
+Even LangChain is starting to realize the limits of black-box databases.
+In June, Harrison wrote about
+[Wiki Memory](https://blog.langchain.com/wiki-memory/), admitting that
+the best format for compressed agent data isn't a proprietary vector
+store — it's files. They are inspectable, editable, and versionable.
+With Lore, you don't have to wait for the industry to build it. You
+already have it.
 
 - **`.lore.md`** at the root of your repo. The curated knowledge the
   team has reviewed and merged. Version-controlled, PR-reviewable,

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -68,36 +68,23 @@ in your repo and your local database, in open formats you can read
 with or without Lore.
 
 <figure>
-  <svg viewBox="0 0 460 460" xmlns="http://www.w3.org/2000/svg" style="max-width: 460px; width: 100%; margin: 1.5rem auto; display: block;" role="img" aria-label="Lore architecture: the harness on top, the model provider API on the bottom, and Lore sits between them as a local-first vendor-neutral proxy whose artifacts live on your machine.">
-    <defs>
-      <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" fill="#1a1a1a" />
-      </marker>
-    </defs>
+```mermaid
+flowchart TB
+    H["Harness<br/>Claude Code · OpenCode · Pi · Codex"]
+    L["Lore<br/>local-first, vendor-neutral proxy<br/>.lore.md + ~/.local/share/lore/lore.db<br/>on your machine, in open formats"]
+    A["Model Provider API<br/>Anthropic · OpenAI · Google · others"]
 
-    <rect x="40" y="20" width="380" height="80" rx="8" fill="#fafafa" stroke="#1a1a1a" stroke-width="1.5" />
-    <text x="230" y="55" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="600" fill="#1a1a1a">Harness</text>
-    <text x="230" y="78" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#5a5a5a">Claude Code · OpenCode · Pi · Codex</text>
+    H --> L
+    L --> A
 
-    <line x1="230" y1="105" x2="230" y2="135" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)" />
-
-    <rect x="20" y="140" width="420" height="170" rx="8" fill="#c4ddc7" stroke="#1a1a1a" stroke-width="2" />
-    <text x="230" y="175" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="700" fill="#1a1a1a">Lore</text>
-    <text x="230" y="198" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-style="italic" fill="#1a1a1a">local-first, vendor-neutral proxy</text>
-
-    <rect x="60" y="225" width="340" height="55" rx="6" fill="#ffffff" stroke="#5a5a5a" stroke-width="1" />
-    <text x="230" y="245" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" fill="#1a1a1a">.lore.md  +  ~/.local/share/lore/lore.db</text>
-    <text x="230" y="265" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-style="italic" fill="#5a5a5a">on your machine, in open formats</text>
-
-    <line x1="230" y1="315" x2="230" y2="345" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)" />
-
-    <rect x="40" y="350" width="380" height="80" rx="8" fill="#fafafa" stroke="#1a1a1a" stroke-width="1.5" />
-    <text x="230" y="385" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="600" fill="#1a1a1a">Model Provider API</text>
-    <text x="230" y="408" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#5a5a5a">Anthropic · OpenAI · Google · others</text>
-  </svg>
-  <figcaption style="text-align: center; font-size: 0.9em; opacity: 0.8; margin-top: 0.5rem;">
-    Lore is the brain. The harness is the body. The model provider API is the cognition.
-  </figcaption>
+    classDef lore fill:#c4ddc7,stroke:#1a3320,stroke-width:2px,color:#1a3320
+    classDef ext fill:#ececec,stroke:#888,color:#333
+    class L lore
+    class H,A ext
+```
+<figcaption style="text-align: center; font-size: 0.9em; opacity: 0.8; margin-top: 0.5rem;">
+  Lore is the brain. The harness is the body. The model provider API is the cognition.
+</figcaption>
 </figure>
 
 What you actually own is two things:
@@ -113,12 +100,12 @@ The engine that ties them together is fair source
 (FSL-1.1-Apache-2.0). The code that touches your tokens is right
 there to read, and it turns into Apache 2.0 on a timer.
 
-The vector database lives inside Lore, on your machine. It is the
-runtime cache for semantic search, and it is the right tool for it.
-When a team changes a memory entry, the engine picks up the change
-on the next session and re-embeds the affected entries automatically
-— fast, transparent, and on your hardware. No batch job, no
-re-indexing window, no waiting for a vendor to apply your team's PR.
+The SQLite file is the vector database. The vectors ride alongside
+the temporal messages, the distillations, and the long-term memory
+entries, in one open file. No separate vector store, no separate
+process, no separate bill. When a team changes a memory entry, the
+engine picks up the change on the next session and re-embeds the
+affected entries. Fast and transparent, on your hardware.
 
 ## The vendor route vs the local-first route
 

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -1,7 +1,7 @@
 ---
 title: "Local-first memory: Why your AI memory should live on your machine"
 subtitle: "Lore doesn't leave you in the hands of the platform. The architecture is local-first, and we aim to keep it that way."
-description: "Lore is a vendor-neutral proxy that runs on your machine. Local, sqlite & markdown. Run by a fair-source engine."
+description: "Lore is a vendor-neutral proxy that runs on your machine. Plain Markdown and an open SQLite database, run by a fair-source engine."
 pubDate: 2026-07-29
 author: Burak Yigit Kaya
 tags:
@@ -64,8 +64,9 @@ and a vendor change returns the team to zero.
 
 Lore is a vendor-neutral proxy that sits between your harness and
 your model. The whole engine runs on your machine. The memory lives
-in your repo and a local SQLite database on your disk. You can read
-both with or without Lore.
+in your repo and your local machine as plain Markdown and an open
+SQLite database. You can read, query, and edit it with or without
+Lore.
 
 ```mermaid
 flowchart LR

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -5,12 +5,8 @@ description: "Lore picks plain Markdown over a vector database for team memory. 
 pubDate: 2026-07-29
 author: Burak Yigit Kaya
 tags:
-  - memory
   - infrastructure
   - open standards
-  - lock-in
-  - markdown
-  - agents
 ---
 
 Last April, Harrison Chase wrote an essay called

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -60,7 +60,7 @@ the same way.
 Six months of careful work, six months of capturing a team's taste,
 and a vendor change returns the team to zero.
 
-## Lore is local-first. We aim to keep it that way.
+## Lore is local-first and we want to keep it that way
 
 Lore is a vendor-neutral proxy that sits between your harness and
 your model. The whole engine runs on your machine. The memory lives
@@ -68,7 +68,7 @@ in your repo and your local database, in open formats you can read
 with or without Lore.
 
 ```mermaid
-flowchart TB
+flowchart LR
     H["Harness<br/>Claude Code · OpenCode · Pi · Codex"]
     L["Lore<br/>local-first, vendor-neutral proxy<br/>.lore.md + ~/.local/share/lore/lore.db<br/>on your machine, in open formats"]
     A["Model Provider API<br/>Anthropic · OpenAI · Google · others"]

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -70,7 +70,7 @@ with or without Lore.
 ```mermaid
 flowchart LR
     H["Harness<br/>Claude Code · OpenCode · Pi · Codex"]
-    L["Lore<br/>local-first, vendor-neutral proxy<br/>.lore.md + ~/.local/share/lore/lore.db<br/>on your machine, in open formats"]
+    L["Lore<br/>local-first, vendor-neutral proxy<br/>.lore.md + lore.db<br/>on your machine, in open formats"]
     A["Model Provider API<br/>Anthropic · OpenAI · Google · others"]
 
     H --> L

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -7,6 +7,8 @@ author: Burak Yigit Kaya
 tags:
   - infrastructure
   - open standards
+  - data
+  - ownership  
 ---
 
 Last April, Harrison Chase wrote an essay called

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -109,22 +109,20 @@ affected entries. Fast and transparent, on your hardware.
 
 ## The vendor route vs the local-first route
 
-A vendor-managed memory stack says: trust us with the shape of your
-team's thinking, and we will give it back to you on retrieval. It
-has to work that way, because the data lives behind an API, and the
-schema is whatever the vendor chose. To change a memory entry, you
-ask the vendor. To delete an entry, you ask the vendor. To export
-the corpus, you ask the vendor. To move to a different harness, you
-ask the vendor. The lock-in lives in the dependencies you cannot
-see.
+Chase is right. You shouldn't put your memory into a vendor's hands.
+The lock-in is real, and the way to escape it is to keep the data
+on your machine, in open formats you can read with `sqlite3` and
+edit with any text editor. To change a memory entry, you edit the
+file. To delete an entry, you delete the row. To export the corpus,
+you run `sqlite3 lore.db .dump`. To move to a different vendor, you
+point the new tool at the same files.
 
-Local-first says: the data lives on your machine, in open formats,
-and the engine is the source code in front of you. To change a
-memory entry, you edit the file. To delete an entry, you delete the
-row. To export the corpus, you run `sqlite3 lore.db .dump`. To move
-to a different harness, you point the new harness at the same files.
-The lock-in lives wherever you let it live, and you can move it any
-time.
+The same logic applies to the harness. You wouldn't lock yourself
+into a single LLM provider, and you shouldn't lock yourself into a
+single harness either. Claude Code today, Pi tomorrow, Codex next
+quarter, something new next year. The memory should outlast the
+harness. The harness is the part you swap; the artifact is the part
+that stays.
 
 When your team is ready to share, the sync engine works the way a
 good group chat does: end-to-end encrypted, scoped to the entries

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -11,7 +11,7 @@ tags:
   - ownership  
 ---
 
-Last April, Harrison Chase wrote an essay called
+In April, Harrison Chase wrote an essay called
 [Your harness, your memory](https://blog.langchain.com/your-harness-your-memory/).
 He named what the AI tooling industry has been circling for a year.
 Memory is the new lock-in. The harness owns it by default, and the

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -134,9 +134,10 @@ reversible.
 
 We have talked before about
 [why knowledge lives in token space, not in weights](/blog/distill-your-own-knowledge/).
-The same logic applies to where the token-space lives. A vector store
-in someone else's cloud is halfway there. A vector store on your
-machine is the rest of the way.
+The same logic applies to where the token-space lives. A database in
+someone else's cloud is halfway there. A database or engine tied to
+your harness might be better. A replaceable middle layer for memory,
+all data local and owned by you, is the rest of the way.
 
 Models will keep changing. They always do. Every part of the AI
 tooling stack above the model is genuinely up for grabs right now.

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -67,7 +67,6 @@ your model. The whole engine runs on your machine. The memory lives
 in your repo and your local database, in open formats you can read
 with or without Lore.
 
-<figure>
 ```mermaid
 flowchart TB
     H["Harness<br/>Claude Code · OpenCode · Pi · Codex"]
@@ -82,10 +81,8 @@ flowchart TB
     class L lore
     class H,A ext
 ```
-<figcaption style="text-align: center; font-size: 0.9em; opacity: 0.8; margin-top: 0.5rem;">
-  Lore is the brain. The harness is the body. The model provider API is the cognition.
-</figcaption>
-</figure>
+
+*Lore is the brain. The harness is the body. The model provider API is the cognition.*
 
 What you actually own is two things:
 

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -69,9 +69,9 @@ with or without Lore.
 
 ```mermaid
 flowchart LR
-    H["Harness<br/>Claude Code · OpenCode · Pi · Codex"]
-    L["Lore<br/>local-first, vendor-neutral proxy<br/>.lore.md + lore.db<br/>on your machine, in open formats"]
-    A["Model Provider API<br/>Anthropic · OpenAI · Google · others"]
+    H["<b>Harness</b><br/>Claude Code · OpenCode · Pi · Codex"]
+    L["<b>Lore</b><br/>local-first, vendor-neutral<br/>.lore.md + lore.db<br/>local, sqlite & markdown"]
+    A["<b>Model Provider API</b><br/>Anthropic · OpenAI · Google · others"]
 
     H --> L
     L --> A

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -1,7 +1,7 @@
 ---
 title: "Local-first memory: Why your AI memory should live on your machine"
 subtitle: "Lore doesn't leave you in the hands of the platform. The architecture is local-first, and we aim to keep it that way."
-description: "Lore is a vendor-neutral memory layer that runs on your machine. The memory lives in your repo and your local database, local, sqlite & markdown, run by a fair-source engine."
+description: "Lore is a vendor-neutral proxy that runs on your machine. The memory lives in your repo and your local database, local, sqlite & markdown, run by a fair-source engine."
 pubDate: 2026-07-29
 author: Burak Yigit Kaya
 tags:
@@ -62,10 +62,10 @@ and a vendor change returns the team to zero.
 
 ## Lore is local-first and we want to keep it that way
 
-Lore is a vendor-neutral memory layer that sits between your harness
-and your model. The whole engine runs on your machine. The memory
-lives in your repo and your local database, local, sqlite & markdown,
-you can read with or without Lore.
+Lore is a vendor-neutral proxy that sits between your harness and
+your model. The whole engine runs on your machine. The memory lives
+in your repo and your local database, local, sqlite & markdown, you
+can read with or without Lore.
 
 ```mermaid
 flowchart LR

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -73,13 +73,13 @@ Open memory is what LangChain is asking for. Open source, model
 agnostic, an open format for the artifacts. That is the bar. The
 question is what the format is.
 
-We picked Markdown. Specifically, a single file at the root of the
-repo called `.lore.md`, with one stable marker per entry, entries
-sorted alphabetically by title within each category. That is the
-whole standard. It is human-readable, machine-parseable, and
-Git-friendly out of the box, because Git already knows how to diff
-it, merge it, and review it. The diff shows up in a pull request
-next to the code change the memory touches.
+We picked Markdown for the curated half. Specifically, a single file
+at the root of the repo called `.lore.md`, with one stable marker per
+entry, entries sorted alphabetically by title within each category.
+That is the whole standard. It is human-readable, machine-parseable,
+and Git-friendly out of the box, because Git already knows how to
+diff it, merge it, and review it. The diff shows up in a pull
+request next to the code change the memory touches.
 
 When the team disagrees about whether an entry is right, you do what
 you already do for any other disagreement: open a PR. The debate
@@ -93,7 +93,30 @@ history.
 This is the part closed vector stores can't copy. They can copy the
 format. They can't copy the workflow. The workflow is the value.
 
-## The Markdown escrow
+## The database underneath
+
+The curated file is only half of what you should own. Most of what
+an agent remembers is not meant to be reviewed and merged. The raw
+conversation, the layered distillations, the long-term memory
+entries, the entities the curator found, all the way back to the
+first session. That record belongs to you too, in a different
+artifact.
+
+Lore stores the rest of it in a local SQLite database at
+`~/.local/share/lore/lore.db`, with an open schema the engine
+publishes. You can open it with `sqlite3`, query it with anything
+that speaks the API, export it to CSV, or build your own tooling
+around it. Stop using Lore tomorrow and the database is still
+there. The engine doesn't sit between you and your data. The
+migrations are versioned, the schema is documented, and what Lore
+stored for you is what you can read.
+
+A vector store asks you to trust the retrieval layer because the
+embedding model and the indexing choices the store made are opaque
+to you. SQLite asks for nothing. The file is the database, the
+database is the file.
+
+## The escrow
 
 A vector store says: trust us with the shape of your team's
 thinking, and we will give it back to you on retrieval. It has to
@@ -101,39 +124,48 @@ be that way, because retrieval depends on the embedding model and
 the indexing choices the store made for you. The lock-in lives in
 the dependencies you can't see.
 
-Markdown says: the file is the memory, the memory is the file.
-Distillation writes a Markdown file. Review edits the file. Agents
-read the file. The model behind the agent doesn't matter. The
-harness behind the model doesn't matter. The next vendor reads the
-same Markdown. The previous vendor never had anything to lock you
-to.
+Lore says: the Markdown file is the curated memory, the SQLite file
+is the full memory, and both are yours. Distillation writes the
+Markdown. Distillation also writes the database. Review edits the
+file. You read the database with or without us. Agents read the
+file. Agents read the database. The model behind the agent doesn't
+matter. The harness behind the model doesn't matter. The next
+vendor reads the same Markdown and queries the same SQLite. The
+previous vendor never had anything to lock you to.
+
+When your team is ready to share, the sync engine works the way a
+good group chat does: end-to-end encrypted, scoped to the entries
+you explicitly approve, and the relay never sees plaintext. The
+keys stay with the participants. Sharing is opt-in, per entry, and
+reversible.
 
 We have talked before about
 [why knowledge lives in token space, not in weights](/blog/distill-your-own-knowledge/).
 A vector store is halfway there. It pulls memory out of the model,
 but it puts memory inside another opaque system. To finish the
-move, memory has to be in text humans already share a workflow
-around. That is the escrow. The agent gets it back when it needs
-it. You keep the original in a place your team already knows how
-to govern.
+move, memory has to be in artifacts humans already share a workflow
+around. Markdown for the team. SQLite for the record. End-to-end
+sync if and when you want it. Everything else is a concession to
+someone else's moat.
 
 Models will keep changing. They always do. Every part of the AI
 tooling stack above the model is genuinely up for grabs right now.
 The part that should not be up for grabs is how a team remembers
-what it decided and why. That belongs to the team, in a format
-the team already owns.
+what it decided and why. That belongs to the team, in formats the
+team already owns.
 
 ## Try it
 
-The format is one file. The file is at the root of your repo. It
-is committed, reviewed, and merged the same way as the code next
-to it.
+The format is one file at the root of your repo, plus a SQLite
+database on your machine. Both are committed, reviewed, queried,
+and merged the same way as the code next to them.
 
 ```bash
 curl -fsSL https://withlore.ai/install | bash
 lore run
 ```
 
-After a few sessions, open `.lore.md`. Read what your agent has
-written down. Open a PR when it gets something wrong. That is the
+After a few sessions, open `.lore.md` *and* the database at
+`~/.local/share/lore/lore.db`. Read what your agent has written
+down. Open a PR when it gets something wrong. That is the
 workflow, and that is the answer.

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -1,14 +1,14 @@
 ---
 title: "Local-first memory: Why your AI memory should live on your machine"
 subtitle: "Lore doesn't leave you in the hands of the platform. The architecture is local-first, and we aim to keep it that way."
-description: "Lore is a vendor-neutral proxy that runs on your machine. The memory lives in your repo and your local database, in open formats, run by a fair-source engine."
+description: "Lore is a vendor-neutral memory layer that runs on your machine. The memory lives in your repo and your local database, local, sqlite & markdown, run by a fair-source engine."
 pubDate: 2026-07-29
 author: Burak Yigit Kaya
 tags:
   - infrastructure
   - open standards
   - data
-  - ownership  
+  - ownership
 ---
 
 In April, Harrison Chase wrote an essay called
@@ -52,20 +52,20 @@ provider's server so you cannot move threads between models. The bad
 one runs a closed harness that interacts with memory in ways you
 cannot see, and the artifacts are not portable. The worst one puts
 everything behind an API, including long-term memory, and you own
-none of it. Anthropic's Claude Managed Agents already lives in the
-second camp; Codex builds an encrypted compaction summary nothing
-outside OpenAI can read. The incentive is everywhere, and it points
-the same way.
+none of it. Anthropic's Claude Managed Agents lives in that worst
+camp. Codex's open-source harness produces an encrypted compaction
+summary nothing outside OpenAI can read, so it creeps toward the
+worst too. The incentive is everywhere, and it points the same way.
 
 Six months of careful work, six months of capturing a team's taste,
 and a vendor change returns the team to zero.
 
 ## Lore is local-first and we want to keep it that way
 
-Lore is a vendor-neutral proxy that sits between your harness and
-your model. The whole engine runs on your machine. The memory lives
-in your repo and your local database, in open formats you can read
-with or without Lore.
+Lore is a vendor-neutral memory layer that sits between your harness
+and your model. The whole engine runs on your machine. The memory
+lives in your repo and your local database, local, sqlite & markdown,
+you can read with or without Lore.
 
 ```mermaid
 flowchart LR
@@ -108,10 +108,10 @@ affected entries. Fast and transparent, on your hardware.
 
 Harrison is right. You shouldn't put your memory into a vendor's hands.
 The lock-in is real, and the way to escape it is to keep the data
-on your machine, in open formats you can read with `sqlite3` and
-edit with any text editor. To change a memory entry, you edit the
-file. To delete an entry, you delete the row. To export the corpus,
-you copy the file. To move to a different vendor, you
+on your machine, local, sqlite & markdown, where you can read with
+`sqlite3` and edit with any text editor. To change a memory entry,
+you edit the file. To delete an entry, you delete the row. To export
+the corpus, you copy the file. To move to a different vendor, you
 point the new tool at the same files.
 
 The same logic applies to the harness. You wouldn't lock yourself

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -1,0 +1,139 @@
+---
+title: "The Embedding Trap: Why AI team memory must live in plain text"
+subtitle: "Vector databases are great for RAG. They are terrible for team consensus."
+description: "Lore picks plain Markdown over a vector database for team memory. Here is why those are not two paths to the same answer."
+pubDate: 2026-07-29
+author: Burak Yigit Kaya
+tags:
+  - memory
+  - infrastructure
+  - open standards
+  - lock-in
+  - markdown
+  - agents
+---
+
+Last April, Harrison Chase wrote an essay called
+[Your harness, your memory](https://blog.langchain.com/your-harness-your-memory/).
+He named what the AI tooling industry has been circling for a year.
+Memory is the new lock-in. The harness owns it by default, and the
+harness is what every platform is racing to be.
+
+He was right. He was also right that the answer is "open memory, open
+harness." What I want to add is the part he left out: *where* that
+memory has to live if it is going to outlive any one vendor.
+
+## The lock-in is the point
+
+When a closed platform builds "agent memory," it stores the team's
+decisions in a proprietary vector store. It has to, because the
+retrieval shapes the agent, and the shape of the agent is the shape
+of the moat. To switch IDEs, to switch models, to switch anything,
+the team rebuilds months of context from scratch. That isn't a bug.
+It is the product.
+
+Harrison names three levels of bad. The mild one stores state on the
+provider's server so you cannot move threads between models. The bad
+one runs a closed harness that interacts with memory in ways you
+cannot see, and the artifacts are not portable. The worst one puts
+everything behind an API, including long-term memory, and you own
+none of it. Anthropic's Claude Managed Agents already lives in the
+second camp; Codex builds an encrypted compaction summary nothing
+outside OpenAI can read. The incentive is everywhere, and it points
+the same way.
+
+Six months of careful work, six months of carefully capturing a
+team's taste, and a vendor change returns the team to zero. That is
+the trap.
+
+## Vector databases are great for RAG. They are bad for consensus.
+
+The pitch is always the same. Embeddings retrieve things that mean
+similar things. They find what you meant, not just what you typed.
+They power modern RAG, and they do it well.
+
+That isn't where the problem is. The problem is what happens after
+retrieval, when a team has to agree on what the agent should do next.
+Embeddings are opaque by design. If your agent hallucinates a rule
+("always reach for Redis"), where in the vector space did it learn
+that? You can't open a Pull Request against a vector store to debate
+the rule. You can't run a linter against it. You can't grep your
+memory to ask why a particular retrieval happened, or change one
+entry without the whole similarity neighborhood shifting around it.
+There is no review mechanism because there is no readable artifact
+to review.
+
+A team is a conversation between people who disagree productively.
+A vector store ends that conversation, because nobody can see the
+thing they are arguing about. What looks like memory is a black box.
+
+## The file you can fork
+
+Open memory is what LangChain is asking for. Open source, model
+agnostic, an open format for the artifacts. That is the bar. The
+question is what the format is.
+
+We picked Markdown. Specifically, a single file at the root of the
+repo called `.lore.md`, with one stable marker per entry, entries
+sorted alphabetically by title within each category. That is the
+whole standard. It is human-readable, machine-parseable, and
+Git-friendly out of the box, because Git already knows how to diff
+it, merge it, and review it. The diff shows up in a pull request
+next to the code change the memory touches.
+
+When the team disagrees about whether an entry is right, you do what
+you already do for any other disagreement: open a PR. The debate
+happens in review, on the same surface as the code the memory covers.
+When the rule changes, the rule changes in the file. The agent's
+behavior changes on the next session with no re-indexing, no
+re-embedding, no background job. The memory moves with the code
+because it lives next to the code, and git history becomes memory
+history.
+
+This is the part closed vector stores can't copy. They can copy the
+format. They can't copy the workflow. The workflow is the value.
+
+## The Markdown escrow
+
+A vector store says: trust us with the shape of your team's
+thinking, and we will give it back to you on retrieval. It has to
+be that way, because retrieval depends on the embedding model and
+the indexing choices the store made for you. The lock-in lives in
+the dependencies you can't see.
+
+Markdown says: the file is the memory, the memory is the file.
+Distillation writes a Markdown file. Review edits the file. Agents
+read the file. The model behind the agent doesn't matter. The
+harness behind the model doesn't matter. The next vendor reads the
+same Markdown. The previous vendor never had anything to lock you
+to.
+
+We have talked before about
+[why knowledge lives in token space, not in weights](/blog/distill-your-own-knowledge/).
+A vector store is halfway there. It pulls memory out of the model,
+but it puts memory inside another opaque system. To finish the
+move, memory has to be in text humans already share a workflow
+around. That is the escrow. The agent gets it back when it needs
+it. You keep the original in a place your team already knows how
+to govern.
+
+Models will keep changing. They always do. Every part of the AI
+tooling stack above the model is genuinely up for grabs right now.
+The part that should not be up for grabs is how a team remembers
+what it decided and why. That belongs to the team, in a format
+the team already owns.
+
+## Try it
+
+The format is one file. The file is at the root of your repo. It
+is committed, reviewed, and merged the same way as the code next
+to it.
+
+```bash
+curl -fsSL https://withlore.ai/install | bash
+lore run
+```
+
+After a few sessions, open `.lore.md`. Read what your agent has
+written down. Open a PR when it gets something wrong. That is the
+workflow, and that is the answer.

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -111,7 +111,7 @@ The lock-in is real, and the way to escape it is to keep the data
 on your machine, in open formats you can read with `sqlite3` and
 edit with any text editor. To change a memory entry, you edit the
 file. To delete an entry, you delete the row. To export the corpus,
-you run `sqlite3 lore.db .dump`. To move to a different vendor, you
+you copy the file. To move to a different vendor, you
 point the new tool at the same files.
 
 The same logic applies to the harness. You wouldn't lock yourself

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -17,19 +17,24 @@ He named what the AI tooling industry has been circling for a year.
 Memory is the new lock-in. The harness owns it by default, and the
 harness is what every platform is racing to be.
 
-He was right about the diagnosis. He was wrong about the
-prescription, and the wrongness is self-serving.
+He was right about the diagnosis. He was not entirely accurate with
+the prescription. He builds LangChain, so he is primed to think in
+terms of harness-first. Broaden your thinking and there is a better,
+more independent way, and Lore is the proof.
 
 > "There is sometimes sentiment that memory is a standalone service,
 > separate from any particular harness. At this point in time, that
 > is not true."
 > — Harrison Chase, [Your harness, your memory](https://blog.langchain.com/your-harness-your-memory/)
 
-LangChain builds harnesses. The argument is a fit for their product.
 The analogy is wrong on the merits too. Memory is part of your brain.
 Agent harnesses are like your body, the limbs and everything. You
 don't move your memory to your limbs. You move your memory to your
 brain.
+
+Our argument is equally self-serving as LangChain's. The difference
+is: you can move away from Lore and keep your organized SQLite
+database to yourself. That is true open memory.
 
 The time has come. Lore is the standalone memory service, and it is
 the architecture that gets you out of the trap.

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -106,7 +106,7 @@ affected entries. Fast and transparent, on your hardware.
 
 ## The vendor route vs the local-first route
 
-Chase is right. You shouldn't put your memory into a vendor's hands.
+Harrison is right. You shouldn't put your memory into a vendor's hands.
 The lock-in is real, and the way to escape it is to keep the data
 on your machine, in open formats you can read with `sqlite3` and
 edit with any text editor. To change a memory entry, you edit the

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -82,7 +82,7 @@ flowchart LR
     class H,A ext
 ```
 
-*Lore is the brain. The harness is the body. The model provider API is the cognition.*
+*The LLM is the cognition, Lore is the memory layer. They form the brain. The harness is the body, the actuator.*
 
 What you actually own is two things:
 

--- a/packages/website/src/content/blog/the-embedding-trap.md
+++ b/packages/website/src/content/blog/the-embedding-trap.md
@@ -1,7 +1,7 @@
 ---
-title: "The Embedding Trap: Why AI team memory must live in plain text"
-subtitle: "Vector databases are great for RAG. They are terrible for team consensus."
-description: "Lore picks plain Markdown over a vector database for team memory. Here is why those are not two paths to the same answer."
+title: "Local-first memory: Why your AI memory should live on your machine"
+subtitle: "Lore doesn't leave you in the hands of the platform. The architecture is local-first, and we aim to keep it that way."
+description: "Lore is a vendor-neutral proxy that runs on your machine. The memory lives in your repo and your local database, in open formats, run by a fair-source engine."
 pubDate: 2026-07-29
 author: Burak Yigit Kaya
 tags:
@@ -17,20 +17,32 @@ He named what the AI tooling industry has been circling for a year.
 Memory is the new lock-in. The harness owns it by default, and the
 harness is what every platform is racing to be.
 
-He was right. He was also right that the answer is "open memory, open
-harness." What I want to add is the part he left out: *where* that
-memory has to live if it is going to outlive any one vendor.
+He was right about the diagnosis. He was wrong about the
+prescription, and the wrongness is self-serving.
 
-## The lock-in is the point
+> "There is sometimes sentiment that memory is a standalone service,
+> separate from any particular harness. At this point in time, that
+> is not true."
+> — Harrison Chase, [Your harness, your memory](https://blog.langchain.com/your-harness-your-memory/)
 
-When a closed platform builds "agent memory," it stores the team's
-decisions in a proprietary vector store. It has to, because the
-retrieval shapes the agent, and the shape of the agent is the shape
-of the moat. To switch IDEs, to switch models, to switch anything,
-the team rebuilds months of context from scratch. That isn't a bug.
-It is the product.
+LangChain builds harnesses. The argument is a fit for their product.
+The analogy is wrong on the merits too. Memory is part of your brain.
+Agent harnesses are like your body, the limbs and everything. You
+don't move your memory to your limbs. You move your memory to your
+brain.
 
-Harrison names three levels of bad. The mild one stores state on the
+The time has come. Lore is the standalone memory service, and it is
+the architecture that gets you out of the trap.
+
+## The platform owns your data. You should.
+
+When a closed platform builds "agent memory," it stores your team's
+decisions in a proprietary database behind an API. Retrieval shapes
+the agent, and the shape of the agent is the shape of the moat.
+Switch IDEs, switch models, switch anything, and the team rebuilds
+months of context from scratch. The lock-in is the product.
+
+Harrison names three levels. The mild one stores state on the
 provider's server so you cannot move threads between models. The bad
 one runs a closed harness that interacts with memory in ways you
 cannot see, and the artifacts are not portable. The worst one puts
@@ -40,96 +52,87 @@ second camp; Codex builds an encrypted compaction summary nothing
 outside OpenAI can read. The incentive is everywhere, and it points
 the same way.
 
-Six months of careful work, six months of carefully capturing a
-team's taste, and a vendor change returns the team to zero. That is
-the trap.
+Six months of careful work, six months of capturing a team's taste,
+and a vendor change returns the team to zero.
 
-## Vector databases are great for RAG. They are bad for consensus.
+## Lore is local-first. We aim to keep it that way.
 
-The pitch is always the same. Embeddings retrieve things that mean
-similar things. They find what you meant, not just what you typed.
-They power modern RAG, and they do it well.
+Lore is a vendor-neutral proxy that sits between your harness and
+your model. The whole engine runs on your machine. The memory lives
+in your repo and your local database, in open formats you can read
+with or without Lore.
 
-That isn't where the problem is. The problem is what happens after
-retrieval, when a team has to agree on what the agent should do next.
-Embeddings are opaque by design. If your agent hallucinates a rule
-("always reach for Redis"), where in the vector space did it learn
-that? You can't open a Pull Request against a vector store to debate
-the rule. You can't run a linter against it. You can't grep your
-memory to ask why a particular retrieval happened, or change one
-entry without the whole similarity neighborhood shifting around it.
-There is no review mechanism because there is no readable artifact
-to review.
+<figure>
+  <svg viewBox="0 0 460 460" xmlns="http://www.w3.org/2000/svg" style="max-width: 460px; width: 100%; margin: 1.5rem auto; display: block;" role="img" aria-label="Lore architecture: the harness on top, the model provider API on the bottom, and Lore sits between them as a local-first vendor-neutral proxy whose artifacts live on your machine.">
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#1a1a1a" />
+      </marker>
+    </defs>
 
-A team is a conversation between people who disagree productively.
-A vector store ends that conversation, because nobody can see the
-thing they are arguing about. What looks like memory is a black box.
+    <rect x="40" y="20" width="380" height="80" rx="8" fill="#fafafa" stroke="#1a1a1a" stroke-width="1.5" />
+    <text x="230" y="55" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="600" fill="#1a1a1a">Harness</text>
+    <text x="230" y="78" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#5a5a5a">Claude Code · OpenCode · Pi · Codex</text>
 
-## The file you can fork
+    <line x1="230" y1="105" x2="230" y2="135" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)" />
 
-Open memory is what LangChain is asking for. Open source, model
-agnostic, an open format for the artifacts. That is the bar. The
-question is what the format is.
+    <rect x="20" y="140" width="420" height="170" rx="8" fill="#c4ddc7" stroke="#1a1a1a" stroke-width="2" />
+    <text x="230" y="175" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="700" fill="#1a1a1a">Lore</text>
+    <text x="230" y="198" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-style="italic" fill="#1a1a1a">local-first, vendor-neutral proxy</text>
 
-We picked Markdown for the curated half. Specifically, a single file
-at the root of the repo called `.lore.md`, with one stable marker per
-entry, entries sorted alphabetically by title within each category.
-That is the whole standard. It is human-readable, machine-parseable,
-and Git-friendly out of the box, because Git already knows how to
-diff it, merge it, and review it. The diff shows up in a pull
-request next to the code change the memory touches.
+    <rect x="60" y="225" width="340" height="55" rx="6" fill="#ffffff" stroke="#5a5a5a" stroke-width="1" />
+    <text x="230" y="245" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" fill="#1a1a1a">.lore.md  +  ~/.local/share/lore/lore.db</text>
+    <text x="230" y="265" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10" font-style="italic" fill="#5a5a5a">on your machine, in open formats</text>
 
-When the team disagrees about whether an entry is right, you do what
-you already do for any other disagreement: open a PR. The debate
-happens in review, on the same surface as the code the memory covers.
-When the rule changes, the rule changes in the file. The agent's
-behavior changes on the next session with no re-indexing, no
-re-embedding, no background job. The memory moves with the code
-because it lives next to the code, and git history becomes memory
-history.
+    <line x1="230" y1="315" x2="230" y2="345" stroke="#1a1a1a" stroke-width="1.5" marker-end="url(#arrow)" />
 
-This is the part closed vector stores can't copy. They can copy the
-format. They can't copy the workflow. The workflow is the value.
+    <rect x="40" y="350" width="380" height="80" rx="8" fill="#fafafa" stroke="#1a1a1a" stroke-width="1.5" />
+    <text x="230" y="385" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="18" font-weight="600" fill="#1a1a1a">Model Provider API</text>
+    <text x="230" y="408" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#5a5a5a">Anthropic · OpenAI · Google · others</text>
+  </svg>
+  <figcaption style="text-align: center; font-size: 0.9em; opacity: 0.8; margin-top: 0.5rem;">
+    Lore is the brain. The harness is the body. The model provider API is the cognition.
+  </figcaption>
+</figure>
 
-## The database underneath
+What you actually own is two things:
 
-The curated file is only half of what you should own. Most of what
-an agent remembers is not meant to be reviewed and merged. The raw
-conversation, the layered distillations, the long-term memory
-entries, the entities the curator found, all the way back to the
-first session. That record belongs to you too, in a different
-artifact.
+- **`.lore.md`** at the root of your repo. The curated knowledge the
+  team has reviewed and merged. Version-controlled, PR-reviewable,
+  human-readable Markdown.
+- **A local SQLite database** at `~/.local/share/lore/lore.db`. The
+  full record: raw conversations, distillations, long-term memory,
+  entities. Open schema, queryable with `sqlite3`, exportable.
 
-Lore stores the rest of it in a local SQLite database at
-`~/.local/share/lore/lore.db`, with an open schema the engine
-publishes. You can open it with `sqlite3`, query it with anything
-that speaks the API, export it to CSV, or build your own tooling
-around it. Stop using Lore tomorrow and the database is still
-there. The engine doesn't sit between you and your data. The
-migrations are versioned, the schema is documented, and what Lore
-stored for you is what you can read.
+The engine that ties them together is fair source
+(FSL-1.1-Apache-2.0). The code that touches your tokens is right
+there to read, and it turns into Apache 2.0 on a timer.
 
-A vector store asks you to trust the retrieval layer because the
-embedding model and the indexing choices the store made are opaque
-to you. SQLite asks for nothing. The file is the database, the
-database is the file.
+The vector database lives inside Lore, on your machine. It is the
+runtime cache for semantic search, and it is the right tool for it.
+When a team changes a memory entry, the engine picks up the change
+on the next session and re-embeds the affected entries automatically
+— fast, transparent, and on your hardware. No batch job, no
+re-indexing window, no waiting for a vendor to apply your team's PR.
 
-## The escrow
+## The vendor route vs the local-first route
 
-A vector store says: trust us with the shape of your team's
-thinking, and we will give it back to you on retrieval. It has to
-be that way, because retrieval depends on the embedding model and
-the indexing choices the store made for you. The lock-in lives in
-the dependencies you can't see.
+A vendor-managed memory stack says: trust us with the shape of your
+team's thinking, and we will give it back to you on retrieval. It
+has to work that way, because the data lives behind an API, and the
+schema is whatever the vendor chose. To change a memory entry, you
+ask the vendor. To delete an entry, you ask the vendor. To export
+the corpus, you ask the vendor. To move to a different harness, you
+ask the vendor. The lock-in lives in the dependencies you cannot
+see.
 
-Lore says: the Markdown file is the curated memory, the SQLite file
-is the full memory, and both are yours. Distillation writes the
-Markdown. Distillation also writes the database. Review edits the
-file. You read the database with or without us. Agents read the
-file. Agents read the database. The model behind the agent doesn't
-matter. The harness behind the model doesn't matter. The next
-vendor reads the same Markdown and queries the same SQLite. The
-previous vendor never had anything to lock you to.
+Local-first says: the data lives on your machine, in open formats,
+and the engine is the source code in front of you. To change a
+memory entry, you edit the file. To delete an entry, you delete the
+row. To export the corpus, you run `sqlite3 lore.db .dump`. To move
+to a different harness, you point the new harness at the same files.
+The lock-in lives wherever you let it live, and you can move it any
+time.
 
 When your team is ready to share, the sync engine works the way a
 good group chat does: end-to-end encrypted, scoped to the entries
@@ -137,33 +140,28 @@ you explicitly approve, and the relay never sees plaintext. The
 keys stay with the participants. Sharing is opt-in, per entry, and
 reversible.
 
+## Why this matters
+
 We have talked before about
 [why knowledge lives in token space, not in weights](/blog/distill-your-own-knowledge/).
-A vector store is halfway there. It pulls memory out of the model,
-but it puts memory inside another opaque system. To finish the
-move, memory has to be in artifacts humans already share a workflow
-around. Markdown for the team. SQLite for the record. End-to-end
-sync if and when you want it. Everything else is a concession to
-someone else's moat.
+The same logic applies to where the token-space lives. A vector store
+in someone else's cloud is halfway there. A vector store on your
+machine is the rest of the way.
 
 Models will keep changing. They always do. Every part of the AI
 tooling stack above the model is genuinely up for grabs right now.
-The part that should not be up for grabs is how a team remembers
-what it decided and why. That belongs to the team, in formats the
-team already owns.
+The part that should not be up for grabs is who owns your team's
+data. That belongs to the team, on infrastructure the team controls.
+
+Lore is local-first. We aim to keep it that way.
 
 ## Try it
-
-The format is one file at the root of your repo, plus a SQLite
-database on your machine. Both are committed, reviewed, queried,
-and merged the same way as the code next to them.
 
 ```bash
 curl -fsSL https://withlore.ai/install | bash
 lore run
 ```
 
-After a few sessions, open `.lore.md` *and* the database at
+After a few sessions, open `.lore.md` and the database at
 `~/.local/share/lore/lore.db`. Read what your agent has written
-down. Open a PR when it gets something wrong. That is the
-workflow, and that is the answer.
+down. Open a PR when it gets something wrong. That is the workflow.

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -184,30 +184,31 @@ const base = import.meta.env.BASE_URL;
       <div class="step sr">
         <div class="step-n">01</div>
         <h3 class="step-t">It lives in Git</h3>
-        <p class="step-b">Memory isn't a black box and shouldn't be one. Lore distills your
-          team's context into an open standard — <code class="code-inline">.lore.md</code> —
-          plain Markdown in your repo, version-controlled, PR-reviewable, and
-          human-readable. The same diff shows up next to the code change it covers.</p>
+        <p class="step-b">The curated team knowledge lands in
+          <code class="code-inline">.lore.md</code> — plain Markdown at the root of your repo,
+          version-controlled, PR-reviewable, and human-readable. The same diff shows up
+          next to the code change it covers.</p>
       </div>
       <div class="step sr">
         <div class="step-n">02</div>
-        <h3 class="step-t">It's portable</h3>
-        <p class="step-b">Your team's "why" doesn't belong to any one harness, model, or vendor.
-          Switch from Cursor to OpenCode, or from Claude to OpenAI, without losing a
-          single team invariant. Lore is a vendor-neutral proxy that sits between
-          your harness and your model — the harness is replaceable, your memory isn't.</p>
+        <h3 class="step-t">It lives in your database</h3>
+        <p class="step-b">Everything else Lore keeps for you — raw conversations,
+          distillations, long-term memory, entities — lives in a local SQLite database
+          with an open schema. Read it with <code class="code-inline">sqlite3</code>, query it,
+          export it, or build your own tools around it. Stop using Lore tomorrow and
+          your data is still there, in an open format.</p>
       </div>
       <div class="step sr">
         <div class="step-n">03</div>
-        <h3 class="step-t">It's secure</h3>
-        <p class="step-b">Your data never leaves your infrastructure unless you want it to. Lore
-          runs locally, the engine is fair source, and the artifacts belong to you.
-          We don't hold your organizational knowledge hostage. We just make it
-          accessible to any agent you choose to hire.</p>
+        <h3 class="step-t">It syncs end-to-end</h3>
+        <p class="step-b">When your team is ready, Lore's sync engine works like a private
+          group chat between your SQLite databases — end-to-end encrypted, and only
+          for the content you explicitly allow. The relay never sees plaintext.
+          The keys stay with the participants.</p>
       </div>
     </div>
     <p class="sec-sub sr" style="max-width:900px;margin:1.5rem auto 0;text-align:center;font-size:.82rem;opacity:.85;">
-      The vector-database route is the lock-in route. The Markdown route is the
+      The vector-database route is the lock-in route. The open-format route is the
       freedom route.
       <a href={`${base}blog/the-embedding-trap/`} style="border-bottom:1px solid var(--g4);color:var(--g2)">Why we chose text &rarr;</a>
     </p>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -12,11 +12,11 @@ const base = import.meta.env.BASE_URL;
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Lore.AI — Shared context that never gets compacted</title>
-  <meta name="description" content="Lore unifies context-window management and long-term memory for AI agents in one local-first pipeline — infinite sessions, compounding knowledge, shared across tools and providers. No Docker, no cloud." />
+  <title>Lore.AI — Local-first memory for AI agents</title>
+  <meta name="description" content="Lore is the local-first memory layer for AI agents. Plain Markdown and an open SQLite database, on your machine. Local, sqlite & markdown. Run by a fair-source engine. Local, sqlite & markdown." />
   <SocialMeta
-    title="Lore.AI — Shared context that never gets compacted"
-    description="Context-window management and long-term memory for AI agents — one local-first pipeline. Infinite sessions, compounding knowledge, shared across your tools."
+    title="Lore.AI — Local-first memory for AI agents"
+    description="Lore is the local-first memory layer for AI agents. Plain Markdown and an open SQLite database, on your machine. Run by a fair-source engine."
     path=""
   />
   <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`}>
@@ -79,7 +79,8 @@ const base = import.meta.env.BASE_URL;
       </h1>
       <p class="hero-desc sr">Your AI never starts over. Lore keeps sessions coherent for days and millions of
         tokens — no lossy summary that wipes your file paths and decisions — and turns every session into
-        compounding memory across tools, providers, and (soon) your team. No context files. No workflow changes.</p>
+        compounding memory that lives on your machine, in plain Markdown and an open SQLite database. No
+        context files. No lock-in. No workflow changes.</p>
       <div class="hero-install sr">
         <div class="install-block" onclick="navigator.clipboard.writeText('curl -fsSL https://withlore.ai/install | bash').then(()=>{this.querySelector('.install-copied').classList.add('show');setTimeout(()=>this.querySelector('.install-copied').classList.remove('show'),2000)})">
           <code><span class="install-prompt">$</span> curl -fsSL https://withlore.ai/install | bash</code>
@@ -194,11 +195,11 @@ const base = import.meta.env.BASE_URL;
         <h3 class="step-t">It lives in your database</h3>
         <p class="step-b">Everything else Lore keeps for you — raw conversations,
           distillations, long-term memory, entities, and the vector embeddings
-          themselves — lives in a local SQLite database with an open schema. The
+          themselves — lives in a local SQLite database on your machine. The
           SQLite file is the vector database: no separate store, no separate bill.
           Read it with <code class="code-inline">sqlite3</code>, query it, export it, or build
           your own tools around it. Stop using Lore tomorrow and your data is
-          still there, in an open format.</p>
+          still there, in plain Markdown and an open SQLite you can read.</p>
       </div>
       <div class="step sr">
         <div class="step-n">03</div>
@@ -210,9 +211,9 @@ const base = import.meta.env.BASE_URL;
       </div>
     </div>
     <p class="sec-sub sr" style="max-width:900px;margin:1.5rem auto 0;text-align:center;font-size:.82rem;opacity:.85;">
-      The vector-database route is the lock-in route. The open-format route is the
+      The vector-database route is the lock-in route. The local-first route is the
       freedom route.
-      <a href={`${base}blog/the-agentic-memory-trap/`} style="border-bottom:1px solid var(--g4);color:var(--g2)">Why we chose text &rarr;</a>
+      <a href={`${base}blog/the-agentic-memory-trap/`} style="border-bottom:1px solid var(--g4);color:var(--g2)">Why we chose local-first &rarr;</a>
     </p>
   </section>
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -193,10 +193,12 @@ const base = import.meta.env.BASE_URL;
         <div class="step-n">02</div>
         <h3 class="step-t">It lives in your database</h3>
         <p class="step-b">Everything else Lore keeps for you — raw conversations,
-          distillations, long-term memory, entities — lives in a local SQLite database
-          with an open schema. Read it with <code class="code-inline">sqlite3</code>, query it,
-          export it, or build your own tools around it. Stop using Lore tomorrow and
-          your data is still there, in an open format.</p>
+          distillations, long-term memory, entities, and the vector embeddings
+          themselves — lives in a local SQLite database with an open schema. The
+          SQLite file is the vector database: no separate store, no separate bill.
+          Read it with <code class="code-inline">sqlite3</code>, query it, export it, or build
+          your own tools around it. Stop using Lore tomorrow and your data is
+          still there, in an open format.</p>
       </div>
       <div class="step sr">
         <div class="step-n">03</div>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -169,10 +169,10 @@ const base = import.meta.env.BASE_URL;
   </section>
 
   <!-- THE BET -->
-  <section class="how" id="bet">
+  <section class="how" id="local-first">
     <div class="sec-hd">
       <div>
-        <p class="eyebrow sr">The bet</p>
+        <p class="eyebrow sr">Local First</p>
         <h2 class="sec-title sr">Own your team's memory, <em>not just your code.</em></h2>
       </div>
       <p class="sec-sub sr">The AI tooling ecosystem is in a war for execution, and your

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -212,7 +212,7 @@ const base = import.meta.env.BASE_URL;
     <p class="sec-sub sr" style="max-width:900px;margin:1.5rem auto 0;text-align:center;font-size:.82rem;opacity:.85;">
       The vector-database route is the lock-in route. The open-format route is the
       freedom route.
-      <a href={`${base}blog/the-embedding-trap/`} style="border-bottom:1px solid var(--g4);color:var(--g2)">Why we chose text &rarr;</a>
+      <a href={`${base}blog/the-agentic-memory-trap/`} style="border-bottom:1px solid var(--g4);color:var(--g2)">Why we chose text &rarr;</a>
     </p>
   </section>
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -13,7 +13,7 @@ const base = import.meta.env.BASE_URL;
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Lore.AI — Local-first memory for AI agents</title>
-  <meta name="description" content="Lore is the local-first memory layer for AI agents. Plain Markdown and an open SQLite database, on your machine. Local, sqlite & markdown. Run by a fair-source engine. Local, sqlite & markdown." />
+  <meta name="description" content="Lore is the local-first memory layer for AI agents. Plain Markdown and an open SQLite database, on your machine. Run by a fair-source engine." />
   <SocialMeta
     title="Lore.AI — Local-first memory for AI agents"
     description="Lore is the local-first memory layer for AI agents. Plain Markdown and an open SQLite database, on your machine. Run by a fair-source engine."

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -167,6 +167,52 @@ const base = import.meta.env.BASE_URL;
     </div>
   </section>
 
+  <!-- THE BET -->
+  <section class="how" id="bet">
+    <div class="sec-hd">
+      <div>
+        <p class="eyebrow sr">The bet</p>
+        <h2 class="sec-title sr">Own your team's memory, <em>not just your code.</em></h2>
+      </div>
+      <p class="sec-sub sr">The AI tooling ecosystem is in a war for execution, and your
+        harness is incentivized to lock you in. When closed platforms build
+        "agent memory," they trap your team's architectural decisions inside
+        proprietary vector databases. Switch IDEs or models and your team
+        gets amnesia. <strong style="color:var(--g1)">Lore is the escape hatch.</strong></p>
+    </div>
+    <div class="steps">
+      <div class="step sr">
+        <div class="step-n">01</div>
+        <h3 class="step-t">It lives in Git</h3>
+        <p class="step-b">Memory isn't a black box and shouldn't be one. Lore distills your
+          team's context into an open standard — <code class="code-inline">.lore.md</code> —
+          plain Markdown in your repo, version-controlled, PR-reviewable, and
+          human-readable. The same diff shows up next to the code change it covers.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">02</div>
+        <h3 class="step-t">It's portable</h3>
+        <p class="step-b">Your team's "why" doesn't belong to any one harness, model, or vendor.
+          Switch from Cursor to OpenCode, or from Claude to OpenAI, without losing a
+          single team invariant. Lore is a vendor-neutral proxy that sits between
+          your harness and your model — the harness is replaceable, your memory isn't.</p>
+      </div>
+      <div class="step sr">
+        <div class="step-n">03</div>
+        <h3 class="step-t">It's secure</h3>
+        <p class="step-b">Your data never leaves your infrastructure unless you want it to. Lore
+          runs locally, the engine is fair source, and the artifacts belong to you.
+          We don't hold your organizational knowledge hostage. We just make it
+          accessible to any agent you choose to hire.</p>
+      </div>
+    </div>
+    <p class="sec-sub sr" style="max-width:900px;margin:1.5rem auto 0;text-align:center;font-size:.82rem;opacity:.85;">
+      The vector-database route is the lock-in route. The Markdown route is the
+      freedom route.
+      <a href={`${base}blog/the-embedding-trap/`} style="border-bottom:1px solid var(--g4);color:var(--g2)">Why we chose text &rarr;</a>
+    </p>
+  </section>
+
   <!-- TICKER -->
   <div class="ticker">
     <div class="ticker-track">

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -80,7 +80,7 @@ const base = import.meta.env.BASE_URL;
       <p class="hero-desc sr">Your AI never starts over. Lore keeps sessions coherent for days and millions of
         tokens — no lossy summary that wipes your file paths and decisions — and turns every session into
         compounding memory that lives on your machine, in plain Markdown and an open SQLite database. No
-        context files. No lock-in. No workflow changes.</p>
+        context files sprawling around. No lock-in. No workflow changes.</p>
       <div class="hero-install sr">
         <div class="install-block" onclick="navigator.clipboard.writeText('curl -fsSL https://withlore.ai/install | bash').then(()=>{this.querySelector('.install-copied').classList.add('show');setTimeout(()=>this.querySelector('.install-copied').classList.remove('show'),2000)})">
           <code><span class="install-prompt">$</span> curl -fsSL https://withlore.ai/install | bash</code>

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -168,7 +168,6 @@ const base = import.meta.env.BASE_URL;
     </div>
   </section>
 
-  <!-- THE BET -->
   <section class="how" id="local-first">
     <div class="sec-hd">
       <div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,10 @@ importers:
         version: 0.79.8(ws@8.21.0)(zod@4.4.3)
 
   packages/website:
+    dependencies:
+      mermaid:
+        specifier: 11.16.0
+        version: 11.16.0
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
@@ -256,6 +260,9 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -659,6 +666,9 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bruits/satteri-darwin-arm64@0.9.5':
     resolution: {integrity: sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==}
     cpu: [arm64]
@@ -707,6 +717,9 @@ packages:
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@clack/core@1.4.1':
     resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
@@ -967,6 +980,12 @@ packages:
 
   '@huggingface/transformers@3.8.1':
     resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1333,6 +1352,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@mistralai/mistralai@2.2.6':
     resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
@@ -2136,6 +2158,99 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -2147,6 +2262,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -2187,6 +2305,9 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2195,6 +2316,9 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitest/coverage-v8@4.1.8':
     resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
@@ -2433,10 +2557,6 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  binpatch@0.1.0:
-    resolution: {integrity: sha512-xhD1I3NwmywSGPK4EqQLT+jcDsnboWzHoBh1UrFrLf/68m4Ohy/i7NCdm4jSIzDv7ZHfiDsjgKtztCQyLY1+kw==}
-    engines: {node: '>=22.5'}
-
   binpatch@0.3.1:
     resolution: {integrity: sha512-KD1kWfjqXp+SaNxY71QJ16I+6NU/U8MJD1H9A9VDLqrmmslXvRi+7evICcYwftdhu+Yxd6lH1OqypfYbjfFb8g==}
     engines: {node: '>=22.5'}
@@ -2560,6 +2680,14 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
@@ -2577,6 +2705,12 @@ packages:
   cookie@2.0.1:
     resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
     engines: {node: '>=22'}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2612,9 +2746,168 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2638,6 +2931,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2679,6 +2975,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2732,6 +3031,9 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -2956,6 +3258,9 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -3080,6 +3385,10 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -3092,11 +3401,21 @@ packages:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -3201,6 +3520,13 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -3208,6 +3534,12 @@ packages:
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -3284,6 +3616,9 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.groupby@4.6.0:
     resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
@@ -3325,6 +3660,11 @@ packages:
     resolution: {integrity: sha512-CspnvVfHSkb/znqdPS4jUR8HtCjq3M/DnrsJCrfLBLvdrgbemmoINKpeWKQYkBiXAoBGejw0cV7xzqrPdup3WA==}
     peerDependencies:
       marked: '>=13 <19'
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marked@17.0.6:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
@@ -3407,6 +3747,9 @@ packages:
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
     engines: {node: '>=20'}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3737,6 +4080,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
@@ -3817,6 +4163,12 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   portable-executable-signature@2.0.6:
     resolution: {integrity: sha512-VV+1GuJca0cJ0PFwnCW/xK8Ro9DDX38e4iUDh6ngPjd9vj7VLiemh9rSlqquvcVGtClkVzYaV/UseMVnUrxS/Q==}
@@ -4020,6 +4372,9 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4029,6 +4384,12 @@ packages:
     resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -4221,6 +4582,9 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -4281,6 +4645,10 @@ packages:
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -4461,6 +4829,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
 
   uuidv7@1.1.0:
     resolution: {integrity: sha512-2VNnOC0+XQlwogChUDzy6pe8GQEys9QFZBGOh54l6qVfwoCUwwRvk7rDTgaIsRgsF5GFa5oiNg8LqXE3jofBBg==}
@@ -4795,6 +5167,11 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.4
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
@@ -5470,6 +5847,8 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bruits/satteri-darwin-arm64@0.9.5':
     optional: true
 
@@ -5504,6 +5883,8 @@ snapshots:
   '@capsizecss/unpack@4.0.1':
     dependencies:
       fontkitten: 1.0.3
+
+  '@chevrotain/types@11.1.2': {}
 
   '@clack/core@1.4.1':
     dependencies:
@@ -5768,6 +6149,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
     optional: true
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@img/colour@1.1.0': {}
 
@@ -6090,6 +6479,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -6728,6 +7121,123 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -6739,6 +7249,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -6783,11 +7295,19 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
@@ -7114,8 +7634,6 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  binpatch@0.1.0: {}
-
   binpatch@0.3.1: {}
 
   binpunch@1.0.0: {}
@@ -7213,6 +7731,10 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   commander@9.5.0: {}
 
   common-ancestor-path@2.0.0: {}
@@ -7222,6 +7744,14 @@ snapshots:
   cookie-es@1.2.3: {}
 
   cookie@2.0.1: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7261,7 +7791,193 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
+
+  dayjs@1.11.21: {}
 
   debug@4.4.3:
     dependencies:
@@ -7284,6 +8000,10 @@ snapshots:
       object-keys: 1.1.1
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   dequal@2.0.3: {}
 
@@ -7319,6 +8039,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -7364,6 +8088,8 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.49.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -7682,6 +8408,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -7928,6 +8656,10 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -7941,9 +8673,15 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
+  import-meta-resolve@4.2.0: {}
+
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -8027,9 +8765,19 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kleur@4.1.5: {}
 
   klona@2.0.6: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -8093,6 +8841,8 @@ snapshots:
       srcset: 5.0.3
       undici: 7.28.0
 
+  lodash-es@4.18.1: {}
+
   lodash.groupby@4.6.0: {}
 
   long@5.3.2: {}
@@ -8129,6 +8879,8 @@ snapshots:
     dependencies:
       github-slugger: 2.0.0
       marked: 17.0.6
+
+  marked@16.4.2: {}
 
   marked@17.0.6: {}
 
@@ -8328,6 +9080,30 @@ snapshots:
   mdn-data@2.27.1: {}
 
   meow@14.1.0: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8839,6 +9615,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
@@ -8903,6 +9681,13 @@ snapshots:
 
   platform@1.3.6:
     optional: true
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   portable-executable-signature@2.0.6: {}
 
@@ -9168,6 +9953,8 @@ snapshots:
 
   retry@0.13.1: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -9220,6 +10007,15 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.0
       fsevents: 2.3.3
     optional: true
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -9468,6 +10264,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.4.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -9538,6 +10336,8 @@ snapshots:
   trough@2.2.0: {}
 
   ts-algebra@2.0.0: {}
+
+  ts-dedent@2.3.0: {}
 
   tslib@2.8.1: {}
 
@@ -9671,6 +10471,8 @@ snapshots:
   url-extras@0.1.0: {}
 
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.1: {}
 
   uuidv7@1.1.0: {}
 


### PR DESCRIPTION
## The bet

The AI tooling ecosystem is in a war for execution, and harnesses are incentivized to lock you in. When a closed platform builds "agent memory," it stores the team's decisions inside a proprietary vector database — and a vendor switch returns the team to zero.

Lore is the escape hatch. A vendor-neutral proxy that distills context into an open standard (`.lore.md`) instead of a black box. The new 'Embedding Trap' post lands the thesis in public: vector stores are great for RAG, terrible for team consensus.

This PR makes that positioning the first thing a visitor reads.

## Changes

- **Landing page (`index.astro`)** — new `The bet` section between the hero and the ticker, with the three pillars (lives in Git, portable, secure) and a forward link to the new blog post.
- **README** — new `Own your memory, not just your code` section between the package list and `## Why` establishing the same vendor-neutral stance.
- **New blog post** — `The Embedding Trap: Why AI team memory must live in plain text`, dated 2026-07-29. Cites [Harrison Chase's 'Your harness, your memory' essay](https://blog.langchain.com/your-harness-your-memory/), lands the `.lore.md`-vs-vector-store thesis, ends with the standard install + `cat .lore.md` CTA.

## Verification

- `pnpm --filter @loreai/website run check` — 0 errors, 0 warnings
- `pnpm run format:check` — clean
- Visual diff against `origin/main` is only the three intended files (`README.md`, `index.astro`, `the-embedding-trap.md`)

## Follow-up

This is the position piece. A 'Why Lore → 'Different' page refresh is a separate concern (that's where the deep comparison to other memory systems lives), and the Folk Lore section on both pages still says 'coming soon' — both already updated separately / not in scope here.