### PR TITLE
fix(lint): drop redundant parens around typed arrow in cli-lint-contract.test.ts

### DIFF
--- a/packages/gateway/test/cli-lint-contract.test.ts
+++ b/packages/gateway/test/cli-lint-contract.test.ts
@@ -527,12 +527,12 @@ describe("Phase 3D.1 — typed lore lint", () => {
 
     const chunks: string[] = [];
     const origWrite = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: string | Buffer): boolean => {
+    process.stdout.write = (chunk: string | Buffer): boolean => {
       chunks.push(
         Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk),
       );
       return true;
-    });
+    };
     try {
       const { buildApplication, buildRouteMap, run } =
         await import("@stricli/core");


### PR DESCRIPTION
oxfmt 0.58.0 (CI) flags `process.stdout.write = ((chunk: ...): boolean => {...})` as needing `((chunk: ...): boolean => {...})` → `(chunk: ...): boolean => {...}` (redundant outer parens around a typed arrow expression).

Caught by CI run 31058566662 — the format check step is global and a single-file drift blocks all PRs that touch any worktree-based work. Pre-existing on main (also failed in run 31044339431, 2026-08-05T20:31Z, before PR #1582 opened). Per [019fab42] separate PR for unrelated CI/workflow fixes; rigorous PR hygiene.