### PR TITLE
fix(import): per-credential default model lookup (adm's openrouter skip)

### DIFF
--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -26,7 +26,11 @@ import {
   getLastSeenAuthProvider,
   type AuthCredential,
 } from "../auth";
-import { defaultModelForProvider, parseWorkerModelEnv } from "../worker-model";
+import {
+  defaultModelForProvider,
+  defaultSelectableModelForProvider,
+  parseWorkerModelEnv,
+} from "../worker-model";
 import { resolveProviderRoute, providerForUpstreamOrigin } from "../config";
 import { hasRecentAuthRejectedFailure } from "../worker-health";
 import { AGENTS, captureUserEnvCredential } from "./agents";
@@ -491,12 +495,22 @@ export function buildAuthFallbackChain(
       ? `opencode.json active provider: ${cred.providerID}`
       : `on-disk auth.json: ${cred.providerID}`;
 
+    // Per-credential model resolution: when cfgModel targets a DIFFERENT
+    // provider than this credential (common when the user has `cfg.model`
+    // pinned to openai but auth.json carries an openrouter key too), honor
+    // cfgModel only for the matching provider. For other providers, fall
+    // back to a per-credential default — `defaultSelectableModelForProvider`
+    // uses models.dev data when the provider has no `WORKER_DEFAULTS` entry
+    // (openrouter, deepseek, groq, opencode, …), so previously-skipped
+    // credentials with valid keys actually get tried instead of being
+    // silently dropped. Adm (2026-07-30) hit this with openrouter in auth.json
+    // while `cfg.model` was openai.
     const model =
       cfgModel && cfgModel.providerID === cred.providerID
         ? cfgModel
         : cred.modelID
           ? { providerID: cred.providerID, modelID: cred.modelID }
-          : defaultModelForProvider(cred.providerID);
+          : defaultSelectableModelForProvider(cred.providerID);
 
     // Skip candidates that lack a model — same guard as tier 2/3.
     if (!model.modelID) continue;

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -613,10 +613,14 @@ export function clearModelDataCache(): void {
 export function _setModelDataForTest(
   entries: Record<string, ModelsDevEntry>,
   byProvider?: Record<string, ModelsDevEntry>,
+  providerModelsIndex?: Record<string, string[]>,
 ): void {
   cachedModelData = new Map(Object.entries(entries));
   cachedModelDataByProvider = byProvider
     ? new Map(Object.entries(byProvider))
+    : null;
+  cachedProviderModels = providerModelsIndex
+    ? new Map(Object.entries(providerModelsIndex))
     : null;
   cachedModelDataAt = Date.now();
   resolutionMemo = new Map();
@@ -1083,6 +1087,48 @@ export function defaultModelForProvider(providerID?: string): {
     return { providerID: p, modelID: "gemini-2.5-flash" };
   }
   return { providerID: p, modelID: "" };
+}
+
+/**
+ * Like `defaultModelForProvider` but also resolves a selectable model id for
+ * providers that have no `WORKER_DEFAULTS` entry (openrouter, deepseek, groq,
+ * opencode, …). Returns the cheapest selectable model id from the cached
+ * models.dev snapshot that passes `isSelectableWorkerModel`.
+ *
+ * Returns `{providerID, modelID: ""}` when no qualifying model is found —
+ * callers should treat empty `modelID` the same as `defaultModelForProvider`'s
+ * signal (skip the candidate; it'd 400 at the upstream).
+ *
+ * Used by the `lore import` auth-fallback chain: when a user has a credential
+ * on disk for openrouter/opencode/etc. but their `cfg.model` points at a
+ * different provider (anthropic, openai, …), the chain previously skipped
+ * those credentials because `defaultModelForProvider("openrouter")` returns
+ * empty. With this helper, the chain can resolve a concrete model for each
+ * credential's provider independently.
+ */
+export function defaultSelectableModelForProvider(providerID?: string): {
+  providerID: string;
+  modelID: string;
+} {
+  const base = defaultModelForProvider(providerID);
+  if (base.modelID) return base;
+
+  const p = providerID ?? "anthropic";
+  const providerModelIds = cachedProviderModels?.get(p);
+  if (!providerModelIds || !cachedModelData) return base;
+
+  let cheapestId: string | undefined;
+  let cheapestCost = Number.POSITIVE_INFINITY;
+  for (const modelId of providerModelIds) {
+    const entry = cachedModelData.get(modelId);
+    if (entry?.cost?.input == null) continue;
+    if (entry.cost.input >= cheapestCost) continue;
+    if (!isSelectableWorkerModel(p, modelId)) continue;
+    cheapestCost = entry.cost.input;
+    cheapestId = modelId;
+  }
+  if (cheapestId) return { providerID: p, modelID: cheapestId };
+  return base;
 }
 
 /** Cost threshold ($/M input) above which we downgrade to a cheaper worker. */

--- a/packages/gateway/test/import-command-autofallback.test.ts
+++ b/packages/gateway/test/import-command-autofallback.test.ts
@@ -60,6 +60,7 @@ import {
   recordWorkerFailure,
   _resetForTest as _resetWorkerHealth,
 } from "../src/worker-health";
+import { _setModelDataForTest, clearModelDataCache } from "../src/worker-model";
 import { load as loadConfig } from "@loreai/core";
 import { conversationImport } from "@loreai/core";
 import type { conversationImport as CI } from "@loreai/core";
@@ -287,6 +288,102 @@ describe("commandImport — auto-fallback on 401 across credential candidates", 
     // to OpenRouter via env-only (no auth.json entry) need to see this as a
     // viable path. Aditya hit this gap after switching his default provider.
     expect(out()).toContain("OPENROUTER_API_KEY");
+  });
+
+  test("adm's 4-entry auth.json (anthropic + openai + openrouter + opencode) iterates all 3 default-model entries", async () => {
+    // Regression test for adm's actual case (Slack 2026-07-30). His
+    // ~/.local/share/opencode/auth.json had 4 entries — anthropic + openai
+    // (both stale api-keys), openrouter (a live api-key), and a custom
+    // `opencode` provider key. The original import log showed only the
+    // first two being tried; the live openrouter entry was never reached.
+    //
+    // Before the per-credential default lookup (defaultSelectableModelForProvider)
+    // the chain skipped openrouter/opencode because those providers have no
+    // WORKER_DEFAULTS entry, even though they have valid keys. After the fix
+    // each credential gets a per-provider default — openrouter is routed
+    // against its cheapest selectable model in the cached models.dev data.
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-stale-adm",
+          providerID: "anthropic",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-openai-stale-adm",
+          providerID: "openai",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-or-live-adm",
+          providerID: "openrouter",
+        },
+        { scheme: "api-key", value: "sk-oc-adm", providerID: "opencode" },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    // Stub the models.dev cache so defaultSelectableModelForProvider can
+    // pick a concrete model id for openrouter (no WORKER_DEFAULTS entry).
+    // Anthropic defaults to claude-sonnet-5 via WORKER_DEFAULTS; openai
+    // defaults to gpt-5.6-luna the same way. opencode (the literal provider
+    // id from adm's auth.json) has no model in the snapshot → still skipped,
+    // which is the correct fallback.
+    _setModelDataForTest(
+      {
+        "claude-sonnet-5": {
+          id: "claude-sonnet-5",
+          family: "claude-sonnet",
+          cost: { input: 2 },
+        },
+        "gpt-5.6-luna": {
+          id: "gpt-5.6-luna",
+          family: "gpt-luna",
+          cost: { input: 1 },
+        },
+        "anthropic/claude-sonnet-4.5": {
+          id: "anthropic/claude-sonnet-4.5",
+          family: "claude-sonnet",
+          cost: { input: 3 },
+        },
+      },
+      undefined,
+      {
+        anthropic: ["claude-sonnet-5"],
+        openai: ["gpt-5.6-luna"],
+        openrouter: ["anthropic/claude-sonnet-4.5"],
+      },
+    );
+
+    promptBehavior = async () => {
+      recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+      return null;
+    };
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    // anthropic + openai + openrouter all 401 (opencode is skipped — the
+    // bare providerID `opencode` has no selectable worker model in the
+    // cached snapshot). The chain MUST try openrouter before bailing so
+    // adm's live key isn't silently ignored.
+    const triedProviders = llmClientCalls.map((call) => {
+      const model = call[2] as { providerID: string };
+      return model.providerID;
+    });
+    expect(triedProviders).toContain("anthropic");
+    expect(triedProviders).toContain("openai");
+    expect(triedProviders).toContain("openrouter");
+    expect(info()).toContain("Trying on-disk auth.json: openrouter");
+    // Combined diagnostic names every provider the chain tried.
+    expect(out()).toContain("anthropic");
+    expect(out()).toContain("openai");
+    expect(out()).toContain("openrouter");
+    expect(out()).toContain("OPENROUTER_API_KEY");
+
+    // Reset the cached model data so other tests aren't affected.
+    clearModelDataCache();
   });
 
   test("first candidate succeeds → no fallback attempted", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1533 + #1534 + #1535. Diagnosed the *actual* root cause of adm's still-failing 401 storm (Slack 2026-07-30): his live openrouter api-key in `~/.local/share/opencode/auth.json` was being silently dropped by the import auth-fallback chain.

## Root cause

`buildAuthFallbackChain`'s per-credential model resolution used `defaultModelForProvider(providerID)`, which returns an *empty modelID* for any provider without a WORKER_DEFAULTS entry (openrouter, deepseek, groq, opencode, …). Line 502's `if (!model.modelID) continue` then silently dropped those credentials.

adm's chain iterated `[anthropic, openai, openrouter, opencode]`. With his `cfg.model` targeting anthropic + openai, the chain:
- anthropic — picked up via WORKER_DEFAULTS (claude-sonnet-5)
- openai — picked up via `cfgModel.providerID` match
- **openrouter — silently skipped** (no WORKER_DEFAULTS, no cfgModel match)
- opencode — silently skipped (literal providerID, no model)

So the diagnostic said "tried anthropic, openai and all rejected" — leaving adm's actual live credential unused.

## Fix

Export new `defaultSelectableModelForProvider` in `packages/gateway/src/worker-model.ts` that wraps `defaultModelForProvider` and, when the WORKER_DEFAULTS lookup returns empty, falls through to picking the *cheapest selectable model* for that provider from the cached models.dev snapshot (using the existing `isSelectableWorkerModel` predicate). Switch the chain's per-credential model resolution to use this helper.

Also extends `_setModelDataForTest` with an optional third arg (`providerModelsIndex`) so tests can populate the cached `cachedProviderModels → modelIds[]` map. Without this, per-credential lookup can't iterate selectable models in a test environment where the fetcher hasn't run.

## Regression test

`adm's 4-entry auth.json (anthropic + openai + openrouter + opencode) iterates all 3 default-model entries` reproduces adm's exact setup:
- 4 entries: anthropic + openai (stale), openrouter (live), opencode (unknown)
- No `LORE_WORKER_MODEL` set (matches adm's environment)
- Stubs the models.dev cache so openrouter resolves to `anthropic/claude-sonnet-4.5`
- Verifies the chain iterates anthropic + openai + openrouter (opencode is the only one still skipped — correct fallback, the literal providerID has no model in the cached snapshot)

## Test results

- 112/112 import-* tests pass (was 111, +1 for adm's regression)
- typecheck clean across all 5 workspace projects
- format:check clean across 665 files