### PR TITLE
feat(cli): migrate lore import to typed Stricli command (Phase 3D.3e)

### DIFF
--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -27,6 +27,7 @@ import { loginCommand, logoutCommand } from "./commands/auth";
 import { syncCommand } from "./commands/sync";
 import { teamCommand } from "./commands/team";
 import { adminCommand } from "./commands/admin";
+import { importCommand } from "./commands/import";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -41,7 +42,6 @@ export const LEGACY_ROUTES: ReadonlySet<string> = new Set([
   "setup",
   "data",
   "recall",
-  "import",
   "entity",
   "upgrade",
 ]);
@@ -123,6 +123,7 @@ export const routes = buildRouteMap({
     sync: syncCommand,
     team: teamCommand,
     admin: adminCommand,
+    import: importCommand,
   },
 });
 

--- a/packages/gateway/src/cli/commands/import.ts
+++ b/packages/gateway/src/cli/commands/import.ts
@@ -53,6 +53,9 @@ export const importCommand = buildOutputCommand<string, ImportFlags, []>({
     "and --mem0-* provider config. No positionals. " +
     "--json emits a structured envelope.",
   parameters: {
+    // Single-character flag alias: -y → --yes (matching the legacy
+    // OPTIONS table's `yes: { type: "boolean", short: "y" }`).
+    aliases: { y: "yes" },
     flags: {
       "dry-run": {
         kind: "boolean",
@@ -61,7 +64,7 @@ export const importCommand = buildOutputCommand<string, ImportFlags, []>({
       },
       yes: {
         kind: "boolean",
-        brief: "Skip confirmation prompts",
+        brief: "Skip confirmation prompts (alias: -y)",
         default: false,
       },
       agent: {

--- a/packages/gateway/src/cli/commands/import.ts
+++ b/packages/gateway/src/cli/commands/import.ts
@@ -1,0 +1,186 @@
+/**
+ * `lore import` — typed Stricli command (Phase 3D.3e).
+ *
+ * Wraps the legacy `commandImport` from `../import` via the shared
+ * `runLegacyAndCollect` bridge. The legacy handler reads flags from a
+ * values dict (no positionals).
+ *
+ * Flags:
+ *   - dry-run, yes/y, global, no-worktrees: booleans
+ *   - agent, source, file, project: strings (filter / source paths)
+ *   - mem0-qdrant, mem0-collection, mem0-server, mem0-token,
+ *     mem0-path, mem0-user: mem0 provider config (strings)
+ *
+ * The kebab-case flag names are mapped to camelCase for the legacy
+ * handler (e.g., `dry-run` → both `flags["dry-run"]` and `flags.dryRun`).
+ *
+ * Output shape:
+ *   - human: rendered legacy text
+ *   - JSON:  { output: <captured stdout> }
+ *
+ * Exit codes: legacy semantics preserved.
+ */
+import { buildOutputCommand } from "../lib/command";
+import { runLegacyAndCollect } from "../lib/legacy-bridge";
+import { commandImport } from "../import";
+
+type ImportFlags = {
+  // dry-run, yes, global, no-worktrees are required booleans because
+  // they declare `default: false` (Stricli narrows the value type to
+  // the literal false otherwise); --json auto-injected
+  "dry-run": boolean;
+  yes: boolean;
+  agent?: string;
+  source?: string;
+  file?: string;
+  global: boolean;
+  "mem0-qdrant"?: string;
+  "mem0-collection"?: string;
+  "mem0-server"?: string;
+  "mem0-token"?: string;
+  "mem0-path"?: string;
+  "mem0-user"?: string;
+  "no-worktrees": boolean;
+  project?: string;
+};
+
+export const importCommand = buildOutputCommand<string, ImportFlags, []>({
+  brief: "Import knowledge from .lore.md / AGENTS.md files",
+  fullDescription:
+    "Bulk-import knowledge entries from .lore.md or AGENTS.md " +
+    "files into the local lore DB. Flags: --dry-run, --yes/-y, " +
+    "--agent, --source, --file, --global, --no-worktrees, --project, " +
+    "and --mem0-* provider config. No positionals. " +
+    "--json emits a structured envelope.",
+  parameters: {
+    flags: {
+      "dry-run": {
+        kind: "boolean",
+        brief: "Show what would be imported without writing",
+        default: false,
+      },
+      yes: {
+        kind: "boolean",
+        brief: "Skip confirmation prompts",
+        default: false,
+      },
+      agent: {
+        kind: "parsed",
+        parse: String,
+        brief: "Filter imports to a specific agent (e.g., claude-code)",
+        optional: true,
+      },
+      source: {
+        kind: "parsed",
+        parse: String,
+        brief: "Source filter (e.g., user, repo, agent)",
+        optional: true,
+      },
+      file: {
+        kind: "parsed",
+        parse: String,
+        brief: "Import from a specific file (instead of scanning)",
+        optional: true,
+      },
+      global: {
+        kind: "boolean",
+        brief: "Import to the global lore DB (default: project-scoped)",
+        default: false,
+      },
+      "mem0-qdrant": {
+        kind: "parsed",
+        parse: String,
+        brief: "Mem0 provider: Qdrant URL",
+        optional: true,
+      },
+      "mem0-collection": {
+        kind: "parsed",
+        parse: String,
+        brief: "Mem0 provider: collection name",
+        optional: true,
+      },
+      "mem0-server": {
+        kind: "parsed",
+        parse: String,
+        brief: "Mem0 provider: server URL",
+        optional: true,
+      },
+      "mem0-token": {
+        kind: "parsed",
+        parse: String,
+        brief: "Mem0 provider: auth token",
+        optional: true,
+      },
+      "mem0-path": {
+        kind: "parsed",
+        parse: String,
+        brief: "Mem0 provider: data path",
+        optional: true,
+      },
+      "mem0-user": {
+        kind: "parsed",
+        parse: String,
+        brief: "Mem0 provider: user identifier",
+        optional: true,
+      },
+      "no-worktrees": {
+        kind: "boolean",
+        brief: "Skip worktree discovery (faster)",
+        default: false,
+      },
+      project: {
+        kind: "parsed",
+        parse: String,
+        brief: "Project directory (default: cwd)",
+        optional: true,
+      },
+    },
+  },
+  config: {
+    renderHuman: (data) => data,
+    toJson: (data) => ({ output: data }),
+  },
+  async handler(flags) {
+    // Forward the kebab-case flag names to the legacy handler, which
+    // reads both the kebab and camelCase forms. We populate the legacy
+    // camelCase aliases too so the legacy handler's existing checks
+    // (flags.dryRun, flags.noWorktrees) work without modification.
+    const values: Record<string, unknown> = {};
+    if (flags["dry-run"]) {
+      values["dry-run"] = true;
+      values.dryRun = true;
+    }
+    if (flags.yes) {
+      values.yes = true;
+      values.y = true;
+    }
+    if (flags.agent !== undefined) values.agent = flags.agent;
+    if (flags.source !== undefined) values.source = flags.source;
+    if (flags.file !== undefined) values.file = flags.file;
+    if (flags.global) values.global = true;
+    if (flags["mem0-qdrant"] !== undefined)
+      values["mem0-qdrant"] = flags["mem0-qdrant"];
+    if (flags["mem0-collection"] !== undefined)
+      values["mem0-collection"] = flags["mem0-collection"];
+    if (flags["mem0-server"] !== undefined)
+      values["mem0-server"] = flags["mem0-server"];
+    if (flags["mem0-token"] !== undefined)
+      values["mem0-token"] = flags["mem0-token"];
+    if (flags["mem0-path"] !== undefined)
+      values["mem0-path"] = flags["mem0-path"];
+    if (flags["mem0-user"] !== undefined)
+      values["mem0-user"] = flags["mem0-user"];
+    if (flags["no-worktrees"]) {
+      values["no-worktrees"] = true;
+      values.noWorktrees = true;
+    }
+    if (flags.project !== undefined) values.project = flags.project;
+    const { exitCode, captured } = await runLegacyAndCollect(() =>
+      commandImport([], values),
+    );
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+    return { kind: "value" as const, data: captured };
+  },
+});

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -38,6 +38,7 @@ export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "sync",
   "team",
   "admin",
+  "import",
 ]);
 
 export interface PreprocessResult {

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -438,8 +438,10 @@ export async function _cli(): Promise<void> {
   //     positionals[0]).
   //   - admin: migrated (Phase 3D.3d) — typed command (3 positional
   //     tuple: sub, target, tier; no flags).
-  //   - import: NOT YET — pending Phase 3D.3e with explicit flag
-  //     schema.
+  //   - import: migrated (Phase 3D.3e) — typed command (14 flags:
+  //     dry-run, yes, agent, source, file, global, no-worktrees,
+  //     project, mem0-{qdrant,collection,server,token,path,user};
+  //     no positionals).
   //
   // Removal milestone: delete the migrated case blocks once programmatic
   // callers migrate to `runCli()` AND a deletion test passes for each.

--- a/packages/gateway/test/cli-import-contract.test.ts
+++ b/packages/gateway/test/cli-import-contract.test.ts
@@ -281,4 +281,99 @@ describe("Phase 3D.3e — typed lore import", () => {
     expect(capturedExitCode).toBe(1);
     vi.resetModules();
   });
+
+  // F-1 (HIGH wire-level): -y short alias must reach the legacy
+  // handler as values.yes = true. The legacy OPTIONS table declares
+  // `yes: { type: "boolean", short: "y" }`; the typed schema must
+  // include `aliases: { y: "yes" }` to match.
+  test("import forwards -y short alias as values.yes = true", async () => {
+    vi.resetModules();
+    const calls: ImportCall[] = [];
+    const importImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("yes-via-short-alias");
+      },
+    );
+    vi.doMock("../src/cli/import", () => ({
+      commandImport: importImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "import", "-y", "--dry-run"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(importImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.values.yes).toBe(true);
+    // CamelCase alias of `dry-run` flag also forwarded.
+    expect(calls[0]?.values["dry-run"]).toBe(true);
+    expect(calls[0]?.values.dryRun).toBe(true);
+    vi.resetModules();
+  });
+
+  // F-2: wire-level coverage for the remaining 5 mem0-* flags. The
+  // main forwarding test exercises mem0-qdrant only; this test
+  // asserts the other 5 reach the legacy handler.
+  test("import forwards all 5 mem0-* string flags", async () => {
+    vi.resetModules();
+    const calls: ImportCall[] = [];
+    const importImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("mem0 ok");
+      },
+    );
+    vi.doMock("../src/cli/import", () => ({
+      commandImport: importImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "import",
+      "--mem0-qdrant",
+      "http://q",
+      "--mem0-collection",
+      "coll",
+      "--mem0-server",
+      "http://s",
+      "--mem0-token",
+      "tk",
+      "--mem0-path",
+      "/tmp/p",
+      "--mem0-user",
+      "u",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(importImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.values["mem0-qdrant"]).toBe("http://q");
+    expect(calls[0]?.values["mem0-collection"]).toBe("coll");
+    expect(calls[0]?.values["mem0-server"]).toBe("http://s");
+    expect(calls[0]?.values["mem0-token"]).toBe("tk");
+    expect(calls[0]?.values["mem0-path"]).toBe("/tmp/p");
+    expect(calls[0]?.values["mem0-user"]).toBe("u");
+    vi.resetModules();
+  });
 });

--- a/packages/gateway/test/cli-import-contract.test.ts
+++ b/packages/gateway/test/cli-import-contract.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Phase 3D.3e — typed `lore import` with 14-flag schema.
+ *
+ * Pins the typed wrapper for `lore import`. The legacy handler reads
+ * 14 flags from the values dict (no positionals). Each flag is
+ * forwarded with both kebab-case and camelCase aliases so the legacy
+ * handler's existing checks work without modification.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
+const origArgv = process.argv;
+
+beforeEach(() => {
+  process.env.LORE_NO_UPDATE_CHECK = "1";
+  process.argv = origArgv;
+});
+
+afterAll(() => {
+  if (origNoUpdateCheck === undefined) delete process.env.LORE_NO_UPDATE_CHECK;
+  else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
+  process.argv = origArgv;
+});
+
+interface ImportCall {
+  positionals: string[];
+  values: Record<string, unknown>;
+}
+
+describe("Phase 3D.3e — typed lore import", () => {
+  test("import is registered in STRICLI_ROUTES", async () => {
+    const { STRICLI_ROUTES } = await import("../src/cli/lib/argv");
+    expect(STRICLI_ROUTES.has("import")).toBe(true);
+  });
+
+  test("import is NOT in LEGACY_ROUTES", async () => {
+    const { LEGACY_ROUTES } = await import("../src/cli/app");
+    expect(LEGACY_ROUTES.has("import")).toBe(false);
+  });
+
+  test("import declares all 14 flags", async () => {
+    const { buildApplication, buildRouteMap, run } =
+      await import("@stricli/core");
+    const { importCommand } = await import("../src/cli/commands/import");
+    const { buildContext } = await import("../src/cli/context");
+
+    const app = buildApplication(
+      buildRouteMap({
+        routes: { import: importCommand },
+        docs: { brief: "lore" },
+      }),
+      { name: "lore" },
+    );
+    const seen = new Set<string>();
+    const origWrite = process.stdout.write;
+    const writeSpy = ((chunk: string | Buffer) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      for (const m of text.matchAll(/--[a-z][a-zA-Z0-9-]*/g)) seen.add(m[0]);
+      return true;
+    }) as never;
+    process.stdout.write = writeSpy;
+    try {
+      await run(app, ["import", "--help"], buildContext(process));
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const expected = [
+      "--dry-run",
+      "--yes",
+      "--agent",
+      "--source",
+      "--file",
+      "--global",
+      "--mem0-qdrant",
+      "--mem0-collection",
+      "--mem0-server",
+      "--mem0-token",
+      "--mem0-path",
+      "--mem0-user",
+      "--no-worktrees",
+      "--project",
+    ];
+    for (const flag of expected) {
+      expect(seen.has(flag), `import help should advertise ${flag}`).toBe(true);
+    }
+  });
+
+  test("import forwards flags as values dict (with camelCase aliases)", async () => {
+    vi.resetModules();
+    const calls: ImportCall[] = [];
+    const importImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("imported 3 entries");
+      },
+    );
+    vi.doMock("../src/cli/import", () => ({
+      commandImport: importImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = [
+      "node",
+      "lore",
+      "import",
+      "--dry-run",
+      "--yes",
+      "--agent",
+      "claude-code",
+      "--source",
+      "user",
+      "--file",
+      "/tmp/test.md",
+      "--global",
+      "--mem0-qdrant",
+      "http://localhost:6333",
+      "--no-worktrees",
+      "--project",
+      "/tmp/project",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(importImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual([]);
+    expect(calls[0]?.values["dry-run"]).toBe(true);
+    expect(calls[0]?.values.dryRun).toBe(true);
+    expect(calls[0]?.values.yes).toBe(true);
+    expect(calls[0]?.values.y).toBe(true);
+    expect(calls[0]?.values.agent).toBe("claude-code");
+    expect(calls[0]?.values.source).toBe("user");
+    expect(calls[0]?.values.file).toBe("/tmp/test.md");
+    expect(calls[0]?.values.global).toBe(true);
+    expect(calls[0]?.values["mem0-qdrant"]).toBe("http://localhost:6333");
+    expect(calls[0]?.values["no-worktrees"]).toBe(true);
+    expect(calls[0]?.values.noWorktrees).toBe(true);
+    expect(calls[0]?.values.project).toBe("/tmp/project");
+    expect(Buffer.concat(stdoutChunks).toString("utf8")).toContain(
+      "imported 3 entries",
+    );
+    vi.resetModules();
+  });
+
+  test("import does NOT forward absent flags", async () => {
+    vi.resetModules();
+    const calls: ImportCall[] = [];
+    const importImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("imported 0 entries");
+      },
+    );
+    vi.doMock("../src/cli/import", () => ({
+      commandImport: importImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "import"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values["dry-run"]).toBeUndefined();
+    expect(calls[0]?.values.dryRun).toBeUndefined();
+    expect(calls[0]?.values.yes).toBeUndefined();
+    expect(calls[0]?.values.global).toBeUndefined();
+    expect(calls[0]?.values["no-worktrees"]).toBeUndefined();
+    expect(calls[0]?.values.agent).toBeUndefined();
+    vi.resetModules();
+  });
+
+  test("import --json produces the structured envelope", async () => {
+    vi.resetModules();
+    const importImpl = vi.fn(async () => {
+      console.log("json-mode ok");
+    });
+    vi.doMock("../src/cli/import", () => ({
+      commandImport: importImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = ["node", "lore", "import", "--json"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    const parsed = JSON.parse(Buffer.concat(stdoutChunks).toString("utf8"));
+    expect(parsed).toEqual({ output: "json-mode ok\n" });
+    vi.resetModules();
+  });
+
+  test("import rejects unknown flag with exit code 20 (UsageError), not 252", async () => {
+    // F-1 regression: unknown flags trigger Stricli's UnknownFlagError
+    // which sets process.exitCode = -4. The remap in cli.ts converts to
+    // 20 (UsageError). Verify the typed import command catches this.
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = ["node", "lore", "import", "--unknown-flag"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(20);
+  });
+
+  test("import propagates legacy exit code", async () => {
+    vi.resetModules();
+    const importImpl = vi.fn(async () => {
+      process.exitCode = 1;
+      console.error("no .lore.md files found");
+    });
+    vi.doMock("../src/cli/import", () => ({
+      commandImport: importImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "import"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3D.3e from the Stricli CLI migration plan. `lore import` now routes through the typed tree with the full 14-flag schema + no positionals. Completes the 3D.3 per-command split (sync, team, admin, import).

## What's in this PR

### commands/import.ts — typed adapter

Wraps `commandImport` from `../import` via the shared `runLegacyAndCollect` bridge.

Schema:
- flags: 14 (`dry-run`, `yes`, `agent`, `source`, `file`, `global`, `mem0-{qdrant,collection,server,token,path,user}`, `no-worktrees`, `project`) + auto-injected `--json`
- no positionals

The legacy `commandImport` reads from a values dict (no args). The typed adapter forwards each flag with both kebab-case AND camelCase aliases so the legacy handler's existing checks (`flags.dryRun`, `flags.noWorktrees`) work without modification. Only forwards flags when the user actually set them (skip when absent), preventing the legacy handler from accidentally treating absent `--dry-run` as truthy.

### Routing

- `lib/argv.ts`: `STRICLI_ROUTES` gains `"import"`.
- `app.ts`: `import` moved out of `LEGACY_ROUTES` into the Stricli tree.
- `main.ts:413-439`: status comment block lists `import` as migrated (Phase 3D.3e).

## Tests

`cli-import-contract.test.ts` — 8 cases:

1. `import` registered in `STRICLI_ROUTES` (routing wiring).
2. `import` NOT in `LEGACY_ROUTES` (per-slice removal rule).
3. All 14 flags declared — `--help` output shows each flag name.
4. Flag forwarding with camelCase aliases (`--dry-run` → `dryRun`, `--no-worktrees` → `noWorktrees`, `--yes` → `y`).
5. Absent flags NOT forwarded (`values.dryRun === undefined` when `--dry-run` not passed).
6. `--json` produces structured envelope `{ output: ... }`.
7. **F-1** regression: unknown flag exits 20 (UsageError), not 252.
8. Legacy exit code propagates (1 not 0).

The legacy handler is mocked via `vi.doMock` so the test doesn't touch Supabase or any IO.

## Verification

- 188 CLI tests pass across 20 files (added 8 new)
- TypeScript clean
- Lint clean (zero errors)
- Format clean
- Bundle succeeds for both CJS (Node) and ESM (Bun) targets

## Next steps

- Phase 3D.4: `entity` — typed Stricli command (destructive policy required)
- Phase 3C: `data`/`entity` — full nested route conversion
- Phase 3B.2: `start` — typed Stricli command (gateway lifecycle, deferred)
- Phase 3B.3: `setup` — typed Stricli commands (deferred — 1500+ lines)
- Phase 3E: `run` — final opaque-argv implementation (hardest)
- Phases 4-8: help / completion / skills / docs / setup-upgrade integration