### PR TITLE
fix(import): skip :free/non-chat models when picking a default worker model

### DIFF
--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -1092,8 +1092,33 @@ export function defaultModelForProvider(providerID?: string): {
 /**
  * Like `defaultModelForProvider` but also resolves a selectable model id for
  * providers that have no `WORKER_DEFAULTS` entry (openrouter, deepseek, groq,
- * opencode, …). Returns the cheapest selectable model id from the cached
- * models.dev snapshot that passes `isSelectableWorkerModel`.
+ * opencode, …). Returns the cheapest *reliably-usable* selectable model id from
+ * the cached models.dev snapshot that passes `isSelectableWorkerModel`.
+ *
+ * "Reliably usable" excludes two classes of model that make bad UNPROMPTED
+ * defaults (the user has NOT picked a model — we're guessing one):
+ *
+ *   1. `:free` tiers (e.g. `cohere/north-mini-code:free`). On aggregators like
+ *      OpenRouter the globally-cheapest model is almost always a `:free` model
+ *      priced at $0, but those are gated behind the provider's data-collection
+ *      policy: an account that hasn't opted into prompt logging gets a 404
+ *      ("no endpoints … data policy") on the very first call. As an unprompted
+ *      default that is a near-guaranteed failure, so we skip the whole `:free`
+ *      tier here. NOTE: this is distinct from `isSelectableWorkerModel`'s
+ *      runtime `:free` handling, which correctly never STATICALLY excludes
+ *      `:free` (a session whose model IS `:free` may work fine once opted in).
+ *      Here we're choosing a default, not honoring the user's own model.
+ *   2. Zero-output-cost entries (`cost.output` is 0 or absent). Aggregators
+ *      catalog non-chat models (audio/image/preview, e.g.
+ *      `google/lyria-3-*-preview`) at $0/$0; those aren't text-completion LLMs
+ *      and would 400/404 an extraction request. Real chat models charge for
+ *      output tokens, so a positive output cost is a cheap, data-driven proxy
+ *      for "this is a usable chat model".
+ *
+ * Falls back to the previous behavior (cheapest `isSelectableWorkerModel`
+ * candidate, `:free`/zero-output included) only when NO paid chat model
+ * qualifies, so a provider that genuinely only offers `:free` models is never
+ * regressed to an empty pick.
  *
  * Returns `{providerID, modelID: ""}` when no qualifying model is found —
  * callers should treat empty `modelID` the same as `defaultModelForProvider`'s
@@ -1117,16 +1142,35 @@ export function defaultSelectableModelForProvider(providerID?: string): {
   const providerModelIds = cachedProviderModels?.get(p);
   if (!providerModelIds || !cachedModelData) return base;
 
-  let cheapestId: string | undefined;
-  let cheapestCost = Number.POSITIVE_INFINITY;
+  // Pass 1: cheapest paid chat model (non-`:free`, positive output cost). This
+  // is the preferred default — it avoids the data-policy-404 `:free` trap and
+  // the zero-cost non-chat (audio/image/preview) entries aggregators publish.
+  let bestId: string | undefined;
+  let bestCost = Number.POSITIVE_INFINITY;
+  // Pass-2 fallback (any selectable model, `:free`/zero-output included), used
+  // only when no paid chat model qualifies so we never regress to empty.
+  let fallbackId: string | undefined;
+  let fallbackCost = Number.POSITIVE_INFINITY;
   for (const modelId of providerModelIds) {
     const entry = cachedModelData.get(modelId);
     if (entry?.cost?.input == null) continue;
-    if (entry.cost.input >= cheapestCost) continue;
     if (!isSelectableWorkerModel(p, modelId)) continue;
-    cheapestCost = entry.cost.input;
-    cheapestId = modelId;
+
+    if (entry.cost.input < fallbackCost) {
+      fallbackCost = entry.cost.input;
+      fallbackId = modelId;
+    }
+
+    // A reliably-usable default: not a `:free` tier, and priced for output
+    // (real chat models charge for output tokens).
+    const usableDefault =
+      !modelId.endsWith(":free") && (entry.cost.output ?? 0) > 0;
+    if (usableDefault && entry.cost.input < bestCost) {
+      bestCost = entry.cost.input;
+      bestId = modelId;
+    }
   }
+  const cheapestId = bestId ?? fallbackId;
   if (cheapestId) return { providerID: p, modelID: cheapestId };
   return base;
 }

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -20,6 +20,7 @@ import {
   resetWorkerModelState,
   clearModelDataCache,
   lookupProviderRoute,
+  defaultSelectableModelForProvider,
   _setModelDataForTest,
   type ModelsDevEntry,
 } from "../src/worker-model";
@@ -2590,5 +2591,148 @@ describe("provider-qualified pricing (getModelEntrySyncForProvider)", () => {
         "deepseek/deepseek-v4-flash",
       ).cost?.cache_read,
     ).toBe(0.0028);
+  });
+});
+
+describe("defaultSelectableModelForProvider", () => {
+  beforeEach(() => {
+    clearModelDataCache();
+    resetWorkerHealth();
+  });
+
+  afterEach(() => {
+    clearModelDataCache();
+    resetWorkerHealth();
+  });
+
+  test("providers WITH a WORKER_DEFAULTS entry keep their validated default", () => {
+    // anthropic has a WORKER_DEFAULTS entry — never touched by the
+    // cheapest-selectable scan (returns the offline family fallback).
+    expect(defaultSelectableModelForProvider("anthropic")).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-sonnet-5",
+    });
+  });
+
+  test("cold cache (no models.dev data) returns the empty base signal", () => {
+    // No snapshot loaded → nothing to scan → empty modelID so the caller
+    // treats it the same as defaultModelForProvider (skip the candidate).
+    expect(defaultSelectableModelForProvider("openrouter")).toEqual({
+      providerID: "openrouter",
+      modelID: "",
+    });
+  });
+
+  test("skips :free tiers even when they are the globally cheapest (adm's data-policy 404)", () => {
+    // Regression for adm's `lore import` failure (Slack 2026-07-30): a fresh
+    // import process has no session model, so the openrouter credential falls
+    // to defaultSelectableModelForProvider. The globally-cheapest openrouter
+    // model is a `:free` tier ($0) that 404s with "data policy — account has
+    // not opted in". We must skip the whole `:free` tier and pick the cheapest
+    // PAID chat model instead, so the working openrouter key actually imports.
+    _setModelDataForTest(
+      {
+        "cohere/north-mini-code:free": {
+          id: "cohere/north-mini-code:free",
+          cost: { input: 0, output: 0 },
+        },
+        "mistralai/mistral-nemo": {
+          id: "mistralai/mistral-nemo",
+          cost: { input: 0.019, output: 0.03 },
+        },
+        "anthropic/claude-sonnet-5": {
+          id: "anthropic/claude-sonnet-5",
+          cost: { input: 2, output: 10 },
+        },
+      },
+      undefined,
+      {
+        openrouter: [
+          "cohere/north-mini-code:free",
+          "mistralai/mistral-nemo",
+          "anthropic/claude-sonnet-5",
+        ],
+      },
+    );
+
+    expect(defaultSelectableModelForProvider("openrouter")).toEqual({
+      providerID: "openrouter",
+      modelID: "mistralai/mistral-nemo",
+    });
+  });
+
+  test("skips zero-output (non-chat audio/preview) entries priced at $0", () => {
+    // Aggregators catalog non-chat models (audio/image/preview) at $0/$0 —
+    // e.g. google/lyria-3-*-preview. Those aren't text-completion LLMs and
+    // would 400/404 an extraction request. A positive OUTPUT cost is the
+    // data-driven proxy for "usable chat model", so the cheaper-by-input
+    // zero-output entry must be skipped in favor of the priced chat model.
+    _setModelDataForTest(
+      {
+        "google/lyria-3-pro-preview": {
+          id: "google/lyria-3-pro-preview",
+          cost: { input: 0, output: 0 },
+        },
+        "inclusionai/ling-2.6-flash": {
+          id: "inclusionai/ling-2.6-flash",
+          cost: { input: 0.01, output: 0.03 },
+        },
+      },
+      undefined,
+      {
+        openrouter: [
+          "google/lyria-3-pro-preview",
+          "inclusionai/ling-2.6-flash",
+        ],
+      },
+    );
+
+    expect(defaultSelectableModelForProvider("openrouter")).toEqual({
+      providerID: "openrouter",
+      modelID: "inclusionai/ling-2.6-flash",
+    });
+  });
+
+  test("picks the cheapest among multiple paid chat models", () => {
+    _setModelDataForTest(
+      {
+        "vendor/expensive": {
+          id: "vendor/expensive",
+          cost: { input: 5, output: 15 },
+        },
+        "vendor/mid": { id: "vendor/mid", cost: { input: 1, output: 3 } },
+        "vendor/cheap": { id: "vendor/cheap", cost: { input: 0.1, output: 0.3 } },
+      },
+      undefined,
+      {
+        openrouter: ["vendor/expensive", "vendor/mid", "vendor/cheap"],
+      },
+    );
+
+    expect(defaultSelectableModelForProvider("openrouter")).toEqual({
+      providerID: "openrouter",
+      modelID: "vendor/cheap",
+    });
+  });
+
+  test("falls back to a :free model only when NO paid chat model exists", () => {
+    // A provider that genuinely offers only `:free` models must not regress to
+    // an empty pick — we still return SOMETHING (the cheapest selectable), so
+    // the credential isn't silently dropped. The fallback pass covers this.
+    _setModelDataForTest(
+      {
+        "x/only-free:free": {
+          id: "x/only-free:free",
+          cost: { input: 0, output: 0 },
+        },
+      },
+      undefined,
+      { openrouter: ["x/only-free:free"] },
+    );
+
+    expect(defaultSelectableModelForProvider("openrouter")).toEqual({
+      providerID: "openrouter",
+      modelID: "x/only-free:free",
+    });
   });
 });


### PR DESCRIPTION
## Summary

`lore import` hard-fails on a **working OpenRouter key** when no session model is configured. This is the still-unfixed tail of the adm openrouter import saga (#1536 → #1538 → #1539 → #1540).

### Root cause

When `cfg.model` is `undefined` (no `.lore.json` model, no `LORE_WORKER_MODEL`, no `model`/`small_model` in `opencode.json`), the cross-provider aggregator routing added in #1539/#1540 can't fire (it requires a truthy `cfgModel`). The auth-fallback chain then falls through to `defaultSelectableModelForProvider(cred.providerID)`, which picked the **globally-cheapest** selectable model.

On OpenRouter the cheapest model is a `:free` tier (e.g. `cohere/north-mini-code:free`, $0), which is gated behind the provider's data-collection policy. An account that hasn't opted into prompt logging gets an immediate:

```
openrouter did not answer (HTTP 404: data policy blocked —
openrouter/cohere/north-mini-code:free unavailable (account has not opted in))
```

The `:free` tier is only skipped **after** an observed data-policy 404 (`areFreeModelsDataBlocked`), which is empty on a fresh `lore import` process — so the bad model is always picked first, and the loop moves to the next *credential* rather than re-resolving OpenRouter to a paid model. The working key is abandoned and the whole import fails.

Even the cheapest *paid* pick is unreliable: aggregators catalog non-chat models (audio/image/preview, e.g. `google/lyria-3-*-preview`) at `$0/$0` that would 400/404 an extraction request.

### Observed failure

```
[lore]   Trying on-disk auth.json: openrouter
[lore]   openrouter did not answer (HTTP 404: data policy blocked — ...:free unavailable ...)
...
[lore] Can't import OpenCode: tried anthropic, openai, openrouter, opencode and all rejected...
[lore] Import complete: 0 entries created, 0 updated (4 chunks failed).
```

## Fix

Tighten `defaultSelectableModelForProvider` to pick the cheapest **reliably-usable** model:

1. **Skip `:free` tiers** — near-guaranteed data-policy 404 as an *unprompted* default. This is distinct from `isSelectableWorkerModel`'s runtime `:free` handling (which correctly never *statically* excludes `:free`, since a session whose model **is** `:free` may work once opted in). Here we're choosing a default, not honoring the user's own model.
2. **Require a positive output cost** — real chat models charge for output tokens; the $0/$0 entries are non-chat (audio/image/preview) models.

Falls back to the previous cheapest-selectable behavior (`:free`/zero-output included) **only** when no paid chat model qualifies, so a provider that genuinely only offers `:free` models is never regressed to an empty pick.

Scoped to the import path only (`import.ts:575`) — the live worker selection path does not use this helper.

### Effect (real models.dev snapshot)

| provider | before | after |
|---|---|---|
| openrouter | `cohere/north-mini-code:free` (data-policy 404) | `inclusionai/ling-2.6-flash` (paid chat) |
| opencode | `trinity-large-preview-free` (unsupported) | `gpt-5-nano` |
| deepseek | `deepseek-v4-flash` | `deepseek-v4-flash` (unchanged) |

## Testing

- New `describe("defaultSelectableModelForProvider")` block (6 tests): WORKER_DEFAULTS passthrough, cold-cache empty signal, `:free` skip (adm's case), zero-output skip, cheapest-paid, and `:free`-only fallback.
- Full gateway suite green: **3469 passed, 0 failures**.
- `pnpm run typecheck` + `pnpm run lint` clean.