### PR TITLE
fix(lint): make judge budget self-contained + always log stderr

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -154,6 +154,16 @@ runs:
         $LORE_CMD "${args[@]}" > /tmp/lore-ic.json 2> /tmp/lore-ic.err
         rc=$?
         set -e
+        # Always surface stderr from the CLI run as a collapsible group — on
+        # success (rc=0) this was previously hidden, which masked useful
+        # diagnostics like the models.dev pre-warm status (`[lore] models.dev:
+        # loaded data for N models across M providers`), the invariant-seed
+        # timing line, and judge-budget logs. On failure (rc != 0) it's the
+        # only signal we have to explain a TOOLING skip. Cheap on a green run
+        # (a few progress lines folded into a group), invaluable on red.
+        echo "::group::lore lint stderr"
+        cat /tmp/lore-ic.err || true
+        echo "::endgroup::"
         if [ $rc -eq 2 ] && [ "${LORE_IC_GATE}" = "true" ]; then
           # Gate block — report findings, then fail the job on purpose.
           echo "skipped=false" >> "$GITHUB_OUTPUT"
@@ -162,7 +172,6 @@ runs:
         fi
         if [ $rc -ne 0 ]; then
           echo "::notice title=Lore lint::skipped (tooling: exit $rc)"
-          cat /tmp/lore-ic.err || true
           echo "skipped=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -94,9 +94,21 @@ const MAX_INVARIANTS_SCAN = 300;
 // don't diverge confusingly.
 const JUDGE_VERDICT_TOKENS = 256;
 const JUDGE_VERDICT_HEADROOM = 8192;
+// Self-contained minimum — survives an empty models.dev cache (or any CI where
+// the fetchModelData pre-warm times out before the first judge call). Matches
+// the gateway's workerReasoningHeadroomFloor (16384 + 8192 = 24576) rounded up
+// to 25600 so the linter never produces empty-content / length-truncated judge
+// responses regardless of models.dev availability. The gateway's
+// `Math.max(callerMax, floor)` honors caller values, so passing this explicitly
+// is a floor-on-the-caller-side that doesn't depend on `workerModelReasons`.
+// Cheap for non-reasoning models (a floor, never a charge — they bill only
+// what they emit), strict for reasoning ones.
+const JUDGE_VERDICT_MIN_BUDGET = 25_600;
 function judgeMaxTokens(effort: ReasoningEffort | undefined): number {
   const budget = anthropicThinkingBudget(effort) ?? 0;
-  return budget > 0 ? budget + JUDGE_VERDICT_HEADROOM : JUDGE_VERDICT_TOKENS;
+  const thinking =
+    budget > 0 ? budget + JUDGE_VERDICT_HEADROOM : JUDGE_VERDICT_TOKENS;
+  return Math.max(thinking, JUDGE_VERDICT_MIN_BUDGET);
 }
 
 // If more than this fraction of judge calls come back unparseable, warn: the

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -1160,4 +1160,60 @@ describe("checkInvariants (funnel, stubbed LLM)", () => {
     });
     expect(result.findings).toHaveLength(0);
   });
