### PR TITLE
fix(core): chunk knowledge_entity_refs inserts + FK fallback

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -2104,19 +2104,62 @@ export function syncEntityRefs(
   }
 
   let count = 0;
-  for (const entityId of linkedEntityIds) {
+  if (linkedEntityIds.size) {
+    // Chunked multi-row INSERT — removes the per-entity N+1 Sentry detects on
+    // `lore.curator` / `lore.consolidation` (LOREAI-GATEWAY-3Y, LOREAI-GATEWAY-4Q).
+    // One statement per chunk (vs N per entry), one fsync per chunk, one span
+    // per chunk in the Sentry transaction tree. CHUNK = 450 keeps the bound
+    // parameter count at 900 (2 params × 450 = 900), well within SQLite's
+    // SQLITE_MAX_VARIABLE_NUMBER=999 default; mirrors the 900-param ceiling
+    // used by batchLoadAliases / batchLoadAliasesOffloaded / etc.
+    // Entity IDs come from the entities/aliases tables above and the
+    // knowledge_id is the resolved logical_id, so FK violations are not
+    // expected on this path. SQLite aborts the whole chunk on FK violation,
+    // so we fall back to per-row inserts to preserve the prior defensive
+    // contract (Seer 15652457 LOW). Per-row count/affected tracking inside
+    // the fallback mirrors the pre-refactor loop's semantics — only
+    // successfully-inserted rows count toward `count` and `affected`
+    // (Seer 15653378 LOW).
+    const ids = Array.from(linkedEntityIds);
+    const CHUNK = 450;
     try {
-      db()
-        .query(
-          "INSERT OR IGNORE INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES (?, ?)",
-        )
-        .run(logicalId, entityId);
-      affected.add(entityId);
-      count++;
+      for (let i = 0; i < ids.length; i += CHUNK) {
+        const chunk = ids.slice(i, i + CHUNK);
+        const values = chunk.map(() => "(?, ?)").join(", ");
+        const params: string[] = [];
+        for (const entityId of chunk) params.push(logicalId, entityId);
+        db()
+          .query(
+            `INSERT OR IGNORE INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES ${values}`,
+          )
+          .run(...params);
+      }
+      // Chunked INSERT succeeded — every row in the batch meets the
+      // INSERT OR IGNORE contract (FK-valid by construction, no
+      // duplicates after the pre-DELETE). All ids are linked.
+      for (const entityId of ids) affected.add(entityId);
+      count = ids.length;
     } catch (e: unknown) {
-      // FK violation (entity or knowledge entry doesn't exist) — skip
-      if (e instanceof Error && /FOREIGN KEY/i.test(e.message)) continue;
-      throw e;
+      if (!(e instanceof Error && /FOREIGN KEY/i.test(e.message))) throw e;
+      // Schema-impossible on this path (entity IDs are FK-valid by
+      // construction), but a hypothetical FK violation aborts the whole
+      // chunk. Fall back to per-row inserts so a single bad row doesn't
+      // tear down the rest.
+      for (const entityId of ids) {
+        try {
+          db()
+            .query(
+              "INSERT OR IGNORE INTO knowledge_entity_refs (knowledge_id, entity_id) VALUES (?, ?)",
+            )
+            .run(logicalId, entityId);
+          affected.add(entityId);
+          count++;
+        } catch (inner: unknown) {
+          if (inner instanceof Error && /FOREIGN KEY/i.test(inner.message))
+            continue;
+          throw inner;
+        }
+      }
     }
   }
 

--- a/packages/core/test/curator-entity-ref-batch.test.ts
+++ b/packages/core/test/curator-entity-ref-batch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { applyOps } from "../src/curator";
 import { db, ensureProject } from "../src/db";
 import * as entities from "../src/entities";
+import * as ltm from "../src/ltm";
 import { type LogSink, registerSink } from "../src/log";
 
 const PROJECT = "/tmp/lore-curator-entity-ref-batch/project";
@@ -21,6 +22,9 @@ function countingSink(counts: Record<string, number>): LogSink {
       }
       if (sql.includes("FROM entity_aliases")) {
         counts.aliases = (counts.aliases ?? 0) + 1;
+      }
+      if (sql.includes("INSERT OR IGNORE INTO knowledge_entity_refs")) {
+        counts.refInsert = (counts.refInsert ?? 0) + 1;
       }
       return fn();
     },
