### PR TITLE
feat(discover --invite): server-side mint+email in one round trip

### DIFF
--- a/packages/gateway/src/cli/team-cmd.ts
+++ b/packages/gateway/src/cli/team-cmd.ts
@@ -27,7 +27,6 @@ import {
   createTeam,
   createTeamInvite,
   discoverGitHubContributors,
-  distinctContributors,
   isEmailAddress,
   listDomainJoinRequests,
   listTeams,
@@ -140,37 +139,17 @@ export async function commandTeam(
           process.exitCode = 1;
           return;
         }
-        const found = await discoverGitHubContributors(
-          freshClient,
-          providerToken,
-          repos,
-        );
-        if (!found || found.length === 0) {
-          console.log("No accessible repos with contributors found.");
-          break;
-        }
-        let onLoreTotal = 0;
-        let offLoreTotal = 0;
-        for (const r of found) {
-          if (r.contributors.length === 0) continue;
-          console.log(`\n${r.repo}`);
-          for (const c of r.contributors) {
-            if (c.onLore) onLoreTotal++;
-            else offLoreTotal++;
-            console.log(
-              `  ${c.onLore ? "✓ on Lore  " : "· not yet  "} ${c.login}`,
-            );
-          }
-        }
 
-        // E-5-d-2: --invite <team> mints an invite per DISTINCT contributor so the admin can hand
-        // out join links. Invite-only for everyone (on-Lore or not) — we never expose Lore user_ids,
-        // so there is no direct auto-add; an on-Lore invitee just gets a frictionless `accept`.
-        // GitHub's API returns no contributor emails, so links are printed rather than auto-emailed.
+        // Resolve --invite <team> ahead of the discovery call so we can pass invite_to_scope into
+        // the EF and have it mint+email server-side (E-5-d-2 + E-5-e). The admin pre-checks
+        // (resolveWritableScope + scopeMemberRole mirror) save us a wasted round trip when the
+        // invitee isn't actually allowed to invite to the named scope.
         const inviteRef = values.invite as string | undefined;
+        let resolvedInvite: {
+          scopeId: string;
+          role: "editor" | "viewer";
+        } | null = null;
         if (inviteRef !== undefined) {
-          // A trailing `--invite` with no value parses as `true` under strict:false — reject it
-          // clearly instead of letting a non-string reach the scope lookup.
           if (typeof inviteRef !== "string") {
             console.error("`--invite` requires a team name or id.");
             process.exitCode = 1;
@@ -182,8 +161,6 @@ export async function commandTeam(
             process.exitCode = 1;
             return;
           }
-          // Resolve the target scope: an explicit team name/id, or — when the value doesn't resolve
-          // and the cwd is a project already linked to a team — that linked scope (repo→scope corr.).
           let scope = resolveWritableScope(inviteRef, user.user_id);
           if (!scope) {
             const pid = projectId(process.cwd());
@@ -198,8 +175,6 @@ export async function commandTeam(
             process.exitCode = 1;
             return;
           }
-          // Only admins may mint invites (server enforces this too). Pre-check the local mirror so an
-          // editor gets ONE clear message instead of N identical per-contributor RPC rejections.
           if (scopeMemberRole(scope.id, user.user_id) !== "admin") {
             console.error(
               `\nYou must be an admin of "${scope.name ?? scope.id}" to invite members.`,
@@ -207,38 +182,68 @@ export async function commandTeam(
             process.exitCode = 1;
             return;
           }
-          const inviteRole =
-            (values.role as string) === "viewer" ? "viewer" : "editor";
-          const people = distinctContributors(found);
-          if (people.length === 0) {
+          resolvedInvite = {
+            scopeId: scope.id,
+            role: (values.role as string) === "viewer" ? "viewer" : "editor",
+          };
+        }
+
+        const discovery = await discoverGitHubContributors(
+          freshClient,
+          providerToken,
+          repos,
+          resolvedInvite ?? undefined,
+        );
+        if (!discovery || discovery.repos.length === 0) {
+          console.log("No accessible repos with contributors found.");
+          break;
+        }
+        let onLoreTotal = 0;
+        let offLoreTotal = 0;
+        for (const r of discovery.repos) {
+          if (r.contributors.length === 0) continue;
+          console.log(`\n${r.repo}`);
+          for (const c of r.contributors) {
+            if (c.onLore) onLoreTotal++;
+            else offLoreTotal++;
             console.log(
-              "\nNo contributors to invite (the accessible repos have none). Nothing minted.",
+              `  ${c.onLore ? "✓ on Lore  " : "· not yet  "} ${c.login}`,
+            );
+          }
+        }
+
+        // Server-side invite phase — the EF has already minted+emailed (best-effort), and the report
+        // tells us how many went by email vs how many came back unsent (no resolvable recipient).
+        if (resolvedInvite && discovery.invited) {
+          const inv = discovery.invited;
+          if (inv.total === 0) {
+            console.log(
+              "\nNo accessible repos with contributors found (nothing to invite).",
             );
             break;
           }
           console.log(
-            `\nMinting ${inviteRole} invites to "${scope.name ?? scope.id}" for ${people.length} contributor${people.length === 1 ? "" : "s"}:`,
+            `\n${inv.role} invites to scope ${inv.scopeId}: ` +
+              `emailed ${inv.emailed}, no-email ${inv.noEmail}` +
+              (inv.overCap > 0 ? `, skipped ${inv.overCap} (over cap)` : "") +
+              ".",
           );
-          for (const c of people) {
-            try {
-              const token = await createTeamInvite(
-                client,
-                scope.id,
-                inviteRole,
-              );
+          const printable = inv.results.filter(
+            (r) => r.status !== "emailed" && r.token,
+          );
+          if (printable.length > 0) {
+            console.log("\nCould not email — share these manually:");
+            for (const r of printable) {
               console.log(
-                `  ${c.login}${c.onLore ? " (on Lore)" : ""}:\n    lore team accept ${token}`,
-              );
-            } catch (e) {
-              console.error(
-                `  ${c.login}: invite failed — ${(e as Error).message}`,
+                `  ${r.login} (${r.status}):\n    lore team accept ${r.token}`,
               );
             }
           }
-          console.log(
-            "\nShare each link with the matching contributor (GitHub doesn't expose their email). " +
-              "To email an address directly, use `lore team invite <scope> --email <addr>`.",
-          );
+          if (inv.emailed === 0 && printable.length === 0 && inv.total > 0) {
+            console.log(
+              "\nNo invites sent. Either nobody had a resolvable email or all sends failed.",
+            );
+          }
           break;
         }
 

--- a/packages/gateway/src/team.ts
+++ b/packages/gateway/src/team.ts
@@ -50,18 +50,34 @@ export interface DiscoveredRepo {
  * the caller can actually read on GitHub, and only as an `onLore` boolean (never a Lore user id).
  *
  * Contributors, NOT collaborators: GitHub's `/repos/{owner}/{name}/collaborators` returns
- * "everyone with at least triage access" — which for a private org repo is effectively the entire
- * org roster (everyone typically gets triage via org rules). `/contributors` returns the commit-
- * attribution roster instead, which is what admins actually want when scanning "who worked here".
+ * "everyone with at least triage" — which for a private org repo is effectively the entire org roster
+ * (everyone typically gets triage via org rules). `/contributors` returns the commit-attribution
+ * roster instead, which is what admins actually want when scanning "who worked here".
+ *
+ * Optional `invite` opts in to server-side invite minting+emailing. When provided:
+ *   - `scopeId` is the UUID of the team to invite to; the EF enforces admin via `scope_role` + RLS.
+ *   - `role` is `editor` (default) or `viewer`.
+ *   - The EF mints one invite per distinct contributor, resolves each recipient server-side (Lore
+ *     email preferred, GitHub public email fallback), and emails them via `send-invite-email`.
+ *   - Contributors without a resolvable email get a token back in `invited.results[]` for manual
+ *     share — the gateway prints them.
+ *   - The resolved recipient email NEVER round-trips through the gateway.
  */
 export async function discoverGitHubContributors(
   client: SupabaseClient,
   providerToken: string | null | undefined,
   repos?: string[],
-): Promise<DiscoveredRepo[] | null> {
+  invite?: { scopeId: string; role: "editor" | "viewer" },
+): Promise<{ repos: DiscoveredRepo[]; invited?: DiscoverInviteReport } | null> {
   if (!providerToken) return null; // no read:org/repo grant (older session / non-github login)
+  const body: Record<string, unknown> = {
+    provider_token: providerToken,
+    repos,
+  };
+  if (invite) body.invite_to_scope = invite.scopeId;
+  if (invite) body.invite_role = invite.role;
   const { data, error } = await client.functions.invoke("github-discover", {
-    body: { provider_token: providerToken, repos },
+    body,
   });
   if (error) throw await enrichFunctionsError("github-discover", error);
   const payload = data as {
@@ -73,8 +89,28 @@ export async function discoverGitHubContributors(
         on_lore: boolean;
       }>;
     }>;
+    invited?: {
+      scope_id: string;
+      role: string;
+      total: number;
+      emailed: number;
+      no_email: number;
+      over_cap: number;
+      results: Array<{
+        login: string;
+        status:
+          | "emailed"
+          | "no_email"
+          | "forbidden"
+          | "invite_failed"
+          | "send_failed"
+          | "skipped";
+        resolved_via: "lore_email" | "github_public_email" | null;
+        token?: string;
+      }>;
+    };
   };
-  return (payload.repos ?? []).map((r) => ({
+  const discoveredRepos = (payload.repos ?? []).map((r) => ({
     repo: r.repo,
     contributors: r.contributors.map((c) => ({
       login: c.login,
@@ -82,6 +118,46 @@ export async function discoverGitHubContributors(
       onLore: c.on_lore,
     })),
   }));
+  return {
+    repos: discoveredRepos,
+    invited: payload.invited
+      ? {
+          scopeId: payload.invited.scope_id,
+          role: payload.invited.role as "editor" | "viewer",
+          total: payload.invited.total,
+          emailed: payload.invited.emailed,
+          noEmail: payload.invited.no_email,
+          overCap: payload.invited.over_cap,
+          results: payload.invited.results.map((r) => ({
+            login: r.login,
+            status: r.status,
+            resolvedVia: r.resolved_via,
+            token: r.token,
+          })),
+        }
+      : undefined,
+  };
+}
+
+export interface DiscoverInviteReport {
+  scopeId: string;
+  role: "editor" | "viewer";
+  total: number;
+  emailed: number;
+  noEmail: number;
+  overCap: number;
+  results: Array<{
+    login: string;
+    status:
+      | "emailed"
+      | "no_email"
+      | "forbidden"
+      | "invite_failed"
+      | "send_failed"
+      | "skipped";
+    resolvedVia: "lore_email" | "github_public_email" | null;
+    token?: string;
+  }>;
 }
 
 /**

--- a/packages/gateway/test/team-cmd.test.ts
+++ b/packages/gateway/test/team-cmd.test.ts
@@ -757,52 +757,74 @@ describe("discover --invite (E-5-d-2)", () => {
       client: FAKE_CLIENT,
       providerToken: "gho_x",
     });
-    vi.mocked(team.discoverGitHubContributors).mockResolvedValue([
-      {
-        repo: "o/a",
-        contributors: [
-          { login: "alice", githubId: 1, onLore: true },
-          { login: "bob", githubId: 2, onLore: false },
+    // EF now does the mint+email server-side; the gateway just receives an `invited` report.
+    vi.mocked(team.discoverGitHubContributors).mockResolvedValue({
+      repos: [
+        {
+          repo: "o/a",
+          contributors: [
+            { login: "alice", githubId: 1, onLore: true },
+            { login: "bob", githubId: 2, onLore: false },
+          ],
+        },
+        {
+          repo: "o/b",
+          contributors: [{ login: "bob", githubId: 2, onLore: false }],
+        },
+      ],
+      invited: {
+        scopeId: "s9",
+        role: "editor",
+        total: 2,
+        emailed: 0,
+        noEmail: 2,
+        overCap: 0,
+        results: [
+          {
+            login: "alice",
+            status: "no_email",
+            resolvedVia: null,
+            token: "tok-alice",
+          },
+          {
+            login: "bob",
+            status: "no_email",
+            resolvedVia: null,
+            token: "tok-bob",
+          },
         ],
       },
-      {
-        repo: "o/b",
-        contributors: [{ login: "bob", githubId: 2, onLore: false }],
-      },
-    ] as never);
+    } as never);
   });
 
   it("mints ONE invite per distinct contributor and prints accept links", async () => {
-    vi.mocked(team.createTeamInvite)
-      .mockResolvedValueOnce("tok-alice")
-      .mockResolvedValueOnce("tok-bob");
     await commandTeam(["discover", "--invite", "Rockets"], {
       invite: "Rockets",
     });
-    // bob appears on two repos → deduped to a single invite (2 people, not 3).
-    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledTimes(2);
-    // resolved to the team scope id + default editor role.
-    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+    // EF does the minting — gateway never calls createTeamInvite. The gateway passes invite_to_scope
+    // + role to the EF so admins introspect their own (no-loop) request once.
+    expect(vi.mocked(team.discoverGitHubContributors)).toHaveBeenCalledWith(
       FAKE_CLIENT,
-      "s9",
-      "editor",
+      "gho_x",
+      ["Rockets"],
+      { scopeId: "s9", role: "editor" },
     );
     const out = logs.join("\n");
+    // The only-token-not-emailed ones get printed for manual share.
     expect(out).toMatch(/lore team accept tok-alice/);
     expect(out).toMatch(/lore team accept tok-bob/);
-    expect(out).toMatch(/alice \(on Lore\)/);
   });
 
   it("honors --role viewer", async () => {
-    vi.mocked(team.createTeamInvite).mockResolvedValue("tok");
     await commandTeam(["discover", "--invite", "Rockets"], {
       invite: "Rockets",
       role: "viewer",
     });
-    expect(vi.mocked(team.createTeamInvite)).toHaveBeenCalledWith(
+    expect(vi.mocked(team.discoverGitHubContributors)).toHaveBeenCalledWith(
       FAKE_CLIENT,
-      "s9",
-      "viewer",
+      "gho_x",
+      ["Rockets"],
+      { scopeId: "s9", role: "viewer" },
     );
   });
 
@@ -812,7 +834,7 @@ describe("discover --invite (E-5-d-2)", () => {
     });
     expect(process.exitCode).toBe(1);
     expect(errs.join("\n")).toMatch(/No team "Nonexistent"/);
-    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+    expect(vi.mocked(team.discoverGitHubContributors)).not.toHaveBeenCalled();
   });
 
   it("refuses an editor caller (only admins may invite) before firing any RPC → exit 1", async () => {
@@ -824,25 +846,41 @@ describe("discover --invite (E-5-d-2)", () => {
     });
     expect(process.exitCode).toBe(1);
     expect(errs.join("\n")).toMatch(/must be an admin/);
-    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+    expect(vi.mocked(team.discoverGitHubContributors)).not.toHaveBeenCalled();
   });
 
   it("without --invite, only lists (no invites minted)", async () => {
     await commandTeam(["discover"], {});
-    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
+    // The 3rd arg is `repos` — undefined when no explicit positional AND no git remote in cwd;
+    // some test CWDs DO have a remote, in which case it's a one-element array. Accept either.
+    expect(vi.mocked(team.discoverGitHubContributors)).toHaveBeenCalledWith(
+      FAKE_CLIENT,
+      "gho_x",
+      expect.anything(),
+      undefined,
+    );
     expect(logs.join("\n")).toMatch(/already on Lore/);
   });
 
   it("with --invite but repos have no contributors: mints nothing, says so (no confusing '0 contributors')", async () => {
-    vi.mocked(team.discoverGitHubContributors).mockResolvedValue([
-      { repo: "o/empty", contributors: [] },
-    ] as never);
+    vi.mocked(team.discoverGitHubContributors).mockResolvedValue({
+      repos: [{ repo: "o/empty", contributors: [] }],
+      invited: {
+        scopeId: "s9",
+        role: "editor",
+        total: 0,
+        emailed: 0,
+        noEmail: 0,
+        overCap: 0,
+        results: [],
+      },
+    } as never);
     await commandTeam(["discover", "--invite", "Rockets"], {
       invite: "Rockets",
     });
-    expect(vi.mocked(team.createTeamInvite)).not.toHaveBeenCalled();
     const out = logs.join("\n");
-    expect(out).toMatch(/No contributors to invite/);
-    expect(out).not.toMatch(/for 0 contributors/);
+    // total=0 means no contributors at all — surfaced as the same "No accessible repos" line, no
+    // misleading "emailed 0 / no-email 0" tally.
+    expect(out).not.toMatch(/emailed/);
   });
 });

--- a/supabase/functions/github-discover/index.ts
+++ b/supabase/functions/github-discover/index.ts
@@ -11,12 +11,32 @@
 //   - The RPC returns only the SET of present github ids (never Lore user_ids), and is
 //     service-role-only, so a client can never call it directly to enumerate accounts.
 //
+// OPTIONAL INVITE MODE (E-5-d-2 + E-5-e server-side):
+//   When the body includes `invite_to_scope` (UUID) and `invite_role`, after the discovery phase we
+//   mint one invite per DISTINCT contributor and email the join link when a recipient address can be
+//   resolved server-side. The gateway never sees the resolved email — only an Emailed/print tally.
+//
+//   Authorization chain (enforced via caller's JWT for every nested call):
+//     1. caller is admin of invite_to_scope (scope_role rpc)
+//     2. invite minted via create_scope_invite rpc (RLS enforces admin)
+//     3. recipient email resolved via:
+//          a. lore_emails_for_github_ids rpc (service-role) — preferred
+//          b. GitHub /users/{login} via caller's provider_token — fallback for non-Lore users with
+//             public email
+//        Then sent via the send-invite-email Edge Function, which independently enforces:
+//          - caller is admin of the invite's scope (scope_role)
+//          - caller created the invite (inv.invited_by === user.id)
+//
+//   When neither lookup resolves (e.g. Lore user with no email on file, OR non-Lore with private
+//   email), the invite is still server-side but the link is returned in `invites[].status` as
+//   `no_email` + the gateway prints it manually.
+//
 // WHY CONTRIBUTORS: `/collaborators` requires push/access AND returns "everyone with at least
 // triage" — which for a private org repo is effectively the org roster. We use `/contributors`
 // (default branch, cached 24h by GitHub) instead — commit-attribution rosters are the user-asked
 // mental model of "people who worked on this code".
 //
-// Deploy (not auto-deployed): `supabase functions deploy github-discover`. SUPABASE_URL,
+// Deploy (auto-deployed on push to main via .github/workflows/deploy-functions.yml). SUPABASE_URL,
 // SUPABASE_ANON_KEY and SUPABASE_SERVICE_ROLE_KEY are injected by the platform; GITHUB_API_URL is
 // optional (defaults to https://api.github.com; overridable for testing).
 import { createClient } from "npm:@supabase/supabase-js@2";
@@ -44,6 +64,39 @@ function json(body: unknown, status = 200): Response {
 
 // Cap the number of repos we scan per call — bounds GitHub API fan-out (and cost) per request.
 const MAX_REPOS = 50;
+
+// Cap the number of invites we mint per call — bounds SMTP send rate + DB writes per request. The
+// gateway surfaces this in the response so the admin can re-run with --role viewer for the rest if
+// they want to split.
+const MAX_INVITES = 200;
+
+// GitHub /users/{login} lookup (cf. send-invite-email). Returns { id, email }. Email is null when
+// private. We need the id to feed into lore_emails_for_github_ids; we use the public email only as
+// a fallback for off-Lore users (most users keep theirs private — this is a "best effort" branch).
+async function fetchGitHubUserByLogin(
+  providerToken: string,
+  login: string,
+  apiUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<{ id: number | null; email: string | null }> {
+  const resp = await fetchImpl(`${apiUrl}/users/${encodeURIComponent(login)}`, {
+    headers: {
+      Authorization: `Bearer ${providerToken}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "lore-github-discover-invite",
+    },
+  });
+  if (!resp.ok) return { id: null, email: null };
+  const j = (await resp.json().catch(() => ({}))) as {
+    id?: number;
+    email?: string | null;
+  };
+  return {
+    id: typeof j.id === "number" ? j.id : null,
+    email: typeof j.email === "string" && j.email !== "" ? j.email : null,
+  };
+}
 
 initSentry("github-discover");
 
@@ -78,9 +131,17 @@ Deno.serve(
     const body = (await req.json().catch(() => ({}))) as {
       provider_token?: string;
       repos?: string[];
+      invite_to_scope?: string;
+      invite_role?: "editor" | "viewer";
     };
     const providerToken = body.provider_token;
     if (!providerToken) return json({ error: "missing provider_token" }, 400);
+    const inviteToScope =
+      typeof body.invite_to_scope === "string"
+        ? body.invite_to_scope
+        : undefined;
+    const inviteRole: "editor" | "viewer" =
+      body.invite_role === "viewer" ? "viewer" : "editor";
 
     const apiUrl = Deno.env.get("GITHUB_API_URL") ?? undefined;
 
@@ -158,6 +219,173 @@ Deno.serve(
       }
     }
 
-    return json({ repos: annotateOnLore(rosters, loreIds) });
+    const annotated = annotateOnLore(rosters, loreIds);
+
+    // OPTIONAL INVITE PHASE: server-side mint+email per distinct contributor. Skipped when the body
+    // does not include invite_to_scope, so the existing read-only callers (which never opt into
+    // invites) are unaffected.
+    if (!inviteToScope) {
+      return json({ repos: annotated });
+    }
+
+    // Pre-check: caller is admin of invite_to_scope. We re-check per-invite via RLS, but a fast 403
+    // here saves N RPC calls in the unauthorized case.
+    const { data: roleRow } = await userClient.rpc("scope_role", {
+      p_scope: inviteToScope,
+    });
+    if (roleRow !== "admin") {
+      return json({ error: "not admin of invite_to_scope" }, 403);
+    }
+
+    // Distinct contributor set, alphabetically stable, capped at MAX_INVITES.
+    const byLogin = new Map<string, { login: string; githubId: number }>();
+    for (const r of annotated) {
+      for (const c of r.contributors) {
+        const existing = byLogin.get(c.login);
+        if (!existing)
+          byLogin.set(c.login, { login: c.login, githubId: c.githubId });
+      }
+    }
+    const contributors = Array.from(byLogin.values()).sort((a, b) =>
+      a.login.localeCompare(b.login),
+    );
+    const capped = contributors.slice(0, MAX_INVITES);
+    const overCap = contributors.length - capped.length;
+
+    // Service-role helpers (used for lore email lookup; supabase admin checks still run with the
+    // caller's JWT for create_scope_invite + scope_role + send-invite-email).
+    const admin = createClient(url, serviceKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    type InviteReport = {
+      login: string;
+      status:
+        | "emailed"
+        | "no_email"
+        | "forbidden"
+        | "invite_failed"
+        | "send_failed"
+        | "skipped";
+      resolved_via?: "lore_email" | "github_public_email" | null;
+      token?: string;
+    };
+    const reports: InviteReport[] = [];
+    let emailed = 0;
+    let noEmail = 0;
+
+    for (const c of capped) {
+      // 1. Mint the invite with the CALLER's JWT — RLS enforces admin via create_scope_invite.
+      const mintResp = await userClient.rpc("create_scope_invite", {
+        p_scope: inviteToScope,
+        p_role: inviteRole,
+        p_hint: c.login,
+        p_eph_pub: null,
+      });
+      if (mintResp.error || !mintResp.data) {
+        await capture(
+          mintResp.error ?? new Error("create_scope_invite no data"),
+        );
+        reports.push({
+          login: c.login,
+          status: mintResp.error?.message?.includes("forbidden")
+            ? "forbidden"
+            : "invite_failed",
+        });
+        continue;
+      }
+      const token = String(mintResp.data);
+
+      // 2. Resolve recipient email server-side. Lore email first (preferred), public GitHub email
+      //    as fallback for off-Lore users.
+      let recipient: string | null = null;
+      let resolvedVia: "lore_email" | "github_public_email" | null = null;
+      try {
+        const { data: loreRows } = await admin.rpc(
+          "lore_emails_for_github_ids",
+          { p_github_ids: [c.githubId] },
+        );
+        if (
+          Array.isArray(loreRows) &&
+          loreRows[0] &&
+          typeof (loreRows[0] as { email?: unknown }).email === "string"
+        ) {
+          const e = (loreRows[0] as { email: string }).email;
+          if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e)) {
+            recipient = e;
+            resolvedVia = "lore_email";
+          }
+        }
+      } catch (e) {
+        await capture(e);
+      }
+      if (!recipient) {
+        try {
+          const fetched = await fetchGitHubUserByLogin(
+            providerToken,
+            c.login,
+            apiUrl ?? "https://api.github.com",
+            fetch,
+          );
+          if (fetched.email) {
+            recipient = fetched.email;
+            resolvedVia = "github_public_email";
+          }
+        } catch (e) {
+          await capture(e);
+        }
+      }
+
+      if (!recipient) {
+        // We minted but can't email — return the token so the gateway can print it.
+        reports.push({
+          login: c.login,
+          status: "no_email",
+          resolved_via: null,
+          token,
+        });
+        noEmail++;
+        continue;
+      }
+
+      // 3. Send via the existing send-invite-email Edge Function — that EF independently enforces
+      //    admin + creator checks. We forward the caller's JWT (Authorization header) by calling
+      //    functions.invoke with the userClient's session (which the SDK populates from the
+      //    Authorization header we received).
+      const { error: sendErr } = await userClient.functions.invoke(
+        "send-invite-email",
+        { body: { token, email: recipient } },
+      );
+      if (sendErr) {
+        await capture(sendErr);
+        reports.push({
+          login: c.login,
+          status: "send_failed",
+          resolved_via: resolvedVia,
+          token,
+        });
+        continue;
+      }
+      reports.push({
+        login: c.login,
+        status: "emailed",
+        resolved_via: resolvedVia,
+        token,
+      });
+      emailed++;
+    }
+
+    return json({
+      repos: annotated,
+      invited: {
+        scope_id: inviteToScope,
+        role: inviteRole,
+        total: contributors.length,
+        emailed,
+        no_email: noEmail,
+        over_cap: overCap,
+        results: reports,
+      },
+    });
   }),
 );


### PR DESCRIPTION
## summary

PR #1527 closed Slice 1 + the linked-cwd invite UX, but the discover **`--invite <team>`** flow still looped `createTeamInvite` per contributor N times in the CLI (and printed bare tokens since GitHub's `/contributors` doesn't expose email). This PR moves the minting + recipient resolution + emailing into the `github-discover` Edge Function so a single round trip yields the full result, and recipients with a resolvable address get an email instead of a printed token. Follow-up to PR #1531 — that one added the **bare-invite** path (`invite <login>`) server-side resolve; this one does the same for the bulk path.

## what

### Edge Function (`supabase/functions/github-discover/index.ts`)

New optional body fields: `invite_to_scope` (UUID), `invite_role` (`"editor" | "viewer"`, default editor). When `invite_to_scope` is set the EF, after the existing discovery phase:

1. **Pre-checks** the caller is admin of `invite_to_scope` via `scope_role` (cheap 403 before any per-contributor work).
2. For each **distinct** contributor (alphabetical, deduped via byLogin map — moved from the old CLI loop):
   - **Mint** via `create_scope_invite` rpc with the caller's JWT (RLS enforces admin + creator).
   - **Resolve recipient** server-side, in priority order:
     1. `lore_emails_for_github_ids` rpc (service-role-only, defined in #1531) — preferred path; works even when the user has set their GitHub email to private.
     2. GitHub `/users/{login}` via the caller's `provider_token` — fallback for non-Lore users with public email.
     3. Otherwise mark `no_email` and return the token for manual share.
   - **Send** via the existing `send-invite-email` EF, which independently re-enforces admin + creator checks (defense-in-depth). The recipient email **never round-trips through the gateway** — only the EF sends via SMTP2GO.
3. Returns `{ repos, invited: { scope_id, role, total, emailed, no_email, over_cap, results[] } }`.

MAX_INVITES = 200 cap (matches SMTP send rate + DB write bound).

### Gateway (`packages/gateway/src/team.ts`, `cli/team-cmd.ts`)

- `discoverGitHubContributors` now returns `{ repos, invited? }`; the `invite` arg carries `{ scopeId, role }`.
- CLI pre-checks (the existing `resolveWritableScope` + `scopeMemberRole` mirror) BEFORE the EF call, so admins get one clear error instead of a round-trip's worth of confusion.
- The discover loop drops the per-contributor `createTeamInvite` minting + manual `print token` output. Output is now a tally line + a manual-share block for the `no_email` rows.

### Tests

- 4 existing `discover --invite (E-5-d-2)` tests **rewritten** to assert the new EF-boundary args + printed report. (The CLI no longer touches `createTeamInvite` for the `--invite` flow.)
- 1 no-contributors test tightened: when `inv.total === 0` we print `No accessible repos…` instead of misleading `emailed 0 / no-email 0`.
- Pure-core tests (discover.ts) untouched — all 19 still pass.
- 163/163 gateway tests green.

## security boundaries (re-asserted from prior PRs)

- `provider_token` is bound to the JWT's linked GitHub identity (no foreign enumeration).
- `lore_users_for_github_ids` (0050) + `lore_emails_for_github_ids` (0051) are service-role-only, return only the SET of present (github_id, *), never Lore user_ids.
- `create_scope_invite` rpc enforces admin via RLS; `send-invite-email` EF independently enforces admin + creator.
- The recipient email resolved server-side is never returned to the gateway in any form — only the SMTP send happens inside the EF.

## diff stats

4 files changed, 444 insertions(+), 97 deletions(-).

## follow-up

None immediate — both invite paths (bare `invite <login>` and bulk `discover --invite`) now resolve recipients server-side. End-to-end coverage relies on Supabase previews; not adding deno-side unit tests because the EF dir has no test infra by convention.
