### PR TITLE
fix(import): surface per-chunk error in chain diagnostic

### DIFF
--- a/packages/core/src/import/extract.ts
+++ b/packages/core/src/import/extract.ts
@@ -12,6 +12,13 @@ import type { LLMClient } from "../types";
 import type { ConversationChunk } from "./types";
 
 /**
+ * Max length of `lastError` in `ExtractionResult`. Keeps diagnostic output
+ * bounded when a per-chunk throw produces a verbose HTTP body (e.g. an
+ * openrouter 400 with a 5KB JSON response). Truncated errors end with "…".
+ */
+const MAX_ERROR_LENGTH = 400;
+
+/**
  * System prompt for import extraction.
  * Extends the standard curator prompt with guidance for historical conversations.
  */
@@ -75,6 +82,19 @@ export type ExtractionResult = {
    * abortedByAuth means we CHOSE to stop, not that every chunk happened to fail.
    */
   abortedByAuth: boolean;
+  /**
+   * First non-abort error from the loop (the per-chunk try/catch swallows
+   * errors to keep the loop running; the first one is preserved here so the
+   * chain's diagnostic can surface it). undefined when every chunk succeeded
+   * (chunksAnswered === chunks.length) or the loop never started (empty
+   * chunks). Truncated to MAX_ERROR_LENGTH chars to keep diagnostic output
+   * bounded.
+   *
+   * Adm (Slack 2026-07-30) hit this with openrouter — the loop threw on
+   * every chunk but the diagnostic said only "openrouter did not answer"
+   * with zero detail.
+   */
+  lastError?: string;
 };
 
 /**
@@ -115,6 +135,7 @@ export async function extractKnowledge(input: {
     chunksFailed: 0,
     chunksAnswered: 0,
     abortedByAuth: false,
+    lastError: undefined,
   };
 
   if (input.chunks.length === 0) {
@@ -190,8 +211,20 @@ export async function extractKnowledge(input: {
       }
 
       result.chunksProcessed++;
-    } catch {
+    } catch (e) {
       result.chunksFailed++;
+      // Preserve the FIRST error so the chain's "no-response" diagnostic
+      // can surface it. Subsequent identical failures are folded into a
+      // count in the surface message. Truncate to keep diagnostic output
+      // bounded (a 304-chunk import with a verbose HTTP body would otherwise
+      // produce an unreadable error).
+      if (result.lastError === undefined) {
+        const msg = e instanceof Error ? e.message : String(e);
+        result.lastError =
+          msg.length > MAX_ERROR_LENGTH
+            ? msg.slice(0, MAX_ERROR_LENGTH) + "…"
+            : msg;
+      }
     }
 
     input.onProgress?.({

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -667,6 +667,17 @@ export function buildAuthFallbackChain(
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Truncate a string for inline log display. Used by the chain's diagnostic
+ * to inline per-candidate errors (e.g. "openrouter did not answer (HTTP 400:
+ * model not found) — falling through..."). Keeps log lines single-line and
+ * within a reasonable width even when the underlying error message is huge.
+ */
+function truncateForLog(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 1) + "…";
+}
+
 function formatDate(ts: number): string {
   return new Date(ts).toISOString().replace("T", " ").slice(0, 16);
 }
@@ -1456,6 +1467,8 @@ export async function commandImport(
         label: string;
         providerID: string;
         reason: "auth-rejected" | "no-response";
+        /** First per-chunk error from the loop, when no-response. undefined when auth-rejected. */
+        lastError?: string;
       }> = [];
 
       for (let i = 0; i < candidates.length; i++) {
@@ -1542,14 +1555,26 @@ export async function commandImport(
           label,
           providerID: auth.model.providerID,
           reason: attemptResult.abortedByAuth ? "auth-rejected" : "no-response",
+          // Preserve the underlying error so the final diagnostic can
+          // surface it (adm's openrouter silent-fail case, Slack 2026-07-30).
+          // Undefined when abortedByAuth (the upstream already told us why).
+          lastError: attemptResult.lastError,
         });
 
         if (i < candidates.length - 1) {
           const reasonText = attemptResult.abortedByAuth
             ? `rejected the credential`
             : `did not answer`;
+          // Surface the underlying error when known so adm (and similar users)
+          // can diagnose without needing to enable debug logging. The "no-response"
+          // diagnostic alone is opaque — could be auth, network, model-not-found,
+          // rate-limit, or a malformed response.
+          const detail =
+            !attemptResult.abortedByAuth && attemptResult.lastError
+              ? ` (${truncateForLog(attemptResult.lastError, 200)})`
+              : "";
           console.log(
-            `[lore]   ${auth.model.providerID} ${reasonText} — ` +
+            `[lore]   ${auth.model.providerID} ${reasonText}${detail} — ` +
               `falling through to next provider.`,
           );
         }