@@ -109,5 +113,160 @@ describe("curator entity-ref sync is batched (no N+1 registry reload)", () => {
     expect(entities.knowledgeForEntity(alpha)).toHaveLength(1);
     expect(entities.knowledgeForEntity(bravo)).toHaveLength(1);
     expect(entities.knowledgeForEntity(charlie)).toHaveLength(1);
+  });
+
+  test("knowledge_entity_refs INSERT runs once per entry, not once per matched entity (LOREAI-GATEWAY-3Y, LOREAI-GATEWAY-4Q)", () => {
+    // Three entities, each mentioned by canonical name in three knowledge
+    // entries → 3 entries × 3 entity matches = 9 refs total. Pre-fix this
+    // produced 9 separate INSERT statements. Post-fix (multi-row INSERT) it
+    // produces exactly 3 (one per entry, well under the chunk size).
+    const e1 = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "DeltaWidget",
+    });
+    const e2 = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "EchoWidget",
+    });
+    const e3 = entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "FoxtrotWidget",
+    });
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "decision",
+          title: "Entry One",
+          content:
+            "DeltaWidget, EchoWidget, and FoxtrotWidget all participate in the first thing.",
+          scope: "project",
+        },
+        {
+          op: "create",
+          category: "decision",
+          title: "Entry Two",
+          content:
+            "DeltaWidget, EchoWidget, and FoxtrotWidget power the second thing.",
+          scope: "project",
+        },
+        {
+          op: "create",
+          category: "decision",
+          title: "Entry Three",
+          content:
+            "DeltaWidget, EchoWidget, and FoxtrotWidget handle the third thing.",
+          scope: "project",
+        },
+      ],
+      { projectPath: PROJECT, sessionID: "sess-multi-row" },
+    );
+
+    expect(result.created).toBe(3);
+
+    // Three entries → exactly three INSERT statements (one per entry). With
+    // chunking: 3 entities / entry < CHUNK=450, so 1 INSERT per entry.
+    expect(counts.refInsert).toBe(3);
+
+    // Behavioral equivalence: every (entity, knowledge) pair is linked.
+    for (const entityId of [e1.id, e2.id, e3.id]) {
+      expect(entities.knowledgeForEntity(entityId)).toHaveLength(3);
+    }
+  });
+
+  test("syncEntityRefs skips INSERT entirely when content matches no entities (empty-skip branch)", () => {
+    // Seed an entity whose canonical name is NOT in the entry content. The
+    // inner `if (linkedEntityIds.size)` guard at entities.ts must skip the
+    // multi-row INSERT altogether — no statement, no Sentry span.
+    // quality/REVIEW.md §5: skip/early-return branches are the highest-risk
+    // surface and must have a test that makes the branch fire.
+    entities.create({
+      projectPath: PROJECT,
+      entityType: "tool",
+      canonicalName: "MysteryTool",
+    });
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    const result = applyOps(
+      [
+        {
+          op: "create",
+          category: "decision",
+          title: "Entry With No Entities",
+          content: "This entry mentions nothing in the entity registry.",
+          scope: "project",
+        },
+      ],
+      { projectPath: PROJECT, sessionID: "sess-empty-skip" },
+    );
+    expect(result.created).toBe(1);
+
+    // Empty linkedEntityIds → zero INSERT statements. The pre-fix per-row
+    // loop also produced 0 (loop didn't execute), so this is a contract-
+    // preservation canary rather than a regression test that fails on the
+    // broken code — both implementations correctly return count=0 with no
+    // SQL fired.
+    expect(counts.refInsert ?? 0).toBe(0);
+  });
+
+  test("syncEntityRefs chunks multi-row INSERTs to stay within SQLite's 999 parameter limit (Seer 15652540)", () => {
+    // CHUNK = 450 entities per chunk (2 params × 450 = 900 params, < 999 limit).
+    // 460 entities in one entry → 2 INSERT statements (chunk 1: 450, chunk 2: 10).
+    // Each entity gets a unique 4-char canonical name; the content mentions
+    // every one so the matcher links them all. We bypass applyOps because it
+    // truncates long content to ~1200 chars; ltm.create stores the full content.
+    const N = 460;
+    const expectedChunks = 2;
+
+    for (let i = 0; i < N; i++) {
+      entities.create({
+        projectPath: PROJECT,
+        entityType: "tool",
+        canonicalName: `w${i.toString(36).padStart(3, "0")}`, // w000, w001, ..., w0cr
+      });
+    }
+    const content = Array.from(
+      { length: N },
+      (_, i) => `w${i.toString(36).padStart(3, "0")}`,
+    ).join(" ");
+
+    const k = ltm.create({
+      projectPath: PROJECT,
+      category: "decision",
+      title: "Chunked Entry",
+      content,
+      scope: "project",
+    });
+
+    const counts: Record<string, number> = {};
+    registerSink(countingSink(counts));
+
+    const linkedCount = entities.syncEntityRefs(k, content);
+    expect(linkedCount).toBe(N);
+
+    // 460 entities single entry → 2 INSERT chunks (450 + 10). Pre-chunk
+    // version would have been 1 INSERT (with 920 params — under SQLite's
+    // default 999 limit but already pushing it; Seer flagged the missing
+    // chunking as MEDIUM).
+    expect(counts.refInsert).toBe(expectedChunks);
+
+    // Every entity is linked to the entry.
+    const refsFromDb = (
+      db()
+        .query(
+          "SELECT COUNT(*) AS c FROM knowledge_entity_refs WHERE knowledge_id = ?",
+        )
+        .get(k) as { c: number }
+    ).c;
+    expect(refsFromDb).toBe(N);
   });
 });


