### PR TITLE
fix(discover): handle 204 empty response from /contributors (#1527 follow-up)

### DIFF
--- a/packages/gateway/test/github-discover.test.ts
+++ b/packages/gateway/test/github-discover.test.ts
@@ -168,6 +168,21 @@ describe("fetchRepoContributors", () => {
     );
     expect(cols).toEqual([]);
   });
+  it("returns [] (empty roster, NOT skip) on 204 — empty repo body", async () => {
+    // Regression for Seer review of PR #1527 (comment 3676072445, finding 15565416/0):
+    // without an explicit 204 branch, `resp.ok === true` and `resp.json()` parses the
+    // empty body as `undefined`, throwing SyntaxError on platforms where JSON.parse("")
+    // fails — the outer try/catch would silently skip the repo as if it were
+    // inaccessible. Documented behavior (discover.ts docstring) says 204 returns [].
+    const f = mockFetch({ "/contributors": { status: 204, body: "" } });
+    const cols = await fetchRepoContributors(
+      "tok",
+      { owner: "o", name: "r" },
+      99,
+      { fetchImpl: f },
+    );
+    expect(cols).toEqual([]);
+  });
   it("follows Link: rel='next' up to MAX_PAGES and dedupes cross-page via Set<id>", async () => {
     const page2Link =
       '<https://api.github.com/repos/o/r/contributors?page=2&anon=true&per_page=100>; rel="next"';

--- a/supabase/functions/github-discover/discover.ts
+++ b/supabase/functions/github-discover/discover.ts
@@ -155,7 +155,12 @@ export async function fetchRepoContributors(
     // 403/404: skip the repo (caller can't read it / no such repo).
     if (resp.status === 403 || resp.status === 404) return null;
     // 202: stats still computing — caller can retry; treat as empty and don't fail the batch.
-    if (resp.status === 202) return [];
+    // 204: repo is readable but GitHub returned no body (typically an empty repo with no
+    //      commits). Without this branch, `resp.ok === true` and `await resp.json()`
+    //      throws `SyntaxError: Unexpected end of JSON input` on the empty body, which
+    //      the outer per-repo try/catch silently swallows as "inaccessible".
+    //      Documented intent (see function docstring) was to return [] for both 202 and 204.
+    if (resp.status === 202 || resp.status === 204) return [];
     if (!resp.ok)
       throw new Error(
         `github /repos/${repo.owner}/${repo.name}/contributors: ${resp.status}`,


### PR DESCRIPTION
Seer review of PR #1527 left a MEDIUM-severity comment that we missed:

  > **Bug:** `fetchRepoContributors` doesn't handle HTTP 204 responses from
  > GitHub for empty repos, causing a `SyntaxError` when `resp.json()` is
  > called on an empty body.

## what

PR #1527 (commit 8ddf516b) added the `/contributors` switch in
`fetchRepoContributors` and documented in the function docstring that
"204: empty contributor list → return []". The implementation, however,
only handled 202 (stats not ready) — leaving 204 to fall through to
`resp.json()`. On strict runtimes (and per spec) parsing the empty body
throws `SyntaxError: Unexpected end of JSON input`, caught by the outer
per-repo try/catch in `index.ts:130`, which silently excludes the repo
from the response as if it were inaccessible.

## fix

add the matching 204 branch next to the 202 branch. on lenient runtimes
the behavior is unchanged (returns [] anyway after parsing the empty
body to `undefined`), on strict runtimes it skips the throw and returns
[] as documented. `+15/-1` total.

## test

new vitest case mirroring the existing 202 test:
`returns [] (empty roster, NOT skip) on 204 — empty repo body`.

closes the dangling Seer review comment on PR #1527.