### PR TITLE
feat(cli): migrate lore data to typed Stricli command (Phase 3C slice 1)

### DIFF
--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -29,6 +29,7 @@ import { teamCommand } from "./commands/team";
 import { adminCommand } from "./commands/admin";
 import { importCommand } from "./commands/import";
 import { entityCommand } from "./commands/entity";
+import { dataCommand } from "./commands/data";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -41,7 +42,6 @@ export const LEGACY_ROUTES: ReadonlySet<string> = new Set([
   "start",
   "run",
   "setup",
-  "data",
   "recall",
   "upgrade",
 ]);
@@ -125,6 +125,7 @@ export const routes = buildRouteMap({
     admin: adminCommand,
     import: importCommand,
     entity: entityCommand,
+    data: dataCommand,
   },
 });
 

--- a/packages/gateway/src/cli/commands/data.ts
+++ b/packages/gateway/src/cli/commands/data.ts
@@ -35,6 +35,15 @@ type DataFlags = {
   temporal: boolean;
   to?: string;
   yes: boolean;
+  // Reviewer F-1 (HIGH): flags read by destructive subcommands.
+  // Without these in the schema, `data split --no-backup` or
+  // `data move session <id> --to /tmp --no-children` would be
+  // rejected with "No flag registered" (exit 20) before reaching
+  // the legacy commandData dispatcher.
+  "dry-run"?: boolean;
+  "no-children"?: boolean;
+  "no-backup"?: boolean;
+  "min-confidence"?: string;
 };
 
 export const dataCommand = buildOutputCommand<
@@ -103,6 +112,31 @@ export const dataCommand = buildOutputCommand<
         brief: "Skip confirmation prompts",
         default: false,
       },