### PR DESCRIPTION
## Summary

Re-introduces the Sentry N+1 fix from #1552 on top of its revert commit
([acfa50d5](https://github.com/BYK/loreai/commit/acfa50d5)) with two
inline-review findings from Seer now addressed.

Fixes [LOREAI-GATEWAY-3Y](https://byk.sentry.io/issues/7615446582/)
(138 events, `lore.curator`) and
[LOREAI-GATEWAY-4Q](https://byk.sentry.io/issues/7635778314/)
(17 events, `lore.consolidation`).

## Why this re-PR

After #1552 was squash-merged, Seer posted two inline review comments
that were missed before merge:

- **MEDIUM (Seer 15652540)** — the multi-row INSERT didn't chunk; SQLite's
  default `SQLITE_MAX_VARIABLE_NUMBER=999` would fail on >499 entities.
- **LOW (Seer 15652457)** — the per-row FK-violation fallback was dropped
  in the refactor; SQLite aborts the whole chunk on any FK violation.

I reverted #1552 to keep the history clean and am re-applying the fix with
both findings addressed.

## What changed

- **packages/core/src/entities.ts** — `syncEntityRefs` now:
  1. Builds the multi-row INSERT in chunks of CHUNK=450 entities
     (2 params × 450 = 900 params, well under SQLite's 999-parameter
     limit). Mirrors the existing 900-param ceiling in
     `batchLoadAliases` / `batchLoadAliasesOffloaded` / etc.
  2. Wraps the chunk loop in a try/catch; on a FK violation
     (schema-impossible on this path — entity IDs come from
     entities/aliases, both FK-constrained to entities(id);
     `knowledge_id` has no FK since v66 per #909) the code falls back
     to per-row inserts to preserve the prior defensive contract.

- **packages/core/test/curator-entity-ref-batch.test.ts** — three tests:
  1. `knowledge_entity_refs INSERT runs once per entry, not once per
     matched entity (LOREAI-GATEWAY-3Y, LOREAI-GATEWAY-4Q)` — verifies
     the multi-row INSERT replaces the per-row loop.
  2. `syncEntityRefs skips INSERT entirely when content matches no
     entities (empty-skip branch)` — canary for the
     `if (linkedEntityIds.size)` guard (quality/REVIEW.md §5).
  3. `syncEntityRefs chunks multi-row INSERTs to stay within SQLite's
     999 parameter limit (Seer 15652540)` — creates 460 entities and
     asserts INSERT count = 2 (chunk 1: 450, chunk 2: 10).

## Verification

- TDD failing-first verified for test 1: `git checkout main --
  packages/core/src/entities.ts` → test fails with `expected 9 to be 3`.
  Restored → passes.
- Test 3 verified end-to-end: 460 entities → 2 INSERT chunks.
- All 4 tests in `curator-entity-ref-batch.test.ts` pass.
- `packages/core/test/entities.test.ts` (66 tests) pass.
- The 7 failures in `packages/core/test/import/auth.test.ts` are
  pre-existing on the reverted main and unrelated to this change.

🤖 Generated with [opencode](https://opencode.ai)