### PR TITLE
feat(gateway): openai-responses worker adapter for github-copilot gpt-5.6-* family

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -49,6 +49,7 @@ import {
 } from "./translate/types";
 import {
   buildOpenAIChatCompletionsUrl,
+  buildOpenAIResponsesUrl,
   copilotHeaders,
 } from "./translate/openai";
 import { accumulateOpenAISSEStream } from "./stream/openai";
@@ -691,6 +692,7 @@ export function normalizeOpenAIUsage(
 type WorkerProtocol =
   | "anthropic"
   | "openai"
+  | "openai-responses"
   | "openai-codex-responses"
   | "vertex"
   | "gemini";
@@ -708,26 +710,54 @@ type ProviderTarget = {
  *
  * Priority:
  *  1. Explicit protocol from caller (threaded from UpstreamSnapshot)
- *  2. Route table lookup via PROVIDER_ROUTES
- *  3. Default: "anthropic" (safest — most aggregators speak Anthropic)
+ *  2. Per-model protocol override (only one case today: github-copilot +
+ *     `gpt-5.6-*` family → Responses API; those models return
+ *     `unsupported_api_for_model` on `/chat/completions` and are only
+ *     reachable via `/responses`, per `earendil-works/pi#6475`)
+ *  3. Route table lookup via PROVIDER_ROUTES
+ *  4. Default: "anthropic" (safest — most aggregators speak Anthropic)
  *
- * `openai-responses` is collapsed to `"openai"` because workers only use
- * simple prompt→response via Chat Completions, not the Responses API — EXCEPT
- * for `openai-codex`, whose ChatGPT backend serves only the Responses API and
- * therefore maps to `"openai-codex-responses"`.
+ * Pass an optional `modelID` to enable per-model routing for hosts that serve
+ * the same provider on BOTH chat-completions and responses (e.g. github-copilot
+ * serves gpt-5-mini via /chat/completions but gpt-5.6-luna only via
+ * /responses). Without `modelID`, behavior matches the prior collapse — all
+ * openai-shape providers keep the default chat-completions path.
+ *
+ * `openai-responses` is preserved (NOT collapsed to `"openai"`) when step 2
+ * selects it for a model that needs the Responses wire shape. The Codex path
+ * (`openai-codex-responses`) is a separate distinct string because ChatGPT
+ * Codex's `/codex/responses` server-side requirements differ (no
+ * `max_output_tokens`, mandatory `store:false`, ChatGPT fingerprint headers)
+ * from generic openai-responses and deserves its own builder.
  */
 export function resolveWorkerProtocol(
   providerID: string,
   explicit?: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini",
+  modelID?: string,
 ): WorkerProtocol {
   // openai-codex MUST use the Responses API — its backend has no Chat
-  // Completions endpoint. This takes precedence over the explicit hint
-  // (which would otherwise collapse openai-responses → openai).
+  // Completions endpoint. This takes precedence over the explicit hint.
   if (providerID === "openai-codex") {
     return "openai-codex-responses";
   }
-  // 1. Explicit protocol from caller (threaded from UpstreamSnapshot)
+  // 1. Explicit protocol from caller (threaded from UpstreamSnapshot) — only
+  //    honored when the route does not have a per-model override. A caller
+  //    thread that explicitly pins "openai" for a github-copilot+gpt-5.6
+  //    worker is a misconfig (the model is unreachable on that path) and we
+  //    still honor the per-model override for safety; an explicit
+  //    "openai-responses" hint must be preserved through (do NOT collapse).
   if (explicit) {
+    // Per-model override beats an explicit openai hint (caller likely did
+    // not know about the gpt-5.6 routing); but an explicit openai-responses
+    // hint is authoritative — caller wired it on purpose.
+    if (explicit === "openai-responses") return "openai-responses";
+    if (
+      providerID === "github-copilot" &&
+      modelID &&
+      isResponsesOnlyModel(modelID)
+    ) {
+      return "openai-responses";
+    }
     // Vertex is a DISTINCT worker protocol: it speaks the Anthropic Messages
     // body but to a :rawPredict URL (model in the path) authenticated with a
     // GCP OAuth2 token — buildVertexWorkerRequest handles all three. It must
@@ -742,15 +772,39 @@ export function resolveWorkerProtocol(
     if (explicit === "gemini") return "gemini";
     return explicit === "anthropic" ? "anthropic" : "openai";
   }
-  // 2. Route table lookup
+  // 2. Per-model override (no explicit hint from caller) — github-copilot +
+  //    gpt-5.6-* is the only case today; adding a new family here means
+  //    adding the family string to the constant.
+  if (
+    providerID === "github-copilot" &&
+    modelID &&
+    isResponsesOnlyModel(modelID)
+  ) {
+    return "openai-responses";
+  }
+  // 3. Route table lookup
   const route = resolveProviderRoute(providerID);
   if (route?.protocol) {
     if (route.protocol === "vertex") return "vertex";
     if (route.protocol === "gemini") return "gemini";
     return route.protocol === "anthropic" ? "anthropic" : "openai";
   }
-  // 3. Default: anthropic (safest for unknown/aggregator providers)
+  // 4. Default: anthropic (safest for unknown/aggregator providers)
   return "anthropic";
+}
+
+/**
+ * Model ids that are reachable ONLY on the OpenAI **Responses** API endpoint
+ * (NOT on `/chat/completions`) on GitHub Copilot. Probed by direct API call
+ * (returns `{"code":"unsupported_api_for_model"}` on /chat/completions) and
+ * confirmed available on /responses. Added in Copilot's
+ * 2026-07-09 rollout (Sol/Terra/Luna). When models.dev grows the family on
+ * github-copilot (per `anomalyco/models.dev#3178`), extend the prefix check
+ * — the current set is the three-member gpt-5.6 generation. Mirror of the
+ * `alreadyCheap` checks in `WORKER_DEFAULTS` for the same family.
+ */
+function isResponsesOnlyModel(modelID: string): boolean {
+  return modelID.startsWith("gpt-5.6-") || modelID === "gpt-5.6";
 }
 
 /**
@@ -1231,6 +1285,70 @@ function buildCodexWorkerRequest(
   };
 }
 
+/**
+ * Build an OpenAI **Responses API** worker request for a generic openai-responses
+ * target (NOT Codex). Used for `github-copilot` workers on the `gpt-5.6-*`
+ * family — those models return `unsupported_api_for_model` on `/chat/completions`
+ * and are ONLY reachable on `/responses`, per `earendil-works/pi#6475`. Other
+ * GitHub-Copilot models (gpt-5-mini, claude-sonnet-4.5, etc.) continue to use
+ * the chat-completions path (see `buildOpenAIWorkerRequest`).
+ *
+ * Wire-format differences vs Chat Completions:
+ *   - `input: [{ role, content }]` items array (NOT `messages`)
+ *   - top-level `instructions: "..."` (NOT a `{role:"system",...}` first message)
+ *   - `max_output_tokens` (NOT `max_completion_tokens`)
+ *   - `reasoning: { effort: ... }` (NOT `reasoning_effort: "..."`)
+ *   - `store: false` — required by Copilot's `/responses` endpoint (observed)
+ *   - URL: host-aware via `buildOpenAIResponsesUrl` (github-copilot omits /v1,
+ *     issue #1052; mirrors the chat-completions URL builder)
+ *
+ * Unlike Codex, this path allows `max_output_tokens` (Copilot's `/responses`
+ * honors it just like the Responses API spec) and threads `reasoningEffort`
+ * through to nested `reasoning.{effort}`. Same `openAIReasoningEffort` returns
+ * null on `off`/undefined so we omit both forms when the caller did not set it.
+ */
+function buildOpenAIResponsesWorkerRequest(
+  target: ProviderTarget,
+  cred: AuthCredential,
+  model: { providerID: string; modelID: string },
+  system: string,
+  user: string,
+  maxTokens: number,
+  temperature?: number,
+  reasoningEffort?: ReasoningEffort,
+): { url: string; headers: Record<string, string>; body: string } {
+  const effort = openAIReasoningEffort(reasoningEffort);
+
+  return {
+    // Host-aware URL construction: github-copilot omits /v1 (issue #1052),
+    // mirrors buildOpenAIChatCompletionsUrl. Other openai-responses hosts
+    // (currently none in our route table) get the default `/v1/responses`.
+    url: buildOpenAIResponsesUrl(target.url),
+    headers: {
+      "Content-Type": "application/json",
+      ...authHeaders(cred),
+      // GitHub Copilot wants Copilot-Integration-Id + X-GitHub-Api-Version;
+      // no-op for other hosts (matches the chat-completions path).
+      ...copilotHeaders(target.url),
+    },
+    body: JSON.stringify({
+      model: model.modelID,
+      store: false,
+      stream: false,
+      max_output_tokens: maxTokens,
+      ...(temperature != null && { temperature }),
+      ...(effort != null && { reasoning: { effort } }),
+      instructions: system,
+      input: [
+        {
+          role: "user",
+          content: user,
+        },
+      ],
+    }),
+  };
+}
+
 /** Extract text response from an Anthropic Messages API response. */
 export function parseAnthropicResponse(data: {
   content?: Array<{ type: string; text?: string; thinking?: string }>;
@@ -1475,6 +1593,17 @@ async function buildWorkerRequest(
         sessionID,
         temperature,
       );
+    case "openai-responses":
+      return buildOpenAIResponsesWorkerRequest(
+        target,
+        cred,
+        model,
+        system,
+        user,
+        maxTokens,
+        temperature,
+        reasoningEffort,
+      );
     case "openai":
       return buildOpenAIWorkerRequest(
         target,
@@ -1534,6 +1663,13 @@ function parseWorkerResponse(
       return parseResponsesWorkerResponse(
         rawData as Parameters<typeof parseResponsesWorkerResponse>[0],
       );
+    case "openai-responses":
+      // Same wire shape as the Codex path — reuse the existing Responses-API
+      // worker parser; openai-responses and openai-codex-responses both
+      // produce `{ output: [...], usage: { input_tokens, output_tokens, ... } }`.
+      return parseResponsesWorkerResponse(
+        rawData as Parameters<typeof parseResponsesWorkerResponse>[0],
+      );
     case "openai":
       return parseOpenAIResponse(rawData as OpenAIChatResponse);
     case "gemini":
@@ -1561,6 +1697,11 @@ function accumulateWorkerSSE(
 ): Promise<GatewayResponse> {
   switch (protocol) {
     case "openai-codex-responses":
+      return accumulateResponsesSSEStream(response);
+    case "openai-responses":
+      // OpenAI Responses API uses the same wire-shape SSE stream as the
+      // Codex-Responses path (`event: response.*` deltas). Reuse the existing
+      // accumulator.
       return accumulateResponsesSSEStream(response);
     case "gemini":
       return accumulateGeminiSSEStream(response);
@@ -1859,6 +2000,7 @@ export function createGatewayLLMClient(
       const protocol = resolveWorkerProtocol(
         model.providerID,
         sameProviderAsSession ? opts?.protocol : undefined,
+        model.modelID,
       );
 
       // Vertex authenticates with lore's own GCP OAuth2 bearer token (minted

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -525,6 +525,12 @@ function buildOpenAIStreamResponse(resp: GatewayResponse): Response {
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH = "/v1/chat/completions";
 
 /**
+ * Default OpenAI **Responses** API path appended to a bare provider origin.
+ * Most OpenAI Responses-compatible providers serve at `<base>/v1/responses`.
+ */
+export const DEFAULT_OPENAI_RESPONSES_PATH = "/v1/responses";
+
+/**
  * Hosts whose OpenAI-compatible Chat Completions endpoint is NOT served at the
  * conventional `<base>/v1/chat/completions`. Maps hostname → the exact path the
  * gateway must append to the provider origin instead:
@@ -548,6 +554,22 @@ const OPENAI_HOST_CHAT_COMPLETIONS_PATHS: ReadonlyMap<string, string> = new Map(
   [["generativelanguage.googleapis.com", "/v1beta/openai/chat/completions"]],
 );
 
+/**
+ * Hosts whose OpenAI Responses API endpoint is NOT served at the bare
+ * `<base>${DEFAULT_OPENAI_RESPONSES_PATH}` shape. Same shape as the
+ * Chat-Completions map; keep them side-by-side to make the per-host quirks easy
+ * to read in one place.
+ *
+ * Currently EMPTY — GitHub Copilot's `/responses` is handled by the
+ * `isGitHubCopilotHost` short-circuit inside `buildOpenAIResponsesUrl`
+ * (mirroring `buildOpenAIChatCompletionsUrl`'s path for `/chat/completions`,
+ * issue #1052). Real OpenAI (`api.openai.com`) uses the default `/v1/responses`
+ * path and needs NO entry here.
+ *
+ * Keyed by hostname so the override holds regardless of which routing tier
+ * produced the base URL. Reserved for future per-host Responses quirks.
+ */
+const OPENAI_HOST_RESPONSES_PATHS: ReadonlyMap<string, string> = new Map();
 /** The API version pinned for GitHub Copilot requests (matches Copilot CLI). */
 export const GITHUB_COPILOT_API_VERSION = "2026-06-01";
 
@@ -632,6 +654,50 @@ export function buildOpenAIChatCompletionsUrl(base: string): string {
     // Unparseable base (e.g. a bare placeholder) — keep the default `/v1` path.
   }
   return `${base}${DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH}`;
+}
+
+/**
+ * Build the OpenAI **Responses API** upstream URL for an upstream base.
+ *
+ * Mirror of {@link buildOpenAIChatCompletionsUrl}, used by background worker
+ * calls for providers/models that require the Responses wire shape (currently
+ * the `gpt-5.6-{sol,terra,luna}` family on `github-copilot`, which Copilot
+ * rolled out on 2026-07-09 — those return
+ * `unsupported_api_for_model` on `/chat/completions` and are ONLY reachable
+ * via `/responses`, per `earendil-works/pi#6475`).
+ *
+ * Routing rules mirror the chat-completions builder:
+ *  1. GitHub Copilot hosts (any `*.githubcopilot.com`, issue #1052) serve at
+ *     `/responses` with no `/v1` prefix.
+ *  2. Hosts in `OPENAI_HOST_RESPONSES_PATHS` (currently empty) use a fixed
+ *     non-`/v1` endpoint path. Reserved for future per-host Responses quirks
+ *     (no real provider needs it today).
+ *  3. A base whose pathname already ends in a version segment serves
+ *     `/responses` at `<base>/responses`; a default `/v1/responses` prefix
+ *     would duplicate the version.
+ *  4. Falls back to `${base}${DEFAULT_OPENAI_RESPONSES_PATH}` (`/v1/responses`).
+ */
+export function buildOpenAIResponsesUrl(base: string): string {
+  try {
+    const { hostname, pathname } = new URL(base);
+    // GitHub Copilot (all hosts, incl. api.individual/business/enterprise.*)
+    // serves /responses with no /v1 prefix — issue #1052.
+    if (isGitHubCopilotHost(hostname)) {
+      return `${base}/responses`;
+    }
+    const hostPath = OPENAI_HOST_RESPONSES_PATHS.get(hostname);
+    if (hostPath !== undefined) {
+      return `${base}${hostPath}`;
+    }
+    // Base already ends in a version segment (`/v4`, `/v1`, …) → the API path
+    // is just `/responses`; a `/v1` prefix would double the version.
+    if (/\/v\d+$/.test(pathname)) {
+      return `${base}/responses`;
+    }
+  } catch {
+    // Unparseable base — keep the default `/v1/responses` path.
+  }
+  return `${base}${DEFAULT_OPENAI_RESPONSES_PATH}`;
 }
 
 export function buildOpenAIUpstreamRequest(

--- a/packages/gateway/test/codex-worker-cache-accounting.test.ts
+++ b/packages/gateway/test/codex-worker-cache-accounting.test.ts
@@ -57,4 +57,29 @@ describe("parseResponsesWorkerResponse cache accounting", () => {
     const { usage } = parseResponsesWorkerResponse({ output_text: "ok" });
     expect(usage).toBeNull();
   });
+
+  test("falls back to output[].content[].text when output_text aggregate is null", () => {
+    // GitHub Copilot's /responses endpoint echoes back `output_text: null` in
+    // its convenience aggregate and instead nests the text under
+    // `output[].content[].text` (verified by live probe against
+    // api.githubcopilot.com/responses on gpt-5.6-luna). The parser MUST
+    // fall back to the item walk — otherwise every Copilot /responses worker
+    // call would return text=null and fail the parseInvariantVerdict step.
+    //
+    // The function's parameter type declares `output_text?: string`, but
+    // Copilot returns null in practice; the parser's `typeof === "string"`
+    // guard at `parseResponsesWorkerResponse:1447` already handles null
+    // correctly. The cast here pins the production behavior without forcing
+    // a (potentially-confusing) widening of the public parameter type.
+    const { text } = parseResponsesWorkerResponse({
+      output_text: null as unknown as string,
+      output: [
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "fallback via item walk" }],
+        },
+      ],
+    });
+    expect(text).toBe("fallback via item walk");
+  });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -278,8 +278,50 @@ describe("resolveWorkerProtocol", () => {
     expect(resolveWorkerProtocol("anthropic", "openai")).toBe("openai");
   });
 
-  test("explicit 'openai-responses' collapses to 'openai'", () => {
+  test("explicit 'openai-responses' is preserved (does NOT collapse to 'openai')", () => {
+    // As of PR B (gpt-5.6-* Responses API routing for github-copilot),
+    // `openai-responses` is a first-class worker protocol — collapsing it to
+    // `openai` would route gpt-5.6-luna to /chat/completions where Copilot
+    // returns `unsupported_api_for_model`. The explicit hint is honored.
+    expect(resolveWorkerProtocol("github-copilot", "openai-responses")).toBe(
+      "openai-responses",
+    );
+    // Even for an unrelated provider id (no per-model override), an explicit
+    // openai-responses hint is preserved through — caller wired it on
+    // purpose and the upstream snapshot sets the canonical protocol field.
     expect(resolveWorkerProtocol("anthropic", "openai-responses")).toBe(
+      "openai-responses",
+    );
+  });
+
+  test("per-model override: github-copilot + gpt-5.6-* resolves to 'openai-responses'", () => {
+    expect(
+      resolveWorkerProtocol("github-copilot", undefined, "gpt-5.6-luna"),
+    ).toBe("openai-responses");
+    expect(
+      resolveWorkerProtocol("github-copilot", undefined, "gpt-5.6-sol"),
+    ).toBe("openai-responses");
+    expect(
+      resolveWorkerProtocol("github-copilot", undefined, "gpt-5.6-terra"),
+    ).toBe("openai-responses");
+  });
+
+  test("per-model override: github-copilot + non-gpt-5.6 stays 'openai' (chat-completions)", () => {
+    // gpt-5-mini, claude-sonnet-4.5, etc. are reachable on /chat/completions;
+    // the routing layer must not flip them to /responses speculatively.
+    expect(
+      resolveWorkerProtocol("github-copilot", undefined, "gpt-5-mini"),
+    ).toBe("openai");
+    expect(
+      resolveWorkerProtocol("github-copilot", undefined, "claude-sonnet-4.5"),
+    ).toBe("openai");
+  });
+
+  test("per-model override does NOT trigger for non-github-copilot providers", () => {
+    // Real api.openai.com has no /responses-routes-only model; even if a
+    // model id matches the prefix, the provider id is the authority and
+    // wins.
+    expect(resolveWorkerProtocol("openai", undefined, "gpt-5.6-luna")).toBe(
       "openai",
     );
   });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -304,6 +304,14 @@ describe("resolveWorkerProtocol", () => {
     expect(
       resolveWorkerProtocol("github-copilot", undefined, "gpt-5.6-terra"),
     ).toBe("openai-responses");
+    // Dashless branch — defensive coverage. models.dev currently only lists
+    // the three-member `gpt-5.6-{sol,terra,luna}` family, but the resolver
+    // also accepts the bare slug. If the family ever gets a name without
+    // a hyphen (e.g. a renaming), this branch should keep working without
+    // a code change.
+    expect(resolveWorkerProtocol("github-copilot", undefined, "gpt-5.6")).toBe(
+      "openai-responses",
+    );
   });
 
   test("per-model override: github-copilot + non-gpt-5.6 stays 'openai' (chat-completions)", () => {

--- a/packages/gateway/test/worker-copilot-responses.test.ts
+++ b/packages/gateway/test/worker-copilot-responses.test.ts
@@ -194,7 +194,10 @@ describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
       { scheme: "bearer", value: "tok" },
       "gpt-5.6-luna",
     );
+    // Defense against a regression that omits or hardcodes the field:
+    // assert the value flows through, not just the key's presence.
     expect(body.max_output_tokens).toBeDefined();
+    expect(body.max_output_tokens).toBeGreaterThan(0);
     expect(body.max_completion_tokens).toBeUndefined();
   });
 

--- a/packages/gateway/test/worker-copilot-responses.test.ts
+++ b/packages/gateway/test/worker-copilot-responses.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Background worker requests for `gpt-5.6-*` model IDs on the `github-copilot`
+ * provider must target the OpenAI Responses API endpoint
+ * `https://api.githubcopilot.com/responses` (NO `/v1`, NO `/chat/completions`)
+ * with a Responses-shaped body:
+ *   - `input: [...]` items array (not `messages`)
+ *   - `instructions: "..."` (not a `{role:"system",...}` first message)
+ *   - `reasoning: { effort: ... }` (not `reasoning_effort: ...`)
+ *   - `max_output_tokens` (not `max_completion_tokens`)
+ *   - `store: false` (Codex parity — required by Copilot too, observed)
+ *
+ * Other github-copilot models (gpt-5-mini, claude-sonnet-4.5, etc.) continue to
+ * route through `/chat/completions` and are guarded by
+ * `worker-github-copilot.test.ts`. This file guards ONLY the gpt-5.6-* route.
+ *
+ * Mirror of the gpt-5-mini → /chat/completions test (the prior protocol that
+ * was the only supported Copilot path); the new path is required for the
+ * `gpt-5.6-{sol,terra,luna}` family that Copilot rolled out on 2026-07-09
+ * (changelog: https://github.blog/changelog/2026-07-09-openais-gpt-5-6-sol-terra-and-luna-are-now-available-in-github-copilot/).
+ * That endpoint is `unsupported_api_for_model` on `/chat/completions` and ONLY
+ * reachable on `/responses` — verified by probe.
+ */
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchArgUrl } from "./helpers/fetch-url";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+import { createGatewayLLMClient } from "../src/llm-adapter";
+import { upstreamFetch } from "../src/fetch";
+import { clearAllCosts } from "../src/cost-tracker";
+import { resetBackgroundLimiter } from "../src/background-limiter";
+import type { AuthCredential } from "../src/auth";
+
+const mockFetch = vi.mocked(upstreamFetch);
+
+// Same shape as the Codex responses fixture the codebase already produces; tests
+// need realistic `usage.input_tokens_details` etc. so the parser path is exercised.
+function responsesOkResponse(text = "worker ok") {
+  return new Response(
+    JSON.stringify({
+      id: "resp_test_1",
+      object: "response",
+      created_at: 1785900000,
+      model: "gpt-5.6-luna",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          id: "msg_test_1",
+          content: [
+            {
+              type: "output_text",
+              text,
+              annotations: [],
+              logprobs: [],
+            },
+          ],
+        },
+      ],
+      usage: {
+        input_tokens: 8,
+        output_tokens: 4,
+        total_tokens: 12,
+        input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+        output_tokens_details: { reasoning_tokens: 0 },
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+// github-copilot resolves through the route table — its protocol hint is
+// "openai" (the protocol field on the route), but the routing layer now
+// detects `gpt-5.6-*` model IDs and forces the response-api protocol. Tests
+// therefore thread the request with NO explicit protocol hint so the
+// discriminator is the discriminator (not the upstream snapshot's hint).
+const UPSTREAMS = {
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com",
+};
+
+async function runWorker(
+  cred: AuthCredential | null,
+  modelID: string,
+  protocolHint?:
+    | "anthropic"
+    | "openai"
+    | "openai-responses"
+    | "vertex"
+    | "gemini",
+) {
+  const client = createGatewayLLMClient(
+    UPSTREAMS,
+    (_sid, providerID) => (providerID === "github-copilot" ? cred : null),
+    { providerID: "github-copilot", modelID },
+  );
+  const result = await client.prompt("system-prompt", "user-prompt", {
+    sessionID: "sess-copilot-responses",
+    workerID: "lore-distill",
+    model: { providerID: "github-copilot", modelID },
+    ...(protocolHint ? { protocol: protocolHint } : {}),
+    upstreamProviderID: "github-copilot",
+  });
+  const call = mockFetch.mock.calls[0];
+  return {
+    result,
+    url: fetchArgUrl(call?.[0]),
+    headers: (call?.[1] as { headers?: Record<string, string> } | undefined)
+      ?.headers,
+    body: JSON.parse(
+      String((call?.[1] as { body?: string } | undefined)?.body ?? "{}"),
+    ) as Record<string, unknown>,
+  };
+}
+
+describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(responsesOkResponse());
+  });
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    resetBackgroundLimiter();
+  });
+
+  test("bearer cred → /responses URL + Copilot headers + Responses body", async () => {
+    const { result, url, headers, body } = await runWorker(
+      { scheme: "bearer", value: "copilot_tok" },
+      "gpt-5.6-luna",
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // URL must be /responses (NOT /chat/completions, NOT /v1 prefix).
+    expect(url).toBe("https://api.githubcopilot.com/responses");
+    expect(url).not.toContain("/chat/completions");
+    expect(url).not.toContain("/v1/");
+    // GitHub Copilot canonical headers from copilotHeaders().
+    expect(headers?.["Copilot-Integration-Id"]).toBe("vscode-chat");
+    expect(headers?.["X-GitHub-Api-Version"]).toBeDefined();
+    // Bearer auth (copilot uses Authorization: Bearer, NOT x-api-key).
+    expect(headers?.Authorization).toBe("Bearer copilot_tok");
+    // Responses body shape — instructions + input items, NOT messages.
+    expect(body.messages).toBeUndefined();
+    expect(body.instructions).toBe("system-prompt");
+    expect(Array.isArray(body.input)).toBe(true);
+    expect(body.input).toEqual([{ role: "user", content: "user-prompt" }]);
+    // No `/chat/completions` keys: max_completion_tokens, reasoning_effort.
+    expect(body.max_completion_tokens).toBeUndefined();
+    expect(body.reasoning_effort).toBeUndefined();
+    // Responses-specific keys present.
+    expect(body.model).toBe("gpt-5.6-luna");
+    expect(body.stream).toBe(false);
+    expect(body.store).toBe(false);
+    // Response parsed back from Responses output[0].content[0].text.
+    expect(result).toContain("worker ok");
+  });
+
+  test("reasoning_effort from caller maps to `reasoning: { effort }` (NOT reasoning_effort)", async () => {
+    const { body } = await runWorker(
+      { scheme: "bearer", value: "tok" },
+      "gpt-5.6-luna",
+    );
+    // Default reasoningEffort is undefined → omit both forms.
+    expect(body.reasoning).toBeUndefined();
+    expect(body.reasoning_effort).toBeUndefined();
+
+    // Force `reasoningEffort: "medium"` via a custom client that overrides opts.
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "github-copilot"
+          ? { scheme: "bearer", value: "tok" }
+          : null,
+      { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+    );
+    await client.prompt("sys", "user", {
+      sessionID: "sess-re",
+      workerID: "lore-curator",
+      model: { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+      reasoningEffort: "medium",
+      upstreamProviderID: "github-copilot",
+    });
+    const call = mockFetch.mock.calls[1];
+    const bodyWithEffort = JSON.parse(
+      String((call?.[1] as { body?: string } | undefined)?.body ?? "{}"),
+    ) as Record<string, unknown>;
+    expect(bodyWithEffort.reasoning).toEqual({ effort: "medium" });
+    expect(bodyWithEffort.reasoning_effort).toBeUndefined();
+  });
+
+  test("max_tokens becomes max_output_tokens (NOT max_completion_tokens)", async () => {
+    const { body } = await runWorker(
+      { scheme: "bearer", value: "tok" },
+      "gpt-5.6-luna",
+    );
+    expect(body.max_output_tokens).toBeDefined();
+    expect(body.max_completion_tokens).toBeUndefined();
+  });
+
+  test("route discriminator: gpt-5.6-* → /responses; gpt-5-mini stays on /chat/completions", async () => {
+    // Both calls go through the github-copilot provider — the discriminator is
+    // the model id (`resolveWorkerProtocol` checks `isResponsesOnlyModel`).
+    // Capture each from its distinct mockFetch.mock.calls[N] since the
+    // helper returns calls[0] (the first mock call of its invocation).
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "github-copilot"
+          ? { scheme: "bearer", value: "tok" }
+          : null,
+      { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+    );
+    await client.prompt("sys", "u", {
+      sessionID: "sess-1",
+      workerID: "lore-distill",
+      model: { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+      upstreamProviderID: "github-copilot",
+    });
+    const r1Url = fetchArgUrl(mockFetch.mock.calls[0]?.[0]);
+    const r1Body = JSON.parse(
+      String(
+        (mockFetch.mock.calls[0]?.[1] as { body?: string } | undefined)?.body ??
+          "{}",
+      ),
+    ) as Record<string, unknown>;
+    expect(r1Url).toBe("https://api.githubcopilot.com/responses");
+    expect(r1Body.input).toBeDefined();
+    expect(r1Body.messages).toBeUndefined();
+
+    // Second call uses the gpt-5-mini model → must stay on /chat/completions.
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "chatcmpl-test",
+          object: "chat.completion",
+          choices: [{ message: { role: "assistant", content: "pong" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client2 = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "github-copilot"
+          ? { scheme: "bearer", value: "tok" }
+          : null,
+      { providerID: "github-copilot", modelID: "gpt-5-mini" },
+    );
+    await client2.prompt("sys", "u", {
+      sessionID: "sess-2",
+      workerID: "lore-distill",
+      model: { providerID: "github-copilot", modelID: "gpt-5-mini" },
+      upstreamProviderID: "github-copilot",
+    });
+    const r2Url = fetchArgUrl(mockFetch.mock.calls[1]?.[0]);
+    const r2Body = JSON.parse(
+      String(
+        (mockFetch.mock.calls[1]?.[1] as { body?: string } | undefined)?.body ??
+          "{}",
+      ),
+    ) as Record<string, unknown>;
+    expect(r2Url).toBe("https://api.githubcopilot.com/chat/completions");
+    expect(r2Body.messages).toBeDefined();
+    expect(r2Body.input).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Mirror pi-mono's `api: "openai-responses"` wiring (`earendil-works/pi#6475`) for the github-copilot worker pipeline. The `gpt-5.6-{sol,terra,luna}` family Copilot rolled out 2026-07-09 is reachable ONLY via `POST https://api.githubcopilot.com/responses` — the `/chat/completions` path returns `unsupported_api_for_model`. Other github-copilot models (gpt-5-mini, claude-sonnet-4.5, etc.) stay on `/chat/completions`; routing is model-aware via `isResponsesOnlyModel()`.

## Architecture

- New `buildOpenAIResponsesWorkerRequest` (llm-adapter.ts) builds Responses body shape: `input: [user item]`, top-level `instructions: system`, `max_output_tokens`, `reasoning: { effort }`, `store: false`. URL via new `buildOpenAIResponsesUrl` (translate/openai.ts) which mirrors the chat-completions host map (github-copilot omits /v1, issue #1052).
- `WorkerProtocol` union gains `openai-responses`; `resolveWorkerProtocol` now takes an optional `modelID` and routes github-copilot + `isResponsesOnlyModel()` to `openai-responses` (preserving explicit openai-responses hints, otherwise collapsing them per the old comment).
- `buildWorkerRequest`/`parseWorkerResponse`/`accumulateWorkerSSE` switches dispatch the new protocol (parseResponsesWorkerResponse reused; same wire shape as Codex).

## TDD regression coverage

4 tests in `packages/gateway/test/worker-copilot-responses.test.ts` cover URL (`/responses`, no /v1, no /chat/completions), Copilot headers (`Copilot-Integration-Id` + `X-GitHub-Api-Version`), body shape (`input` not `messages`, `instructions` not first-message-system, `max_output_tokens` not `max_completion_tokens`), reasoning-effort mapping (`reasoning: { effort }` not `reasoning_effort`, `openAIReasoningEffort` reused), and the gpt-5.6-* vs gpt-5-mini discriminator (the model-aware routing). `llm-adapter.test.ts` resolveWorkerProtocol suite updated: 'explicit openai-responses is preserved' (replaces 'collapses to openai'), +4 cases for the per-model override + non-github-copilot providers don't trigger.

## Probe-verified

Direct API probe against `api.githubcopilot.com/responses` with `gpt-5.6-luna` returns valid JSON; `reasoning: { effort: 'low' }` correctly maps. `/chat/completions` returns `{"code":"unsupported_api_for_model"}` for the same model.

Refs: earendil-works/pi#6475, anomalyco/models.dev#3178.