@@ -1575,9 +1600,20 @@ export async function commandImport(
             : "";
 
         if (allNonAuth) {
+          // Show the underlying error from the first no-response attempt so
+          // the user can diagnose without enabling --debug. The error is
+          // truncated because HTTP bodies can be huge (openrouter 4xx often
+          // returns a JSON blob with full request details).
+          const noResponseEntry = triedProviders.find(
+            (t) => t.reason === "no-response",
+          );
+          const lastError = noResponseEntry?.lastError?.trim() || undefined;
+          const errorDetail = lastError
+            ? `\n[lore] First error: ${truncateForLog(lastError, 300)}`
+            : "";
           console.error(
             `\n[lore] Can't import ${result.agentDisplayName}: tried ${triedList || "all available"} ` +
-              `and none answered (no HTTP 401 — likely transient network/timeout/model issue).\n` +
+              `and none answered (no HTTP 401 — likely transient network/timeout/model issue).${errorDetail}\n` +
               `[lore]\n` +
               `[lore] Re-run \`lore import\` after a moment. If this keeps happening, file an ` +
               `issue with the full output of \`lore import --debug\`.\n`,

--- a/packages/gateway/test/import-command-autofallback.test.ts
+++ b/packages/gateway/test/import-command-autofallback.test.ts
@@ -41,6 +41,7 @@ vi.mock("../src/cli/start", () => ({
 // "first candidate 401s, second succeeds" sequence without real network.
 const llmClientCalls: unknown[][] = [];
 let promptBehavior: () => Promise<string | null> = async () => "[]";
+let promptThrowsWith: Error | null = null;
 let promptCalls = 0;
 vi.mock("../src/llm-adapter", () => ({
   createGatewayLLMClient: (...args: unknown[]) => {
@@ -48,6 +49,7 @@ vi.mock("../src/llm-adapter", () => ({
     return {
       prompt: vi.fn(async () => {
         promptCalls++;
+        if (promptThrowsWith) throw promptThrowsWith;
         return promptBehavior();
       }),
     };
@@ -161,6 +163,7 @@ describe("commandImport — auto-fallback on 401 across credential candidates", 
     logs.length = 0;
     errs.length = 0;
     llmClientCalls.length = 0;
+    promptThrowsWith = null;
     promptCalls = 0;
     logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
       logs.push(a.join(" "));
@@ -680,6 +683,91 @@ describe("commandImport — auto-fallback on 401 across credential candidates", 
     expect(out()).toContain("transient network/timeout/model issue");
     expect(out()).not.toContain("export LORE_WORKER_API_KEY");
     expect(out()).not.toContain("opencode auth login");
+  });
+
+  test("per-candidate 'did not answer' surfaces the underlying error inline", async () => {
+    // The "did not answer" message should include the underlying error
+    // (from ExtractionResult.lastError) when known, so the user can diagnose
+    // without enabling --debug. Adm's openrouter case (Slack 2026-07-30)
+    // had this happen silently before this PR.
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-ant-valid",
+          providerID: "anthropic",
+        },
+        {
+          scheme: "api-key",
+          value: "sk-or-valid",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+
+    // anthropic returns null (no auth-rejected probe fires → "did not
+    // answer"); openrouter also throws so the chain's final diagnostic
+    // mentions both.
+    promptBehavior = async () => null;
+    promptThrowsWith = new Error("HTTP 429: rate limit exceeded");
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    // First candidate prints its own "did not answer" line + falls through.
+    expect(info()).toContain("anthropic did not answer");
+    // The first candidate's per-line message includes the underlying error.
+    expect(info()).toContain("HTTP 429");
+    // Both candidates tried → final diagnostic surfaces the first error.
+    expect(out()).toContain("First error:");
+    expect(out()).toContain("HTTP 429");
+
+    promptThrowsWith = null;
+  });
+
+  test("per-chunk throw is surfaced in 'did not answer' diagnostic (adm's openrouter case)", async () => {
+    // Regression test for adm (Slack 2026-07-30): his openrouter cred threw
+    // on every chunk (no 401, just a silent error), the chain printed only
+    // "openrouter did not answer" with zero detail, and he had no way to
+    // diagnose without --debug. After this PR, the first error is captured
+    // in ExtractionResult.lastError and surfaced in the final combined
+    // diagnostic ("First error: <actual error>").
+    registerAuthProvider(
+      fakeAuthProvider("opencode-fake", [
+        {
+          scheme: "api-key",
+          value: "sk-or-live",
+          providerID: "openrouter",
+        },
+      ]),
+    );
+    registerProvider(
+      fakeProvider({ name: "opencode-fake", displayName: "OpenCode" }),
+    );
+    // openrouter has no WORKER_DEFAULTS entry — must set a model to route
+    // through it. Use the session model id from adm's case.
+    process.env.LORE_WORKER_MODEL = "openrouter/anthropic/claude-sonnet-5";
+
+    // Every prompt throws a realistic error — mimics what would happen when
+    // openrouter returns a 4xx with a JSON body, or the upstream times out.
+    promptBehavior = async () => null;
+    promptThrowsWith = new Error("HTTP 400: model 'gpt-5.6-luna' not found");
+
+    await commandImport([], { project, agent: "opencode-fake", yes: true });
+
+    // Only 1 candidate (openrouter) → no per-candidate "did not answer" line
+    // printed (it's only emitted when there are more candidates to fall
+    // through to). The FIRST error surfaces in the final combined diagnostic.
+    expect(out()).toContain("Can't import");
+    expect(out()).toContain("First error:");
+    expect(out()).toContain("HTTP 400");
+    expect(out()).toContain("model 'gpt-5.6-luna' not found");
+    // The error is truncated to fit on one line (HTTP bodies can be huge).
+    // Resets so subsequent tests don't throw.
+    promptThrowsWith = null;
   });
 
   test("tier-4 last-seen session credential for defaultless provider → needsModel signal (workerApiKey unset)", async () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #1536/#1538/#1539/#1540. adm (Slack 2026-07-30) reported the chain still failed after those merged — but this time the failure mode is different: the openrouter call is **throwing on every chunk**, and the chain's diagnostic says only "openrouter did not answer" with zero detail.

## Root cause

The per-chunk try/catch in `packages/core/src/import/extract.ts:193` silently swallows the error:

```ts
} catch {
  result.chunksFailed++;
}
```

Result: `chunksAnswered = 0`, `chunksFailed = 304`, `abortedByAuth = false` → "openrouter did not answer". Adm had no way to know whether it was auth, network, model-not-found, rate-limit, or a malformed response.

## Fix

Capture the first error in `ExtractionResult.lastError` (truncated to 400 chars). The chain's diagnostic now includes the error inline:

```
[lore]   openrouter did not answer (HTTP 400: model 'gpt-5.6-luna' not found) — falling through...
```

And the final combined diagnostic adds a dedicated line:

```
[lore] First error: HTTP 400: model 'gpt-5.6-luna' not found
```

Truncation ends with "…" so the user can tell. The catch is still silent at the per-chunk level (no log spam) but the first error of a run is preserved.

After this PR, when the user sees "openrouter did not answer", they see WHY (e.g. "HTTP 400: model not found" → cfg.model is wrong for openrouter). The per-candidate inline error tells the user WHICH provider is the problem AND why. The final First error: line is the last-resort signal even when there's only one candidate.

## Test results

- 115/115 import-* tests pass
- typecheck clean across all 5 workspace projects
- format:check clean across 665 files