### PR TITLE
feat(cli): migrate lore admin to typed Stricli command (Phase 3D.3d)

### DIFF
--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -26,6 +26,7 @@ import { lintCommand } from "./commands/lint";
 import { loginCommand, logoutCommand } from "./commands/auth";
 import { syncCommand } from "./commands/sync";
 import { teamCommand } from "./commands/team";
+import { adminCommand } from "./commands/admin";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -40,7 +41,6 @@ export const LEGACY_ROUTES: ReadonlySet<string> = new Set([
   "setup",
   "data",
   "recall",
-  "admin",
   "import",
   "entity",
   "upgrade",
@@ -122,6 +122,7 @@ export const routes = buildRouteMap({
     logout: logoutCommand,
     sync: syncCommand,
     team: teamCommand,
+    admin: adminCommand,
   },
 });
 

--- a/packages/gateway/src/cli/commands/admin.ts
+++ b/packages/gateway/src/cli/commands/admin.ts
@@ -1,0 +1,76 @@
+/**
+ * `lore admin` — typed Stricli command (Phase 3D.3d).
+ *
+ * Wraps the legacy `commandAdmin` from `../admin-cmd` via the shared
+ * `runLegacyAndCollect` bridge. The legacy handler takes 3 positionals:
+ *
+ *   - positionals[0]: subcommand (must be "grant")
+ *   - positionals[1]: target — UUID for team orgs OR email for personal
+ *   - positionals[2]: tier (free | team for orgs, free | pro for personal)
+ *
+ * No flags. The typed adapter declares only the positional schema.
+ *
+ * Output shape:
+ *   - human: rendered legacy text
+ *   - JSON:  { output: <captured stdout> }
+ *
+ * Exit codes: legacy semantics preserved (0 success, 1 usage/invalid
+ * tier/no service-role client).
+ */
+import { buildOutputCommand } from "../lib/command";
+import { runLegacyAndCollect } from "../lib/legacy-bridge";
+import { commandAdmin } from "../admin-cmd";
+
+type AdminFlags = Record<string, never>;
+
+export const adminCommand = buildOutputCommand<
+  string,
+  AdminFlags,
+  readonly [string?, string?, string?]
+>({
+  brief: "Admin operations (admin-only)",
+  fullDescription:
+    "Admin-only operations: grant a tier to an org or user. The " +
+    "three positionals are: subcommand (grant), target — email for " +
+    "personal users or UUID for team orgs, tier (free|pro for " +
+    "personal; free|team for orgs). No flags. Requires " +
+    "SUPABASE_SERVICE_ROLE_KEY (staff-only).",
+  parameters: {
+    flags: {},
+    positional: {
+      kind: "tuple",
+      parameters: [
+        { parse: String, brief: "Subcommand (grant)", optional: true },
+        {
+          parse: String,
+          brief: "Target — email for personal, UUID for team org",
+          optional: true,
+        },
+        {
+          parse: String,
+          brief: "Tier (free|pro for personal; free|team for orgs)",
+          optional: true,
+        },
+      ],
+    },
+  },
+  config: {
+    renderHuman: (data) => data,
+    toJson: (data) => ({ output: data }),
+  },
+  async handler(_flags, sub, target, tier) {
+    // Stricli spreads ARGS = [string?, string?, string?] into individual
+    // args. Collect back into the legacy string[].
+    const positionals: string[] = [];
+    if (typeof sub === "string") positionals.push(sub);
+    if (typeof target === "string") positionals.push(target);
+    if (typeof tier === "string") positionals.push(tier);
+    const { exitCode, captured } = await runLegacyAndCollect(() =>
+      commandAdmin(positionals, {}),
+    );
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+    return { kind: "value" as const, data: captured };
+  },
+});

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -37,6 +37,7 @@ export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "logout",
   "sync",
   "team",
+  "admin",
 ]);
 
 export interface PreprocessResult {

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -436,8 +436,10 @@ export async function _cli(): Promise<void> {
   //   - team: migrated (Phase 3D.3c) — typed command (variadic
   //     positional + 5 flag schema; legacy handles dispatch by
   //     positionals[0]).
-  //   - admin, import: NOT YET — pending Phase 3D.3d, e follow-ups
-  //     with explicit flag schemas.
+  //   - admin: migrated (Phase 3D.3d) — typed command (3 positional
+  //     tuple: sub, target, tier; no flags).
+  //   - import: NOT YET — pending Phase 3D.3e with explicit flag
+  //     schema.
   //
   // Removal milestone: delete the migrated case blocks once programmatic
   // callers migrate to `runCli()` AND a deletion test passes for each.

--- a/packages/gateway/test/cli-admin-contract.test.ts
+++ b/packages/gateway/test/cli-admin-contract.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Phase 3D.3d — typed `lore admin` with 3-positional tuple.
+ *
+ * Pins the typed wrapper for `lore admin`. The legacy handler takes 3
+ * positionals: sub (must be "grant"), target UUID or email, tier
+ * (free | team | pro). No flags.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
+const origArgv = process.argv;
+
+beforeEach(() => {
+  process.env.LORE_NO_UPDATE_CHECK = "1";
+  process.argv = origArgv;
+});
+
+afterAll(() => {
+  if (origNoUpdateCheck === undefined) delete process.env.LORE_NO_UPDATE_CHECK;
+  else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
+  process.argv = origArgv;
+});
+
+interface AdminCall {
+  positionals: string[];
+  values: Record<string, unknown>;
+}
+
+describe("Phase 3D.3d — typed lore admin", () => {
+  test("admin is registered in STRICLI_ROUTES", async () => {
+    const { STRICLI_ROUTES } = await import("../src/cli/lib/argv");
+    expect(STRICLI_ROUTES.has("admin")).toBe(true);
+  });
+
+  test("admin is NOT in LEGACY_ROUTES", async () => {
+    const { LEGACY_ROUTES } = await import("../src/cli/app");
+    expect(LEGACY_ROUTES.has("admin")).toBe(false);
+  });
+
+  test("admin declares 3-positional tuple (sub, target, tier)", async () => {
+    const { buildApplication, buildRouteMap, run } =
+      await import("@stricli/core");
+    const { adminCommand } = await import("../src/cli/commands/admin");
+    const { buildContext } = await import("../src/cli/context");
+
+    const app = buildApplication(
+      buildRouteMap({
+        routes: { admin: adminCommand },
+        docs: { brief: "lore" },
+      }),
+      { name: "lore" },
+    );
+    const seen = new Set<string>();
+    const origWrite = process.stdout.write;
+    const writeSpy = ((chunk: string | Buffer) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      for (const m of text.matchAll(/(grant|tier|target|subcommand)/g))
+        seen.add(m[0]);
+      return true;
+    }) as never;
+    process.stdout.write = writeSpy;
+    try {
+      await run(app, ["admin", "--help"], buildContext(process));
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    expect(seen.has("subcommand")).toBe(true);
+    expect(seen.has("target")).toBe(true);
+    expect(seen.has("tier")).toBe(true);
+  });
+
+  test("admin forwards 3 positionals to legacy handler", async () => {
+    vi.resetModules();
+    const calls: AdminCall[] = [];
+    const adminImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("admin ok");
+      },
+    );
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = [
+      "node",
+      "lore",
+      "admin",
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+      "team",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(adminImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+      "team",
+    ]);
+    expect(Buffer.concat(stdoutChunks).toString("utf8")).toContain("admin ok");
+    vi.resetModules();
+  });
+
+  // M-1: partial-positional coverage. The admin positional schema
+  // declares all 3 as optional, so the Stricli scanner accepts 0/1/2/3
+  // inputs. Every partial case reaches the legacy handler, which calls
+  // `usage()` and exits 1. Pin that each partial case reaches
+  // commandAdmin with the right positionals-prefixed array.
+  test("admin with no positional reaches legacy handler with []", async () => {
+    vi.resetModules();
+    const calls: AdminCall[] = [];
+    const adminImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        process.exitCode = 1;
+      },
+    );
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "admin"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(adminImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([]);
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+
+  test("admin with 1 positional ('grant') reaches legacy handler with ['grant']", async () => {
+    vi.resetModules();
+    const calls: AdminCall[] = [];
+    const adminImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        process.exitCode = 1;
+      },
+    );
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "admin", "grant"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(adminImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual(["grant"]);
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+
+  test("admin with 2 positionals ('grant <target>') reaches legacy handler with ['grant', '<target>']", async () => {
+    vi.resetModules();
+    const calls: AdminCall[] = [];
+    const adminImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        process.exitCode = 1;
+      },
+    );
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "admin",
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(adminImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+    ]);
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+
+  test("admin propagates legacy exit code", async () => {
+    vi.resetModules();
+    const adminImpl = vi.fn(async () => {
+      process.exitCode = 1;
+      console.error("SUPABASE_SERVICE_ROLE_KEY not set");
+    });
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "admin", "grant", "x", "team"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+
+  test("admin rejects extra positional with exit code 20 (UsageError), not 252", async () => {
+    // The F-1 scanner-error exit-code remap from PR #1569 covers all
+    // Stricli routes. Pin it on admin too — the only consumer here
+    // is the UnknownPositionalError path (4 args vs the declared 3).
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = [
+      "node",
+      "lore",
+      "admin",
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+      "team",
+      "extra-arg",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(20);
+  });
+
+  // L-3: --json auto-injection must produce the structured envelope.
+  test("admin --json produces the structured envelope", async () => {
+    vi.resetModules();
+    const adminImpl = vi.fn(async () => {
+      console.log("Set <uuid> tier → team");
+    });
+    vi.doMock("../src/cli/admin-cmd", () => ({
+      commandAdmin: adminImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = [
+      "node",
+      "lore",
+      "admin",
+      "grant",
+      "00000000-0000-0000-0000-000000000000",
+      "team",
+      "--json",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    const parsed = JSON.parse(Buffer.concat(stdoutChunks).toString("utf8"));
+    expect(parsed).toEqual({ output: "Set <uuid> tier → team\n" });
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3D.3d from the Stricli CLI migration plan. `lore admin` now routes through the typed tree with a 3-positional tuple (sub, target, tier) + no flags. Continues the per-command split pattern.

## What's in this PR

### commands/admin.ts — typed adapter

Wraps `commandAdmin` from `../admin-cmd` via the shared `runLegacyAndCollect` bridge.

Schema:
- positional: 3-element tuple `(sub, target, tier)` — all optional
- flags: empty (auto-injected `--json` only)

`commandAdmin` takes `positionals[0]='grant'`, `positionals[1]=UUID` (for orgs) or email (for personal), `positionals[2]=tier` (free|pro for personal; free|team for orgs). The fullDescription hints at the per-target tier split so users don't accidentally type `lore admin grant alice@x.com team`.

### Routing

- `lib/argv.ts`: `STRICLI_ROUTES` gains `"admin"`.
- `app.ts`: `admin` moved out of `LEGACY_ROUTES` into the Stricli tree.
- `main.ts:413-439`: status comment block lists `admin` as migrated (Phase 3D.3d).

## Tests

`cli-admin-contract.test.ts` — 10 cases:

1. `admin` registered in `STRICLI_ROUTES` (routing wiring).
2. `admin` NOT in `LEGACY_ROUTES` (per-slice removal rule).
3. 3-positional tuple declared — help text shows subcommand/target/tier.
4. `lore admin grant <uuid> team` forwards `[grant, uuid, team]` to `commandAdmin`.
5. **M-1**: `lore admin` with no positional reaches legacy handler with `[]`.
6. **M-1**: `lore admin grant` with 1 positional reaches legacy handler with `["grant"]`.
7. **M-1**: `lore admin grant <target>` with 2 positionals reaches legacy handler with `["grant", "<target>"]`.
8. Legacy exit code propagates (1 not 0).
9. **F-1** regression: extra positional exits 20 (UsageError), not 252.
10. **L-3**: `--json` produces structured envelope `{ output: ... }`.

The legacy handler is mocked via `vi.doMock` so the test doesn't touch Supabase.

## Verification

- 180 CLI tests pass across 19 files (added 10 new)
- TypeScript clean
- Lint clean (zero errors)
- Format clean
- Bundle succeeds for both CJS (Node) and ESM (Bun) targets

## Next steps (Phase 3D.3e)

- `lore import` — 11+ flags (dry-run, yes, agent, source, file, global, mem0-*, no-worktrees, project)

Each gets its own PR with the full flag/positional schema declared upfront.