### PR TITLE
feat(invite-email): server-side recipient resolution for bare invites

### DIFF
--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -373,22 +373,49 @@ export async function commandTeam(
         const token = await createTeamInvite(client, scope.id, role, hint, {
           offline,
         });
-        // E-5-e: if the resolved hint is a real email, email the join link. A send failure NEVER
-        // loses the invite — the token/link is always still printed.
-        const willEmail = !!hint && isEmailAddress(hint);
-        const emailed = willEmail
-          ? await sendInviteEmail(client, token, hint)
-          : false;
+        // E-5-e (server-side resolve): when the hint is NOT a real email, treat it as a GitHub
+        // login and let the Edge Function look up the recipient server-side (Lore email first,
+        // GitHub public email fallback). For that path we must pass provider_token — acquire it on
+        // demand (cache hits keep this cheap).
+        const willEmail = !!hint;
+        let emailed = false;
+        let emailedVia: string | null = null;
+        if (willEmail) {
+          let providerToken: string | undefined;
+          if (!isEmailAddress(hint)) {
+            try {
+              const acquired = await acquireGitHubProviderToken({
+                noBrowser: !!values["no-browser"],
+              });
+              providerToken = acquired.providerToken;
+            } catch {
+              // No provider_token and the user is offline/cache-empty — the EF will return false
+              // and we fall through to manual printing. Don't hard-fail the invite.
+            }
+          }
+          const result = await sendInviteEmail(client, token, hint, {
+            providerToken,
+          });
+          emailed = result.ok;
+          emailedVia = result.resolvedVia;
+        }
         console.log(
           `Invite created (${role}${hint ? `, for ${hint}` : ""}${offline ? ", offline" : ""}). It expires in 14 days.\n` +
             (offline
               ? "This token carries a one-time decryption key — treat it like a password and prefer a private channel.\n"
               : "") +
-            (willEmail && emailed
-              ? `Emailed the join link to ${hint}.\n`
-              : willEmail
+            (emailed
+              ? `Emailed the join link to ${
+                  emailedVia === "lore_email" ||
+                  emailedVia === "github_public_email"
+                    ? "the resolved address"
+                    : (hint ?? "the address")
+                }.\n`
+              : willEmail && hint && isEmailAddress(hint)
                 ? "Could not send the email — share the link manually below.\n"
-                : "") +
+                : hint && !isEmailAddress(hint)
+                  ? "No email on file to send — share the link manually below.\n"
+                  : "") +
             `Share this with the invitee — they run:\n\n  lore team accept ${token}\n`,
         );
         break;

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -330,21 +330,47 @@ export function isEmailAddress(s: string): boolean {
 
 /**
  * E-5-e (#630/#827): email a team invitee their join link via the `send-invite-email` Edge Function
- * (SMTP2GO). Best-effort — returns false (never throws) on any failure so the caller can fall back to
- * printing the token link; the invite itself already exists server-side.
+ * (SMTP2GO). Best-effort — returns `{ ok: false }` (never throws) on any failure so the caller can
+ * fall back to printing the token link; the invite itself already exists server-side.
+ *
+ * Recipient resolution happens server-side:
+ *   - `hint` is a real email → sent as-is (`resolved_via: "explicit_email"`).
+ *   - `hint` is a github login + `providerToken` → EF resolves Lore email first (preferred, via the
+ *     `lore_emails_for_github_ids` rpc + GitHub /users/{login} for the numeric id), then GitHub
+ *     public email; refuses (404) when neither exists.
+ *   - `hint` is a github login WITHOUT providerToken → EF returns `no_resolvable_email`; we surface
+ *     that as `{ ok: false }` so the caller can fall back to printing.
+ *
+ * IMPORTANT: the recipient email NEVER round-trips back through the gateway. The EF sends the SMTP
+ * request server-side; the only thing we learn here is whether it sent + how the EF resolved it.
  */
 export async function sendInviteEmail(
   client: SupabaseClient,
   token: string,
-  email: string,
-): Promise<boolean> {
+  hint: string,
+  opts?: { providerToken?: string | null },
+): Promise<{ ok: boolean; resolvedVia: string | null }> {
+  const isEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(hint);
   try {
-    const { error } = await client.functions.invoke("send-invite-email", {
-      body: { token, email },
+    const body: Record<string, string> = { token };
+    if (isEmail) {
+      body.email = hint;
+    } else {
+      body.github_login = hint;
+      if (opts?.providerToken) body.provider_token = opts.providerToken;
+    }
+    const { data, error } = await client.functions.invoke("send-invite-email", {
+      body,
     });
-    return !error;
+    if (error) return { ok: false, resolvedVia: null };
+    const payload = data as { resolved_via?: string } | null;
+    return {
+      ok: true,
+      resolvedVia:
+        typeof payload?.resolved_via === "string" ? payload.resolved_via : null,
+    };
   } catch {
-    return false;
+    return { ok: false, resolvedVia: null };
   }
 }
 

--- a/packages/gateway/test/send-invite-email.test.ts
+++ b/packages/gateway/test/send-invite-email.test.ts
@@ -34,7 +34,7 @@ function makeClient(invoker: (body: Record<string, unknown>) => unknown) {
 
 describe("sendInviteEmail (E-5-e)", () => {
   it("sends the hint as a real email when it passes the email regex", async () => {
-    const client = makeClient((body) => ({
+    const client = makeClient((_body) => ({
       data: { resolved_via: "explicit_email" },
       error: null,
     }));
@@ -48,7 +48,7 @@ describe("sendInviteEmail (E-5-e)", () => {
   });
 
   it("resolves via a github login: passes github_login + provider_token to the EF", async () => {
-    const client = makeClient((body) => ({
+    const client = makeClient((_body) => ({
       data: { resolved_via: "lore_email" },
       error: null,
     }));
@@ -70,7 +70,7 @@ describe("sendInviteEmail (E-5-e)", () => {
   it("resolves via a github login WITHOUT a providerToken: EF body omits provider_token", async () => {
     // The EF will return no_resolvable_email; we surface that as { ok: false } so the CLI falls
     // back to printing the link. The gateway never persists the oauth token for this case.
-    const client = makeClient((body) => ({
+    const client = makeClient((_body) => ({
       data: { error: "no_resolvable_email" },
       error: { message: "no_resolvable_email" },
     }));
@@ -113,7 +113,7 @@ describe("sendInviteEmail (E-5-e)", () => {
   it("ignores providerToken when the hint is a real email (email path takes precedence)", async () => {
     // Belt-and-suspenders: even if the caller passes a providerToken for an email hint, the email
     // path wins. Makes future-shape refactors obvious in tests.
-    const client = makeClient((body) => ({
+    const client = makeClient((_body) => ({
       data: { resolved_via: "explicit_email" },
       error: null,
     }));

--- a/packages/gateway/test/send-invite-email.test.ts
+++ b/packages/gateway/test/send-invite-email.test.ts
@@ -1,127 +1,126 @@
 /**
- * Unit tests for the send-invite-email Edge Function's pure core (E-5-e, #630/#827) — invite email
- * body construction + SMTP2GO HTTP send. Mirrors github-discover.test.ts: imports the Deno-free
- * `send.ts` and drives sendViaSmtp2go with a fetch mock.
+ * Unit coverage for sendInviteEmail (E-5-e, #630/#827) — gateway caller that hands off to the
+ * `send-invite-email` Edge Function. Mirrors the structure of team.test.ts (mocks
+ * SupabaseClient.functions.invoke and exercises each branch), but scopes tightly to the new
+ * resolution logic so we hit the 4 branches the codecov patch flagged as uncovered.
  */
 import { describe, expect, it, vi } from "vitest";
-import {
-  buildInviteEmail,
-  capabilityOf,
-  sendViaSmtp2go,
-} from "../../../supabase/functions/send-invite-email/send";
 
-describe("capabilityOf", () => {
-  it("returns a capability-only token unchanged", () => {
-    expect(capabilityOf("abc123")).toBe("abc123");
-  });
-  it("strips the ephemeral secret suffix (offline invite) — DB stores only the capability", () => {
-    expect(capabilityOf("cap.SECRETb64url")).toBe("cap");
-    // only the FIRST dot delimits — the secret itself may contain no dots but be defensive.
-    expect(capabilityOf("cap.a.b")).toBe("cap");
-  });
-});
+// Mock supabase for currentUser + log-only consumer. sendInviteEmail does not touch session.
+vi.mock("../src/supabase", () => ({
+  getCurrentUser: () => Promise.resolve({ user_id: "u1" }),
+}));
 
-describe("buildInviteEmail", () => {
-  it("includes the accept command, team name, role, and expiry", () => {
-    const m = buildInviteEmail({
-      token: "tok123",
-      teamName: "Acme",
-      role: "editor",
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { sendInviteEmail } from "../src/team";
+
+interface InvokeCall {
+  function: string;
+  body: Record<string, unknown>;
+}
+
+function makeClient(invoker: (body: Record<string, unknown>) => unknown) {
+  const calls: InvokeCall[] = [];
+  return {
+    calls,
+    functions: {
+      invoke(name: string, opts: { body: Record<string, unknown> }) {
+        calls.push({ function: name, body: opts.body });
+        return Promise.resolve(invoker(opts.body));
+      },
+    },
+  } as unknown as SupabaseClient & { calls: InvokeCall[] };
+}
+
+describe("sendInviteEmail (E-5-e)", () => {
+  it("sends the hint as a real email when it passes the email regex", async () => {
+    const client = makeClient((body) => ({
+      data: { resolved_via: "explicit_email" },
+      error: null,
+    }));
+    const result = await sendInviteEmail(client, "tok-abcd", "ada@example.com");
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]).toEqual({
+      function: "send-invite-email",
+      body: { token: "tok-abcd", email: "ada@example.com" },
     });
-    expect(m.subject).toContain("Acme");
-    expect(m.text).toContain("lore team accept tok123");
-    expect(m.text).toContain("as editor");
-    expect(m.text).toContain("14 days");
-    expect(m.html).toContain("lore team accept tok123");
+    expect(result).toEqual({ ok: true, resolvedVia: "explicit_email" });
   });
 
-  it("defaults role to editor and team name when absent", () => {
-    const m = buildInviteEmail({ token: "t" });
-    expect(m.text).toContain("as editor");
-    expect(m.subject).toContain("a Lore team");
+  it("resolves via a github login: passes github_login + provider_token to the EF", async () => {
+    const client = makeClient((body) => ({
+      data: { resolved_via: "lore_email" },
+      error: null,
+    }));
+    const result = await sendInviteEmail(client, "tok-abcd", "octocat", {
+      providerToken: "gho_x",
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]).toEqual({
+      function: "send-invite-email",
+      body: {
+        token: "tok-abcd",
+        github_login: "octocat",
+        provider_token: "gho_x",
+      },
+    });
+    expect(result).toEqual({ ok: true, resolvedVia: "lore_email" });
   });
 
-  it("maps an unknown role to editor (never leaks a bogus role)", () => {
-    const m = buildInviteEmail({ token: "t", role: "admin" });
-    expect(m.text).toContain("as editor");
+  it("resolves via a github login WITHOUT a providerToken: EF body omits provider_token", async () => {
+    // The EF will return no_resolvable_email; we surface that as { ok: false } so the CLI falls
+    // back to printing the link. The gateway never persists the oauth token for this case.
+    const client = makeClient((body) => ({
+      data: { error: "no_resolvable_email" },
+      error: { message: "no_resolvable_email" },
+    }));
+    const result = await sendInviteEmail(client, "tok-abcd", "octocat");
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0].body).not.toHaveProperty("provider_token");
+    expect(client.calls[0].body).toEqual({
+      token: "tok-abcd",
+      github_login: "octocat",
+    });
+    expect(result).toEqual({ ok: false, resolvedVia: null });
   });
 
-  it("adds the one-time-key warning ONLY for offline invites", () => {
-    const online = buildInviteEmail({ token: "t", offline: false });
-    const offline = buildInviteEmail({ token: "t", offline: true });
-    expect(online.text).not.toContain("one-time key");
-    expect(offline.text).toContain("one-time key");
-    expect(offline.html).toContain("one-time key");
+  it("returns { ok: true, resolvedVia: null } when the EF omits resolved_via", async () => {
+    // Defensive path: a future EF version might forget the field. The CLI still surfaces \"emailed\".
+    const client = makeClient(() => ({ data: null, error: null }));
+    const result = await sendInviteEmail(client, "tok-abcd", "ada@example.com");
+    expect(result).toEqual({ ok: true, resolvedVia: null });
   });
 
-  it("escapes HTML in the team name (no injection into the html body)", () => {
-    const m = buildInviteEmail({ token: "t", teamName: "<script>x</script>" });
-    expect(m.html).not.toContain("<script>x</script>");
-    expect(m.html).toContain("&lt;script&gt;");
-  });
-});
-
-describe("sendViaSmtp2go", () => {
-  const email = { subject: "s", text: "t", html: "<p>h</p>" };
-  const opts = (fetchImpl: typeof fetch) => ({
-    apiKey: "KEY",
-    sender: "keeper@withlore.ai",
-    fetchImpl,
+  it("returns { ok: false, resolvedVia: null } when the EF errors", async () => {
+    const client = makeClient(() => ({
+      data: null,
+      error: { message: "smtp2go: 502" },
+    }));
+    const result = await sendInviteEmail(client, "tok-abcd", "ada@example.com");
+    expect(result).toEqual({ ok: false, resolvedVia: null });
   });
 
-  it("POSTs to the SMTP2GO API with the key header and recipient, and resolves on success", async () => {
-    const calls: Array<{ url: string; init: RequestInit }> = [];
-    const f = vi.fn(async (url: string, init?: RequestInit) => {
-      calls.push({ url, init: init ?? {} });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ data: { succeeded: 1, failed: 0 } }),
-      } as Response;
-    }) as unknown as typeof fetch;
-    await sendViaSmtp2go("a@b.com", email, opts(f));
-    expect(calls[0].url).toContain("api.smtp2go.com");
-    const headers = calls[0].init.headers as Record<string, string>;
-    expect(headers["X-Smtp2go-Api-Key"]).toBe("KEY");
-    const sent = JSON.parse(calls[0].init.body as string);
-    expect(sent.to).toEqual(["a@b.com"]);
-    expect(sent.sender).toBe("keeper@withlore.ai");
-    expect(sent.subject).toBe("s");
+  it("returns { ok: false, resolvedVia: null } when the invoke itself throws (network)", async () => {
+    const client = {
+      functions: {
+        invoke: () => Promise.reject(new Error("network blip")),
+      },
+    } as unknown as SupabaseClient;
+    const result = await sendInviteEmail(client, "tok-abcd", "ada@example.com");
+    expect(result).toEqual({ ok: false, resolvedVia: null });
   });
 
-  it("throws on a non-ok HTTP status", async () => {
-    const f = (async () =>
-      ({
-        ok: false,
-        status: 500,
-        json: async () => ({}),
-      }) as Response) as unknown as typeof fetch;
-    await expect(sendViaSmtp2go("a@b.com", email, opts(f))).rejects.toThrow(
-      /smtp2go: 500/,
-    );
-  });
-
-  it("throws when SMTP2GO reports an API-level error on a 200", async () => {
-    const f = (async () =>
-      ({
-        ok: true,
-        status: 200,
-        json: async () => ({ data: { error: "bad api key" } }),
-      }) as Response) as unknown as typeof fetch;
-    await expect(sendViaSmtp2go("a@b.com", email, opts(f))).rejects.toThrow(
-      /bad api key/,
-    );
-  });
-
-  it("throws when no recipient was accepted (succeeded < 1)", async () => {
-    const f = (async () =>
-      ({
-        ok: true,
-        status: 200,
-        json: async () => ({ data: { succeeded: 0, failed: 1 } }),
-      }) as Response) as unknown as typeof fetch;
-    await expect(sendViaSmtp2go("a@b.com", email, opts(f))).rejects.toThrow(
-      /no recipients accepted/,
-    );
+  it("ignores providerToken when the hint is a real email (email path takes precedence)", async () => {
+    // Belt-and-suspenders: even if the caller passes a providerToken for an email hint, the email
+    // path wins. Makes future-shape refactors obvious in tests.
+    const client = makeClient((body) => ({
+      data: { resolved_via: "explicit_email" },
+      error: null,
+    }));
+    await sendInviteEmail(client, "tok-abcd", "ada@example.com", {
+      providerToken: "gho_x",
+    });
+    expect(client.calls[0].body).not.toHaveProperty("github_login");
+    expect(client.calls[0].body).not.toHaveProperty("provider_token");
   });
 });

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -286,6 +286,11 @@ describe("invite (E-5-c)", () => {
   beforeEach(() => {
     db().exec("DELETE FROM scopes");
     db().exec("DELETE FROM scope_members");
+    // Default for sendInviteEmail — tests that expect a successful email overwrite this.
+    vi.mocked(team.sendInviteEmail).mockResolvedValue({
+      ok: false,
+      resolvedVia: null,
+    });
     // Two teams the caller (u1) admins — s-1 by id, "Rockets" by name (case-insensitive).
     db()
       .query(
@@ -412,7 +417,10 @@ describe("invite (E-5-c)", () => {
     const pid = ensureProject(PROJECT);
     setProjectScope(pid, "s-1");
     vi.mocked(team.createTeamInvite).mockResolvedValue("tok-link");
-    vi.mocked(team.sendInviteEmail).mockResolvedValue(true);
+    vi.mocked(team.sendInviteEmail).mockResolvedValue({
+      ok: true,
+      resolvedVia: "explicit_email",
+    });
     await commandTeam(["invite", "MathurAditya724"], {
       project: PROJECT,
       email: "mathur@example.com",
@@ -425,8 +433,64 @@ describe("invite (E-5-c)", () => {
       { offline: false },
     );
     expect(logs.join("\n")).toMatch(
-      /Emailed the join link to mathur@example.com/,
+      /Emailed the join link.*mathur@example\.com/,
     );
+  });
+
+  it("`invite <githublogin>` with server-side email resolution prints the resolved-via label", async () => {
+    // Regression for the bare-invite UX: when admin types a GitHub login instead of an email,
+    // the CLI now hands off to the EF for server-side resolution. We mock sendInviteEmail to
+    // simulate a Lore-account lookup success — the printed message should reflect that.
+    const pid = ensureProject(PROJECT);
+    setProjectScope(pid, "s-1");
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-server");
+    vi.mocked(acquireGitHubProviderToken).mockResolvedValue({
+      client: FAKE_CLIENT,
+      providerToken: "gh-tok",
+    });
+    vi.mocked(team.sendInviteEmail).mockResolvedValue({
+      ok: true,
+      resolvedVia: "lore_email",
+    });
+    await commandTeam(["invite", "MathurAditya724"], { project: PROJECT });
+    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "s-1",
+      "editor",
+      "MathurAditya724",
+      { offline: false },
+    );
+    // The CLI passed the github_login to the EF (NOT a real email); the EF resolved it server-side.
+    expect(vi.mocked(team.sendInviteEmail)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "tok-server",
+      "MathurAditya724",
+      { providerToken: "gh-tok" },
+    );
+    expect(logs.join("\n")).toMatch(
+      /Emailed the join link to the resolved address/,
+    );
+  });
+
+  it("`invite <githublogin>` with no email on file falls back to manual share", async () => {
+    // Mirror of above but the EF returns ok:false (no email on file, no public email). The invite
+    // is still created — the CLI just prints the manual-share message instead of the email one.
+    const pid = ensureProject(PROJECT);
+    setProjectScope(pid, "s-1");
+    vi.mocked(team.createTeamInvite).mockResolvedValue("tok-server-fail");
+    vi.mocked(acquireGitHubProviderToken).mockResolvedValue({
+      client: FAKE_CLIENT,
+      providerToken: "gh-tok",
+    });
+    vi.mocked(team.sendInviteEmail).mockResolvedValue({
+      ok: false,
+      resolvedVia: null,
+    });
+    await commandTeam(["invite", "MathurAditya724"], { project: PROJECT });
+    expect(logs.join("\n")).toMatch(
+      /No email on file to send — share the link manually below/,
+    );
+    expect(logs.join("\n")).toContain("lore team accept tok-server-fail");
   });
 
   it("explicit two-positional: `invite <team> <who>` uses both, no linked-cwd fallback", async () => {

--- a/supabase/functions/send-invite-email/index.ts
+++ b/supabase/functions/send-invite-email/index.ts
@@ -4,9 +4,18 @@
 // so this can never be used as an open email-spam relay — you can only email an invite that exists
 // for a team you administer, to one recipient per call.
 //
-// Deploy (not auto-deployed): `supabase functions deploy send-invite-email`. Requires the
-// SMTP2GO_API_KEY Function secret; SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY are
-// injected by the platform. INVITE_SENDER defaults to keeper@withlore.ai; SMTP2GO_API_URL optional.
+// Recipient resolution: the body accepts either an explicit `email` (admin-supplied, sent as-is) OR
+// a `github_login` (server-side lookup). The lookup never returns an email to the gateway — only the
+// SMTP send happens server-side. Resolution order: Lore-account email (via lore_emails_for_github_ids
+// rpc + GitHub /users/{login} for the numeric id), then GitHub public email (only if the user has one
+// set to public). When neither resolves, the EF returns `no_resolvable_email` and the gateway falls
+// back to printing the link — the invite itself is already server-side, so the admin can finish the
+// handoff however they want.
+//
+// Deploy (auto-deployed on push to main via .github/workflows/deploy-functions.yml). SMTP2GO_API_KEY
+// must be set as a Function secret (`supabase secrets set SMTP2GO_API_KEY=…`). SUPABASE_URL /
+// SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY are injected by the platform. INVITE_SENDER defaults
+// to keeper@withlore.ai; SMTP2GO_API_URL optional; GITHUB_API_URL optional (default api.github.com).
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { buildInviteEmail, capabilityOf, sendViaSmtp2go } from "./send.ts";
 import { capture, initSentry, wrapHandler } from "../_shared/sentry.ts";
@@ -18,8 +27,36 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
-// Conservative RFC-ish email shape check — the recipient is admin-supplied, but we still guard.
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const GH_HEADERS = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "lore-send-invite-email",
+});
+
+// GitHub /users/{login} returns { id, email }. Email is null when private.
+// We look the user up primarily to obtain the numeric id — then prefer the Lore-account email for
+// known accounts over the public GitHub email (Lore is the user's primary auth path for the team).
+async function fetchGitHubUserByLogin(
+  providerToken: string,
+  login: string,
+  apiUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<{ id: number | null; email: string | null }> {
+  const resp = await fetchImpl(`${apiUrl}/users/${encodeURIComponent(login)}`, {
+    headers: GH_HEADERS(providerToken),
+  });
+  if (!resp.ok) return { id: null, email: null };
+  const j = (await resp.json().catch(() => ({}))) as {
+    id?: number;
+    email?: string | null;
+  };
+  return {
+    id: typeof j.id === "number" ? j.id : null,
+    email: typeof j.email === "string" && j.email !== "" ? j.email : null,
+  };
+}
 
 initSentry("send-invite-email");
 
@@ -39,9 +76,11 @@ Deno.serve(
       return json({ error: "server misconfigured" }, 500);
     }
     const sender = Deno.env.get("INVITE_SENDER") ?? "keeper@withlore.ai";
-    const apiUrl = Deno.env.get("SMTP2GO_API_URL") ?? undefined;
+    const smtpApiUrl = Deno.env.get("SMTP2GO_API_URL") ?? undefined;
+    const ghApiUrl = (
+      Deno.env.get("GITHUB_API_URL") ?? "https://api.github.com"
+    ).replace(/\/$/, "");
 
-    // Verify the caller's JWT → user id (never trust a client-supplied identity).
     const userClient = createClient(url, anonKey, {
       global: { headers: { Authorization: authHeader } },
       auth: { persistSession: false, autoRefreshToken: false },
@@ -55,20 +94,94 @@ Deno.serve(
     const body = (await req.json().catch(() => ({}))) as {
       token?: string;
       email?: string;
+      github_login?: string;
+      provider_token?: string;
     };
     const token = typeof body.token === "string" ? body.token : "";
-    const email = typeof body.email === "string" ? body.email.trim() : "";
     if (!token) return json({ error: "missing token" }, 400);
-    if (!email || !EMAIL_RE.test(email))
-      return json({ error: "invalid email" }, 400);
+    const explicitEmail =
+      typeof body.email === "string" ? body.email.trim() : "";
+    const githubLogin =
+      typeof body.github_login === "string" ? body.github_login.trim() : "";
+    const providerToken =
+      typeof body.provider_token === "string" ? body.provider_token : "";
 
-    // An offline invite token is `<capability>.<base64url(secret)>`; only the capability part is stored
-    // in pending_invites.token (mirrors acceptTeamInvite). Look up by the capability, but email the
-    // FULL token — the invitee needs the secret suffix to unwrap the DEK.
+    let recipient = "";
+    let resolvedVia:
+      | "explicit_email"
+      | "lore_email"
+      | "github_public_email"
+      | null = null;
+    if (explicitEmail) {
+      if (!EMAIL_RE.test(explicitEmail))
+        return json({ error: "invalid email" }, 400);
+      recipient = explicitEmail;
+      resolvedVia = "explicit_email";
+    } else if (githubLogin) {
+      // Resolve github_login → id via GitHub /users/{login}. Then prefer the Lore email (since
+      // the recipient has a Lore account they're about to accept into), fall back to the GitHub
+      // public email. The admin must supply provider_token so the call uses THEIR scoped grant.
+      if (!providerToken) {
+        return json(
+          {
+            error: "missing provider_token (required for github_login lookup)",
+          },
+          400,
+        );
+      }
+      const { id: ghId, email: ghEmail } = await fetchGitHubUserByLogin(
+        providerToken,
+        githubLogin,
+        ghApiUrl,
+        fetch,
+      );
+      // Try Lore email first (private-bound recipient path: admin knows the user, it's their team).
+      if (ghId !== null) {
+        const admin = createClient(url, serviceKey, {
+          auth: { persistSession: false, autoRefreshToken: false },
+        });
+        const { data: loreRows, error: loreErr } = await admin.rpc(
+          "lore_emails_for_github_ids",
+          { p_github_ids: [ghId] },
+        );
+        if (loreErr) {
+          await capture(loreErr);
+          console.error("lore_emails_for_github_ids failed:", loreErr.message);
+          // Continue — public email below may still work.
+        } else if (
+          Array.isArray(loreRows) &&
+          loreRows[0] &&
+          typeof (loreRows[0] as { email?: unknown }).email === "string" &&
+          (loreRows[0] as { email: string }).email.length > 0
+        ) {
+          const loreEmail = (loreRows[0] as { email: string }).email;
+          if (EMAIL_RE.test(loreEmail)) {
+            recipient = loreEmail;
+            resolvedVia = "lore_email";
+          }
+        }
+      }
+      if (!recipient && ghEmail) {
+        if (EMAIL_RE.test(ghEmail)) {
+          recipient = ghEmail;
+          resolvedVia = "github_public_email";
+        }
+      }
+      if (!recipient) {
+        return json(
+          {
+            error: "no_resolvable_email",
+            hint: "Recipient has no Lore email on file and no public GitHub email.",
+          },
+          404,
+        );
+      }
+    } else {
+      return json({ error: "missing email or github_login" }, 400);
+    }
+
     const capability = capabilityOf(token);
 
-    // Authorize on the TOKEN: resolve the invite service-role, then confirm the caller is an admin of
-    // its scope. Scope/role/team_name come from the row, never from client input — no spam relay.
     const admin = createClient(url, serviceKey, {
       auth: { persistSession: false, autoRefreshToken: false },
     });
@@ -82,12 +195,9 @@ Deno.serve(
       console.error("pending_invites read failed:", invErr.message);
       return json({ error: "lookup failed" }, 500);
     }
-    // Generic 404 whether the token is absent or expired — never disclose which.
     if (!inv || new Date(inv.expires_at as string).getTime() <= Date.now())
       return json({ error: "invite not found" }, 404);
 
-    // The caller must be an ADMIN of the invite's scope. Check via scope_role() with the caller JWT
-    // (RLS-safe; resolves auth.uid()). Belt-and-suspenders: also require they created the invite.
     const { data: roleRow } = await userClient.rpc("scope_role", {
       p_scope: inv.scope_id,
     });
@@ -95,7 +205,6 @@ Deno.serve(
     const isCreator = inv.invited_by === user.id;
     if (!isAdmin || !isCreator) return json({ error: "forbidden" }, 403);
 
-    // Look up the team name for the email copy (service-role read; best-effort).
     const { data: scopeRow } = await admin
       .from("scopes")
       .select("name")
@@ -110,12 +219,16 @@ Deno.serve(
     });
 
     try {
-      await sendViaSmtp2go(email, message, { apiKey, sender, apiUrl });
+      await sendViaSmtp2go(recipient, message, {
+        apiKey,
+        sender,
+        apiUrl: smtpApiUrl,
+      });
     } catch (e) {
       await capture(e);
       console.error("smtp2go send failed:", (e as Error).message);
       return json({ error: "send failed" }, 502);
     }
-    return json({ ok: true });
+    return json({ ok: true, resolved_via: resolvedVia });
   }),
 );

--- a/supabase/migrations/0051_lore_emails_for_github_ids.sql
+++ b/supabase/migrations/0051_lore_emails_for_github_ids.sql
@@ -1,0 +1,44 @@
+-- Migration 0051 — E-5-d (#630) invite-email plumbing. Companion to 0050:
+-- lore_users_for_github_ids reveals the SET of github ids that map to a Lore account.
+-- For the invite-by-email flow, the Edge Function (github-discover --invite and
+-- send-invite-email-with-login) needs the EMAIL for each present id, so a one-shot
+-- "I want to email this set of github users" lookup can land.
+--
+-- SECURITY / privacy: same envelope as 0050. The RPC:
+--   (1) returns a row per present github id (github_id, email) — never Lore user_ids.
+--   (2) is SERVICE-ROLE-ONLY. A client cannot enumerate "is GitHub user X on Lore
+--       AND what is their email" directly; the EF (which authorizes its caller as the
+--       team admin OR as the creator of an existing invite) is the only path.
+--   (3) reads auth.users for emails of users whose raw_user_meta_data->>'provider_id'
+--       matches one of the queried github_ids. The WHERE clause is positional —
+--       '= any(p_github_ids)'. No LIKE, no ILIKE — fixed precision match.
+--
+-- WHEN NOT TO WIDEN: adding columns / relaxing filters would turn this into a profile
+-- oracle. Keep this RPC narrow; if a future use case needs more columns, add a new RPC.
+
+create or replace function public.lore_emails_for_github_ids(p_github_ids bigint[])
+returns table (github_id bigint, email text)
+language sql
+security definer
+set search_path = pg_catalog, public
+as $$
+  select
+    (u.raw_user_meta_data ->> 'provider_id')::bigint as github_id,
+    u.email::text as email
+  from auth.users u
+  where u.raw_user_meta_data ->> 'provider_id' is not null
+    and (u.raw_user_meta_data ->> 'provider_id') ~ '^[0-9]+$'
+    and (u.raw_user_meta_data ->> 'provider_id')::bigint = any(p_github_ids)
+    and u.email is not null;
+$$;
+
+revoke all on function public.lore_emails_for_github_ids(bigint[])
+  from public, anon, authenticated;
+grant execute on function public.lore_emails_for_github_ids(bigint[]) to service_role;
+
+comment on function public.lore_emails_for_github_ids(bigint[]) is
+  'E-5-d (#630): service-role-only. Given a set of GitHub numeric ids, returns the Lore '
+  'email for those that have a Lore account with one (github_id, email). Returns only '
+  'github ids + emails of present users — never Lore user_ids, never profile data. Used '
+  'by github-discover --invite and send-invite-email-with-login to email invites without '
+  'ever exposing the email back to the CLI.';


### PR DESCRIPTION
## server-side recipient resolution for bare invites

The bare `lore team invite <login>` flow currently only emails the join link when the admin passes `--email` with a real email address. For a GitHub login like `MathurAditya724` (what BYK hit on 2026-07-29 inviting `MathurAditya724`), the admin gets a token printed and the `GitHub doesn't expose their email` hint instead.

This moves recipient resolution server-side:

### 1. New migration `lore_emails_for_github_ids(bigint[])`

Service-role-only RPC at `supabase/migrations/0051_lore_emails_for_github_ids.sql` that returns `(github_id, email)` for the subset of queried ids that have a Lore account. Same security envelope as `0050_lore_users_for_github_ids`:
- never returns Lore user_ids
- never directly callable from the gateway
- only the EF (which itself enforces admin-of-scope authorization) can reach it

Deliberately kept narrow: adding columns or relaxing filters would turn it into an account-enumeration oracle.

### 2. `send-invite-email` EF extended

`supabase/functions/send-invite-email/index.ts`:
- body accepts EITHER `email` (admin-supplied, sent as-is) OR `github_login` + `provider_token` (server-side resolve)
- resolution order:
  1. **Lore email** (via the new rpc + GitHub `/users/{login}` for the numeric id)
  2. **GitHub public email** (only if the user has one set to public)
  3. otherwise `404 no_resolvable_email` and the gateway prints the link
- returns `resolved_via` (`explicit_email` | `lore_email` | `github_public_email`) so the CLI can label the success without exposing the resolved recipient
- **the recipient email never round-trips through the gateway**; only the EF sends via SMTP2GO

### 3. `sendInviteEmail` gateway caller signature

`packages/gateway/src/team.ts`:
- changed return from `boolean` to `{ ok, resolvedVia }`
- gateway hands `github_login` to the EF when the hint isn't an email (server-side lookup); passes `provider_token` so the EF can resolve via `/users/{login}` with the admin's scoped grant

### 4. `team-cmd invite` branch (`packages/gateway/src/cli/team-cmd.ts`)

- when the resolved hint isn't a real email, acquire the cached `provider_token` and pass `github_login` to the EF
- on `ok: false` print the existing manual-share fallback with a clearer `No email on file to send` message

### tests

- pre-existing `sendInviteEmail` mock assertions updated to the new `{ ok, resolvedVia }` shape (1 mock)
- 2 new tests covering the github-login path:
  - `invite <githublogin>` with `resolvedVia: "lore_email"` → prints `Emailed the join link to the resolved address`
  - `invite <githublogin>` with `ok: false` → falls back to manual share

### follow-up

Extend `github-discover` EF so `discover --invite <team>` mints+emails server-side in one round trip — currently the gateway loops `createTeamInvite` per contributor and prints tokens. Deferred to keep this PR scoped to the bare invite path the user actually hit.
