### PR TITLE
fix(import): narrow cross-provider routing to OPENAI_COMPATIBLE_AGGREGATORS only

### DIFF
--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -181,21 +181,14 @@ export function resolveAgentImportAuth(
     // aggregator (openrouter, groq, cerebras, huggingface) or shares the same
     // upstream protocol as the cfgModel's provider — these aggregators can
     // proxy the session model id (e.g. `openai/gpt-5.6-luna` → openrouter).
-    const cfgRoute = cfgModel
-      ? resolveProviderRoute(cfgModel.providerID)
-      : null;
     const credRoute = resolveProviderRoute(usable.providerID);
     const isOpenAIAggregator =
       credRoute?.protocol === "openai" &&
       OPENAI_COMPATIBLE_AGGREGATORS.has(usable.providerID);
-    const sameProtocol =
-      cfgRoute != null &&
-      credRoute != null &&
-      cfgRoute.protocol === credRoute.protocol;
     const model =
       cfgModel && cfgModel.providerID === usable.providerID
         ? cfgModel
-        : cfgModel && (sameProtocol || isOpenAIAggregator)
+        : cfgModel && isOpenAIAggregator
           ? { providerID: usable.providerID, modelID: cfgModel.modelID }
           : usable.modelID
             ? { providerID: usable.providerID, modelID: usable.modelID }
@@ -568,21 +561,14 @@ export function buildAuthFallbackChain(
     //      Anthropic-billed, not OpenAI-billed).
     //   3. cred.modelID — explicit per-credential override.
     //   4. per-credential default from models.dev — last-resort fallback.
-    const cfgRoute = cfgModel
-      ? resolveProviderRoute(cfgModel.providerID)
-      : null;
     const credRoute = resolveProviderRoute(cred.providerID);
     const isOpenAIAggregator =
       credRoute?.protocol === "openai" &&
       OPENAI_COMPATIBLE_AGGREGATORS.has(cred.providerID);
-    const sameProtocol =
-      cfgRoute != null &&
-      credRoute != null &&
-      cfgRoute.protocol === credRoute.protocol;
     const model =
       cfgModel && cfgModel.providerID === cred.providerID
         ? cfgModel
-        : cfgModel && (sameProtocol || isOpenAIAggregator)
+        : cfgModel && isOpenAIAggregator
           ? { providerID: cred.providerID, modelID: cfgModel.modelID }
           : cred.modelID
             ? { providerID: cred.providerID, modelID: cred.modelID }

--- a/packages/gateway/test/import-command-autofallback.test.ts
+++ b/packages/gateway/test/import-command-autofallback.test.ts
@@ -436,6 +436,55 @@ describe("commandImport — auto-fallback on 401 across credential candidates", 
     }
   });
 
+  test("non-aggregator OpenAI-compatible providers (vllm/mistral) do NOT receive cfg.model", async () => {
+    // Regression test for Seer review on PR #1539 (HIGH severity, ID 15601472/0).
+    // The cross-provider routing for cfg.model must be gated on
+    // OPENAI_COMPATIBLE_AGGREGATORS, NOT on shared protocol. vllm, mistral,
+    // deepseek, github-models all use the OpenAI Chat Completions protocol
+    // but each serves its own model catalog — sending `openai/gpt-5.6-luna`
+    // to a vllm provider would 400 because vllm doesn't recognize that id.
+    //
+    // This test verifies that a `vllm` credential is NOT cross-routed to
+    // `openai/gpt-5.6-luna` from cfg.model; instead the chain falls back to
+    // vllm's own default model (or no model → skipped, since vllm isn't in
+    // OPENAI_COMPATIBLE_AGGREGATORS).
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        { scheme: "api-key", value: "mistral-key", providerID: "mistral" },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    const lorePath = join(project, ".lore.json");
+    writeFileSync(
+      lorePath,
+      JSON.stringify({
+        model: { providerID: "openai", modelID: "gpt-5.6-luna" },
+      }),
+    );
+    await loadConfig(project);
+
+    promptBehavior = async () => {
+      recordWorkerFailure("_unknown", "lore-import", "auth-rejected");
+      return null;
+    };
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    // The chain should NOT have called mistral with `gpt-5.6-luna` (openai's
+    // model id). Either it skipped mistral entirely (needsModel/no default)
+    // or called it with mistral's own default model.
+    const mistralCalls = llmClientCalls.filter((call) => {
+      const model = call[2] as { providerID: string; modelID: string };
+      return model.providerID === "mistral";
+    });
+    for (const call of mistralCalls) {
+      const model = call[2] as { providerID: string; modelID: string };
+      expect(model.modelID).not.toBe("gpt-5.6-luna");
+    }
+  });
+
   test("first candidate succeeds → no fallback attempted", async () => {
     registerAuthProvider(
       fakeAuthProvider("opencode-fake", [


### PR DESCRIPTION
## Summary

Follow-up to PR #1539 (Seer review 15601472/0, HIGH severity).

## Seer's concern

`sameProtocol` check in `buildAuthFallbackChain` (line 578) and tier-2 `resolveAgentImportAuth` (line 191) is too broad. vllm, mistral, deepseek, github-models all use the `openai` Chat Completions protocol but each serves its OWN model catalog. Sending `openai/gpt-5.6-luna` to a vllm provider would 400 because vllm doesn't recognize that id.

## Fix

Drop the `sameProtocol` check entirely. The only cross-provider routing gate is now `isOpenAIAggregator` — the `OPENAI_COMPATIBLE_AGGREGATORS` set ({openrouter, groq, cerebras, huggingface}) is precisely the list of providers that proxy ANY model id in their catalog. Other OpenAI-compatible providers need their own default model, not a borrowed one from another provider.

The aggregator set already covers adm's use case (openrouter cred proxies `openai/*` model ids). Adm's fix continues to work — only non-aggregator providers lose the cross-routing, which they shouldn't have had in the first place.

## Regression test

`non-aggregator OpenAI-compatible providers (vllm/mistral) do NOT receive cfg.model` verifies that a mistral credential is NOT cross-routed to `openai/gpt-5.6-luna` from cfg.model.

## Test results

- 113/113 import-* tests pass
- typecheck clean across all 5 workspace projects