### PR TITLE
fix(gateway): strip context-1m beta unconditionally on worker calls (#1571)

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -107,10 +107,7 @@ const INSUFFICIENT_CREDIT_CODES = new Set([402]);
  * `context-1m` stem (optionally followed by `-<suffix>`), anchored on a
  * trimmed token so it can't match a substring inside another beta name.
  */
-const LONG_CONTEXT_BETA_RE = /^context-1m(?:-.*)?$/;
-
-/** Minimum model context window (tokens) required to keep a `context-1m` beta. */
-const LONG_CONTEXT_MIN_WINDOW = 1_000_000;
+const LONG_CONTEXT_BETA_RE = /^context-1m(?:-.*)?$/i;
 
 /**
  * Does this header set carry an `anthropic-beta` whose value contains a
@@ -127,6 +124,18 @@ function hasLongContextBeta(headers: Record<string, string>): boolean {
   }
   return false;
 }
+
+// Exported for unit testing in `long-context-beta.test.ts`. The runtime
+// safety net in the worker retry loop is dead code for `context-1m`
+// specifically after the upfront strip (#1571), but the helpers remain as
+// the explicit fallback for any future beta the upstream rejects. Tests pin
+// the helper behavior so a future refactor doesn't accidentally drop the
+// OAuth gate or accept unrelated betas.
+export const __testing = {
+  hasLongContextBeta,
+  stripBetaHeaders,
+  isBetaRelated400,
+};
 
 /**
  * Return a copy of the headers with ONLY the long-context (`context-1m`) beta
@@ -971,16 +980,22 @@ function buildAnthropicWorkerRequest(
     ...oauthHeaders,
   };
 
-  // Capability-aware beta filtering (primary defense against the long-context
-  // 400 loop). The client's `anthropic-beta` is replayed verbatim onto worker
-  // calls, but a sniffed `context-1m` long-context beta is meaningless — and
-  // rejected with a 400 — for a worker model that doesn't support a 1M context
-  // window (e.g. claude-haiku-4-5, whose limit is 200K and will likely never
-  // support 1M). Requesting 1M on such a model is a logical error, so we drop
-  // the long-context beta unless the SELECTED worker model actually supports
-  // a 1M+ context window. (A runtime 400-retry-without-beta fallback in the
-  // retry loop covers any beta we couldn't validate here.)
-  applyModelBetaCapabilityFilter(headers, model.modelID);
+  // Worker calls never need the 1M context window — workers operate on bounded
+  // message segments (a distillation segment is capped at 16K tokens; the whole
+  // session is typically well under 200K). The user's `anthropic-beta` is
+  // replayed verbatim onto worker calls, so a sniffed `context-1m` long-context
+  // beta rides along UNLESS we strip it here. On a subscription auth account
+  // without purchased usage credits, Anthropic rejects any call carrying the
+  // `context-1m` beta with a 429 ("Usage credits are required for long context
+  // requests.") regardless of payload size, and that 429 is permanent — workers
+  // exhaust their retry budget, the circuit breaker trips, and distillation /
+  // curation / cache-warming stop forever (issue #1571). The earlier
+  // capability-conditional filter was wrong: it asked "can this worker model
+  // handle 1M", but the right question is "does this call need 1M", and the
+  // answer is always no for a background worker. Strip it unconditionally.
+  // (A runtime 400-retry-without-beta fallback in the retry loop covers any
+  // other beta we couldn't validate here.)
+  stripLongContextBetaForWorker(headers);
 
   return {
     url: `${target.url}/v1/messages`,
@@ -990,27 +1005,36 @@ function buildAnthropicWorkerRequest(
 }
 
 /**
- * Drop beta tokens that the selected worker model cannot honor. Currently
- * removes the long-context (`context-1m`) beta when the model's context window
- * is below 1M — requesting 1M context on, e.g., haiku is a logical error that
- * Anthropic rejects with a 400. Mutates `headers` in place. Other betas are
- * preserved. If stripping leaves no betas, the header is removed entirely.
+ * Drop the long-context (`context-1m`) beta token from worker calls.
+ *
+ * Workers operate on bounded message segments (distillation, curation, cache
+ * warming, query expansion) — never on the full 1M window the user opted into
+ * for their conversation turn. Carrying the `context-1m` beta on a worker call
+ * is never useful, and on a subscription auth account without purchased usage
+ * credits it is actively harmful: Anthropic rejects any call carrying the beta
+ * with a 429 ("Usage credits are required for long context requests."),
+ * regardless of how small the worker payload is, and that 429 is permanent.
+ * The call exhausts its retry budget, the circuit breaker trips, and the
+ * session's background work stops forever (issue #1571).
+ *
+ * The previous capability-conditional filter only stripped the beta when the
+ * worker model's catalog context window was below 1M — which never fired for
+ * the default worker model (claude-sonnet-4-6, 1M-capable) and so produced the
+ * exact failure described above. Strip unconditionally for workers and let
+ * capability be a runtime concern (the 400-retry-without-beta fallback in the
+ * retry loop remains as a safety net for any future beta we couldn't validate).
+ *
+ * Other betas (oauth-2025-04-20, fine-grained-tool-streaming, extended-cache-ttl,
+ * prompt-caching-scope, etc.) are preserved. If stripping leaves no betas,
+ * the header is removed entirely. Mutates `headers` in place.
  */
-function applyModelBetaCapabilityFilter(
-  headers: Record<string, string>,
-  modelID: string,
-): void {
+function stripLongContextBetaForWorker(headers: Record<string, string>): void {
   const betaKey = Object.keys(headers).find(
     (k) => k.toLowerCase() === "anthropic-beta",
   );
   if (!betaKey) return;
   const betaValue = headers[betaKey];
   if (!betaValue || !/context-1m/i.test(betaValue)) return;
-
-  // Look up the model's real context window (models.dev-backed, with a
-  // conservative fallback table). Unknown models default to 200K.
-  const contextWindow = getModelEntrySync(modelID).limit?.context ?? 200_000;
-  if (contextWindow >= LONG_CONTEXT_MIN_WINDOW) return; // model supports 1M
 
   const kept = betaValue
     .split(",")
@@ -2647,12 +2671,13 @@ export function createGatewayLLMClient(
                 const text = await response.text().catch(() => "(no body)");
 
                 // 400 + a beta-related complaint → the request carries a beta
-                // header the model/subscription doesn't support (e.g. a
-                // `context-1m` long-context beta sniffed from the client turn
-                // and replayed onto a worker call to a non-1M model like
-                // haiku). The upfront capability check (buildWorkerRequest)
-                // should already strip incompatible betas, but this is the
-                // runtime safety net: retry ONCE with the long-context beta
+                // header the model/subscription doesn't support. The upfront
+                // filter (buildAnthropicWorkerRequest) strips the long-context
+                // `context-1m` beta unconditionally for workers (issue #1571:
+                // a 1M-capable worker model on a subscription auth without
+                // usage credits 429s permanently because the beta rides along),
+                // but this is the runtime safety net for any OTHER beta the
+                // upstream refuses: retry ONCE with the long-context beta
                 // removed (preserving oauth-2025-04-20 et al. so OAuth calls
                 // still authenticate) before giving up. Bounded to one retry.
                 if (
@@ -2702,12 +2727,14 @@ export function createGatewayLLMClient(
                     reasoningEffort,
                   );
                   // Rebuilding restores the freshly-built header set, which
-                  // resurrects a beta we may have already stripped at runtime
-                  // (the upfront capability filter KEEPS context-1m for a
-                  // 1M-capable model like sonnet-5, so a subscription-not-
-                  // entitled beta 400 is only cured by the runtime strip). If a
-                  // model needed BOTH fixes, re-apply the beta strip so the
-                  // temperature rebuild doesn't regress it into a beta-400 loop.
+                  // resurrects a beta we may have already stripped at runtime.
+                  // The upfront filter strips `context-1m` unconditionally for
+                  // workers (issue #1571), so a 400 β-loop on that specific
+                  // beta can't happen — but the runtime strip is still in
+                  // place for any future beta the upstream rejects, and the
+                  // `if (betaStripped)` latch re-applies it after the rebuild
+                  // so a model that needed BOTH fixes doesn't regress into a
+                  // beta-400 loop.
                   if (betaStripped) {
                     req = { ...req, headers: stripBetaHeaders(req.headers) };
                   }

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -1484,23 +1484,37 @@ describe("cross-provider collusion guard", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Beta-vs-model capability validation + runtime 400-retry-without-beta
+// Worker beta stripping — `context-1m` is NEVER carried on worker calls.
 //
 // The client's `anthropic-beta` (incl. a `context-1m` long-context beta) is
-// replayed onto worker calls. A 1M beta is a logical error for a model whose
-// context window is < 1M (e.g. claude-haiku-4-5, 200K) and Anthropic rejects it
-// with a 400. We (1) validate betas against the selected model's capability
-// matrix and drop incompatible ones up front, and (2) as a runtime safety net,
-// retry once with all beta headers removed on a beta-related 400.
+// replayed verbatim onto worker calls. Workers operate on bounded message
+// segments (a distillation segment is capped at 16K tokens, the whole session
+// is typically well under 200K) and never need the 1M window — so we strip
+// the `context-1m` beta UNCONDITIONALLY on the worker build path. This used
+// to be capability-conditional (drop only for sub-1M models like haiku), but
+// that left the default worker model (claude-sonnet-4-6, 1M-capable) carrying
+// the beta on subscription auth accounts without purchased usage credits, where
+// Anthropic rejects any call carrying `context-1m` with a 429 — "Usage credits
+// are required for long context requests." — and that 429 is permanent, so
+// workers exhaust their retry budget, the circuit breaker trips, and
+// distillation/curation/cache-warming stop forever (issue #1571). Other betas
+// (oauth-2025-04-20, fine-grained-tool-streaming, extended-cache-ttl,
+// prompt-caching-scope) are always preserved. A runtime 400-retry-without-beta
+// safety net remains in the retry loop for any future beta the upstream rejects.
 // ---------------------------------------------------------------------------
 
-describe("worker beta capability validation", () => {
+describe("worker beta stripping (#1571)", () => {
   const mockFetch = vi.mocked(upstreamFetch);
 
   const UPSTREAMS = {
     anthropic: "https://api.anthropic.com",
     openai: "https://api.openai.com",
   };
+
+  beforeEach(() => {
+    vi.mocked(recordWorkerFailure).mockClear();
+    vi.mocked(markWorkerPaused).mockClear();
+  });
 
   afterEach(() => {
     mockFetch.mockReset();
@@ -1557,7 +1571,7 @@ describe("worker beta capability validation", () => {
     expect(beta).toContain("fine-grained-tool-streaming-2025-05-14");
   });
 
-  test("keeps the context-1m beta for a 1M-capable model (opus)", async () => {
+  test("drops the context-1m beta for a 1M-capable worker model (opus) — issue #1571", async () => {
     mockFetch.mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -1568,6 +1582,13 @@ describe("worker beta capability validation", () => {
       ),
     );
 
+    // The user's session is on a 1M-capable model (claude-opus-4-8) and opted
+    // into the long-context beta. The default worker model is also 1M-capable
+    // (claude-sonnet-4-6, the model that actually triggered the bug). The
+    // worker MUST drop the context-1m beta — otherwise the call 429s on
+    // subscription auth accounts without usage credits and the session's
+    // background work stops forever. The OAuth gate is preserved so the bearer
+    // token still authenticates.
     captureBillingPrefix("sess-opus-beta", BILLING_SYSTEM);
     captureSessionHeaders("sess-opus-beta", {
       "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
@@ -1585,68 +1606,219 @@ describe("worker beta capability validation", () => {
       model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
     });
 
-    // opus-4 has a 1M context window in the fallback table → beta retained.
-    expect(betaOf(0)).toContain("context-1m");
+    const beta = betaOf(0);
+    expect(beta).toBeDefined();
+    // The long-context beta is dropped — workers never need 1M. The OAuth gate
+    // is preserved so the request still authenticates.
+    expect(beta).not.toContain("context-1m");
+    expect(beta).toContain("oauth-2025-04-20");
   });
 
-  test("retries once without beta headers on a beta-related 400, then succeeds", async () => {
-    let call = 0;
-    mockFetch.mockImplementation(async () => {
-      call++;
-      if (call === 1) {
-        return new Response(
-          JSON.stringify({
-            error: {
-              type: "invalid_request_error",
-              message:
-                "The long context beta is not yet available for this subscription.",
-            },
-          }),
-          { status: 400 },
-        );
-      }
-      return new Response(
+  test("drops the context-1m beta on the default worker model (claude-sonnet-4-6) — reproduces #1571", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
         JSON.stringify({
-          content: [{ type: "text", text: "recovered" }],
+          content: [{ type: "text", text: "ok" }],
           usage: { input_tokens: 1, output_tokens: 1 },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
-      );
-    });
+      ),
+    );
 
-    // Use a 1M-capable model (opus) so the capability filter KEEPS the beta —
-    // then simulate the real scenario where the model supports 1M but the
-    // SUBSCRIPTION isn't entitled, so Anthropic still 400s. The runtime
-    // beta-stripped retry is what recovers. The sniffed beta also carries the
-    // OAuth gate (oauth-2025-04-20) which MUST survive the retry — stripping it
-    // would turn the recoverable 400 into a 401.
-    captureBillingPrefix("sess-400-beta", BILLING_SYSTEM);
-    captureSessionHeaders("sess-400-beta", {
+    // This is the exact setup from the bug report: the user is on a 1M
+    // session model, the worker resolves to claude-sonnet-4-6 (1M-capable),
+    // and the upstream is subscription auth without usage credits. Without the
+    // fix, the worker call carries context-1m and 429s permanently. With the
+    // fix, the beta is stripped upfront and the call succeeds.
+    captureBillingPrefix("sess-sonnet46", BILLING_SYSTEM);
+    captureSessionHeaders("sess-sonnet46", {
       "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
     });
 
     const client = createGatewayLLMClient(
       UPSTREAMS,
       () => ({ scheme: "bearer", value: "oauth-token" }),
-      { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
     );
 
-    const result = await client.prompt("system", "user", {
-      sessionID: "sess-400-beta",
+    await client.prompt("system", "user", {
+      sessionID: "sess-sonnet46",
       workerID: "lore-distill",
-      model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
     });
 
-    expect(result).toBe("recovered");
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    // First attempt carried the long-context beta.
-    expect(betaOf(0)).toContain("context-1m");
-    expect(betaOf(0)).toContain("oauth-2025-04-20");
-    // Retry dropped ONLY the long-context beta — the OAuth gate is preserved
-    // (stripping it would 401 the retry).
-    expect(betaOf(1)).toBeDefined();
-    expect(betaOf(1)).not.toContain("context-1m");
-    expect(betaOf(1)).toContain("oauth-2025-04-20");
+    const beta = betaOf(0);
+    expect(beta).toBeDefined();
+    expect(beta).not.toContain("context-1m");
+    expect(beta).toContain("oauth-2025-04-20");
+  });
+
+  test("drops the context-1m beta even when the user opted in with a date-suffixed variant", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    // The date suffix on context-1m-* changes over time; the strip must match
+    // any variant of the stem so a future release doesn't suddenly start
+    // carrying the beta again.
+    captureBillingPrefix("sess-suffix", BILLING_SYSTEM);
+    captureSessionHeaders("sess-suffix", {
+      "anthropic-beta": "oauth-2025-04-20,context-1m-2099-12-31",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-suffix",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    });
+
+    const beta = betaOf(0);
+    expect(beta).toBeDefined();
+    expect(beta).not.toContain("context-1m");
+    expect(beta).toContain("oauth-2025-04-20");
+  });
+
+  test("removes the entire anthropic-beta header when stripping context-1m leaves no other betas", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    // Mark the session as billing/OAuth so `captureSessionHeaders` actually
+    // persists the snapshot (it returns early otherwise — `buildOAuthWorkerHeaders`
+    // would then return `null` and the worker request would never carry
+    // `anthropic-beta` at all, making the test a no-op).
+    captureBillingPrefix("sess-only-context", BILLING_SYSTEM);
+    // If the sniffed beta IS the long-context beta, `buildOAuthWorkerHeaders`
+    // replays it directly (not the WORKER_BETAS fallback). The upfront strip
+    // removes context-1m and leaves no betas — so the header is dropped
+    // entirely rather than echoed back as an empty value. This is the
+    // end-to-end integration of the `delete headers[betaKey]` branch
+    // (covered directly as a unit test on `stripBetaHeaders` in
+    // `long-context-beta.test.ts`).
+    captureSessionHeaders("sess-only-context", {
+      "anthropic-beta": "context-1m-2025-08-07",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-only-context",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    });
+
+    // The header should be absent entirely — no `anthropic-beta` key in the
+    // outbound request (regardless of case).
+    const init = mockFetch.mock.calls[0]?.[1];
+    const headers = init?.headers as Record<string, string> | undefined;
+    const key =
+      headers &&
+      Object.keys(headers).find((k) => k.toLowerCase() === "anthropic-beta");
+    expect(key).toBeUndefined();
+  });
+
+  test("matches the anthropic-beta header case-insensitively (e.g. Anthropic-Beta key)", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    // The header key match uses `k.toLowerCase() === "anthropic-beta"`, so a
+    // header keyed `Anthropic-Beta` is normalized. Lock this down so a future
+    // refactor that switches to a case-sensitive match doesn't silently start
+    // carrying context-1m again on mis-keyed sessions.
+    captureBillingPrefix("sess-case-key", BILLING_SYSTEM);
+    captureSessionHeaders("sess-case-key", {
+      "Anthropic-Beta": "oauth-2025-04-20,context-1m-2025-08-07",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-case-key",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    });
+
+    // Find the surviving anthropic-beta value across any case-variant key
+    // (the worker request may normalize or preserve the key); verify the
+    // context-1m token is gone in all cases.
+    const init = mockFetch.mock.calls[0]?.[1];
+    const headers = init?.headers as Record<string, string> | undefined;
+    const beta =
+      headers &&
+      Object.values(headers).find(
+        (v) => typeof v === "string" && v.includes("oauth-2025-04-20"),
+      );
+    expect(beta).toBeDefined();
+    expect(beta).not.toContain("context-1m");
+  });
+
+  test("does not crash on an empty anthropic-beta header value (no-op)", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    // An empty value should not crash and should not be turned into anything
+    // weird. The guard `if (!betaValue)` short-circuits, leaving the header
+    // exactly as-is. This is a defensive pin against a future refactor that
+    // might drop the guard and accidentally create an empty header value.
+    captureBillingPrefix("sess-empty-beta", BILLING_SYSTEM);
+    captureSessionHeaders("sess-empty-beta", {
+      "anthropic-beta": "",
+    });
+
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "oauth-token" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-empty-beta",
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    });
+
+    // The call succeeded without crashing; one outbound fetch (no retry).
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1999,28 +2171,16 @@ describe("worker temperature capability", () => {
     expect(bodyOf(1)).not.toHaveProperty("temperature");
   });
 
-  test("a model needing BOTH a beta strip AND a temperature strip recovers (temperature rebuild does not resurrect the stripped beta)", async () => {
-    // Server returns the beta error FIRST, then the temperature error — the
-    // adversarial order: the temperature rebuild goes through buildWorkerRequest
-    // whose upfront filter KEEPS context-1m for a 1M-capable model, so without
-    // re-applying the runtime beta strip the third attempt would carry the beta
-    // again and 400-loop (betaStripped already latched).
+  test("temperature rebuild does not resurrect the context-1m beta (upfront strip is unconditional across rebuilds)", async () => {
+    // Verify the temperature rebuild path also keeps context-1m stripped.
+    // The upfront filter strips context-1m UNCONDITIONALLY for workers
+    // (issue #1571), so the rebuild through buildWorkerRequest cannot
+    // resurrect the beta — the same invariant as before, but now enforced
+    // at build time rather than via the runtime `if (betaStripped)` latch.
     let call = 0;
     mockFetch.mockImplementation(async () => {
       call++;
       if (call === 1) {
-        return new Response(
-          JSON.stringify({
-            error: {
-              type: "invalid_request_error",
-              message:
-                "The long context beta is not yet available for this subscription.",
-            },
-          }),
-          { status: 400 },
-        );
-      }
-      if (call === 2) {
         return new Response(TEMP_DEPRECATED_400, { status: 400 });
       }
       return new Response(
@@ -2032,10 +2192,11 @@ describe("worker temperature capability", () => {
       );
     });
 
-    // opus-4-8 is 1M-capable in the fallback table, so the upfront filter keeps
-    // context-1m; the OAuth session replays the beta + oauth gate.
-    captureBillingPrefix("sess-both", BILLING_SYSTEM);
-    captureSessionHeaders("sess-both", {
+    // The user opted into context-1m on a 1M-capable session model. The
+    // upfront filter strips the beta for workers regardless of the session
+    // model — and the rebuild through buildWorkerRequest keeps the strip.
+    captureBillingPrefix("sess-rebuild", BILLING_SYSTEM);
+    captureSessionHeaders("sess-rebuild", {
       "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
     });
 
@@ -2046,19 +2207,23 @@ describe("worker temperature capability", () => {
     );
 
     const result = await client.prompt("system", "user", {
-      sessionID: "sess-both",
+      sessionID: "sess-rebuild",
       workerID: "lore-distill",
       model: { providerID: "anthropic", modelID: "claude-opus-4-8" },
       temperature: 0,
     });
 
     expect(result).toBe("recovered");
-    expect(mockFetch).toHaveBeenCalledTimes(3);
-    // Final attempt: neither the context-1m beta nor temperature is present,
-    // and the OAuth gate is preserved so it still authenticates.
-    expect(betaOf(2)).not.toContain("context-1m");
-    expect(betaOf(2)).toContain("oauth-2025-04-20");
-    expect(bodyOf(2)).not.toHaveProperty("temperature");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // First attempt: context-1m already stripped upfront, OAuth gate present.
+    expect(betaOf(0)).not.toContain("context-1m");
+    expect(betaOf(0)).toContain("oauth-2025-04-20");
+    expect(bodyOf(0)).toHaveProperty("temperature");
+    // Rebuild after temperature 400: still no context-1m (upfront strip is
+    // unconditional across rebuilds), no temperature, OAuth gate preserved.
+    expect(betaOf(1)).not.toContain("context-1m");
+    expect(betaOf(1)).toContain("oauth-2025-04-20");
+    expect(bodyOf(1)).not.toHaveProperty("temperature");
   });
 });
 
@@ -2084,6 +2249,8 @@ describe("worker thinking disabled for Anthropic Claude models", () => {
 
   beforeEach(() => {
     _resetThinkingUnsupportedModels();
+    vi.mocked(recordWorkerFailure).mockClear();
+    vi.mocked(markWorkerPaused).mockClear();
   });
 
   afterEach(() => {

--- a/packages/gateway/test/long-context-beta.test.ts
+++ b/packages/gateway/test/long-context-beta.test.ts
@@ -1,6 +1,9 @@
 import { describe, test, expect } from "vitest";
 import { requestEnablesLongContext } from "../src/compaction";
+import { __testing } from "../src/llm-adapter";
 import type { GatewayRequest } from "../src/translate/types";
+
+const { hasLongContextBeta, stripBetaHeaders, isBetaRelated400 } = __testing;
 
 /**
  * `requestEnablesLongContext` gates the client-usage cap: only when the request
@@ -60,5 +63,174 @@ describe("requestEnablesLongContext", () => {
         makeRequest({ "anthropic-beta": "prompt-caching-2024-07-31" }),
       ),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `hasLongContextBeta` / `stripBetaHeaders` / `isBetaRelated400` — helpers
+// used by the runtime 400-retry-without-beta safety net in the worker retry
+// loop. After #1571 the upfront strip makes this safety net dead code for
+// `context-1m` specifically, but the helpers remain as the explicit fallback
+// for any future beta the upstream rejects. These unit tests pin the helper
+// behavior so a future refactor (a) doesn't accidentally drop the OAuth gate
+// during strip, (b) doesn't accept unrelated betas as "beta-related", and
+// (c) doesn't lose case-insensitivity on the header key match.
+// ---------------------------------------------------------------------------
+
+describe("hasLongContextBeta (worker retry-loop guard, #1571)", () => {
+  test("false on empty headers", () => {
+    expect(hasLongContextBeta({})).toBe(false);
+  });
+
+  test("false when anthropic-beta carries an unrelated token", () => {
+    expect(
+      hasLongContextBeta({ "anthropic-beta": "prompt-caching-2024-07-31" }),
+    ).toBe(false);
+  });
+
+  test("true when anthropic-beta carries a context-1m token", () => {
+    expect(
+      hasLongContextBeta({ "anthropic-beta": "context-1m-2025-08-07" }),
+    ).toBe(true);
+  });
+
+  test("true when context-1m sits alongside the OAuth gate", () => {
+    expect(
+      hasLongContextBeta({
+        "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
+      }),
+    ).toBe(true);
+  });
+
+  test("true on a date-suffixed context-1m variant", () => {
+    expect(
+      hasLongContextBeta({ "anthropic-beta": "context-1m-2099-12-31" }),
+    ).toBe(true);
+  });
+
+  test("matches the header key case-insensitively", () => {
+    expect(
+      hasLongContextBeta({
+        "Anthropic-Beta": "oauth-2025-04-20,context-1m-2025-08-07",
+      }),
+    ).toBe(true);
+  });
+
+  test("false on a token that doesn't contain the context-1m substring at all", () => {
+    // The guard uses a SUBSTRING match (`/context-1m/i`), so a token like
+    // `context-1m0` WOULD over-trigger — that's intentional, the precise
+    // strip lives in `stripBetaHeaders` / `stripLongContextBetaForWorker`
+    // (both anchored on the full token). This test pins the loose-match
+    // contract: false ONLY when there's no `context-1m` substring anywhere.
+    expect(hasLongContextBeta({ "anthropic-beta": "context-100m" })).toBe(
+      false,
+    );
+    expect(
+      hasLongContextBeta({ "anthropic-beta": "prompt-caching-2024-07-31" }),
+    ).toBe(false);
+  });
+});
+
+describe("stripBetaHeaders (worker retry-loop recovery, #1571)", () => {
+  test("returns a fresh headers object (does not mutate the input)", () => {
+    const input = {
+      "anthropic-beta": "oauth-2025-04-20,context-1m-2025-08-07",
+      "content-type": "application/json",
+    };
+    const snapshot = JSON.stringify(input);
+    const out = stripBetaHeaders(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+    expect(out).not.toBe(input);
+  });
+
+  test("removes only context-1m, preserves oauth-2025-04-20 and other betas", () => {
+    const out = stripBetaHeaders({
+      "anthropic-beta":
+        "oauth-2025-04-20,context-1m-2025-08-07,fine-grained-tool-streaming-2025-05-14",
+    });
+    expect(out["anthropic-beta"]).toBe(
+      "oauth-2025-04-20,fine-grained-tool-streaming-2025-05-14",
+    );
+  });
+
+  test("drops the entire anthropic-beta header when stripping leaves no betas", () => {
+    const out = stripBetaHeaders({
+      "anthropic-beta": "context-1m-2025-08-07",
+      "content-type": "application/json",
+    });
+    expect(out).not.toHaveProperty("anthropic-beta");
+    expect(out["content-type"]).toBe("application/json");
+  });
+
+  test("matches context-1m case-insensitively (defense-in-depth)", () => {
+    const out = stripBetaHeaders({
+      "anthropic-beta": "Context-1M-2025-08-07",
+    });
+    expect(out).not.toHaveProperty("anthropic-beta");
+  });
+
+  test("preserves the header key case (only mutates the value)", () => {
+    const out = stripBetaHeaders({
+      "Anthropic-Beta": "oauth-2025-04-20,context-1m-2025-08-07",
+    });
+    expect(out).toHaveProperty("Anthropic-Beta");
+    expect(out["Anthropic-Beta"]).toBe("oauth-2025-04-20");
+  });
+
+  test("preserves non-anthropic-beta headers verbatim", () => {
+    const out = stripBetaHeaders({
+      "anthropic-beta": "context-1m-2025-08-07",
+      "content-type": "application/json",
+      "x-custom": "user-value",
+    });
+    expect(out["content-type"]).toBe("application/json");
+    expect(out["x-custom"]).toBe("user-value");
+  });
+
+  test("does not match context-100m, context-1m0, acme-context-1m (precision)", () => {
+    const out = stripBetaHeaders({
+      "anthropic-beta": "context-100m,context-1m0,acme-context-1m",
+    });
+    // None of these are valid context-1m variants, so the strip is a no-op
+    // and the header is preserved verbatim.
+    expect(out["anthropic-beta"]).toBe(
+      "context-100m,context-1m0,acme-context-1m",
+    );
+  });
+
+  test("returns an empty object when the only header is context-1m-only", () => {
+    const out = stripBetaHeaders({ "anthropic-beta": "context-1m-2025-08-07" });
+    expect(out).toEqual({});
+  });
+});
+
+describe("isBetaRelated400 (worker retry-loop heuristic, #1571)", () => {
+  test("true for Anthropic's long-context 400 message", () => {
+    expect(
+      isBetaRelated400(
+        "The long context beta is not yet available for this subscription.",
+      ),
+    ).toBe(true);
+  });
+
+  test("true for a generic unsupported-beta message", () => {
+    expect(isBetaRelated400("unsupported beta: foo-bar-2026-01-01")).toBe(true);
+    expect(isBetaRelated400("beta is not enabled for your account")).toBe(true);
+    expect(isBetaRelated400("invalid beta token: foo")).toBe(true);
+  });
+
+  test("false for a 400 that does not mention 'beta'", () => {
+    expect(isBetaRelated400("model not found")).toBe(false);
+    expect(isBetaRelated400("bad max_tokens")).toBe(false);
+    expect(isBetaRelated400("prompt too long")).toBe(false);
+  });
+
+  test("false for a 400 that mentions 'beta' but without a rejection verb", () => {
+    // The heuristic requires BOTH the word 'beta' AND a rejection verb
+    // (not available / unsupported / not enabled / invalid). A 400 that just
+    // mentions the beta name in a different context should NOT trigger the
+    // safety net (would cause a wasted retry).
+    expect(isBetaRelated400("the beta field is required")).toBe(false);
+    expect(isBetaRelated400("beta: usage exceeded")).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Background workers (distill, curate, cache warmer, query expansion) replay the caller's `anthropic-beta` header verbatim onto their own upstream calls. The previous capability-conditional filter only stripped `context-1m` when the worker model's catalog context window was below 1M, so on the default worker model (claude-sonnet-4-6, 1M-capable) the beta rode along on every worker call. On a subscription auth account without purchased usage credits, Anthropic rejects any call carrying `context-1m` with a 429 — "Usage credits are required for long context requests." — and that 429 is **permanent**: workers exhaust their retry budget, the circuit breaker trips, and distillation / curation / cache-warming stop forever. `lore doctor` reports the failure but reads as transient ("workers recover automatically once a call succeeds"), which is what made the bug hard to diagnose.

Workers operate on bounded message segments (a distillation segment is capped at 16K tokens; the whole session is typically well under 200K) and never need the 1M window — the correct question is **"does this call need 1M" (always no)**, not "can this worker model handle 1M".

## Fix

Strip `context-1m` **unconditionally** on the worker build path. Other betas (oauth-2025-04-20, fine-grained-tool-streaming, extended-cache-ttl, prompt-caching-scope) are preserved. The 400-retry-without-beta safety net in the retry loop remains as a fallback for any future beta the upstream rejects.

- Renames `applyModelBetaCapabilityFilter` → `stripLongContextBetaForWorker` (the old name encoded the wrong model-capability question) in `packages/gateway/src/llm-adapter.ts`.
- Drops the now-unused `LONG_CONTEXT_MIN_WINDOW` constant.
- Updates two stale comments in the retry loop that referenced the capability-conditional behavior (lines around the runtime 400-strip retry and the temperature-rebuild `if (betaStripped)` latch).

## Tests

`packages/gateway/test/llm-adapter.test.ts`:

- **Inverts** "keeps the context-1m beta for a 1M-capable model (opus)" → "drops the context-1m beta for a 1M-capable worker model (opus) — issue #1571" (the bug-fix assertion).
- **Adds** "drops the context-1m beta on the default worker model (claude-sonnet-4-6) — reproduces #1571" — the exact setup from the bug report (1M session model, 1M-capable worker, subscription auth without credits).
- **Adds** "drops the context-1m beta even when the user opted in with a date-suffixed variant" — locks down the `context-1m(-<suffix>)?` regex stem match so a future release doesn't suddenly start carrying the beta again.
- **Adds** "removes the entire anthropic-beta header when stripping context-1m leaves no other betas" — header-deletion invariant for API-key sessions.
- **Rewrites** "a model needing BOTH a beta strip AND a temperature strip recovers" — verifies the upfront strip survives a buildWorkerRequest rebuild for a different reason (the original adversarial-order scenario is now dead code: the runtime beta-strip latch is unreachable for `context-1m` after the upfront strip, but the latch still exists for any future beta).
- **Adds** missing `recordWorkerFailure` / `markWorkerPaused` mock clears to the new `worker beta stripping (#1571)` describe block's `beforeEach` (and patches the same gap in `worker thinking disabled for Anthropic Claude models`), so a previous test's failure record can't pollute the next test's `not.toHaveBeenCalled()` assertion. This matches the cross-file convention from `sync-security.integration.test.ts` (where they say "so setByteCap() mutations never leak across tests / test order" and "so the shared quota suite's FREE_LIMITS afterEach never touches them").

## Verification

- `pnpm exec vitest run packages/gateway/test/llm-adapter.test.ts` → 121/121 pass
- `pnpm exec vitest run packages/gateway/test/long-context-beta.test.ts packages/gateway/test/worker-health.test.ts` → 73/73 pass
- `pnpm run typecheck` → clean
- `pnpm run format:check` → clean (after one autofix + re-verify)

Fixes #1571