### PR TITLE
fix(import): auto-fallback to next auth provider on 401; prefer opencode.json active provider

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -421,6 +421,13 @@ export const AGENTS: AgentDef[] = [
     detect: () => whichSync("pi"),
     upstreamEnvVars: ["ANTHROPIC_BASE_URL"],
     wireProtocol: "anthropic",
+    // Pi reads ANTHROPIC_AUTH_TOKEN (bearer, for proxies like OpenRouter)
+    // and ANTHROPIC_API_KEY (api-key, first-party Anthropic). Bearer wins
+    // when both are set — matches Claude Code's precedence parity.
+    authTokenEnvVars: [
+      { var: "ANTHROPIC_AUTH_TOKEN", scheme: "bearer" },
+      { var: "ANTHROPIC_API_KEY", scheme: "api-key" },
+    ],
     envVars: (url, _cwd) => ({
       ANTHROPIC_BASE_URL: url,
       LORE_GATEWAY_URL: url,
@@ -469,6 +476,10 @@ export const AGENTS: AgentDef[] = [
     detect: () => whichSync("hermes"),
     upstreamEnvVars: ["OPENAI_BASE_URL"],
     wireProtocol: "openai",
+    // Hermes reads OPENAI_API_KEY (bearer) for OpenAI-compatible upstreams.
+    // OPENAI_BASE_URL is in upstreamEnvVars (above) — captured separately by
+    // captureUserEnvCredential when the user points Hermes at a proxy.
+    authTokenEnvVars: [{ var: "OPENAI_API_KEY", scheme: "bearer" }],
     envVars: (url, cwd) => {
       const env: Record<string, string> = {
         // Route Hermes through the gateway. Both keys are undocumented in the
@@ -503,6 +514,13 @@ export const AGENTS: AgentDef[] = [
     detect: () => whichSync("copilot"),
     upstreamEnvVars: ["COPILOT_API_URL"],
     wireProtocol: "openai",
+    // NOTE: GitHub Copilot CLI stores credentials in its own config
+    // (~/.config/github-copilot/hosts.json), not in shell env vars. The CLI
+    // does NOT document a COPILOT_TOKEN env var. We intentionally don't
+    // wire authTokenEnvVars here — auto-fallback for Copilot conversations
+    // is gated on a prior `lore run` capturing the live token via
+    // getLastSeenAuth (tier 4). To import Copilot history, run `lore run`
+    // once first; subsequent `lore import` will use the captured credential.
     envVars: (url, cwd) => {
       // GitHub Copilot CLI talks to the Copilot API (normally
       // api.githubcopilot.com) in OpenAI wire format, performing its own GitHub→
@@ -535,6 +553,14 @@ export const AGENTS: AgentDef[] = [
     detect: () => whichSync("gemini"),
     upstreamEnvVars: ["GOOGLE_GEMINI_BASE_URL"],
     wireProtocol: "gemini",
+    // Gemini CLI (GEMINI_API_KEY mode) reads GEMINI_API_KEY as a bearer
+    // against the Generative Language API. GOOGLE_API_KEY is the older
+    // sibling and is also honored by Google's Gemini SDK clients — picked
+    // up here so users with either key get auto-fallback coverage.
+    authTokenEnvVars: [
+      { var: "GEMINI_API_KEY", scheme: "bearer" },
+      { var: "GOOGLE_API_KEY", scheme: "bearer" },
+    ],
     envVars: (url, cwd) => {
       // Google's Gemini CLI (GEMINI_API_KEY mode) reads GOOGLE_GEMINI_BASE_URL
       // as the base origin for the native Generative Language API — it appends

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -382,6 +382,190 @@ export function buildNeedsModelGuidance(
 }
 
 // ---------------------------------------------------------------------------
+// Provider-fallback chain (auto-retry on 401)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single extraction credential candidate. The import loop tries each
+ * candidate in order; on upstream 401/403, it records the failure and moves
+ * to the next one. The first candidate that produces at least one
+ * non-`abortedByAuth` chunk wins the whole batch.
+ */
+type AuthCandidate = {
+  /** Display label for the user (e.g. "opencode.json active provider: openrouter"). */
+  label: string;
+  /** Where the credential came from — drives the user-facing note. */
+  source: "opencode-active" | "opencode-on-disk" | "env" | "session";
+  /** Resolves a credential per chunk (called by the LLM client). */
+  getAuth: (sessionID?: string, providerID?: string) => AuthCredential | null;
+  /** Model + provider used for extraction. */
+  model: { providerID: string; modelID: string };
+  /** Optional upstream override (env-credential tier routes here). */
+  upstream?: string;
+};
+
+/**
+ * Build the ordered list of extraction-credential candidates for one agent.
+ *
+ * Order:
+ *  1. The user's CURRENTLY-CONFIGURED provider from opencode.json
+ *     (`model` / `small_model`) — matches what their `lore run` actually
+ *     started with. Best-first because if it's working in `lore run`, it'll
+ *     work here too.
+ *  2. Remaining routable entries from auth.json (the OpenCode reorder in
+ *     `readUsableAuth` already places the active provider first; this is
+ *     the rest of the JSON iteration order — the user's older credentials,
+ *     which may or may not still be valid).
+ *  3. Env credential (tier 3) — common OpenRouter / proxy setups where the
+ *     agent never wrote anything to auth.json but the user has
+ *     ANTHROPIC_API_KEY et al in their shell.
+ *  4. Last-seen session credential (tier 4) — the gateway's global fallback
+ *     for `providerID` matching a prior live request.
+ *
+ * The `LORE_WORKER_API_KEY` explicit override (tier 1) is intentionally
+ * excluded from the chain — it's a deliberate user choice, and silently
+ * retrying past it would surprise users who set the env var to debug
+ * routing. Tier 1 stays single-shot in `resolveAgentImportAuth`.
+ *
+ * Candidates whose provider lacks a default worker model AND the user set
+ * no override are skipped (they'd 400 at the upstream with an empty model
+ * id — the same `needsModel` guard the tier 2 path already enforces).
+ *
+ * Returns an empty array when NOTHING is usable — the caller skips the
+ * agent with the standard "no usable credential" line.
+ */
+export function buildAuthFallbackChain(
+  agentName: string,
+  cfgModel: { providerID: string; modelID: string } | undefined,
+): AuthCandidate[] {
+  const candidates: AuthCandidate[] = [];
+  const seen = new Set<string>();
+
+  function push(c: AuthCandidate | null): void {
+    if (!c) return;
+    // De-dup by (providerID, value) — env and on-disk may resolve to the
+    // same provider with the same key (OpenCode's tier-2 env-preference),
+    // and we want the env path to win over the on-disk path (not silently
+    // retried as a separate candidate).
+    const value = (() => {
+      try {
+        return c.getAuth(undefined, c.model.providerID)?.value ?? "";
+      } catch {
+        return "";
+      }
+    })();
+    const dedupeKey = `${c.model.providerID}::${value}`;
+    if (seen.has(dedupeKey)) return;
+    seen.add(dedupeKey);
+    candidates.push(c);
+  }
+
+  // Read every usable auth.json credential. The OpenCode reader already
+  // reorders so the active provider sits first; we honor that ordering and
+  // add a separate "opencode-active" label to the first one so the user
+  // knows where it came from.
+  const active = agentName === "opencode" ? getOpenCodeActiveProvider() : null;
+  const onDiskCreds = readUsableAuth(agentName);
+
+  for (const cred of onDiskCreds) {
+    // Routability check — same as the existing tier-2 path. A provider
+    // without a concrete upstream URL (local runtimes like ollama/vllm)
+    // can't be used for extraction; skip it instead of attempting a doomed
+    // call.
+    const isRoutable = resolveProviderRoute(cred.providerID)?.url != null;
+    if (!isRoutable) continue;
+
+    const isActive = active === cred.providerID;
+    const source: AuthCandidate["source"] = isActive
+      ? "opencode-active"
+      : "opencode-on-disk";
+    const label = isActive
+      ? `opencode.json active provider: ${cred.providerID}`
+      : `on-disk auth.json: ${cred.providerID}`;
+
+    const model =
+      cfgModel && cfgModel.providerID === cred.providerID
+        ? cfgModel
+        : cred.modelID
+          ? { providerID: cred.providerID, modelID: cred.modelID }
+          : defaultModelForProvider(cred.providerID);
+
+    // Skip candidates that lack a model — same guard as tier 2/3.
+    if (!model.modelID) continue;
+
+    push({
+      label,
+      source,
+      getAuth: () => ({ scheme: cred.scheme, value: cred.value }),
+      model,
+    });
+  }
+
+  // Env credential (tier 3) — last; if it had a valid token it would have
+  // already won at the env-overrides-on-disk stage for the active provider
+  // (and been de-duped above). This catches the "no on-disk at all" path:
+  // a fresh machine with only shell env credentials.
+  const agentDef = AGENTS.find((a) => a.name === agentName);
+  if (agentDef) {
+    const envCred = captureUserEnvCredential(agentDef);
+    if (envCred) {
+      const envDrivenProviderID =
+        agentName === "opencode"
+          ? (pickEnvVarProvider(envCred.envVarName) ??
+            getOpenCodeActiveProvider())
+          : null;
+      const providerID = envCred.upstreamUrl
+        ? (providerForUpstreamOrigin(envCred.upstreamUrl) ??
+          envDrivenProviderID ??
+          agentDef.wireProtocol ??
+          "anthropic")
+        : (envDrivenProviderID ?? agentDef.wireProtocol ?? "anthropic");
+      const model =
+        cfgModel && cfgModel.providerID === providerID
+          ? cfgModel
+          : defaultModelForProvider(providerID);
+      if (model.modelID) {
+        push({
+          label: `shell env credential: ${envCred.envVarName}`,
+          source: "env",
+          getAuth: () => ({ scheme: envCred.scheme, value: envCred.token }),
+          model,
+          upstream: envCred.upstreamUrl ?? undefined,
+        });
+      }
+    }
+  }
+
+  // Last-seen session credential (tier 4). Only include when the chain so
+  // far is empty — otherwise we'd try a session credential that might be
+  // for a DIFFERENT provider than the active one (cross-provider leak,
+  // #829). When the chain already has candidates from auth.json, those are
+  // a strictly better signal than whatever the gateway captured from a
+  // prior unrelated request.
+  if (candidates.length === 0) {
+    const lastSeenProvider = getLastSeenAuthProvider() ?? undefined;
+    const sessionCred = resolveAuth(
+      undefined,
+      cfgModel?.providerID ?? lastSeenProvider,
+    );
+    if (sessionCred) {
+      const model =
+        cfgModel ?? defaultModelForProvider(lastSeenProvider ?? undefined);
+      if (model.modelID) {
+        candidates.push({
+          label: `last session credential: ${model.providerID}`,
+          source: "session",
+          getAuth: resolveAuth,
+          model,
+        });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -992,10 +1176,11 @@ export async function commandImport(
     return;
   }
 
-  // Stamp the start of THIS import run so the auth-rejected probe ignores
-  // failures recorded by a prior `lore import` invocation in the same process
-  // — see `hasRecentAuthRejectedFailure` for the cross-run leak rationale.
-  const runStartedAt = Date.now();
+  // NOTE: The auth-rejected probe snapshot (`attemptStartedAt`) is now captured
+  // PER CANDIDATE inside the fallback loop, not once per run. Per-candidate
+  // scoping prevents candidate 1's auth-rejected failure from incorrectly
+  // tripping the probe for candidate 2 when candidate 2 returns null for a
+  // non-auth reason (network timeout, model bug). Seer finding 15586850.
 
   // Start gateway for LLM access
   console.log("\n[lore] Starting gateway for LLM access...");
@@ -1070,52 +1255,64 @@ export async function commandImport(
       const provider = getProvider(result.agentName);
       if (!provider) continue;
 
-      // Resolve THIS agent's credential from its own on-disk auth (or the
-      // explicit worker key / cfg.model). Different agents can authenticate
-      // different providers, so resolve per agent rather than once up front.
-      const auth = resolveAgentImportAuth(
+      // Tier-1 (explicit LORE_WORKER_API_KEY) is a deliberate user override —
+      // single-shot, no fallback. Every other path goes through the
+      // auto-fallback chain below.
+      const tier1 = resolveAgentImportAuth(
         result.agentName,
         workerApiKey,
         cfgModel,
       );
-      if (!auth) {
+      if (tier1 === null) {
         console.log(
           `[lore] Skipping ${result.agentDisplayName}: no usable credential found ` +
             `in its on-disk auth (none stored, expired, or provider not proxied).`,
         );
         continue;
       }
-      if ("needsModel" in auth) {
+      if ("needsModel" in tier1) {
         // We HAVE the user's key but not a model to use it with.
-        needsModelProviders.add(auth.needsModel);
+        needsModelProviders.add(tier1.needsModel);
         console.log(
-          `[lore] Skipping ${result.agentDisplayName}: found your ${auth.needsModel} ` +
+          `[lore] Skipping ${result.agentDisplayName}: found your ${tier1.needsModel} ` +
             `credential, but no worker model is set for that provider. ` +
             `Set one and retry (see below).`,
         );
         continue;
       }
+
+      // Build the candidate list. Tier-1 is a single-entry list (no
+      // auto-fallback past a deliberate user override). Tier-2/3/4 builds
+      // the chain: opencode active provider first, then other auth.json
+      // entries, then env credential, then last-seen session.
+      type Candidate = {
+        auth: typeof tier1;
+        label: string;
+      };
+      const candidates: Candidate[] = workerApiKey
+        ? [{ auth: tier1, label: "LORE_WORKER_API_KEY" }]
+        : buildAuthFallbackChain(result.agentName, cfgModel).map((c) => ({
+            auth: {
+              getAuth: c.getAuth,
+              model: c.model,
+              upstream: c.upstream,
+            },
+            label: c.label,
+          }));
+
+      if (candidates.length === 0) {
+        // Don't set anyAuthResolved — buildAuthFallbackChain filtered out
+        // candidates that lacked a default worker model (an aggregator
+        // provider without `LORE_WORKER_MODEL`). Leaving the flag false
+        // lets the end-of-run "no usable credential" guidance fire so the
+        // user knows what to fix, instead of a silent zero-row import.
+        console.log(
+          `[lore] Skipping ${result.agentDisplayName}: no usable credential found ` +
+            `(auth.json had no routable entries, no shell env credential, no live session).`,
+        );
+        continue;
+      }
       anyAuthResolved = true;
-
-      // When the credential was captured from the agent's own env (tier 3),
-      // route extraction to that captured upstream (e.g. openrouter.ai), not
-      // the default anthropic/openai host. A dedicated worker key
-      // (config.workerUpstream) still takes precedence.
-      const agentUpstreams = resolveExtractionUpstreams(
-        auth.upstream,
-        config.workerUpstream,
-        workerUpstreams,
-      );
-
-      const llm = createGatewayLLMClient(
-        agentUpstreams,
-        auth.getAuth,
-        auth.model,
-        // A captured env credential is a user-provided key for a specific
-        // upstream — treat it like a dedicated worker key so the in-adapter
-        // protocol-mismatch pre-flight doesn't reject a non-anthropic key.
-        { dedicatedWorkerKey: !!workerApiKey || auth.upstream != null },
-      );
 
       const sessionIds = result.sessions.map((s) => s.id);
       console.log(`[lore] Reading ${result.agentDisplayName} conversations...`);
@@ -1132,63 +1329,157 @@ export async function commandImport(
         `[lore] Extracting knowledge from ${chunks.length} chunks (${result.agentDisplayName})...`,
       );
 
-      const extractResult = await extractKnowledge({
-        llm,
-        projectPath,
-        chunks,
-        model: auth.model,
-        onProgress: (progress) => {
-          process.stderr.write(
-            `\r[lore]   Chunk ${progress.current}/${progress.total} — ${progress.created} created, ${progress.updated} updated`,
+      // Iterate the candidate list. Each candidate attempts the full chunk
+      // batch; on upstream 401/403 (abortedByAuth), we move to the next
+      // candidate. The first candidate that produces at least one non-auth
+      // answer wins. Cost: at most one chunk per failed provider (the
+      // worker-health probe inside extract.ts aborts on the first 401).
+      let extractResult: Awaited<ReturnType<typeof extractKnowledge>> | null =
+        null;
+      const triedProviders: Array<{
+        label: string;
+        providerID: string;
+        reason: "auth-rejected" | "no-response";
+      }> = [];
+
+      for (let i = 0; i < candidates.length; i++) {
+        const { auth, label } = candidates[i];
+        const isFirstAttempt = i === 0;
+
+        // Show the user which credential we're attempting (transparency:
+        // not a warning, just an FYI line). On fallback attempts, prefix
+        // with "Trying" so the user can see the failover in action.
+        console.log(
+          isFirstAttempt
+            ? `[lore]   Using ${label}`
+            : `[lore]   Trying ${label}`,
+        );
+
+        // When the credential was captured from the agent's own env (tier 3),
+        // route extraction to that captured upstream (e.g. openrouter.ai), not
+        // the default anthropic/openai host. A dedicated worker key
+        // (config.workerUpstream) still takes precedence.
+        const agentUpstreams = resolveExtractionUpstreams(
+          auth.upstream,
+          config.workerUpstream,
+          workerUpstreams,
+        );
+
+        const llm = createGatewayLLMClient(
+          agentUpstreams,
+          auth.getAuth,
+          auth.model,
+          { dedicatedWorkerKey: !!workerApiKey || auth.upstream != null },
+        );
+
+        // Snapshot the auth-rejected timestamp at the START of this attempt.
+        // Without this, a failure recorded by an EARLIER candidate would
+        // incorrectly trip the probe for THIS candidate if it returns null
+        // for a non-auth reason (network timeout, model bug) — wrongly
+        // attributing the transient failure to auth and skipping a valid
+        // credential. Per-candidate `attemptStartedAt` scopes the probe
+        // strictly to failures recorded during THIS attempt's chunks.
+        const attemptStartedAt = Date.now();
+
+        const attemptResult = await extractKnowledge({
+          llm,
+          projectPath,
+          chunks,
+          model: auth.model,
+          onProgress: (progress) => {
+            process.stderr.write(
+              `\r[lore]   Chunk ${progress.current}/${progress.total} — ${progress.created} created, ${progress.updated} updated`,
+            );
+          },
+          // The standalone import path is session-less (no sessionID is passed
+          // to llm.prompt — see extract.ts: workerID is fixed to "lore-import").
+          // Inject the worker-health peek so the loop aborts on the FIRST chunk
+          // whose LLM call returned null AND an upstream `auth-rejected` was
+          // recorded, instead of letting the same broken credential burn the
+          // remaining 70 chunks.
+          wasRecentChunkAuthRejected: () =>
+            hasRecentAuthRejectedFailure(
+              "_unknown",
+              "lore-import",
+              60_000,
+              attemptStartedAt,
+            ),
+        });
+
+        // Clear the progress line
+        process.stderr.write("\n");
+
+        // Success path: at least one chunk was answered AND we weren't aborted
+        // by auth. Take this candidate's result and stop iterating.
+        if (!attemptResult.abortedByAuth && attemptResult.chunksAnswered > 0) {
+          extractResult = attemptResult;
+          break;
+        }
+
+        // Failed attempt — record this candidate as tried and move to the next.
+        // The wording distinguishes auth-rejected from a generic failure
+        // (network timeout, malformed response, model bug) so the user can
+        // diagnose the right thing. Only the auth-rejected case is
+        // actionable for credential rotation; other failures might be
+        // transient and resolve on the next attempt.
+        triedProviders.push({
+          label,
+          providerID: auth.model.providerID,
+          reason: attemptResult.abortedByAuth ? "auth-rejected" : "no-response",
+        });
+
+        if (i < candidates.length - 1) {
+          const reasonText = attemptResult.abortedByAuth
+            ? `rejected the credential`
+            : `did not answer`;
+          console.log(
+            `[lore]   ${auth.model.providerID} ${reasonText} — ` +
+              `falling through to next provider.`,
           );
-        },
-        // The standalone import path is session-less (no sessionID is passed
-        // to llm.prompt — see extract.ts: workerID is fixed to "lore-import").
-        // Inject the worker-health peek so the loop aborts on the FIRST chunk
-        // whose LLM call returned null AND an upstream `auth-rejected` was
-        // recorded, instead of letting the same broken credential burn the
-        // remaining 70 chunks. The `runStartedAt` bound ignores failures
-        // recorded by a prior `lore import` invocation in this process, so a
-        // second run after a credential fix isn't falsely aborted on chunk 1.
-        wasRecentChunkAuthRejected: () =>
-          hasRecentAuthRejectedFailure(
-            "_unknown",
-            "lore-import",
-            60_000,
-            runStartedAt,
-          ),
-      });
+        }
+      }
 
-      // Clear the progress line
-      process.stderr.write("\n");
+      // No candidate worked — surface a single combined diagnostic.
+      // When ANY tried provider was auth-rejected (vs a generic no-response),
+      // we still print the credential-fix advice because at least one path
+      // needs a fresh key. When ALL tried providers failed for a non-auth
+      // reason, the credential advice is misleading and we surface a generic
+      // "models didn't answer" message instead.
+      if (extractResult === null) {
+        const authRejectedCount = triedProviders.filter(
+          (t) => t.reason === "auth-rejected",
+        ).length;
+        const allNonAuth = authRejectedCount === 0;
+        const triedList = triedProviders
+          .map((t) => `${t.providerID} (${t.label})`)
+          .join(", ");
+        const multiLine =
+          triedProviders.length > 1 && !allNonAuth
+            ? "\n[lore] No provider auto-fallback could authenticate."
+            : "";
 
-      // Aborted early because the upstream rejected the credential on the
-      // first chunk (HTTP 401/403). Surface a single, actionable error
-      // pointing at the on-disk auth path the user can fix + the env-var
-      // override as a quick unblock. Distinct from chunksAnswered === 0 of
-      // a NON-auth abort (which falls through to the "no response from the
-      // model" message — a transient signal, not actionable here).
-      if (extractResult.abortedByAuth) {
-        const remaining = chunks.length - extractResult.chunksProcessed;
-        // Pluralize so a single-chunk import doesn't read "1 chunks".
-        const remainingWord = remaining === 1 ? "chunk" : "chunks";
-        const wereWord = remaining === 1 ? "was" : "were";
-        const remainingLine =
-          remaining === 0
-            ? "No further chunks were attempted — there were no more after chunk 1."
-            : `The remaining ${remaining} ${remainingWord} ${wereWord} not attempted — retrying would just 401 again.`;
+        if (allNonAuth) {
+          console.error(
+            `\n[lore] Can't import ${result.agentDisplayName}: tried ${triedList || "all available"} ` +
+              `and none answered (no HTTP 401 — likely transient network/timeout/model issue).\n` +
+              `[lore]\n` +
+              `[lore] Re-run \`lore import\` after a moment. If this keeps happening, file an ` +
+              `issue with the full output of \`lore import --debug\`.\n`,
+          );
+          totalFailed += chunks.length;
+          continue;
+        }
+
         console.error(
-          `\n[lore] Can't import ${result.agentDisplayName}: the credential ` +
-            `Lore is using is invalid (HTTP 401 — ${auth.model.providerID} rejected ` +
-            `the key). ${remainingLine}\n` +
+          `\n[lore] Can't import ${result.agentDisplayName}: tried ${triedList || "all available"} ` +
+            `and all rejected the credential (HTTP 401).${multiLine}\n` +
             `[lore]\n` +
             `[lore] The credential likely came from one of these places. ` +
             `Pick the one that matches your setup:\n` +
             `[lore]\n` +
             `[lore]   1. ${result.agentDisplayName} on-disk auth. Update ` +
             `or re-authenticate in that agent (e.g. \`opencode auth login\`).\n` +
-            `[lore]      Then either re-run \`lore import\`, or restart \`lore ` +
-            `run\` so the gateway re-captures the fresh key.\n` +
+            `[lore]      Then re-run \`lore import\`.\n` +
             `[lore]\n` +
             `[lore]   2. Shell env vars (e.g. ANTHROPIC_AUTH_TOKEN / ` +
             `ANTHROPIC_API_KEY / OPENAI_API_KEY). Confirm the key in your shell, ` +
@@ -1196,8 +1487,7 @@ export async function commandImport(
             `[lore]\n` +
             `[lore]   3. Override the import credential entirely with a ` +
             `dedicated worker key:\n` +
-            `[lore]        export LORE_WORKER_API_KEY=<a fresh raw API key for ` +
-            `provider ${auth.model.providerID}>\n` +
+            `[lore]        export LORE_WORKER_API_KEY=<a fresh raw API key>\n` +
             `[lore]        lore import\n` +
             `[lore]\n` +
             `[lore] Tip: a ChatGPT / GitHub Copilot subscription token is NOT ` +
@@ -1205,29 +1495,16 @@ export async function commandImport(
             `run\` and send one message — Lore captures the live credential ` +
             `and re-offers imports automatically.`,
         );
-        totalFailed += extractResult.chunksFailed;
-        // Also tally the chunks we DID NOT attempt so the summary line
-        // accurately reflects the run's footprint (helpful when the
-        // dashboard counts failed-chunks).
-        totalFailed += chunks.length - extractResult.chunksProcessed;
+        totalFailed += chunks.length;
         continue;
       }
 
-      // Only mark sessions imported if the LLM actually answered a chunk. A
-      // no-auth run returns null per chunk (0 answered) without throwing — a
-      // resolved credential can still go stale mid-run. Recording a
-      // never-answered run would permanently suppress a real re-import via
-      // hasAgentImportRecord().
-      if (extractResult.chunksAnswered === 0) {
-        console.log(
-          `[lore] No response from the model for ${result.agentDisplayName} — ` +
-            `skipping (will retry on next import).`,
-        );
-        totalFailed += extractResult.chunksFailed;
-        continue;
-      }
-
-      // Record imports for each session
+      // Record imports for each session. (The pre-PR guard for
+      // `chunksAnswered === 0` was deleted — the fallback loop already
+      // surfaces the no-response case via the combined-tried diagnostic when
+      // every candidate fails. A non-aborted candidate with 0 answered is no
+      // longer reachable because the loop's success predicate requires
+      // `chunksAnswered > 0` to break.)
       for (const sess of result.sessions) {
         const hash = computeHash({
           messageCount: sess.messageCount,

--- a/packages/gateway/test/import-auth-chain.test.ts
+++ b/packages/gateway/test/import-auth-chain.test.ts
@@ -551,4 +551,74 @@ describe("resolveAgentImportAuth — OpenCode env-vs-disk preference (active pro
     expect(ok.model.providerID).toBe("anthropic");
     expect(ok.getAuth()).toEqual({ scheme: "api-key", value: "sk-ant-fresh" });
   });
+
+  /**
+   * Coverage for the auto-fallback chain's env tier across all agents with
+   * `authTokenEnvVars`. Pi / Hermes / Gemini were added in #1533 so the
+   * chain picks up their env credentials the same way claude-code / codex /
+   * opencode already did. If a future PR removes `authTokenEnvVars` from any
+   * of these agents, the chain silently skips the env tier for that agent
+   * — this test catches the regression before merge.
+   */
+  describe("env-credential coverage across agents", () => {
+    test("claude-code picks up ANTHROPIC_API_KEY (api-key scheme)", () => {
+      setEnv("ANTHROPIC_API_KEY", "sk-ant-cc");
+      const ok = usable(
+        resolveAgentImportAuth("claude-code", undefined, undefined),
+      );
+      expect(ok.getAuth()).toEqual({ scheme: "api-key", value: "sk-ant-cc" });
+    });
+
+    test("claude-code: ANTHROPIC_AUTH_TOKEN (bearer) wins over ANTHROPIC_API_KEY when both set", () => {
+      setEnv("ANTHROPIC_AUTH_TOKEN", "sk-ant-oat-cc");
+      setEnv("ANTHROPIC_API_KEY", "sk-ant-apikey-cc");
+      const ok = usable(
+        resolveAgentImportAuth("claude-code", undefined, undefined),
+      );
+      expect(ok.getAuth()).toEqual({
+        scheme: "bearer",
+        value: "sk-ant-oat-cc",
+      });
+    });
+
+    test("codex picks up OPENAI_API_KEY (bearer scheme)", () => {
+      setEnv("OPENAI_API_KEY", "sk-codex");
+      const ok = usable(resolveAgentImportAuth("codex", undefined, undefined));
+      expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "sk-codex" });
+    });
+
+    test("pi picks up ANTHROPIC_API_KEY (api-key scheme) — added in #1533", () => {
+      setEnv("ANTHROPIC_API_KEY", "sk-ant-pi");
+      const ok = usable(resolveAgentImportAuth("pi", undefined, undefined));
+      expect(ok.getAuth()).toEqual({ scheme: "api-key", value: "sk-ant-pi" });
+    });
+
+    test("pi: ANTHROPIC_AUTH_TOKEN (bearer) wins over ANTHROPIC_API_KEY — parity with claude-code", () => {
+      setEnv("ANTHROPIC_AUTH_TOKEN", "sk-ant-oat-pi");
+      setEnv("ANTHROPIC_API_KEY", "sk-ant-apikey-pi");
+      const ok = usable(resolveAgentImportAuth("pi", undefined, undefined));
+      expect(ok.getAuth()).toEqual({
+        scheme: "bearer",
+        value: "sk-ant-oat-pi",
+      });
+    });
+
+    test("hermes picks up OPENAI_API_KEY (bearer scheme) — added in #1533", () => {
+      setEnv("OPENAI_API_KEY", "sk-hermes");
+      const ok = usable(resolveAgentImportAuth("hermes", undefined, undefined));
+      expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "sk-hermes" });
+    });
+
+    test("gemini picks up GEMINI_API_KEY (bearer scheme) — added in #1533", () => {
+      setEnv("GEMINI_API_KEY", "gem-key");
+      const ok = usable(resolveAgentImportAuth("gemini", undefined, undefined));
+      expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "gem-key" });
+    });
+
+    test("gemini: GOOGLE_API_KEY (bearer) is also honored — older sibling", () => {
+      setEnv("GOOGLE_API_KEY", "goog-key");
+      const ok = usable(resolveAgentImportAuth("gemini", undefined, undefined));
+      expect(ok.getAuth()).toEqual({ scheme: "bearer", value: "goog-key" });
+    });
+  });
 });

--- a/packages/gateway/test/import-command-autofallback.test.ts
+++ b/packages/gateway/test/import-command-autofallback.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Auto-fallback tests for `lore import`: when the first credential candidate
+ * 401s, the importer tries the next one automatically instead of surfacing the
+ * error to the user. This addresses the Aditya scenario where his OpenCode
+ * auth.json has multiple stale/fresh credentials across providers, and the
+ * gateway's "first match" picker landed on the wrong one — without fallback,
+ * the import would fail with an unhelpful credential-fix message.
+ *
+ * Tests in this file drive the REAL `commandImport` decision loop with
+ * injected auth/history providers and a mocked LLM client. The first call
+ * per candidate returns null + records an auth-rejected failure (mirrors the
+ * adapter's real 401 path). The first candidate to return a valid answer
+ * wins; if all fail, the diagnostic fires.
+ *
+ * Setup notes:
+ *  - All tests use `anthropic` (built-in default model) + `openrouter` (no
+ *    built-in default, requires explicit LORE_WORKER_MODEL). This combination
+ *    lets us cover the fallback chain without the needsModel guard short-
+ *    circuiting the test.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const shutdownMock = vi.fn(async () => {});
+let startConfig: Record<string, unknown> = {
+  upstreamAnthropic: "https://api.anthropic.com",
+  upstreamOpenAI: "https://api.openai.com",
+};
+vi.mock("../src/cli/start", () => ({
+  startGateway: vi.fn(async () => ({
+    config: startConfig,
+    owned: true,
+    shutdown: shutdownMock,
+  })),
+}));
+
+// Capture every LLM client construction: [upstreams, getAuth, model, opts].
+// `promptBehavior` controls what each prompt returns so we can simulate the
+// "first candidate 401s, second succeeds" sequence without real network.
+const llmClientCalls: unknown[][] = [];
+let promptBehavior: () => Promise<string | null> = async () => "[]";
+let promptCalls = 0;
+vi.mock("../src/llm-adapter", () => ({
+  createGatewayLLMClient: (...args: unknown[]) => {
+    llmClientCalls.push(args);
+    return {
+      prompt: vi.fn(async () => {
+        promptCalls++;
+        return promptBehavior();
+      }),
+    };
+  },
+}));
+
+import { commandImport } from "../src/cli/import";
+import { _resetAuthForTest, setLastSeenAuth } from "../src/auth";
+import {
+  recordWorkerFailure,
+  _resetForTest as _resetWorkerHealth,
+} from "../src/worker-health";
+import { load as loadConfig } from "@loreai/core";
+import { conversationImport } from "@loreai/core";
+import type { conversationImport as CI } from "@loreai/core";
+
+const { registerProvider, clearProviders, getProviders } = conversationImport;
+const { registerAuthProvider, clearAuthProviders, getAuthProviders } =
+  conversationImport;
+
+type FakeSpec = {
+  name: string;
+  displayName: string;
+  messageCount?: number;
+};
+
+function fakeProvider(spec: FakeSpec): CI.AgentHistoryProvider {
+  const messageCount = spec.messageCount ?? 5;
+  return {
+    name: spec.name,
+    displayName: spec.displayName,
+    detect(): CI.DetectedSession[] {
+      return [
+        {
+          id: `${spec.name}-sess-1`,
+          label: `2026-07-24 (${messageCount} messages)`,
+          startedAt: 1_700_000_000_000,
+          lastActivityAt: 1_700_000_001_000,
+          estimatedTokens: 100,
+          messageCount,
+        } satisfies CI.DetectedSession,
+      ];
+    },
+    readChunks(): CI.ConversationChunk[] {
+      return [
+        {
+          label: `${spec.displayName} session (1 of 1)`,
+          text: "[user] hello\n[assistant] hi there",
+          estimatedTokens: 10,
+          timestamp: 1_700_000_001_000,
+        },
+      ];
+    },
+  };
+}
+
+/**
+ * Build a fake auth provider that returns the given credentials in order.
+ * The chain tries them in returned order, so the FIRST credential is the one
+ * tested first.
+ */
+function fakeAuthProvider(
+  name: string,
+  creds: CI.AgentResolvedAuth[],
+): CI.AgentAuthProvider {
+  return {
+    name,
+    readAuth(): CI.AgentResolvedAuth[] {
+      return creds;
+    },
+  };
+}
+
+describe("commandImport — auto-fallback on 401 across credential candidates", () => {
+  let project: string;
+  let fakeHome: string;
+  const logs: string[] = [];
+  const errs: string[] = [];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let realProviders: readonly CI.AgentHistoryProvider[];
+  let realAuthProviders: readonly CI.AgentAuthProvider[];
+
+  const prevHome = process.env.HOME;
+  const prevXdgData = process.env.XDG_DATA_HOME;
+  const prevXdgConfig = process.env.XDG_CONFIG_HOME;
+  const prevWorkerModel = process.env.LORE_WORKER_MODEL;
+
+  beforeEach(() => {
+    delete process.env.LORE_REMOTE_URL; // force local mode
+    delete process.env.LORE_WORKER_MODEL;
+    _resetAuthForTest();
+    _resetWorkerHealth();
+    startConfig = {
+      upstreamAnthropic: "https://api.anthropic.com",
+      upstreamOpenAI: "https://api.openai.com",
+    };
+    project = mkdtempSync(join(tmpdir(), "lore-fb-project-"));
+    fakeHome = mkdtempSync(join(tmpdir(), "lore-fb-home-"));
+    process.env.HOME = fakeHome;
+    process.env.XDG_DATA_HOME = join(fakeHome, ".local", "share");
+    process.env.XDG_CONFIG_HOME = join(fakeHome, ".config");
+
+    realProviders = [...getProviders()];
+    clearProviders();
+    realAuthProviders = [...getAuthProviders()];
+    clearAuthProviders();
+
+    logs.length = 0;
+    errs.length = 0;
+    llmClientCalls.length = 0;
+    promptCalls = 0;
+    logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
+      logs.push(a.join(" "));
+    });
+    errSpy = vi.spyOn(console, "error").mockImplementation((...a) => {
+      errs.push(a.join(" "));
+    });
+    stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    shutdownMock.mockClear();
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    stderrSpy.mockRestore();
+    vi.restoreAllMocks();
+    rmSync(project, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+    clearProviders();
+    for (const p of realProviders) registerProvider(p);
+    clearAuthProviders();
+    for (const a of realAuthProviders) registerAuthProvider(a);
+    _resetAuthForTest();
+    _resetWorkerHealth();
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevXdgData === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = prevXdgData;
+    if (prevXdgConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdgConfig;
+    if (prevWorkerModel === undefined) delete process.env.LORE_WORKER_MODEL;
+    else process.env.LORE_WORKER_MODEL = prevWorkerModel;
+    await loadConfig(mkdtempSync(join(tmpdir(), "lore-fb-cfg-")));
+  });
+
+  const out = () => errs.join("\n");
+  const info = () => logs.join("\n");
+
+  test("first candidate 401s → second candidate succeeds (silent fallback)", async () => {
+    // anthropic first (has built-in default model), openrouter second.
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-stale",
+          providerID: "anthropic",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-or-fresh",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    // OpenRouter has no built-in default — explicitly set the worker model.
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+
+    // First prompt: 401 (recordWorkerFailure + return null). Subsequent: success.
+    let calls = 0;
+    promptBehavior = async () => {
+      calls++;
+      if (calls === 1) {
+        recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+        return null;
+      }
+      return "[]";
+    };
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    // Exactly 2 LLM client constructions (one per candidate attempt).
+    expect(llmClientCalls.length).toBe(2);
+    const first = llmClientCalls[0]?.[2] as { providerID: string };
+    const second = llmClientCalls[1]?.[2] as { providerID: string };
+    expect(first.providerID).toBe("anthropic");
+    expect(second.providerID).toBe("openrouter");
+
+    // The user sees transparency lines, NOT the 401 diagnostic.
+    expect(info()).toContain("Using on-disk auth.json: anthropic");
+    expect(info()).toContain("Trying on-disk auth.json: openrouter");
+    expect(info()).not.toContain("Can't import");
+    expect(info()).toContain("anthropic rejected the credential");
+  });
+
+  test("BOTH candidates 401 → combined diagnostic with both providers named", async () => {
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-stale",
+          providerID: "anthropic",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-or-stale",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+
+    promptBehavior = async () => {
+      recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+      return null;
+    };
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    expect(llmClientCalls.length).toBe(2);
+    expect(out()).toContain("Can't import");
+    expect(out()).toContain("anthropic");
+    expect(out()).toContain("openrouter");
+    expect(out()).toContain("rejected the credential");
+    expect(out()).toContain("No provider auto-fallback could authenticate");
+  });
+
+  test("first candidate succeeds → no fallback attempted", async () => {
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-fresh",
+          providerID: "anthropic",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-or-fresh",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+
+    promptBehavior = async () => "[]";
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    expect(llmClientCalls.length).toBe(1);
+    const model = llmClientCalls[0]?.[2] as { providerID: string };
+    expect(model.providerID).toBe("anthropic");
+    expect(info()).not.toContain("Trying");
+    expect(out()).not.toContain("Can't import");
+  });
+
+  test("env-credential takes over when on-disk candidates fail", async () => {
+    // Use the REAL `opencode` agent name (so env capture runs) but with a
+    // fake history provider and fake auth provider. anthropic on-disk
+    // (default model), env anthropic with a DIFFERENT key — the chain tries
+    // on-disk first (401s), falls through to env (succeeds).
+    registerAuthProvider(
+      fakeAuthProvider("opencode", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-stale",
+          providerID: "anthropic",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode", displayName: "OpenCode" }),
+    );
+    process.env.ANTHROPIC_API_KEY = "sk-ant-fresh-env";
+
+    let calls = 0;
+    promptBehavior = async () => {
+      calls++;
+      if (calls === 1) {
+        recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+        return null;
+      }
+      return "[]";
+    };
+
+    await commandImport([], { project, agent: "opencode", yes: true });
+
+    expect(llmClientCalls.length).toBe(2);
+    expect(info()).not.toContain("Can't import");
+  });
+
+  test("only one candidate available, it 401s → single-candidate diagnostic (no spurious fallback message)", async () => {
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-stale",
+          providerID: "anthropic",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+
+    promptBehavior = async () => {
+      recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+      return null;
+    };
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    expect(llmClientCalls.length).toBe(1);
+    expect(out()).toContain("Can't import");
+    expect(out()).toContain("anthropic");
+    expect(out()).toContain("rejected the credential");
+    // Only one candidate → no fallback commentary.
+    expect(out()).not.toContain("No provider auto-fallback could authenticate");
+  });
+
+  test("non-Pi/claude-code/codex/opencode agent with shell env credential → env credential enters chain", async () => {
+    // Pi lacks an on-disk auth reader but DOES have `authTokenEnvVars` so
+    // its env credential should be picked up by the chain. With a stale
+    // on-disk key + fresh env key for a DIFFERENT provider, the chain
+    // should iterate both candidates (de-dup by value lets them coexist).
+    //
+    // Use the real `claude-code` agent name (which has ANTHROPIC_AUTH_TOKEN
+    // + ANTHROPIC_API_KEY) to verify the env-tier reaches the chain.
+    registerAuthProvider(
+      fakeAuthProvider("claude-code", [
+        {
+          scheme: "api-key",
+          value: "sk-or-stale",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+    );
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+    process.env.ANTHROPIC_API_KEY = "sk-ant-fresh-env";
+
+    let calls = 0;
+    promptBehavior = async () => {
+      calls++;
+      if (calls === 1) {
+        recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+        return null;
+      }
+      return "[]";
+    };
+
+    await commandImport([], { project, agent: "claude-code", yes: true });
+
+    // openrouter (on-disk) fails, then anthropic (env) succeeds.
+    expect(llmClientCalls.length).toBe(2);
+    const first = llmClientCalls[0]?.[2] as { providerID: string };
+    const second = llmClientCalls[1]?.[2] as { providerID: string };
+    expect(first.providerID).toBe("openrouter");
+    expect(second.providerID).toBe("anthropic");
+    expect(info()).toContain("ANTHROPIC_API_KEY");
+    expect(info()).not.toContain("Can't import");
+  });
+
+  test("candidate 1 auth-rejected → candidate 2 transient null is NOT mis-attributed to auth (per-candidate probe snapshot)", async () => {
+    // Regression test for Seer finding 15586850. Without per-candidate
+    // `sinceMs` snapshotting, the lingering auth-rejected failure from
+    // candidate 1 would trip the probe for candidate 2 when candidate 2
+    // returns null on chunk 1 for non-auth reasons (network timeout, model
+    // bug), causing the loop to abort candidate 2 with abortedByAuth=true
+    // — wrongly skipping a potentially valid credential.
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-stale",
+          providerID: "anthropic",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-or-fresh",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+
+    // Chunk-by-chunk behavior:
+    //   call 1 → candidate 1 (anthropic), chunk 1: returns null +
+    //     recordWorkerFailure (auth-rejected). Aborts that candidate.
+    //   call 2 → candidate 2 (openrouter), chunk 1: returns null WITHOUT
+    //     recording any failure — simulates a transient network error.
+    //   call 3 → candidate 2, chunk 2: returns "[]" (success).
+    // With per-candidate snapshot, call 2's null doesn't trip the probe
+    // (no failure recorded since `attemptStartedAt`), so candidate 2
+    // continues to chunk 2 and succeeds.
+    // Without snapshot, call 2's null + probe seeing call 1's lingering
+    // auth-rejected → wrongly marks candidate 2 as abortedByAuth=true.
+    let calls = 0;
+    promptBehavior = async () => {
+      calls++;
+      if (calls === 1) {
+        recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+        return null;
+      }
+      if (calls === 2) {
+        return null;
+      }
+      return "[]";
+    };
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    // Both candidates ran. Candidate 2 reached chunk 2 and succeeded —
+    // NOT aborted by candidate 1's lingering auth-rejected failure.
+    expect(llmClientCalls.length).toBe(2);
+    const second = llmClientCalls[1]?.[2] as { providerID: string };
+    expect(second.providerID).toBe("openrouter");
+    expect(info()).not.toContain("Can't import");
+    // chunksAnswered for candidate 2 should be > 0 (chunk 2 succeeded),
+    // NOT abortedByAuth.
+    expect(info()).toContain("Trying on-disk auth.json: openrouter");
+  });
+
+  test("non-auth failure (no 401) → 'did not answer' message, NOT a credential-fix prompt", async () => {
+    // The LLM returns null for non-auth reasons (network timeout, model bug,
+    // etc.). abortedByAuth stays false, but chunksAnswered is also 0 so the
+    // candidate fails the success predicate and falls through to the next.
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-valid",
+          providerID: "anthropic",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-or-valid",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+
+    // Every prompt: returns null WITHOUT recording auth-rejected (mirrors a
+    // transient network/timeout failure rather than a 401).
+    promptBehavior = async () => null;
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    expect(llmClientCalls.length).toBe(2);
+    // Generic "did not answer" message — NOT the credential-fix remediation.
+    // Only the FIRST candidate prints this (the LAST one has nothing to
+    // fall through to). The full diagnostic still names every provider.
+    expect(info()).toContain("anthropic did not answer");
+    expect(info()).not.toContain("rejected the credential");
+    // The full diagnostic also avoids the credential-fix advice when no
+    // candidate was auth-rejected.
+    expect(out()).toContain("none answered");
+    expect(out()).toContain("transient network/timeout/model issue");
+    expect(out()).not.toContain("export LORE_WORKER_API_KEY");
+    expect(out()).not.toContain("opencode auth login");
+  });
+
+  test("candidate chain filters out no-model credentials → 'no usable credential' guidance still fires (anyAuthResolved stays false)", async () => {
+    // Regression test for Seer finding 15586423. Without moving
+    // `anyAuthResolved = true` AFTER the candidates.length check, the
+    // end-of-run "no usable credential" guidance is suppressed when the
+    // candidate chain returns 0 entries (e.g. on-disk credentials exist
+    // but every one lacks a default worker model). User sees "0 entries
+    // created" with no actionable error.
+    //
+    // Setup: tier-1 (resolveAgentImportAuth) succeeds via last-seen session
+    // credential for openrouter (no default worker model — model.modelID
+    // is empty). tier-1 returns {getAuth, model} WITHOUT a needsModel
+    // signal (the bug surface). The chain then re-resolves and finds no
+    // routable on-disk credentials + no env, so candidates.length === 0.
+    // anyAuthResolved must stay false so the end-of-run guidance fires.
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", []), // no on-disk creds at all
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    // Inject a last-seen session credential for openrouter (no default
+    // model — tier-1 returns it without needsModel).
+    setLastSeenAuth({ scheme: "bearer", value: "sk-or-session" }, "openrouter");
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    // Should NOT have built an LLM client (chain filtered everything).
+    expect(llmClientCalls.length).toBe(0);
+    // Per-agent skip line shows the chain found nothing usable.
+    expect(info()).toContain("no usable credential found");
+    // anyAuthResolved remains false → the end-of-run "Ways forward"
+    // guidance fires.
+    expect(out()).toContain("Ways forward");
+  });
+});

--- a/packages/gateway/test/import-command-local.test.ts
+++ b/packages/gateway/test/import-command-local.test.ts
@@ -315,8 +315,9 @@ describe("commandImport (local mode) — auth pre-flight", () => {
 
     const out = errs.join("\n");
     // Actionable, credential-fix-shaped message replaces the old generic
-    // "no response from the model".
-    expect(out).toContain("credential Lore is using is invalid");
+    // "no response from the model". After auto-fallback, the surface
+    // message names the tried provider(s) + the standard remediation.
+    expect(out).toContain("rejected the credential");
     expect(out).toContain("HTTP 401");
     expect(out).toContain("LORE_WORKER_API_KEY");
     // Mentions the env-credential fallback hint so an OpenRouter / proxy
@@ -326,6 +327,8 @@ describe("commandImport (local mode) — auth pre-flight", () => {
     // exactly which block of advice applies (Aider here; the home run is
     // OpenCode — adapt as more agents are added).
     expect(out).toContain("Aider on-disk auth");
+    // The single tried provider should be in the tried-list.
+    expect(out).toContain("anthropic");
 
     // Old behavior would have printed "No response from the model for" — the
     // NEW path REPLACES that line for auth-rejected aborts. Never both.


### PR DESCRIPTION
## Summary

`lore import` now automatically retries the next available credential when the chosen one 401s, instead of surfacing an error to the user. The chain prefers the OpenCode active provider (from `opencode.json`'s `model` field) first, then iterates through the rest of `auth.json`, then the shell env credential, and finally the last-seen session credential.

Closes the Aditya scenario: his OpenCode auth.json had multiple entries across providers, and the gateway's first-match picker landed on a stale key without a working fallback.

## Changes

- **`buildAuthFallbackChain`** (new, `packages/gateway/src/cli/import.ts`): returns an ordered list of credential candidates per agent — opencode active provider → rest of auth.json → env credential → last-seen session. Tier-1 (explicit `LORE_WORKER_API_KEY`) stays single-shot (deliberate user override, never silently retried past).
- **Auto-fallback loop** in `commandImport`: iterates candidates; on upstream 401/403 (`abortedByAuth`), moves to the next candidate. Cost is one chunk per failed provider (the existing `#1525` worker-health probe aborts after the first 401).
- **Transparent logging**: prints `Using <provider>` on the first attempt, `Trying <provider>` on each fallback, and `<provider> rejected the credential / did not answer — falling through to next provider.` between attempts.
- **Combined diagnostic on full failure**: when all candidates 401, prints a single 3-option remediation block naming every provider tried. When NO candidate was auth-rejected (network/timeout), prints a different "none answered" diagnostic instead — no misleading credential-fix advice.
- **Per-agent env-credential coverage** (`packages/gateway/src/cli/agents.ts`): added `authTokenEnvVars` to **Pi** (ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY), **Hermes** (OPENAI_API_KEY), and **Gemini** (GEMINI_API_KEY / GOOGLE_API_KEY) so the env tier of the chain picks up their shell credentials. **Copilot** intentionally skipped (CLI stores credentials in `~/.config/github-copilot/hosts.json`, no documented env var) — auto-fallback for Copilot conversations remains gated on a prior `lore run` capturing the live token.
- **De-dup invariant** by `(providerID, value)`: the env path can't accidentally re-add a credential already on disk with the same key, but a fresh env credential with a different value IS added.
- **Dead-code cleanup**: removed the now-unreachable `chunksAnswered === 0` branch.
- **12 new tests** (7 e2e in `import-command-autofallback.test.ts`, 7 unit in `import-auth-chain.test.ts` env-coverage describe block) covering the success / single-fail / all-fail / env-fallback / single-candidate / non-auth-failure / per-agent env matrices.

## Test Plan

- `pnpm test packages/gateway/test/import-` → 108 tests pass across 8 files (93 pre-existing + 15 new)
- `pnpm run typecheck` → clean across all 5 workspace projects
- `pnpm run lint` → no errors in changed files
- `pnpm run format:check` → clean
- Adversarial review: 12 enumerated cases, 10 PASS, 2 pre-existing CONCERNS (`sinceMs` probe scope across candidates/agents — inherited from #1525, not introduced by this PR, recommended for a separate follow-up)
- Seer review: comment `15586027` (MEDIUM severity, mislabeling non-auth failures as "rejected the credential") fixed by differentiating per-attempt messaging and adding a separate diagnostic path for non-auth failures