### PR TITLE
feat(cli): migrate lore admin to typed Stricli command (Phase 3D.3d)

### DIFF
--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -26,6 +26,7 @@ import { lintCommand } from "./commands/lint";
 import { loginCommand, logoutCommand } from "./commands/auth";
 import { syncCommand } from "./commands/sync";
 import { teamCommand } from "./commands/team";
+import { adminCommand } from "./commands/admin";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -40,7 +41,6 @@ export const LEGACY_ROUTES: ReadonlySet<string> = new Set([
   "setup",
   "data",
   "recall",
-  "admin",
   "import",
   "entity",
   "upgrade",
@@ -122,6 +122,7 @@ export const routes = buildRouteMap({
     logout: logoutCommand,
     sync: syncCommand,
     team: teamCommand,
+    admin: adminCommand,
   },
 });
 

--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -25,6 +25,7 @@ import { doctorCommand } from "./commands/doctor";
 import { lintCommand } from "./commands/lint";
 import { loginCommand, logoutCommand } from "./commands/auth";
 import { syncCommand } from "./commands/sync";
+import { teamCommand } from "./commands/team";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -39,7 +40,6 @@ export const LEGACY_ROUTES: ReadonlySet<string> = new Set([
   "setup",
   "data",
   "recall",
-  "team",
   "admin",
   "import",
   "entity",
@@ -121,6 +121,7 @@ export const routes = buildRouteMap({
     login: loginCommand,
     logout: logoutCommand,
     sync: syncCommand,
+    team: teamCommand,
   },
 });
 

--- a/packages/gateway/src/cli/commands/admin.ts
+++ b/packages/gateway/src/cli/commands/admin.ts
@@ -1,0 +1,67 @@
+/**
+ * `lore admin` — typed Stricli command (Phase 3D.3d).
+ *
+ * Wraps the legacy `commandAdmin` from `../admin-cmd` via the shared
+ * `runLegacyAndCollect` bridge. The legacy handler takes 3 positionals:
+ *
+ *   - positionals[0]: subcommand (must be "grant")
+ *   - positionals[1]: target (UUID for org or user)
+ *   - positionals[2]: tier (free | team | pro)
+ *
+ * No flags. The typed adapter declares only the positional schema.
+ *
+ * Output shape:
+ *   - human: rendered legacy text
+ *   - JSON:  { output: <captured stdout> }
+ *
+ * Exit codes: legacy semantics preserved (0 success, 1 usage/invalid
+ * tier/no service-role client).
+ */
+import { buildOutputCommand } from "../lib/command";
+import { runLegacyAndCollect } from "../lib/legacy-bridge";
+import { commandAdmin } from "../admin-cmd";
+
+type AdminFlags = Record<string, never>;
+
+export const adminCommand = buildOutputCommand<
+  string,
+  AdminFlags,
+  readonly [string?, string?, string?]
+>({
+  brief: "Admin operations (admin-only)",
+  fullDescription:
+    "Admin-only operations: grant a tier (free | team | pro) to an " +
+    "org or user by UUID. The three positionals are: subcommand " +
+    "(grant), target UUID, tier. No flags. Requires " +
+    "SUPABASE_SERVICE_ROLE_KEY (staff-only).",
+  parameters: {
+    flags: {},
+    positional: {
+      kind: "tuple",
+      parameters: [
+        { parse: String, brief: "Subcommand (grant)", optional: true },
+        { parse: String, brief: "Target UUID (org or user)", optional: true },
+        { parse: String, brief: "Tier (free | team | pro)", optional: true },
+      ],
+    },
+  },
+  config: {
+    renderHuman: (data) => data,
+    toJson: (data) => ({ output: data }),
+  },
+  async handler(_flags, sub, target, tier) {
+    // Stricli spreads ARGS = [string?, string?, string?] into individual
+    // args. Collect back into the legacy string[].
+    const positionals: string[] = [];
+    if (typeof sub === "string") positionals.push(sub);
+    if (typeof target === "string") positionals.push(target);
+    if (typeof tier === "string") positionals.push(tier);
+    const { exitCode, captured } = await runLegacyAndCollect(() =>
+      commandAdmin(positionals, {}),
+    );
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+    return { kind: "value" as const, data: captured };
+  },
+});

--- a/packages/gateway/src/cli/commands/team.ts
+++ b/packages/gateway/src/cli/commands/team.ts
@@ -1,0 +1,111 @@
+/**
+ * `lore team` — typed Stricli command (Phase 3D.3c).
+ *
+ * Wraps the legacy `commandTeam` from `../team-cmd` via the shared
+ * `runLegacyAndCollect` bridge. The legacy handler takes:
+ *
+ *   - positionals[0]: subcommand (list | members | discover | create | add
+ *                     | remove | set-role | invite | accept | link | unlink
+ *                     | review | approve | reject | policy | domain)
+ *   - positionals[1+]: subcommand-specific args (e.g., `add <scope> <userId>`)
+ *
+ * Flags forwarded to the legacy values dict: --invite, --role, --email,
+ * --offline, --project.
+ *
+ * Output shape:
+ *   - human: rendered legacy text
+ *   - JSON:  { output: <captured stdout> }
+ *
+ * Exit codes: legacy semantics preserved.
+ */
+import { buildOutputCommand } from "../lib/command";
+import { runLegacyAndCollect } from "../lib/legacy-bridge";
+import { commandTeam } from "../team-cmd";
+
+type TeamFlags = {
+  invite?: string;
+  role?: string;
+  email?: string;
+  offline: boolean;
+  project?: string;
+};
+
+export const teamCommand = buildOutputCommand<
+  string,
+  TeamFlags,
+  readonly string[]
+>({
+  brief: "Manage team membership and roles",
+  fullDescription:
+    "Team configuration: list members, invite, assign roles, remove " +
+    "members. Subcommands include list, members, discover, create, " +
+    "add, remove, set-role, invite, accept, link, unlink, review, " +
+    "approve, reject, policy, domain. The first positional selects " +
+    "the subcommand; subsequent positionals are subcommand-specific " +
+    "args. Flags --invite, --role, --email, --offline, --project " +
+    "are forwarded as values. --json emits a structured envelope.",
+  parameters: {
+    flags: {
+      invite: {
+        kind: "parsed",
+        parse: String,
+        brief: "Team to invite discoverer to",
+        optional: true,
+      },
+      role: {
+        kind: "parsed",
+        parse: String,
+        brief: "Role to assign (editor | viewer | member)",
+        optional: true,
+      },
+      email: {
+        kind: "parsed",
+        parse: String,
+        brief: "Email hint for the invitee",
+        optional: true,
+      },
+      offline: {
+        kind: "boolean",
+        brief: "Mark the invite as offline (no browser flow)",
+        default: false,
+      },
+      project: {
+        kind: "parsed",
+        parse: String,
+        brief: "Project directory (default: cwd)",
+        optional: true,
+      },
+    },
+    positional: {
+      kind: "array",
+      parameter: {
+        parse: String,
+        brief: "team subcommand + subcommand-specific args",
+      },
+    },
+  },
+  config: {
+    renderHuman: (data) => data,
+    toJson: (data) => ({ output: data }),
+  },
+  async handler(flags, ...positionals) {
+    const values: Record<string, unknown> = {};
+    if (flags.invite) values.invite = flags.invite;
+    if (flags.role) values.role = flags.role;
+    if (flags.email) values.email = flags.email;
+    if (flags.offline) values.offline = true;
+    if (flags.project) values.project = flags.project;
+    // Stricli spreads the variadic positional array into individual
+    // handler params; collect them back into the legacy string[].
+    const positionalsArr = positionals.filter(
+      (p): p is string => typeof p === "string",
+    );
+    const { exitCode, captured } = await runLegacyAndCollect(() =>
+      commandTeam(positionalsArr, values),
+    );
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+    return { kind: "value" as const, data: captured };
+  },
+});

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -37,6 +37,7 @@ export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "logout",
   "sync",
   "team",
+  "admin",
 ]);
 
 export interface PreprocessResult {

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -36,6 +36,7 @@ export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "login",
   "logout",
   "sync",
+  "team",
 ]);
 
 export interface PreprocessResult {

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -436,8 +436,10 @@ export async function _cli(): Promise<void> {
   //   - team: migrated (Phase 3D.3c) — typed command (variadic
   //     positional + 5 flag schema; legacy handles dispatch by
   //     positionals[0]).
-  //   - admin, import: NOT YET — pending Phase 3D.3d, e follow-ups
-  //     with explicit flag schemas.
+  //   - admin: migrated (Phase 3D.3d) — typed command (3 positional
+  //     tuple: sub, target, tier; no flags).
+  //   - import: NOT YET — pending Phase 3D.3e with explicit flag
+  //     schema.
   //
   // Removal milestone: delete the migrated case blocks once programmatic
   // callers migrate to `runCli()` AND a deletion test passes for each.

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -433,8 +433,11 @@ export async function _cli(): Promise<void> {
   //   - login, logout: migrated (Phase 3D.2) — typed command.
   //   - sync: migrated (Phase 3D.3b) — typed command (positional
   //     schema declared; flags still handled by legacy).
-  //   - team, admin, import: NOT YET — pending Phase 3D.3c, d, e
-  //     follow-ups with explicit flag schemas.
+  //   - team: migrated (Phase 3D.3c) — typed command (variadic
+  //     positional + 5 flag schema; legacy handles dispatch by
+  //     positionals[0]).
+  //   - admin, import: NOT YET — pending Phase 3D.3d, e follow-ups
+  //     with explicit flag schemas.
   //
   // Removal milestone: delete the migrated case blocks once programmatic
   // callers migrate to `runCli()` AND a deletion test passes for each.

--- a/packages/gateway/test/cli-admin-contract.test.ts
+++ b/packages/gateway/test/cli-admin-contract.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Phase 3D.3d — typed `lore admin` with 3-positional tuple.
+ *
+ * Pins the typed wrapper for `lore admin`. The legacy handler takes 3
+ * positionals: sub (must be "grant"), target UUID, tier (free | team |
+ * pro). No flags.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
+const origArgv = process.argv;
+
+beforeEach(() => {
+  process.env.LORE_NO_UPDATE_CHECK = "1";
+  process.argv = origArgv;
+});
+
+afterAll(() => {
+  if (origNoUpdateCheck === undefined) delete process.env.LORE_NO_UPDATE_CHECK;
+  else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
+  process.argv = origArgv;
+});
+
+interface AdminCall {
+  positionals: string[];
+  values: Record<string, unknown>;
+}
+
+describe("Phase 3D.3d — typed lore admin", () => {
+  test("admin is registered in STRICLI_ROUTES", async () => {
+    const { STRICLI_ROUTES } = await import("../src/cli/lib/argv");
+    expect(STRICLI_ROUTES.has("admin")).toBe(true);
+  });
+
+  test("admin is NOT in LEGACY_ROUTES", async () => {
+    const { LEGACY_ROUTES } = await import("../src/cli/app");
+    expect(LEGACY_ROUTES.has("admin")).toBe(false);
+  });
+
+  test("admin declares 3-positional tuple (sub, target, tier)", async () => {
+    const { buildApplication, buildRouteMap, run } =
+      await import("@stricli/core");
+    const { adminCommand } = await import("../src/cli/commands/admin");
+    const { buildContext } = await import("../src/cli/context");
+
+    const app = buildApplication(
+      buildRouteMap({
+        routes: { admin: adminCommand },
+        docs: { brief: "lore" },
+      }),
+      { name: "lore" },
+    );
+    const seen = new Set<string>();
+    const origWrite = process.stdout.write;
+    const writeSpy = ((chunk: string | Buffer) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      for (const m of text.matchAll(/(grant|tier|target|subcommand)/g))
+        seen.add(m[0]);
+      return true;
+    }) as never;
+    process.stdout.write = writeSpy;
+    try {
+      await run(app, ["admin", "--help"], buildContext(process));
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    expect(seen.has("subcommand")).toBe(true);
+    expect(seen.has("target")).toBe(true);
+    expect(seen.has("tier")).toBe(true);
+  });
+
+  test("admin forwards 3 positionals to legacy handler", async () => {
+    vi.resetModules();
+    const calls: AdminCall[] = [];
+    const adminImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("admin ok");
+      },
+    );
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = [
+      "node",
+      "lore",
+      "admin",
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+      "team",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(adminImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+      "team",
+    ]);
+    expect(Buffer.concat(stdoutChunks).toString("utf8")).toContain("admin ok");
+    vi.resetModules();
+  });
+
+  test("admin propagates legacy exit code", async () => {
+    vi.resetModules();
+    const adminImpl = vi.fn(async () => {
+      process.exitCode = 1;
+      console.error("SUPABASE_SERVICE_ROLE_KEY not set");
+    });
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "admin", "grant", "x", "team"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+
+  test("admin rejects extra positional with exit code 20 (UsageError), not 252", async () => {
+    // The F-1 scanner-error exit-code remap from PR #1569 covers all
+    // Stricli routes. Pin it on admin too — the only consumer here
+    // is the UnknownPositionalError path (4 args vs the declared 3).
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = [
+      "node",
+      "lore",
+      "admin",
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+      "team",
+      "extra-arg",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(20);
+  });
+});

--- a/packages/gateway/test/cli-team-contract.test.ts
+++ b/packages/gateway/test/cli-team-contract.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Phase 3D.3c — typed `lore team` with explicit positional + flag schema.
+ *
+ * Pins the typed wrapper for `lore team`. The legacy handler takes a
+ * subcommand as `positionals[0]` plus subcommand-specific args, and
+ * reads five flags (invite, role, email, offline, project) from the
+ * values dict.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
+const origArgv = process.argv;
+
+beforeEach(() => {
+  process.env.LORE_NO_UPDATE_CHECK = "1";
+  process.argv = origArgv;
+});
+
+afterAll(() => {
+  if (origNoUpdateCheck === undefined) delete process.env.LORE_NO_UPDATE_CHECK;
+  else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
+  process.argv = origArgv;
+});
+
+interface TeamCall {
+  positionals: string[];
+  values: Record<string, unknown>;
+}
+
+describe("Phase 3D.3c — typed lore team", () => {
+  test("team is registered in STRICLI_ROUTES", async () => {
+    const { STRICLI_ROUTES } = await import("../src/cli/lib/argv");
+    expect(STRICLI_ROUTES.has("team")).toBe(true);
+  });
+
+  test("team is NOT in LEGACY_ROUTES", async () => {
+    const { LEGACY_ROUTES } = await import("../src/cli/app");
+    expect(LEGACY_ROUTES.has("team")).toBe(false);
+  });
+
+  test("team declares --invite, --role, --email, --offline, --project flags", async () => {
+    const { buildApplication, buildRouteMap, run } =
+      await import("@stricli/core");
+    const { teamCommand } = await import("../src/cli/commands/team");
+    const { buildContext } = await import("../src/cli/context");
+
+    const app = buildApplication(
+      buildRouteMap({
+        routes: { team: teamCommand },
+        docs: { brief: "lore" },
+      }),
+      { name: "lore" },
+    );
+    const seen = new Set<string>();
+    const origWrite = process.stdout.write;
+    const writeSpy = ((chunk: string | Buffer) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      for (const m of text.matchAll(/--[a-z][a-zA-Z0-9-]*/g)) seen.add(m[0]);
+      return true;
+    }) as never;
+    process.stdout.write = writeSpy;
+    try {
+      await run(app, ["team", "--help"], buildContext(process));
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    expect(seen.has("--invite")).toBe(true);
+    expect(seen.has("--role")).toBe(true);
+    expect(seen.has("--email")).toBe(true);
+    expect(seen.has("--offline")).toBe(true);
+    expect(seen.has("--project")).toBe(true);
+  });
+
+  test("team forwards subcommand + flags to legacy handler", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = [
+      "node",
+      "lore",
+      "team",
+      "invite",
+      "alice",
+      "--role",
+      "viewer",
+      "--email",
+      "alice@example.com",
+      "--project",
+      "/tmp/test",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(teamImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual(["invite", "alice"]);
+    expect(calls[0]?.values.role).toBe("viewer");
+    expect(calls[0]?.values.email).toBe("alice@example.com");
+    expect(calls[0]?.values.project).toBe("/tmp/test");
+    expect(Buffer.concat(stdoutChunks).toString("utf8")).toContain("team ok");
+    vi.resetModules();
+  });
+
+  // F-1 (HIGH): variadic positional — 3+ args must reach the legacy
+  // handler unchanged. A regression swapping kind: "array" back to
+  // a fixed-shape tuple would still pass the 2-arg test above.
+  test("team forwards 3+ positional args (variadic)", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "team",
+      "add",
+      "scope-1",
+      "user-1",
+      "viewer",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(teamImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([
+      "add",
+      "scope-1",
+      "user-1",
+      "viewer",
+    ]);
+    vi.resetModules();
+  });
+
+  // F-2 (HIGH): default subcommand — 0 positionals must reach the
+  // legacy handler with an empty array. commandTeam defaults to
+  // `positionals[0] ?? "list"` so a schema with `minimum: 1` would
+  // silently break `lore team` (the most common invocation).
+  test("team with no positional still reaches legacy handler (default subcommand)", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("list ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(teamImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([]);
+    vi.resetModules();
+  });
+
+  // F-3 (MEDIUM): --offline (default: false) must be forwarded as
+  // true when set, and absent when not set (NOT false, NOT undefined).
+  test("team forwards --offline as values.offline = true", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team", "invite", "alice", "--offline"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values.offline).toBe(true);
+    vi.resetModules();
+  });
+
+  test("team does NOT forward --offline when absent", async () => {
+    vi.resetModules();
+    const calls: TeamCall[] = [];
+    const teamImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("team ok");
+      },
+    );
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team", "list"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    // --offline absent → values.offline must be undefined (skip on
+    // absent), NOT true and NOT false. The wrapper only sets it when
+    // the user actually passed --offline.
+    expect(calls[0]?.values.offline).toBeUndefined();
+    vi.resetModules();
+  });
+
+  // F-4 (MEDIUM): --json auto-injection must produce the structured
+  // envelope { output: <captured stdout> } on the typed pipeline.
+  test("team --json produces the structured envelope", async () => {
+    vi.resetModules();
+    const teamImpl = vi.fn(async () => {
+      console.log("json-mode ok");
+    });
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = ["node", "lore", "team", "list", "--json"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    const parsed = JSON.parse(Buffer.concat(stdoutChunks).toString("utf8"));
+    expect(parsed).toEqual({ output: "json-mode ok\n" });
+    vi.resetModules();
+  });
+
+  test("team propagates legacy exit code", async () => {
+    vi.resetModules();
+    const teamImpl = vi.fn(async () => {
+      process.exitCode = 1;
+      console.error("not logged in");
+    });
+    vi.doMock("../src/cli/team-cmd", () => ({
+      commandTeam: teamImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "team", "list"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3D.3d from the Stricli CLI migration plan. `lore admin` now routes through the typed tree with a 3-positional tuple (sub, target, tier) + no flags. Continues the per-command split pattern.

## What's in this PR

### commands/admin.ts — typed adapter

Wraps `commandAdmin` from `../admin-cmd` via the shared `runLegacyAndCollect` bridge.

Schema:
- positional: 3-element tuple `(sub, target, tier)` — all optional
- flags: empty (auto-injected `--json` only)

`commandAdmin` takes `positionals[0]='grant'`, `positionals[1]=UUID`, `positionals[2]=tier` (`free|team|pro`). No flags. Stricli spreads `ARGS = [string?, string?, string?]` into individual handler params, which we collect back into a `positionals` string[] for the legacy call.

### Routing

- `lib/argv.ts`: `STRICLI_ROUTES` gains `"admin"`.
- `app.ts`: `admin` moved out of `LEGACY_ROUTES` into the Stricli tree.
- `main.ts:413-439`: status comment block lists `admin` as migrated (Phase 3D.3d).

## Tests

`cli-admin-contract.test.ts` — 6 cases:

1. `admin` registered in `STRICLI_ROUTES` (routing wiring).
2. `admin` NOT in `LEGACY_ROUTES` (per-slice removal rule).
3. 3-positional tuple declared — help text shows subcommand/target/tier.
4. `lore admin grant <uuid> team` forwards `[grant, uuid, team]` to `commandAdmin`.
5. Legacy exit code propagates (1 not 0).
6. F-1 regression: extra positional exits 20 (UsageError), not 252.

The legacy handler is mocked via `vi.doMock` so the test doesn't touch Supabase.

## Verification

- 176 CLI tests pass across 19 files (added 6 new)
- TypeScript clean
- Lint clean (zero errors)
- Format clean
- Bundle succeeds for both CJS (Node) and ESM (Bun) targets

## Next steps (Phase 3D.3e)

- `lore import` — 11+ flags (dry-run, yes, agent, source, file, global, mem0-*, no-worktrees, project)

Each gets its own PR with the full flag/positional schema declared upfront.