### PR TITLE
feat(cli): migrate lore doctor to typed Stricli command (Phase 3A.5)

### DIFF
--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -21,6 +21,7 @@ import { whoamiCommand } from "./commands/whoami";
 import { logsCommand } from "./commands/logs";
 import { stopCommand } from "./commands/stop";
 import { logCommand, diffCommand } from "./commands/log";
+import { doctorCommand } from "./commands/doctor";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -33,7 +34,6 @@ export const LEGACY_ROUTES: ReadonlySet<string> = new Set([
   "start",
   "run",
   "setup",
-  "doctor",
   "data",
   "recall",
   "lint",
@@ -117,6 +117,7 @@ export const routes = buildRouteMap({
     stop: stopCommand,
     log: logCommand,
     diff: diffCommand,
+    doctor: doctorCommand,
   },
 });
 

--- a/packages/gateway/src/cli/commands/doctor.ts
+++ b/packages/gateway/src/cli/commands/doctor.ts
@@ -1,0 +1,173 @@
+/**
+ * `lore doctor` — run inventory + diagnostics.
+ *
+ * Phase 3A.5: typed Stricli command. The typed handler delegates to the
+ * legacy `runDoctorDiagnostics` (pure, takes injected inputs) and adds
+ * a `collectDoctorInput` shim that gathers the IO it needs. The legacy
+ * `commandDoctor` remains in place for programmatic callers that
+ * import it directly (tests, library users).
+ *
+ * Output shape:
+ *   - human: inventory + findings (matches legacy format byte-for-byte)
+ *   - JSON:  { inventory, findings, summary }
+ *
+ * Exit codes:
+ *   - 0  no FAIL findings
+ *   - 1  one or more FAIL findings
+ */
+import { buildOutputCommand } from "../lib/command";
+import { probeGateway } from "../start";
+import { readPortFile } from "../../portfile";
+import {
+  collectInventory,
+  fetchMemoryHealth,
+  isNpmPackageInstalledSafe,
+  runDoctorDiagnostics,
+  type Finding,
+  type AppInventory,
+  formatFinding,
+} from "../inventory";
+
+type DoctorFlags = Record<string, never>;
+
+interface DoctorSummary {
+  total: number;
+  fail: number;
+  warn: number;
+  pass: number;
+}
+
+interface DoctorResult {
+  inventory: AppInventory[];
+  findings: Finding[];
+  summary: DoctorSummary;
+}
+
+function summarize(findings: Finding[]): DoctorSummary {
+  let fail = 0;
+  let warn = 0;
+  for (const f of findings) {
+    if (f.level === "FAIL") fail++;
+    else if (f.level === "WARN") warn++;
+  }
+  return {
+    total: findings.length,
+    fail,
+    warn,
+    pass: findings.length - fail - warn,
+  };
+}
+
+function renderInventory(inventory: AppInventory[]): string[] {
+  // Mirror of the legacy `printInventoryStatus` (packages/gateway/src/cli/inventory.ts:331)
+  // but rendered as strings so we can emit them through buildOutputCommand's
+  // stdout/stderr pipeline. Format is intentionally byte-for-byte identical
+  // to the legacy command so consumers that grep `lore doctor` output keep
+  // working.
+  const lines: string[] = [];
+  for (const inv of inventory) {
+    lines.push(`[lore] ${inv.app}  (${inv.file})`);
+    if (!inv.fileExists) {
+      lines.push(`[lore]   file missing — not configured.`);
+      continue;
+    }
+    if (inv.rows.length === 0) {
+      lines.push(`[lore]   no lore-managed keys found.`);
+    }
+    for (const row of inv.rows) {
+      const trimmed = formatInventoryRowCompat(row).trim();
+      lines.push(`[lore]   ${trimmed}`);
+    }
+    if (inv.hasBackup) {
+      const appSlug = inv.app.toLowerCase().replace(/\s+/g, "-");
+      lines.push(
+        `[lore]   backup present (run \`lore setup undo ${appSlug}\` to revert).`,
+      );
+    }
+    lines.push("");
+  }
+  return lines;
+}
+
+/**
+ * Local mirror of `formatInventoryRow` so we don't depend on internal
+ * rendering drift. (The legacy inventory printer uses
+ * `formatInventoryRow(row).trim()` and pads columns; we replicate the
+ * shape but inline it to avoid leaking the helper signature.)
+ */
+function formatInventoryRowCompat(row: {
+  app: string;
+  file: string;
+  fileExists: boolean;
+  key: string;
+  routing: { kind: string; value?: string };
+  priorValue?: string;
+}): string {
+  return `  ${row.app}   ${row.key}   ${row.routing.kind}  ${row.routing.value ?? ""}`;
+}
+
+function renderHuman(data: DoctorResult): string {
+  const lines: string[] = [];
+  lines.push("[lore] Setup inventory:");
+  lines.push(...renderInventory(data.inventory));
+  lines.push("[lore] Diagnostics:");
+  for (const f of data.findings) {
+    const formatted = formatFinding(f);
+    for (const line of formatted.split("\n")) {
+      lines.push(`[lore]   ${line}`);
+    }
+  }
+  const s = data.summary;
+  lines.push(
+    `[lore] ${s.total} finding(s): ${s.fail} FAIL, ${s.warn} WARN, ${s.pass} PASS.`,
+  );
+  return lines.join("\n");
+}
+
+function toJson(data: DoctorResult): unknown {
+  return data;
+}
+
+export const doctorCommand = buildOutputCommand<DoctorResult, DoctorFlags, []>({
+  brief: "Diagnose lore setup (inventory + gateway + memory health)",
+  fullDescription:
+    "Print setup inventory for every supported agent, then run live " +
+    "diagnostics on the gateway, gateway-side memory health, and shell " +
+    "environment overrides. Exit code is 1 when any FAIL finding is " +
+    "present, 0 otherwise. JSON output is { inventory, findings, summary }.",
+  parameters: { flags: {} },
+  config: { renderHuman, toJson },
+  async handler() {
+    const inventory = collectInventory();
+    const gatewayPort = readPortFile();
+    const gatewayAlive = gatewayPort
+      ? await probeGateway(`http://127.0.0.1:${gatewayPort}`)
+      : false;
+    const memoryHealth =
+      gatewayAlive && gatewayPort
+        ? await fetchMemoryHealth(`http://127.0.0.1:${gatewayPort}`)
+        : null;
+    const findings = runDoctorDiagnostics({
+      inventory,
+      gatewayAlive,
+      gatewayPort,
+      env: {
+        ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+        OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+        CLAUDE_CODE_USE_BEDROCK: process.env.CLAUDE_CODE_USE_BEDROCK,
+        CLAUDE_CODE_USE_VERTEX: process.env.CLAUDE_CODE_USE_VERTEX,
+        ANTHROPIC_BEDROCK_BASE_URL: process.env.ANTHROPIC_BEDROCK_BASE_URL,
+      },
+      opencodePluginInstalled: isNpmPackageInstalledSafe("@loreai/opencode"),
+      memoryHealth,
+    });
+    const summary = summarize(findings);
+    if (summary.fail > 0) {
+      process.exitCode = 1;
+    }
+    return {
+      kind: "value" as const,
+      data: { inventory, findings, summary },
+    };
+  },
+});

--- a/packages/gateway/src/cli/commands/doctor.ts
+++ b/packages/gateway/src/cli/commands/doctor.ts
@@ -2,13 +2,16 @@
  * `lore doctor` — run inventory + diagnostics.
  *
  * Phase 3A.5: typed Stricli command. The typed handler delegates to the
- * legacy `runDoctorDiagnostics` (pure, takes injected inputs) and adds
- * a `collectDoctorInput` shim that gathers the IO it needs. The legacy
+ * legacy `runDoctorDiagnostics` (pure, takes injected inputs) and does
+ * its own thin IO shell for `collectInventory()` / `probeGateway()` /
+ * `fetchMemoryHealth()` / `isNpmPackageInstalledSafe()`. The legacy
  * `commandDoctor` remains in place for programmatic callers that
  * import it directly (tests, library users).
  *
  * Output shape:
- *   - human: inventory + findings (matches legacy format byte-for-byte)
+ *   - human: inventory + findings (matches legacy format byte-for-byte
+ *     via the exported `formatInventoryRow` shared with the legacy
+ *     printer — Seer finding #1)
  *   - JSON:  { inventory, findings, summary }
  *
  * Exit codes:

--- a/packages/gateway/src/cli/commands/doctor.ts
+++ b/packages/gateway/src/cli/commands/doctor.ts
@@ -26,6 +26,7 @@ import {
   type Finding,
   type AppInventory,
   formatFinding,
+  formatInventoryRow,
 } from "../inventory";
 
 type DoctorFlags = Record<string, never>;
@@ -63,7 +64,8 @@ function renderInventory(inventory: AppInventory[]): string[] {
   // but rendered as strings so we can emit them through buildOutputCommand's
   // stdout/stderr pipeline. Format is intentionally byte-for-byte identical
   // to the legacy command so consumers that grep `lore doctor` output keep
-  // working.
+  // working. Uses the exported `formatInventoryRow` so the legacy and
+  // typed paths stay in lockstep (Seer finding #1 on this PR).
   const lines: string[] = [];
   for (const inv of inventory) {
     lines.push(`[lore] ${inv.app}  (${inv.file})`);
@@ -75,7 +77,7 @@ function renderInventory(inventory: AppInventory[]): string[] {
       lines.push(`[lore]   no lore-managed keys found.`);
     }
     for (const row of inv.rows) {
-      const trimmed = formatInventoryRowCompat(row).trim();
+      const trimmed = formatInventoryRow(row).trim();
       lines.push(`[lore]   ${trimmed}`);
     }
     if (inv.hasBackup) {
@@ -87,23 +89,6 @@ function renderInventory(inventory: AppInventory[]): string[] {
     lines.push("");
   }
   return lines;
-}
-
-/**
- * Local mirror of `formatInventoryRow` so we don't depend on internal
- * rendering drift. (The legacy inventory printer uses
- * `formatInventoryRow(row).trim()` and pads columns; we replicate the
- * shape but inline it to avoid leaking the helper signature.)
- */
-function formatInventoryRowCompat(row: {
-  app: string;
-  file: string;
-  fileExists: boolean;
-  key: string;
-  routing: { kind: string; value?: string };
-  priorValue?: string;
-}): string {
-  return `  ${row.app}   ${row.key}   ${row.routing.kind}  ${row.routing.value ?? ""}`;
 }
 
 function renderHuman(data: DoctorResult): string {

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -657,7 +657,7 @@ export async function fetchMemoryHealth(base: string): Promise<{
 
 // Local copy to avoid importing the private isNpmPackageInstalled from setup.ts.
 // Mirrors its behavior; kept here so doctor doesn't grow setup.ts's surface.
-function isNpmPackageInstalledSafe(pkg: string): boolean {
+export function isNpmPackageInstalledSafe(pkg: string): boolean {
   try {
     // Lazy require so this file loads even if npm isn't on PATH.
     const { execFileSync } =

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -31,6 +31,7 @@ const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "stop",
   "log",
   "diff",
+  "doctor",
 ]);
 
 export interface PreprocessResult {

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -23,7 +23,7 @@ const HIDDEN_DIAGNOSTICS = new Set([
  * keep going through the legacy `_cli()` dispatcher. Subsequent phases
  * extend this list as each command family migrates.
  */
-const STRICLI_ROUTES: ReadonlySet<string> = new Set([
+export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "help",
   "version",
   "whoami",

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -426,6 +426,7 @@ export async function _cli(): Promise<void> {
   //   - logs:  migrated (Phase 3A.2) — typed command.
   //   - log:   migrated (Phase 3A.4) — typed command.
   //   - diff:  migrated (Phase 3A.4) — typed command.
+  //   - doctor: migrated (Phase 3A.5) — typed command.
   //   - stop:  migrated (Phase 3B.1) — typed command.
   //
   // Removal milestone: delete the migrated case blocks once programmatic

--- a/packages/gateway/test/cli-doctor-contract.test.ts
+++ b/packages/gateway/test/cli-doctor-contract.test.ts
@@ -213,4 +213,32 @@ describe("Phase 3A.5 — typed lore doctor", () => {
     expect(stdout).toContain("[FAIL]");
     expect(stdout).toContain("no gateway responding");
   });
+
+  // Seer finding #1 (MEDIUM): the typed doctor command's inventory
+  // printer must produce byte-for-byte identical output to the legacy
+  // `commandDoctor` so consumers that grep `lore doctor` keep working.
+  // The typed adapter now imports `formatInventoryRow` directly from
+  // inventory.ts, so the legacy and typed paths can't drift. This test
+  // pins the format by calling the same renderer on a known fixture
+  // and asserting the exact line shape.
+  test("inventory row format matches legacy formatInventoryRow (Seer #1)", async () => {
+    // Importing the renderer and asserting its output pins the format.
+    const { formatInventoryRow } = await import("../src/cli/inventory");
+    const row: import("../src/cli/inventory").InventoryRow = {
+      app: "Claude Code",
+      file: "~/.claude/settings.json",
+      fileExists: true,
+      key: "env.ANTHROPIC_BASE_URL",
+      routing: { kind: "lore", value: "http://127.0.0.1:3207" },
+    };
+    // The doctor's renderInventory helper internally calls
+    // `formatInventoryRow(row).trim()`. The legacy pads app to 14 chars
+    // and key to 38 chars, then renders the routing and file part. Pin
+    // the exact shape so a regression in either the legacy helper or
+    // the typed adapter (which used to diverge via
+    // formatInventoryRowCompat) is caught.
+    expect(formatInventoryRow(row).trim()).toBe(
+      "Claude Code    env.ANTHROPIC_BASE_URL                 lore  http://127.0.0.1:3207   [~/.claude/settings.json]",
+    );
+  });
 });

--- a/packages/gateway/test/cli-doctor-contract.test.ts
+++ b/packages/gateway/test/cli-doctor-contract.test.ts
@@ -29,16 +29,25 @@ vi.mock("../src/cli/lib/version-check", () => ({
   abortPendingVersionCheck: () => {},
 }));
 
-const fakeState = vi.hoisted(() => ({
-  port: 3207 as number | null,
+interface MemoryHealth {
+  embeddings: { available: boolean; state: string; detail: string };
+  worker: { ok: boolean; detail: string };
+}
+
+interface FakeState {
+  port: number | null;
+  alive: boolean;
+  memory: MemoryHealth | null;
+  opencodeInstalled: boolean;
+}
+
+const fakeState = vi.hoisted<FakeState>(() => ({
+  port: 3207,
   alive: true,
   memory: {
     embeddings: { available: true, state: "loaded", detail: "ok" },
     worker: { ok: true, detail: "ok" },
-  } as {
-    embeddings: { available: boolean; state: string; detail: string };
-    worker: { ok: boolean; detail: string };
-  } | null,
+  },
   opencodeInstalled: true,
 }));
 

--- a/packages/gateway/test/cli-doctor-contract.test.ts
+++ b/packages/gateway/test/cli-doctor-contract.test.ts
@@ -11,23 +11,12 @@
  * Mocks the IO sources (portfile, probeGateway, fetchMemoryHealth,
  * isNpmPackageInstalledSafe) so the test runs hermetically without
  * touching the filesystem or the network.
+ *
+ * The test exercises the Stricli route (runCli → STRICLI_ROUTES),
+ * so the legacy `version-check` shim and `LORE_NO_UPDATE_CHECK` env
+ * var are not needed here (they only affect the legacy `_cli()` path).
  */
-import {
-  afterAll,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi,
-} from "vitest";
-
-vi.mock("../src/cli/lib/version-check", () => ({
-  shouldSuppressNotification: () => true,
-  maybeCheckForUpdateInBackground: () => {},
-  getUpdateNotification: () => null,
-  abortPendingVersionCheck: () => {},
-}));
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 interface MemoryHealth {
   embeddings: { available: boolean; state: string; detail: string };
@@ -39,6 +28,22 @@ interface FakeState {
   alive: boolean;
   memory: MemoryHealth | null;
   opencodeInstalled: boolean;
+  inventory: Array<{
+    app: string;
+    file: string;
+    fileExists: boolean;
+    rows: Array<{
+      app: string;
+      file: string;
+      fileExists: boolean;
+      key: string;
+      routing:
+        | { kind: "lore"; value: string }
+        | { kind: "other"; value: string }
+        | { kind: "unset" };
+    }>;
+    hasBackup: boolean;
+  }>;
 }
 
 const fakeState = vi.hoisted<FakeState>(() => ({
@@ -49,6 +54,7 @@ const fakeState = vi.hoisted<FakeState>(() => ({
     worker: { ok: true, detail: "ok" },
   },
   opencodeInstalled: true,
+  inventory: [],
 }));
 
 vi.mock("../src/portfile", () => ({
@@ -65,7 +71,7 @@ vi.mock("../src/cli/inventory", async (importOriginal) => {
     ...actual,
     fetchMemoryHealth: async () => fakeState.memory,
     isNpmPackageInstalledSafe: () => fakeState.opencodeInstalled,
-    collectInventory: () => [],
+    collectInventory: () => fakeState.inventory,
   };
 });
 
@@ -124,7 +130,6 @@ async function runWith(
 
 describe("Phase 3A.5 — typed lore doctor", () => {
   const origArgv = process.argv;
-  const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
 
   beforeEach(() => {
     fakeState.port = 3207;
@@ -134,17 +139,11 @@ describe("Phase 3A.5 — typed lore doctor", () => {
       worker: { ok: true, detail: "ok" },
     };
     fakeState.opencodeInstalled = true;
-    process.env.LORE_NO_UPDATE_CHECK = "1";
+    fakeState.inventory = [];
   });
 
   afterEach(() => {
     process.argv = origArgv;
-  });
-
-  afterAll(() => {
-    if (origNoUpdateCheck === undefined)
-      delete process.env.LORE_NO_UPDATE_CHECK;
-    else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
   });
 
   test("human mode renders the three sections: inventory, diagnostics, summary", async () => {
@@ -179,12 +178,10 @@ describe("Phase 3A.5 — typed lore doctor", () => {
     fakeState.memory = null;
     const { stdout, exitCode } = await runWith(["doctor"]);
     expect(exitCode).toBe(1);
-    const json = stdout.match(/\{[\s\S]*\}/);
-    // We can't get JSON mode here because we're in human mode by
-    // default. Just assert the human output has a FAIL finding.
+    // Human mode: assert a [FAIL] finding shows up in the rendered
+    // section and the summary line counts it correctly.
     expect(stdout).toContain("[FAIL]");
     expect(stdout).toMatch(/finding\(s\): 1 FAIL, 0 WARN, \d+ PASS/);
-    void json;
   });
 
   test("embeddings unavailable → WARN finding, exit code still 0", async () => {
@@ -204,6 +201,23 @@ describe("Phase 3A.5 — typed lore doctor", () => {
     expect(parsed.summary.fail).toBe(0);
   });
 
+  // Human-mode sibling of the JSON-mode embeddings WARN test (Finding #8):
+  // the rendered `[WARN] memory: embeddings: ...` line is a real user-facing
+  // surface; the prior PR's Seer #1 was about exactly this rendering. Pin
+  // the human-mode shape so a regression to the bracket/padding logic trips
+  // the test.
+  test("human mode renders [WARN] for embeddings-unavailable finding", async () => {
+    fakeState.memory = {
+      embeddings: { available: false, state: "retrying", detail: "broken" },
+      worker: { ok: true, detail: "ok" },
+    };
+    const { stdout, exitCode } = await runWith(["doctor"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("[WARN]");
+    expect(stdout).toContain("memory: embeddings");
+    expect(stdout).not.toContain("[FAIL]");
+  });
+
   test("gateway probe unreachable (no portfile) → FAIL finding", async () => {
     fakeState.port = null;
     fakeState.alive = false;
@@ -221,6 +235,51 @@ describe("Phase 3A.5 — typed lore doctor", () => {
   // inventory.ts, so the legacy and typed paths can't drift. This test
   // pins the format by calling the same renderer on a known fixture
   // and asserting the exact line shape.
+  // Finding #5: pin the inventory rendering end-to-end with a populated
+  // AppInventory fixture so the typed adapter's per-row rendering is
+  // exercised. Earlier tests mocked collectInventory to [] which left
+  // this whole code path uncovered.
+  test("renders populated inventory rows with the same format as the legacy printer", async () => {
+    fakeState.inventory = [
+      {
+        app: "Claude Code",
+        file: "~/.claude/settings.json",
+        fileExists: true,
+        rows: [
+          {
+            app: "Claude Code",
+            file: "~/.claude/settings.json",
+            fileExists: true,
+            key: "env.ANTHROPIC_BASE_URL",
+            routing: { kind: "lore", value: "http://127.0.0.1:3207" },
+          },
+        ],
+        hasBackup: false,
+      },
+    ];
+    const { stdout } = await runWith(["doctor"]);
+    expect(stdout).toContain("[lore] Setup inventory:");
+    expect(stdout).toContain("[lore] Claude Code  (~/.claude/settings.json)");
+    // Per-row format pinned to the legacy shape.
+    expect(stdout).toContain(
+      "[lore]   Claude Code    env.ANTHROPIC_BASE_URL                 lore  http://127.0.0.1:3207   [~/.claude/settings.json]",
+    );
+  });
+
+  test('missing inventory file renders a clear "file missing" line', async () => {
+    fakeState.inventory = [
+      {
+        app: "Codex",
+        file: "~/.codex/config.json",
+        fileExists: false,
+        rows: [],
+        hasBackup: false,
+      },
+    ];
+    const { stdout } = await runWith(["doctor"]);
+    expect(stdout).toContain("[lore]   file missing — not configured.");
+  });
+
   test("inventory row format matches legacy formatInventoryRow (Seer #1)", async () => {
     // Importing the renderer and asserting its output pins the format.
     const { formatInventoryRow } = await import("../src/cli/inventory");
@@ -240,5 +299,19 @@ describe("Phase 3A.5 — typed lore doctor", () => {
     expect(formatInventoryRow(row).trim()).toBe(
       "Claude Code    env.ANTHROPIC_BASE_URL                 lore  http://127.0.0.1:3207   [~/.claude/settings.json]",
     );
+  });
+
+  // Finding #3: pin the routing wiring. \`lore doctor\` must go through
+  // the Stricli route (STRICLI_ROUTES), not the legacy case block in
+  // main.ts. A future refactor that reverts the route to legacy would
+  // otherwise fail no test that asserts it hasn't.
+  test("doctor is registered in STRICLI_ROUTES (routing wiring)", async () => {
+    const { STRICLI_ROUTES } = await import("../src/cli/lib/argv");
+    expect(STRICLI_ROUTES.has("doctor")).toBe(true);
+  });
+
+  test("doctor is NOT in LEGACY_ROUTES (routing safety)", async () => {
+    const { LEGACY_ROUTES } = await import("../src/cli/app");
+    expect(LEGACY_ROUTES.has("doctor")).toBe(false);
   });
 });

--- a/packages/gateway/test/cli-doctor-contract.test.ts
+++ b/packages/gateway/test/cli-doctor-contract.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Phase 3A.5 — typed `lore doctor` contract.
+ *
+ * Pins the typed adapter:
+ *   - Exit code 0 when no FAIL findings, 1 when any FAIL is present.
+ *   - Human mode renders inventory + diagnostics + summary line.
+ *   - JSON mode emits { inventory, findings, summary } with the
+ *     right summary counts.
+ *   - The handler stamps process.exitCode when a FAIL is present.
+ *
+ * Mocks the IO sources (portfile, probeGateway, fetchMemoryHealth,
+ * isNpmPackageInstalledSafe) so the test runs hermetically without
+ * touching the filesystem or the network.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+vi.mock("../src/cli/lib/version-check", () => ({
+  shouldSuppressNotification: () => true,
+  maybeCheckForUpdateInBackground: () => {},
+  getUpdateNotification: () => null,
+  abortPendingVersionCheck: () => {},
+}));
+
+const fakeState = vi.hoisted(() => ({
+  port: 3207 as number | null,
+  alive: true,
+  memory: {
+    embeddings: { available: true, state: "loaded", detail: "ok" },
+    worker: { ok: true, detail: "ok" },
+  } as {
+    embeddings: { available: boolean; state: string; detail: string };
+    worker: { ok: boolean; detail: string };
+  } | null,
+  opencodeInstalled: true,
+}));
+
+vi.mock("../src/portfile", () => ({
+  readPortFile: () => fakeState.port,
+}));
+
+vi.mock("../src/cli/start", () => ({
+  probeGateway: async () => fakeState.alive,
+}));
+
+vi.mock("../src/cli/inventory", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/cli/inventory")>();
+  return {
+    ...actual,
+    fetchMemoryHealth: async () => fakeState.memory,
+    isNpmPackageInstalledSafe: () => fakeState.opencodeInstalled,
+    collectInventory: () => [],
+  };
+});
+
+import { runCli } from "../src/cli/cli";
+
+async function runWith(
+  argv: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  process.argv = ["node", "lore", ...argv];
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+    for (const a of args) {
+      stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+    }
+  });
+  const errorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
+    for (const a of args) {
+      stderrChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+    }
+  });
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk) => {
+      stdoutChunks.push(
+        Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+      );
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk) => {
+      stderrChunks.push(
+        Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+      );
+      return true;
+    });
+  const priorExitCode = process.exitCode;
+  process.exitCode = 0;
+  try {
+    await runCli();
+  } finally {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+  const exitCode = process.exitCode;
+  process.exitCode = priorExitCode;
+  return {
+    stdout: Buffer.concat(stdoutChunks).toString("utf8"),
+    stderr: Buffer.concat(stderrChunks).toString("utf8"),
+    exitCode,
+  };
+}
+
+describe("Phase 3A.5 — typed lore doctor", () => {
+  const origArgv = process.argv;
+  const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
+
+  beforeEach(() => {
+    fakeState.port = 3207;
+    fakeState.alive = true;
+    fakeState.memory = {
+      embeddings: { available: true, state: "loaded", detail: "ok" },
+      worker: { ok: true, detail: "ok" },
+    };
+    fakeState.opencodeInstalled = true;
+    process.env.LORE_NO_UPDATE_CHECK = "1";
+  });
+
+  afterEach(() => {
+    process.argv = origArgv;
+  });
+
+  afterAll(() => {
+    if (origNoUpdateCheck === undefined)
+      delete process.env.LORE_NO_UPDATE_CHECK;
+    else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
+  });
+
+  test("human mode renders the three sections: inventory, diagnostics, summary", async () => {
+    const { stdout, exitCode } = await runWith(["doctor"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("[lore] Setup inventory:");
+    expect(stdout).toContain("[lore] Diagnostics:");
+    expect(stdout).toMatch(
+      /\[lore\] \d+ finding\(s\): 0 FAIL, 0 WARN, \d+ PASS\./,
+    );
+  });
+
+  test("--json returns structured payload with correct summary counts", async () => {
+    const { stdout, exitCode } = await runWith(["doctor", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed).toEqual({
+      inventory: [],
+      findings: expect.any(Array),
+      summary: expect.objectContaining({
+        fail: 0,
+        warn: expect.any(Number),
+        pass: expect.any(Number),
+      }),
+    });
+    // summary.total equals findings.length.
+    expect(parsed.summary.total).toBe(parsed.findings.length);
+  });
+
+  test("gateway not alive → FAIL finding, exit code 1", async () => {
+    fakeState.alive = false;
+    fakeState.memory = null;
+    const { stdout, exitCode } = await runWith(["doctor"]);
+    expect(exitCode).toBe(1);
+    const json = stdout.match(/\{[\s\S]*\}/);
+    // We can't get JSON mode here because we're in human mode by
+    // default. Just assert the human output has a FAIL finding.
+    expect(stdout).toContain("[FAIL]");
+    expect(stdout).toMatch(/finding\(s\): 1 FAIL, 0 WARN, \d+ PASS/);
+    void json;
+  });
+
+  test("embeddings unavailable → WARN finding, exit code still 0", async () => {
+    fakeState.memory = {
+      embeddings: { available: false, state: "retrying", detail: "broken" },
+      worker: { ok: true, detail: "ok" },
+    };
+    const { stdout, exitCode } = await runWith(["doctor", "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout.trim());
+    const embeddingsFinding = parsed.findings.find(
+      (f: { label: string }) => f.label === "memory: embeddings",
+    );
+    expect(embeddingsFinding).toBeTruthy();
+    expect(embeddingsFinding.level).toBe("WARN");
+    expect(parsed.summary.warn).toBeGreaterThanOrEqual(1);
+    expect(parsed.summary.fail).toBe(0);
+  });
+
+  test("gateway probe unreachable (no portfile) → FAIL finding", async () => {
+    fakeState.port = null;
+    fakeState.alive = false;
+    fakeState.memory = null;
+    const { stdout, exitCode } = await runWith(["doctor"]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("[FAIL]");
+    expect(stdout).toContain("no gateway responding");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3A.5 from the [Stricli CLI migration plan](quality/plans/lore-cli-stricli-agent-experience.md). `lore doctor` now runs through the typed tree (Stricli + CliError + CommandOutput) and ships structured JSON.

## What's in this PR

### commands/doctor.ts — typed adapter

- `DoctorResult` envelope: `{ inventory, findings, summary }`.
- Wraps the legacy `runDoctorDiagnostics` (pure, takes injected inputs) with a thin IO shell that calls `collectInventory()`, `probeGateway()`, `fetchMemoryHealth()`, and `isNpmPackageInstalledSafe()`.
- Mirrors the legacy `printInventoryStatus` rendering byte-for-byte so consumers that grep `lore doctor` output keep working.
- Exit code: 1 when any `FAIL` finding is present (stamp via `process.exitCode`, not `process.exit`).
- No thrown errors — diagnostics are findings, not exceptions.

### inventory.ts

- Exports `isNpmPackageInstalledSafe` so the typed adapter can reuse the legacy npm-ls probe.

### Routing

- `lib/argv.ts`: `STRICLI_ROUTES` gains `"doctor"`.
- `app.ts`: `doctor` moved out of `LEGACY_ROUTES` into the Stricli tree.

## Tests

`cli-doctor-contract.test.ts` — 5 cases:

1. Human mode renders the three sections (inventory + diagnostics + summary line).
2. `--json` returns structured payload with correct summary counts.
3. Gateway not alive → `FAIL` finding, exit code 1.
4. Embeddings unavailable → `WARN` finding, exit code still 0.
5. No portfile → `FAIL` finding (no gateway responding).

`portfile`, `probeGateway`, `fetchMemoryHealth`, and `isNpmPackageInstalledSafe` are mocked via `vi.mock` so the test runs hermetically without touching the filesystem or network.

## Verification

- 127 CLI tests pass across 14 files (added 5 new)
- TypeScript clean
- Lint clean (zero errors)
- Format clean
- Bundle succeeds for both CJS (Node) and ESM (Bun) targets

## Deferred (follow-up PRs)

Per the plan: `start`, `setup`, `data`/`entity`, `auth`/`sync`/`team`/`import`/`lint`, `run`, plus help/completion/skills/docs/integration. Each gets its own PR with focused tests against the legacy contract.