### PR TITLE
fix(import): re-run oxfmt on worker-model.test.ts to unblock nightly

### DIFF
--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -2701,7 +2701,10 @@ describe("defaultSelectableModelForProvider", () => {
           cost: { input: 5, output: 15 },
         },
         "vendor/mid": { id: "vendor/mid", cost: { input: 1, output: 3 } },
-        "vendor/cheap": { id: "vendor/cheap", cost: { input: 0.1, output: 0.3 } },
+        "vendor/cheap": {
+          id: "vendor/cheap",
+          cost: { input: 0.1, output: 0.3 },
+        },
       },
       undefined,
       {


### PR DESCRIPTION
## Summary

Aditya's PR #1545 (skip :free tiers, require positive output cost) passed all CI gates, but the new test file `packages/gateway/test/worker-model.test.ts` fails `oxfmt --check`. The main CI is now failing because the format check is blocking nightly publish.

This commit re-runs oxfmt to fix the formatting on the test file. No code changes — purely a formatting fix.

```
pnpm run format   # auto-fixes
pnpm run format:check   # verify
```

## Verification

- format:check passes on 665 files
- 117/117 import-* tests still pass
- 97/97 worker-model.test.ts tests pass