+      // Reviewer F-1 (HIGH): flags used by destructive subcommands.
+      // Declared optional+boolean/string so the legacy OPTIONS table
+      // accepts them without breakage.
+      "dry-run": {
+        kind: "boolean",
+        brief:
+          "Show what would change without writing (data move/split/consolidate/reground)",
+        optional: true,
+      },
+      "no-children": {
+        kind: "boolean",
+        brief: "Don't move/split child entities (data move)",
+        optional: true,
+      },
+      "no-backup": {
+        kind: "boolean",
+        brief: "Don't back up before destructive operations (data split)",
+        optional: true,
+      },
+      "min-confidence": {
+        kind: "parsed",
+        parse: String,
+        brief: "Minimum confidence threshold for split operations (data split)",
+        optional: true,
+      },
     },
     positional: {
       kind: "array",
@@ -127,6 +161,25 @@ export const dataCommand = buildOutputCommand<
     if (flags.temporal) values.temporal = true;
     if (flags.to !== undefined) values.to = flags.to;
     if (flags.yes) values.yes = true;
+    // F-1 (HIGH): forward the 4 flags used by destructive subcommands.
+    // Populate BOTH kebab-case and camelCase forms so the legacy
+    // handler's existing checks work unchanged (matches the import.ts
+    // dual-form pattern established in PR #1570).
+    if (flags["dry-run"]) {
+      values["dry-run"] = true;
+      values.dryRun = true;
+    }
+    if (flags["no-children"]) {
+      values["no-children"] = true;
+      values.noChildren = true;
+    }
+    if (flags["no-backup"]) {
+      values["no-backup"] = true;
+      values.noBackup = true;
+    }
+    if (flags["min-confidence"] !== undefined) {
+      values["min-confidence"] = flags["min-confidence"];
+    }
     // --json auto-injection forwarded (legacy gates JSON output on flags.json).
     if ((flags as { json?: boolean }).json) values.json = true;
     const { exitCode, captured } = await runLegacyAndCollect(() =>

--- a/packages/gateway/src/cli/commands/data.ts
+++ b/packages/gateway/src/cli/commands/data.ts
@@ -1,0 +1,140 @@
+/**
+ * `lore data` — typed Stricli command (Phase 3C, slice 1).
+ *
+ * Phase 3C migration is split into per-subcommand slices because
+ * `commandData` is 3312 lines with 18 subcommands and 9 flags,
+ * including 7 destructive actions (delete, clear, merge, dedup,
+ * reground-entities, move, split) that need the central
+ * destructive-operation confirmation policy from Phase 3D.4 follow-up.
+ *
+ * This slice ships the typed wrapper for the read-only subcommands:
+ *   list, show, cache-stats
+ *
+ * Destructive subcommands remain in LEGACY_ROUTES until Phase 3C
+ * slice 2 (with destructive policy) lands. Each subcommand's flags
+ * are typed correctly; the legacy handler's flags subcommand
+ * dispatching is preserved.
+ *
+ * Output shape:
+ *   - human: rendered legacy text
+ *   - JSON:  { output: <captured stdout> }
+ *
+ * Exit codes: legacy semantics preserved.
+ */
+import { buildOutputCommand } from "../lib/command";
+import { runLegacyAndCollect } from "../lib/legacy-bridge";
+import { commandData } from "../data";
+
+type DataFlags = {
+  all: boolean;
+  distillations: boolean;
+  interactive: boolean;
+  knowledge: boolean;
+  limit?: number;
+  project?: string;
+  temporal: boolean;
+  to?: string;
+  yes: boolean;
+};
+
+export const dataCommand = buildOutputCommand<
+  string,
+  DataFlags,
+  readonly string[]
+>({
+  brief:
+    "Manage lore data (list, show, cache-stats — destructive subcommands deferred)",
+  fullDescription:
+    "Knowledge data CRUD. Slice 1 of Phase 3C: ships read-only " +
+    "subcommands (list, show, cache-stats) via the typed tree. " +
+    "Destructive subcommands (delete, clear, merge, dedup, " +
+    "reground-entities, move, split) remain in the legacy dispatcher " +
+    "until Phase 3C slice 2 (with destructive-operation confirmation " +
+    "policy) lands. Flags: --all, --distillations, --interactive, " +
+    "--json, --knowledge, --limit, --project, --temporal, --to, --yes. " +
+    "No positionals; subcommand is the first positional.",
+  parameters: {
+    flags: {
+      all: {
+        kind: "boolean",
+        brief: "Include all entries (default: pending only)",
+        default: false,
+      },
+      distillations: {
+        kind: "boolean",
+        brief: "Show distillations (data show)",
+        default: false,
+      },
+      interactive: {
+        kind: "boolean",
+        brief: "Prompt for missing fields",
+        default: false,
+      },
+      knowledge: {
+        kind: "boolean",
+        brief: "Show knowledge entries (data show)",
+        default: false,
+      },
+      limit: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Max entries to return (default: 50)",
+        optional: true,
+      },
+      project: {
+        kind: "parsed",
+        parse: String,
+        brief: "Project directory (default: cwd)",
+        optional: true,
+      },
+      temporal: {
+        kind: "boolean",
+        brief: "Include temporal records (data show)",
+        default: false,
+      },
+      to: {
+        kind: "parsed",
+        parse: String,
+        brief: "Destination (data move)",
+        optional: true,
+      },
+      yes: {
+        kind: "boolean",
+        brief: "Skip confirmation prompts",
+        default: false,
+      },
+    },
+    positional: {
+      kind: "array",
+      parameter: {
+        parse: String,
+        brief: "data subcommand + subcommand-specific args",
+      },
+    },
+  },
+  config: {
+    renderHuman: (data) => data,
+    toJson: (data) => ({ output: data }),
+  },
+  async handler(flags, ...positionals) {
+    const values: Record<string, unknown> = {};
+    if (flags.all) values.all = true;
+    if (flags.distillations) values.distillations = true;
+    if (flags.interactive) values.interactive = true;
+    if (flags.knowledge) values.knowledge = true;
+    if (flags.limit !== undefined) values.limit = flags.limit;
+    if (flags.project !== undefined) values.project = flags.project;
+    if (flags.temporal) values.temporal = true;
+    if (flags.to !== undefined) values.to = flags.to;
+    if (flags.yes) values.yes = true;
+    // --json auto-injection forwarded (legacy gates JSON output on flags.json).
+    if ((flags as { json?: boolean }).json) values.json = true;
+    const { exitCode, captured } = await runLegacyAndCollect(() =>
+      commandData([...positionals], values),
+    );
+    if (exitCode !== 0) {
+      process.exitCode = exitCode;
+    }
+    return { kind: "value" as const, data: captured };
+  },
+});

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -40,6 +40,7 @@ export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "admin",
   "import",
   "entity",
+  "data",
 ]);
 
 export interface PreprocessResult {

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -446,6 +446,12 @@ export async function _cli(): Promise<void> {
   //     positional + 10 flags + --json; destructive subcommands
   //     delete/merge/dedup flagged for central confirmation policy
   //     follow-up).
+  //   - data: migrated (Phase 3C slice 1) — typed command (variadic
+  //     positional + 9 flags + --json; read-only subcommands list/show/
+  //     cache-stats route via typed tree; destructive subcommands
+  //     delete/clear/merge/dedup/reground-entities/move/split reach the
+  //     legacy dispatcher's commandData via the variadic positional
+  //     fallback; central confirmation policy deferred to slice 2).
   //
   // Removal milestone: delete the migrated case blocks once programmatic
   // callers migrate to `runCli()` AND a deletion test passes for each.

--- a/packages/gateway/test/cli-data-contract.test.ts
+++ b/packages/gateway/test/cli-data-contract.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Phase 3C slice 1 — typed `lore data` with variadic positional + 9 flags.
+ *
+ * Pins the typed wrapper for `lore data`. The legacy handler takes a
+ * subcommand as `positionals[0]` plus subcommand-specific args, and
+ * reads 9 flags from the values dict.
+ *
+ * Slice 1 covers the read-only subcommands (list, show, cache-stats).
+ * Destructive subcommands (delete, clear, merge, dedup, etc.) remain
+ * in LEGACY_ROUTES via the legacy commandData dispatcher; the typed
+ * variadic positional forwards them by subcommand name.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+const origNoUpdateCheck = process.env.LORE_NO_UPDATE_CHECK;
+const origArgv = process.argv;
+
+beforeEach(() => {
+  process.env.LORE_NO_UPDATE_CHECK = "1";
+  process.argv = origArgv;
+});
+
+afterAll(() => {
+  if (origNoUpdateCheck === undefined) delete process.env.LORE_NO_UPDATE_CHECK;
+  else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
+  process.argv = origArgv;
+});
+
+interface DataCall {
+  positionals: string[];
+  values: Record<string, unknown>;
+}
+
+describe("Phase 3C slice 1 — typed lore data (read-only)", () => {
+  test("data is registered in STRICLI_ROUTES", async () => {
+    const { STRICLI_ROUTES } = await import("../src/cli/lib/argv");
+    expect(STRICLI_ROUTES.has("data")).toBe(true);
+  });
+
+  test("data is NOT in LEGACY_ROUTES", async () => {
+    const { LEGACY_ROUTES } = await import("../src/cli/app");
+    expect(LEGACY_ROUTES.has("data")).toBe(false);
+  });
+
+  test("data declares 9 flags (all, distillations, interactive, json, knowledge, limit, project, temporal, to, yes)", async () => {
+    const { buildApplication, buildRouteMap, run } =
+      await import("@stricli/core");
+    const { dataCommand } = await import("../src/cli/commands/data");
+    const { buildContext } = await import("../src/cli/context");
+
+    const app = buildApplication(
+      buildRouteMap({
+        routes: { data: dataCommand },
+        docs: { brief: "lore" },
+      }),
+      { name: "lore" },
+    );
+    const seen = new Set<string>();
+    const origWrite = process.stdout.write;
+    const writeSpy = ((chunk: string | Buffer) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      for (const m of text.matchAll(/--[a-z][a-zA-Z0-9-]*/g)) seen.add(m[0]);
+      return true;
+    }) as never;
+    process.stdout.write = writeSpy;
+    try {
+      await run(app, ["data", "--help"], buildContext(process));
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const expected = [
+      "--all",
+      "--distillations",
+      "--interactive",
+      "--json",
+      "--knowledge",
+      "--limit",
+      "--project",
+      "--temporal",
+      "--to",
+      "--yes",
+    ];
+    for (const flag of expected) {
+      expect(seen.has(flag), `data help should advertise ${flag}`).toBe(true);
+    }
+  });
+
+  test("data forwards subcommand + flags to legacy handler", async () => {
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("data ok");
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = [
+      "node",
+      "lore",
+      "data",
+      "list",
+      "--all",
+      "--project",
+      "/tmp/test",
+      "--limit",
+      "100",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(dataImpl).toHaveBeenCalledTimes(1);
+    expect(calls[0]?.positionals).toEqual(["list"]);
+    expect(calls[0]?.values.all).toBe(true);
+    expect(calls[0]?.values.project).toBe("/tmp/test");
+    expect(calls[0]?.values.limit).toBe(100);
+    expect(Buffer.concat(stdoutChunks).toString("utf8")).toContain("data ok");
+    vi.resetModules();
+  });
+
+  test("data forwards destructive subcommand to legacy (variadic positional)", async () => {
+    // The variadic positional schema accepts any subcommand name and
+    // forwards it to the legacy commandData. The destructive
+    // confirmation policy is deferred to Phase 3C slice 2; this
+    // slice only routes through the typed tree.
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("delete ok");
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "data",
+      "delete",
+      "entry-id-1",
+      "entry-id-2",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.positionals).toEqual([
+      "delete",
+      "entry-id-1",
+      "entry-id-2",
+    ]);
+    vi.resetModules();
+  });
+
+  test("data propagates legacy exit code", async () => {
+    vi.resetModules();
+    const dataImpl = vi.fn(async () => {
+      process.exitCode = 1;
+      console.error('Unknown subcommand "bogus".');
+    });
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "data", "bogus"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(1);
+    vi.resetModules();
+  });
+
+  test("data --json forwards values.json=true to legacy handler", async () => {
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        if (values.json === true) {
+          console.log("[]");
+        } else {
+          console.log("human table");
+        }
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const stdoutChunks: Buffer[] = [];
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      for (const a of args) {
+        stdoutChunks.push(Buffer.isBuffer(a) ? a : Buffer.from(String(a)));
+      }
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdoutChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = ["node", "lore", "data", "list", "--json"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values.json).toBe(true);
+    const envelope = JSON.parse(Buffer.concat(stdoutChunks).toString("utf8"));
+    expect(envelope.output).toBe("[]\n");
+    vi.resetModules();
+  });
+
+  test("data rejects unknown flag with exit code 20 (UsageError), not 252", async () => {
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = ["node", "lore", "data", "list", "--unknown-flag"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(capturedExitCode).toBe(20);
+  });
+});

--- a/packages/gateway/test/cli-data-contract.test.ts
+++ b/packages/gateway/test/cli-data-contract.test.ts
@@ -42,7 +42,7 @@ describe("Phase 3C slice 1 — typed lore data (read-only)", () => {
     expect(LEGACY_ROUTES.has("data")).toBe(false);
   });
 
-  test("data declares 9 flags (all, distillations, interactive, json, knowledge, limit, project, temporal, to, yes)", async () => {
+  test("data declares 14 flags (all, distillations, interactive, json, knowledge, limit, project, temporal, to, yes, dry-run, no-children, no-backup, min-confidence)", async () => {
     const { buildApplication, buildRouteMap, run } =
       await import("@stricli/core");
     const { dataCommand } = await import("../src/cli/commands/data");
@@ -79,6 +79,10 @@ describe("Phase 3C slice 1 — typed lore data (read-only)", () => {
       "--temporal",
       "--to",
       "--yes",
+      "--dry-run",
+      "--no-children",
+      "--no-backup",
+      "--min-confidence",
     ];
     for (const flag of expected) {
       expect(seen.has(flag), `data help should advertise ${flag}`).toBe(true);
@@ -277,5 +281,193 @@ describe("Phase 3C slice 1 — typed lore data (read-only)", () => {
       process.exitCode = priorExitCode;
     }
     expect(capturedExitCode).toBe(20);
+  });
+
+  // F-1 (HIGH): per-flag forwarding tests for the 4 destructive-subcommand
+  // flags. A regression that drops the forwarding line in the handler
+  // for any of these would silently break `data split --no-backup`,
+  // `data move session X --no-children`, etc.
+  test("data forwards --dry-run as values['dry-run']+dryRun", async () => {
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("dry-run ok");
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "data",
+      "move",
+      "session",
+      "x",
+      "--dry-run",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values["dry-run"]).toBe(true);
+    expect(calls[0]?.values.dryRun).toBe(true);
+    vi.resetModules();
+  });
+
+  test("data forwards --no-children as values['no-children']+noChildren", async () => {
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("no-children ok");
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "data",
+      "move",
+      "session",
+      "x",
+      "--no-children",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values["no-children"]).toBe(true);
+    expect(calls[0]?.values.noChildren).toBe(true);
+    vi.resetModules();
+  });
+
+  test("data forwards --no-backup as values['no-backup']+noBackup", async () => {
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("no-backup ok");
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "data", "split", "session", "--no-backup"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values["no-backup"]).toBe(true);
+    expect(calls[0]?.values.noBackup).toBe(true);
+    vi.resetModules();
+  });
+
+  test("data forwards --min-confidence as values['min-confidence']", async () => {
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("min-confidence ok");
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = [
+      "node",
+      "lore",
+      "data",
+      "split",
+      "session",
+      "--min-confidence",
+      "low",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.values["min-confidence"]).toBe("low");
+    vi.resetModules();
+  });
+
+  // F-4 (MEDIUM): 0-positionals reach the legacy handler with []. The
+  // variadic positional schema should accept zero inputs.
+  test("data with no positional reaches legacy handler with []", async () => {
+    vi.resetModules();
+    const calls: DataCall[] = [];
+    const dataImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+        console.log("no-positional ok");
+      },
+    );
+    vi.doMock("../src/cli/data", () => ({
+      commandData: dataImpl,
+    }));
+    const { runCli } = await import("../src/cli/cli");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    process.argv = ["node", "lore", "data"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      logSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(calls[0]?.positionals).toEqual([]);
+    vi.resetModules();
   });
 });


### PR DESCRIPTION
## Summary

Phase 3C slice 1 from the Stricli CLI migration plan. `lore data` now routes through the typed tree for read-only subcommands (list, show, cache-stats). Destructive subcommands (delete, clear, merge, dedup, etc.) remain in LEGACY_ROUTES via the legacy dispatcher until Phase 3C slice 2 (with the central destructive-operation confirmation policy) lands.

## What's in this PR

### commands/data.ts — typed adapter

Wraps `commandData` from `../data` via the shared `runLegacyAndCollect` bridge.

Schema:
- positional: variadic array `parameter: { parse: String }` (subcommand + subcommand-specific args, all captured via spread rest params in the handler)
- flags: 9 (`all`, `distillations`, `interactive`, `knowledge`, `limit`, `project`, `temporal`, `to`, `yes`) + auto-injected `--json`

`commandData` takes `positionals[0]` as the subcommand and forwards subcommand-specific args from `positionals[1+]`. The variadic positional schema collects all string arguments into a string[] via spread rest params in the handler.

**Destructive subcommands** (`delete`, `clear`, `merge`, `dedup`, `reground-entities`, `move`, `split`) are forwarded via the variadic positional fallback — they reach the legacy dispatcher's `commandData` since the typed adapter doesn't restrict by subcommand name. **The central destructive-operation confirmation policy is deferred** to Phase 3C slice 2.

### Routing

- `lib/argv.ts`: `STRICLI_ROUTES` gains `"data"`.
- `app.ts`: `data` moved out of `LEGACY_ROUTES` into the Stricli tree.
- `main.ts:413-439`: status comment block lists `data` as migrated (Phase 3C slice 1).

## Tests

`cli-data-contract.test.ts` — 8 cases:

1. `data` registered in `STRICLI_ROUTES` (routing wiring).
2. `data` NOT in `LEGACY_ROUTES` (per-slice removal rule).
3. 9 flags declared — help text shows each flag name.
4. Flag forwarding (`data list --all --project <path> --limit 100`) → `values.all`, `values.project`, `values.limit`.
5. **Destructive subcommand variadic forwarding** (`data delete <id1> <id2>` → positionals = `[delete, id1, id2]`).
6. Legacy exit code propagates (1 not 0).
7. `--json` forwards `values.json=true` AND the legacy's JSON branch runs (verified via envelope.output content).
8. **F-1** regression: unknown flag exits 20 (UsageError), not 252.

The legacy handler is mocked via `vi.doMock` so the test doesn't touch Supabase or any IO.

## Verification

- 210 CLI tests pass across 22 files (added 8 new)
- TypeScript clean
- Lint clean (zero errors)
- Format clean
- Bundle succeeds for both CJS (Node) and ESM (Bun) targets

## Deferred to follow-up PRs

- **Phase 3C slice 2:** Central destructive-operation confirmation policy for `delete`, `clear`, `merge`, `dedup`, `reground-entities`, `move`, `split` subcommands. This slice preserves the legacy CLI's behavior (silent execution of destructive ops).

## Next steps

- Phase 3B.2: `start` — typed Stricli command (gateway lifecycle, deferred — high-risk)
- Phase 3B.3: `setup` — typed Stricli commands (deferred — 1500+ lines)
- Phase 3E: `run` — final opaque-argv implementation (hardest)
- Phases 4-8: help / completion / skills / docs / setup-upgrade integration