+
+  it("passes a self-contained minimum judge budget that survives an empty models.dev cache", async () => {
+    // The gateway's `workerReasoningHeadroomFloor` only applies for OpenAI/Gemini
+    // protocols when `workerModelReasons(model)` returns true — which itself
+    // depends on `getModelEntrySync` returning an entry with non-empty
+    // `reasoning_options`. When models.dev is unreachable (CI pre-warm timeout,
+    // 503, etc.), `getModelEntrySync` falls back to a stripped entry with no
+    // reasoning_options and the floor collapses to 0. Without a self-contained
+    // caller maxTokens, the linter's tiny default budget (256 tokens) would be
+    // entirely burned on hidden reasoning by OpenAI reasoning models like
+    // gpt-5-mini → empty content → "unparseable". The judge MUST therefore pass
+    // a budget that wins regardless of the gateway's reasoning-floor logic.
+    const captured: Array<{ maxTokens?: number; reasoningEffort?: string }> =
+      [];
+    const prompt = vi.fn(
+      async (
+        _system: string,
+        _user: string,
+        opts?: { maxTokens?: number; reasoningEffort?: string },
+      ) => {
+        captured.push(opts ?? {});
+        return JSON.stringify({ violates: false, reason: "ok" });
+      },
+    );
+    const llm: LLMClient = { prompt };
+
+    for (const effort of [undefined, "off", "low", "medium", "high"] as const) {
+      const project = `/tmp/ic-test-proj-budget-floor-${effort ?? "default"}`;
+      await seed(
+        project,
+        "node:sqlite import boundary",
+        "node:sqlite must never be imported outside driver.node.ts",
+        v(1, 0, 0),
+      );
+      vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([
+        v(1, 0, 0),
+      ]);
+      captured.length = 0;
+      await checkInvariants({
+        projectPath: project,
+        hunks: [
+          {
+            file: "src/other.ts",
+            text: '@@\n+import { X } from "node:sqlite"',
+          },
+        ],
+        range: FAKE_RANGE,
+        llm,
+        sessionID: `s-budget-${effort ?? "default"}`,
+        ...(effort !== undefined ? { effort } : {}),
+      });
+      expect(captured).toHaveLength(1);
+      // Floor MUST clear 25600 so the verdict is parseable even with no models.dev data.
+      expect(captured[0].maxTokens).toBeGreaterThanOrEqual(25_600);
+    }
+  });
 });


### PR DESCRIPTION
Two related fixes for the `lore lint` advisory job:

## Bug

The semantic-linter (PR #1550 default judge: `github-copilot/gpt-5-mini`) was producing **6/6 unparseable** judge responses in CI on PR #1552 (run 30756490503). Investigation:

- `packages/core/src/invariant-check.ts:1055` passes `maxTokens: judgeMaxTokens(effort)` = **256** for effort=off
- The gateway applies `workerReasoningHeadroomFloor` (= **24576** for reasoning models) via `Math.max(callerMax, floor)` — but only when `workerModelReasons(model)` returns true
- `workerModelReasons` requires `getModelEntrySync(model).reasoning_options` to be non-empty — i.e. **models.dev to be loaded**
- When the pre-warm `fetchModelData()` times out / 503s / fails silently, `cachedModelData` stays null, fallback entry has no reasoning_options, floor collapses to 0, **budget stays at 256**
- gpt-5-mini burns the entire 256 on hidden reasoning → empty content → unparseable

The action.yml was hiding stderr on success (`rc=0`), so the `[lore] models.dev: loaded data for N models` line never surfaced to confirm the diagnosis.

## Fix

1. **Self-contained judge budget** (`packages/core/src/invariant-check.ts`): `judgeMaxTokens(effort)` now returns `Math.max(thinking, JUDGE_VERDICT_MIN_BUDGET = 25_600)`. The gateway's `Math.max(callerMax, floor)` honors caller values, so this is a floor-on-the-caller-side that doesn't depend on `workerModelReasons`. Cheap for non-reasoning models (a floor, never a charge).
2. **Always log stderr** (`.github/actions/lint/action.yml`): the lint step now wraps `cat /tmp/lore-ic.err` in an `echo "::group::lore lint stderr" / ::endgroup::` block — surfaces `models.dev` pre-warm status, embedding timing, judge-budget logs on every run (folded as a group on green; visible on red).

## Regression test

`packages/core/test/invariant-check.test.ts`: `passes a self-contained minimum judge budget that survives an empty models.dev cache` — stubs `llm.prompt`, runs `checkInvariants` for `effort ∈ {undefined, off, low, medium, high}`, asserts `opts.maxTokens >= 25_600` per call.

**TDD failing-first verified**: stash the fix → test fails (`expected 25,600, got 256`) → restore → test passes.

## Related

- Replaces/supersedes the temporary diagnostics in #1550 (pre-warm race fix) — both fixes stack, this one makes the system robust against models.dev unavailability regardless of pre-warm timing.
- Closes the gap that produced PR #1552's 6/6 unparseable warnings.

🤖 Generated with [opencode](https://opencode.ai)