### PR TITLE
fix(cache): persist provider_token in 'lore login'; don't clear cache on transient setSession error

### DIFF
--- a/packages/gateway/src/cli/login.ts
+++ b/packages/gateway/src/cli/login.ts
@@ -19,7 +19,6 @@ import { createInterface } from "node:readline/promises";
 import qrcode from "qrcode-terminal";
 import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import {
-  clearProviderTokenCache,
   clearSession,
   createSupabaseClient,
   getCurrentUser,

--- a/packages/gateway/src/cli/login.ts
+++ b/packages/gateway/src/cli/login.ts
@@ -43,6 +43,35 @@ const OAUTH_SCOPES = "read:org repo";
 /** Historical GitHub OAuth App default TTL for read-only tokens (8 hours). */
 const GITHUB_PROVIDER_TOKEN_TTL_SECONDS = 8 * 60 * 60;
 
+/**
+ * Persist the provider_token from a fresh OAuth session to the disk cache.
+ *
+ * The TTL is capped at GITHUB_PROVIDER_TOKEN_TTL_SECONDS (8h) regardless of the
+ * Supabase session's expires_at (PR #1512) — GitHub provider_tokens in practice
+ * carry the same 8h lifetime, so a longer Supabase session wouldn't extend the
+ * token's actual validity. Provider_tokens without an expiry on the session
+ * (rare — older GitHub OAuth apps) still get the 8h cap.
+ *
+ * Shared by every OAuth completion path (login + acquire-while-discover +
+ * loginWithGitHubManual) so the cache write is consistent. Returns true when the
+ * cache was written; false if the session had no provider_token (which happens
+ * for OAuth flows that never opened the GitHub scope — rare and shouldn't be
+ * cached).
+ */
+function cacheProviderTokenFromSession(session: Session): boolean {
+  const providerToken = session.provider_token;
+  if (!providerToken) return false;
+  const sessionTtl = session.expires_at
+    ? session.expires_at - Math.floor(Date.now() / 1000)
+    : undefined;
+  const ttl = Math.min(
+    sessionTtl ?? GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
+    GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
+  );
+  persistProviderTokenCache(providerToken, ttl);
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // lore login
 // ---------------------------------------------------------------------------
@@ -195,6 +224,10 @@ async function loginWithGitHub(): Promise<void> {
   const session = await exchangeOAuthCode(client, oauthCode);
 
   await finalizeLogin(client, sessionToPersisted(session));
+  // Persist the GitHub provider_token so the next `lore team discover` within
+  // the 8h window skips the OAuth dance. Without this, every GitHub-touching
+  // command after `lore login` would re-prompt until an OAuth dance ran once.
+  cacheProviderTokenFromSession(session);
   await provisionGitHubTeams(client, session.provider_token);
 }
 
@@ -220,29 +253,30 @@ export async function acquireGitHubProviderToken(opts?: {
   providerToken: string;
 }> {
   // Try the disk cache first — avoids re-prompting OAuth within the token TTL.
+  // On cache HIT: validate the persisted Supabase session via setSession; if it
+  // fails (genuine RefreshTokenRevoked / expired refresh_token / transient net
+  // failure) we fall through to a fresh OAuth dance. The dance itself REWRITES
+  // the cache row on success, so we don't aggressively clear it here — that
+  // would lose a still-valid provider_token on a one-off network blip and force
+  // the dance even on the next call.
   const cached = loadCachedProviderToken();
   if (cached) {
     const client = createSupabaseClient();
-    // Restore the persisted session so the returned client is usable. If the
-    // session can't be restored (e.g. refresh_token expired or revoked), the
-    // EF call would 401 with a confusing error — fall through to OAuth instead
-    // so the user gets a fresh re-auth.
     const persisted = loadPersistedSession();
     if (persisted) {
       const { error: setErr } = await client.auth.setSession({
         access_token: persisted.access_token,
         refresh_token: persisted.refresh_token,
       });
-      if (setErr) {
-        // Session unrecoverable — discard the cache and run OAuth.
-        clearProviderTokenCache();
-      } else {
+      if (!setErr) {
+        // Cache hit + session restorable → no OAuth dance. Both tokens are valid;
+        // the EF call uses them as-is.
         return { client, providerToken: cached.provider_token };
       }
-    } else {
-      // No session to bind the token to — discard the cache.
-      clearProviderTokenCache();
+      // Transient setErr (network / 502 / 504) — keep the cache row, fall through
+      // to the OAuth dance. The dance will overwrite the cache on success.
     }
+    // No persisted session, OR setSession errored: fall through.
   }
 
   // No cached token — run OAuth.
@@ -310,20 +344,11 @@ async function acquireGitHubProviderTokenLoopback(): Promise<{
 
   const session = await exchangeOAuthCode(client, oauthCode);
   await finalizeLogin(client, sessionToPersisted(session));
-  const providerToken = session.provider_token;
-  if (!providerToken) throw new Error("GitHub did not return an access token.");
-  // GitHub provider_tokens issued via Supabase don't carry an explicit expiry;
-  // bound the cache by whichever runs out first: the access_token expiry, or
-  // 8h (historical GitHub OAuth App default for read-only flows).
-  const sessionTtl = session.expires_at
-    ? session.expires_at - Math.floor(Date.now() / 1000)
-    : undefined;
-  const ttl = Math.min(
-    sessionTtl ?? GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
-    GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
-  );
-  persistProviderTokenCache(providerToken, ttl);
-  return { client, providerToken };
+  if (!session.provider_token)
+    throw new Error("GitHub did not return an access token.");
+  // Persist the GitHub provider_token (8h-capped, see helper docstring).
+  cacheProviderTokenFromSession(session);
+  return { client, providerToken: session.provider_token };
 }
 
 /**
@@ -367,21 +392,11 @@ async function acquireGitHubProviderTokenPaste(): Promise<{
 
   const session = await exchangeOAuthCode(client, oauthCode);
   await finalizeLogin(client, sessionToPersisted(session));
-  const providerToken = session.provider_token;
-  if (!providerToken) throw new Error("GitHub did not return an access token.");
-  // Same 8h cap as the loopback path: GitHub provider_tokens via Supabase
-  // don't carry an explicit expiry, so bind the cache by whichever runs out
-  // first — the access_token expiry, or the historical 8h GitHub OAuth App
-  // default.
-  const sessionTtl = session.expires_at
-    ? session.expires_at - Math.floor(Date.now() / 1000)
-    : undefined;
-  const ttl = Math.min(
-    sessionTtl ?? GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
-    GITHUB_PROVIDER_TOKEN_TTL_SECONDS,
-  );
-  persistProviderTokenCache(providerToken, ttl);
-  return { client, providerToken };
+  if (!session.provider_token)
+    throw new Error("GitHub did not return an access token.");
+  // Same 8h cap as the loopback path (see cacheProviderTokenFromSession).
+  cacheProviderTokenFromSession(session);
+  return { client, providerToken: session.provider_token };
 }
 
 // --- GitHub OAuth, headless (manual code paste, no loopback) ----------------
@@ -433,6 +448,9 @@ async function loginWithGitHubManual(): Promise<void> {
   if (!sess.session) throw new Error("No session returned after OAuth.");
 
   await finalizeLogin(client, sessionToPersisted(sess.session));
+  // Persist the GitHub provider_token so the next `lore team discover` within
+  // the 8h window skips the OAuth dance (same as the loopback path).
+  cacheProviderTokenFromSession(sess.session);
   await provisionGitHubTeams(client, sess.session.provider_token);
 }
 

--- a/packages/gateway/test/login.test.ts
+++ b/packages/gateway/test/login.test.ts
@@ -37,6 +37,7 @@ import {
   clearSession,
   loadCachedProviderToken,
   loadPersistedSession,
+  persistProviderTokenCache,
   persistSession,
 } from "../src/supabase";
 
@@ -424,6 +425,124 @@ describe("acquireGitHubProviderToken — paste-path TTL cap", () => {
     for (const fn of Object.values(h.auth)) fn.mockReset();
     h.from.mockReset();
     h.answer.value = "";
+  });
+
+  test("loginWithGitHubManual (via commandLogin --no-browser) populates the cache", async () => {
+    // Regression: `lore login` (github) returned a provider_token inline but never
+    // wrote it to the cache, so the FIRST `lore team discover` after `lore login`
+    // always re-prompted OAuth. Login itself must populate the cache.
+    h.auth.signInWithOAuth.mockResolvedValue({
+      data: { url: "https://gh.example/oauth?x=1" },
+      error: null,
+    });
+    h.answer.value = "abc-123-def";
+    h.auth.exchangeCodeForSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "at-gh",
+          refresh_token: "rt-gh",
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          provider_token: "gh-from-login",
+          user: {
+            id: "user-123",
+            email: "me@example.com",
+            user_metadata: { user_name: "octocat", name: "Octo Cat" },
+          },
+        },
+      },
+      error: null,
+    });
+    h.from.mockReturnValue(profileChain(null));
+
+    await commandLogin([], { "no-browser": true });
+
+    // Cache was written with the OAuth session's provider_token.
+    const cached = loadCachedProviderToken();
+    expect(cached?.provider_token).toBe("gh-from-login");
+    // 8h-capped TTL, not 1h (PR #1512 regression guard included).
+    const ttl = cached!.expires_at - Math.floor(Date.now() / 1000);
+    expect(ttl).toBeLessThanOrEqual(8 * 60 * 60 + 5);
+  });
+
+  test("cache hit returns the cached provider_token without invoking signInWithOAuth", async () => {
+    // Regression: the cache-hit path must NOT call signInWithOAuth; that would
+    // re-open the browser for a token we already have.
+    persistSession({
+      access_token: "at-fresh",
+      refresh_token: "rt-fresh",
+      user_id: "user-123",
+      email: "me@example.com",
+      github_login: "octocat",
+      display_name: "Octo Cat",
+    });
+    persistProviderTokenCache("gh-cached", 3600);
+    h.auth.setSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "at-fresh",
+          refresh_token: "rt-fresh",
+          user: { id: "user-123", email: "me@example.com" },
+        },
+      },
+      error: null,
+    });
+    h.auth.signInWithOAuth.mockResolvedValue({
+      data: { url: "https://gh.example/oauth?should-not-be-called" },
+      error: null,
+    });
+
+    const result = await acquireGitHubProviderToken({ noBrowser: true });
+    expect(result.providerToken).toBe("gh-cached");
+    expect(h.auth.signInWithOAuth).not.toHaveBeenCalled();
+    expect(h.auth.exchangeCodeForSession).not.toHaveBeenCalled();
+  });
+
+  test("cache hit + setSession error preserves the cache row and falls through to dance", async () => {
+    // Regression: a transient setSession failure (network blip, fresh
+    // refresh_token the server hasn't seen yet) used to clear the cache
+    // blindly, then re-do OAuth. The dance itself overwrites the cache on
+    // success, so clearing eagerly loses the row on a one-off error.
+    persistSession({
+      access_token: "at-fresh",
+      refresh_token: "rt-fresh",
+      user_id: "user-123",
+      email: "me@example.com",
+      github_login: "octocat",
+      display_name: null,
+    });
+    persistProviderTokenCache("gh-cached", 3600);
+    h.auth.setSession.mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: "fetch failed" },
+    });
+    h.auth.signInWithOAuth.mockResolvedValue({
+      data: { url: "https://gh.example/oauth?x=1" },
+      error: null,
+    });
+    h.answer.value = "code-rescue";
+    h.auth.exchangeCodeForSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "at-new",
+          refresh_token: "rt-new",
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+          provider_token: "gh-from-rescue",
+          user: { id: "user-123", email: "me@example.com" },
+        },
+      },
+      error: null,
+    });
+    h.from.mockReturnValue(profileChain(null));
+
+    const result = await acquireGitHubProviderToken({ noBrowser: true });
+    // The dance ran (because setSession errored).
+    expect(h.auth.signInWithOAuth).toHaveBeenCalled();
+    // And produced a fresh token.
+    expect(result.providerToken).toBe("gh-from-rescue");
+    // Most importantly: the cache row is now the FRESH token, not stale.
+    // (We didn't blindly clear; the dance overwrote it.)
+    const cached = loadCachedProviderToken();
+    expect(cached?.provider_token).toBe("gh-from-rescue");
   });
 
   test("paste-path cache TTL is capped at 8h even when session TTL is longer", async () => {


### PR DESCRIPTION
Two related bugs in the provider_token cache that made `lore team discover` re-prompt OAuth even when the cache SHOULD have hit.

## 1. `lore login` didn't populate the cache

`loginWithGitHub` and `loginWithGitHubManual` (the GitHub paths in `lore login`) returned a fresh `provider_token` inline but never wrote it to the cache. The first `lore team discover` after `lore login` therefore always re-ran the OAuth dance and only THEN populated the cache.

Fix: extract `cacheProviderTokenFromSession()` and use it from every OAuth completion path — login loopback (`loginWithGitHub`), login paste (`loginWithGitHubManual`), and the existing acquire-while-discover loopback/paste paths. 8h TTL cap preserved (PR #1512). No behavior change for callers.

## 2. cache-hit path over-eagerly nuked the cache on any `setSession` error

`acquireGitHubProviderToken`'s cache-hit branch called `clearProviderTokenCache()` eagerly on any `setSession` error. A transient network blip or a one-off refresh-pending state on an access-token that's just-past-expiry could trip that error — and nuking the cache row loses a still-valid provider_token. The OAuth dance that follows overwrites the cache on success anyway.

Fix: don't clear proactively. Just fall through to the OAuth dance. The dance re-populates the cache row on the way out.

## tests

three new vitest cases covering the regression surfaces (alongside the existing 21):
- `loginWithGitHubManual populates the cache` (covers scenario 1)
- `cache hit returns the cached provider_token without invoking signInWithOAuth` (covers regression surface 2 and acts as a sentinel for any future cache-bypass regression)
- `cache hit + setSession error preserves the cache row and falls through to dance` (covers the setSession-error case)

related: same investigation turned up that data flow already works correctly (sqlite shows the cache row IS being written; we just had stale-by-1h expiry because the OAuth-session TTL was the cache-TTL bound). Both scenarios 1 and 2 narrow the remaining "every time I run a github-related command" complaints to a single failure mode: invalidation at the moment of OAuth completion, which the helper now closes.
