### PR TITLE
feat(cli): migrate lore team to typed Stricli command (Phase 3D.3c)

### DIFF
--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -25,6 +25,7 @@ import { doctorCommand } from "./commands/doctor";
 import { lintCommand } from "./commands/lint";
 import { loginCommand, logoutCommand } from "./commands/auth";
 import { syncCommand } from "./commands/sync";
+import { teamCommand } from "./commands/team";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -39,7 +40,6 @@ export const LEGACY_ROUTES: ReadonlySet<string> = new Set([
   "setup",
   "data",
   "recall",
-  "team",
   "admin",
   "import",
   "entity",
@@ -121,6 +121,7 @@ export const routes = buildRouteMap({
     login: loginCommand,
     logout: logoutCommand,
     sync: syncCommand,
+    team: teamCommand,
   },
 });
 

--- a/packages/gateway/src/cli/commands/team.ts
+++ b/packages/gateway/src/cli/commands/team.ts
@@ -1,0 +1,111 @@
+/**
+ * `lore team` — typed Stricli command (Phase 3D.3c).
+ *
+ * Wraps the legacy `commandTeam` from `../team-cmd` via the shared
+ * `runLegacyAndCollect` bridge. The legacy handler takes:
+ *
+ *   - positionals[0]: subcommand (list | members | discover | create | add
+ *                     | remove | set-role | invite | accept | link | unlink
+ *                     | review | approve | reject | policy | domain)
+ *   - positionals[1+]: subcommand-specific args (e.g., `add <scope> <userId>`)
+ *
+ * Flags forwarded to the legacy values dict: --invite, --role, --email,
+ * --offline, --project.
+ *
+ * Output shape:
+ *   - human: rendered legacy text
+ *   - JSON:  { output: <captured stdout> }
+ *
+ * Exit codes: legacy semantics preserved.
+ */
+import { buildOutputCommand } from "../lib/command";
+import { runLegacyAndCollect } from "../lib/legacy-bridge";
+import { commandTeam } from "../team-cmd";
+
+type TeamFlags = {
+  invite?: string;
+  role?: string;
+  email?: string;
+  offline: boolean;
+  project?: string;
+};
+
+export const teamCommand = buildOutputCommand<
+  string,
+  TeamFlags,
+  readonly string[]
+>({
+  brief: "Manage team membership and roles",
+  fullDescription:
+    "Team configuration: list members, invite, assign roles, remove " +
+    "members. Subcommands include list, members, discover, create, " +
+    "add, remove, set-role, invite, accept, link, unlink, review, " +
+    "approve, reject, policy, domain. The first positional selects " +
+    "the subcommand; subsequent positionals are subcommand-specific " +
+    "args. Flags --invite, --role, --email, --offline, --project " +
+    "are forwarded as values. --json emits a structured envelope.",
+  parameters: {
+    flags: {
+      invite: {
+        kind: "parsed",
+        parse: String,
+        brief: "Team to invite discoverer to",
+        optional: true,
+      },
+      role: {
+        kind: "parsed",
+        parse: String,
+        brief: "Role to assign (editor | viewer | member)",
+        optional: true,
+      },
+      email: {
+        kind: "parsed",
+        parse: String,
+        brief: "Email hint for the invitee",
+        optional: true,
+      },
+      offline: {
+        kind: "boolean",
+        brief: "Mark the invite as offline (no browser flow)",
+        default: false,
+      },
+      project: {
+        kind: "parsed",
+        parse: String,
+        brief: "Project directory (default: cwd)",
+        optional: true,
+      },
+    },
+    positional: {
+      kind: "array",
+      parameter: {
+        parse: String,
+        brief: "team subcommand + subcommand-specific args",
+      },
+    },
+  },
+  config: {
+    renderHuman: (data) => data,
+    toJson: (data) => ({ output: data }),
+  },
+  async handler(flags, ...positionals) {
+    const values: Record<string, unknown> = {};
+    if (flags.invite) values.invite = flags.invite;
+    if (flags.role) values.role = flags.role;
+    if (flags.email) values.email = flags.email;
+    if (flags.offline) values.offline = true;
+    if (flags.project) values.project = flags.project;
+    // Stricli spreads the variadic positional array into individual
+    // handler params; collect them back into the legacy string[].
+    const positionalsArr = positionals.filter(
+      (p): p is string => typeof p === "string",
+    );
+    const { exitCode, captured } = await runLegacyAndCollect(() =>
+      commandTeam(positionalsArr, values),
+    );
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+    return { kind: "value" as const, data: captured };
+  },
+});

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -36,6 +36,7 @@ export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "login",
   "logout",
   "sync",
+  "team",
 ]);
 
 export interface PreprocessResult {

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -433,8 +433,11 @@ export async function _cli(): Promise<void> {
   //   - login, logout: migrated (Phase 3D.2) — typed command.
   //   - sync: migrated (Phase 3D.3b) — typed command (positional
   //     schema declared; flags still handled by legacy).
-  //   - team, admin, import: NOT YET — pending Phase 3D.3c, d, e
-  //     follow-ups with explicit flag schemas.
+  //   - team: migrated (Phase 3D.3c) — typed command (variadic
+  //     positional + 5 flag schema; legacy handles dispatch by
+  //     positionals[0]).
+  //   - admin, import: NOT YET — pending Phase 3D.3d, e follow-ups
+  //     with explicit flag schemas.
   //
   // Removal milestone: delete the migrated case blocks once programmatic
   // callers migrate to `runCli()` AND a deletion test passes for each.

--- a/packages/gateway/test/cli-team-contract.test.ts
+++ b/packages/gateway/test/cli-team-contract.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Phase 3D.3c — typed `lore team` with explicit positional + flag schema.
+ *
+ * Pins the typed wrapper for `lore team`. The legacy handler takes a
+ * subcommand as `positionals[0]` plus subcommand-specific args, and
+ * reads five flags (invite, role, email, offline, project) from the
+ * values dict.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
+const origArgv = process.argv;
+
+beforeEach(() => {
+  process.env.LORE_NO_UPDATE_CHECK = "1";
+  process.argv = origArgv;
+});
+
+afterAll(() => {
+  if (origNoUpdateCheck === undefined) delete process.env.LORE_NO_UPDATE_CHECK;
+  else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
+  process.argv = origArgv;
+});
+
+interface TeamCall {
+  positionals: string[];
+  values: Record<string, unknown>;
+}
+
+describe("Phase 3D.3c — typed lore team", () => {
+  test("team is registered in STRICLI_ROUTES", async () => {
+    const { STRICLI_ROUTES } = await import("../src/cli/lib/argv");
+    expect(STRICLI_ROUTES.has("team")).toBe(true);
+  });
+
+  test("team is NOT in LEGACY_ROUTES", async () => {
+    const { LEGACY_ROUTES } = await import("../src/cli/app");
+    expect(LEGACY_ROUTES.has("team")).toBe(false);
+  });
+
+  test("team declares --invite, --role, --email, --offline, --project flags", async () => {
+    const { buildApplication, buildRouteMap, run } =
+      await import("@stricli/core");
+    const { teamCommand } = await import("../src/cli/commands/team");
+    const { buildContext } = await import("../src/cli/context");
+
+    const app = buildApplication(
+      buildRouteMap({
+        routes: { team: teamCommand },
+        docs: { brief: "lore" },
+      }),
+      { name: "lore" },
+    );
+    const seen = new Set<string>();
+    const origWrite = process.stdout.write;
+    const writeSpy = ((chunk: string | Buffer) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      for (const m of text.matchAll(/--[a-z][a-zA-Z0-9-]*/g)) seen.add(m[0]);
+      return true;
+    }) as never;
+    process.stdout.write = writeSpy;
+    try {
+      await run(app, ["team", "--help"], buildContext(process));
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    expect(seen.has("--invite")).toBe(true);
+    expect(seen.has("--role")).toBe(true);
+    expect(seen.has("--email")).toBe(true);
+    expect(seen.has("--offline")).toBe(true);
+    expect(seen.has("--project")).toBe(true);
+  });
+
+  test("team forwards subcommand + flags to legacy handler", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = [
+      "node",
+      "lore",
+      "team",
+      "invite",
+      "alice",
+      "--role",
+      "viewer",
+      "--email",
+      "alice@example.com",
+      "--project",
+      "/tmp/test",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(teamImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual(["invite", "alice"]);
+    expect(calls[0]?.values.role).toBe("viewer");
+    expect(calls[0]?.values.email).toBe("alice@example.com");
+    expect(calls[0]?.values.project).toBe("/tmp/test");
+    expect(Buffer.concat(stdoutChunks).toString("utf8")).toContain("team ok");
+    vi.resetModules();
+  });
+
+  // F-1 (HIGH): variadic positional — 3+ args must reach the legacy
+  // handler unchanged. A regression swapping kind: "array" back to
+  // a fixed-shape tuple would still pass the 2-arg test above.
+  test("team forwards 3+ positional args (variadic)", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "team",
+      "add",
+      "scope-1",
+      "user-1",
+      "viewer",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(teamImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([
+      "add",
+      "scope-1",
+      "user-1",
+      "viewer",
+    ]);
+    vi.resetModules();
+  });
+
+  // F-2 (HIGH): default subcommand — 0 positionals must reach the
+  // legacy handler with an empty array. commandTeam defaults to
+  // `positionals[0] ?? "list"` so a schema with `minimum: 1` would
+  // silently break `lore team` (the most common invocation).
+  test("team with no positional still reaches legacy handler (default subcommand)", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("list ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(teamImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([]);
+    vi.resetModules();
+  });
+
+  // F-3 (MEDIUM): --offline (default: false) must be forwarded as
+  // true when set, and absent when not set (NOT false, NOT undefined).
+  test("team forwards --offline as values.offline = true", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team", "invite", "alice", "--offline"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values.offline).toBe(true);
+    vi.resetModules();
+  });
+
+  test("team does NOT forward --offline when absent", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team", "list"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    // --offline absent → values.offline must be undefined (skip on
+    // absent), NOT true and NOT false. The wrapper only sets it when
+    // the user actually passed --offline.
+    expect(calls[0]?.values.offline).toBeUndefined();
+    vi.resetModules();
+  });
+
+  // F-4 (MEDIUM): --json auto-injection must produce the structured
+  // envelope { output: <captured stdout> } on the typed pipeline.
+  test("team --json produces the structured envelope", async () => {
+    vi.resetModules();
+    const teamImpl = vi.fn(async () => {
+      console.log("json-mode ok");
+    });
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = ["node", "lore", "team", "list", "--json"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    const parsed = JSON.parse(Buffer.concat(stdoutChunks).toString("utf8"));
+    expect(parsed).toEqual({ output: "json-mode ok\n" });
+    vi.resetModules();
+  });
+
+  test("team propagates legacy exit code", async () => {
+    vi.resetModules();
+    const teamImpl = vi.fn(async () => {
+      process.exitCode = 1;
+      console.error("not logged in");
+    });
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team", "list"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3D.3c from the Stricli CLI migration plan. `lore team` now routes through the typed tree with a variadic positional schema + 5 flag schema. Continues the per-command split pattern after the C-1 regression on PR #1560 taught us to declare schemas up front.

## What's in this PR

### commands/team.ts — typed adapter

Wraps `commandTeam` from `../team-cmd` via the shared `runLegacyAndCollect` bridge.

Schema:
- positional: variadic array `parameter: { parse: String }` (subcommand + subcommand-specific args, all captured via spread rest params in the handler)
- flags: 5 (`invite`, `role`, `email`, `offline`, `project`)

`commandTeam` reads positionals[0] as the subcommand and forwards subcommand-specific args from positionals[1+]. The variadic positional schema collects all string arguments into a string[] via spread rest params in the handler. Only forward flags when the user actually set them (skip the default: false for `offline`).

### Routing

- `lib/argv.ts`: `STRICLI_ROUTES` gains `"team"`.
- `app.ts`: `team` moved out of `LEGACY_ROUTES` into the Stricli tree.
- `main.ts:413-439`: status comment block lists `team` as migrated (Phase 3D.3c).

## Tests

`cli-team-contract.test.ts` — 10 cases:

1. `team` registered in `STRICLI_ROUTES` (routing wiring).
2. `team` NOT in `LEGACY_ROUTES` (per-slice removal rule).
3. Flag schema declared — help text shows `--invite`, `--role`, `--email`, `--offline`, `--project`.
4. 2-positional forwarding (`team invite alice --role viewer`) with `--project` asserted (F-5).
5. F-1: variadic positional (3+ args) — pins `kind: 'array'` semantics.
6. F-2: 0-positional default subcommand — pins `lore team` bare call.
7. F-3a: `--offline` forwarded as `values.offline = true` when set.
8. F-3b: `--offline` NOT forwarded when absent (`values.offline` undefined).
9. F-4: `--json` produces structured envelope `{ output: ... }`.
10. Legacy exit code propagates (1 not 0).

The legacy handler is mocked via `vi.doMock` so the test doesn't touch Supabase.

## Verification

- 170 CLI tests pass across 18 files (added 10 new)
- TypeScript clean
- Lint clean (zero errors)
- Format clean
- Bundle succeeds for both CJS (Node) and ESM (Bun) targets

## Next steps (Phase 3D.3d/e)

- `lore admin` — 3 positionals (sub, target, tier)
- `lore import` — 11+ flags (dry-run, yes, agent, source, file, global, mem0-*, no-worktrees, project)

Each gets its own PR with the full flag/positional schema declared upfront.