### PR TITLE
feat(ci): switch semantic-linter default judge from gpt-5-mini to gpt-5.6-luna

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -17,14 +17,14 @@ inputs:
     default: ""
   model:
     description: >-
-      Judge model (provider/id). Defaults to `github-copilot/gpt-5-mini` when
+      Judge model (provider/id). Defaults to `github-copilot/gpt-5.6-luna` when
       the workflow uses the zero-secret GitHub Copilot path (the default).
       In that case the CLI authenticates with the `github.token` built-in, no
       additional configuration needed. The reference workflow's model-precedence
       table still lets `LORE_INVARIANT_MODEL` (repo var) or a dedicated
       `LORE_WORKER_API_KEY` override this.
     required: false
-    default: "github-copilot/gpt-5-mini"
+    default: "github-copilot/gpt-5.6-luna"
   effort:
     description: >-
       Reasoning effort for the judge (off|low|medium|high|xhigh). A cost/depth

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -26,9 +26,11 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    # gpt-5-mini is the default judge (PR #1493 cross-model validation:
+    # gpt-5.6-luna is the default judge (PR #1493 cross-model validation:
     # 6/6 control PRs clean, 0 unparseable). Reachable via GitHub Copilot's
-    # chat-completions endpoint (NOT /responses-only — see worker-model.ts).
+    # /responses endpoint (NOT /chat/completions — see worker-model.ts and
+    # PR #1582's `openai-responses` worker adapter, gated by
+    # `isResponsesOnlyModel` in llm-adapter.ts).
     # Warm cache ~2-4 min; cold start with a fresh GITHUB_TOKEN + Copilot
     # quota lookup can take ~10-15 min on a PR with many hunks and many
     # invariants. 25 min gives ~10 min of headroom for cold-start variation,
@@ -61,12 +63,14 @@ jobs:
           # Judge model + credential. Two supported setups:
           #  1. Zero-secret (default): GitHub Copilot via the built-in
           #     GITHUB_TOKEN + `copilot-requests: write` above. Uses
-          #     github-copilot/gpt-5-mini as the default judge — highest
-          #     precision across the OpenAI model family on this task
-          #     (measured on the 6-PR control corpus in PR #1493; 0 false
-          #     positives, 0 unparseable). The token is sent as a Bearer
-          #     credential to api.githubcopilot.com/chat/completions; no
-          #     Copilot-specific token exchange needed in CI.
+          #     github-copilot/gpt-5.6-luna as the default judge — best
+          #     cost/quality point across the OpenAI model family on this
+          #     task (measured on the 6-PR control corpus in PR #1493; 0
+          #     false positives, 0 unparseable). The token is sent as a Bearer
+          #     credential to api.githubcopilot.com/responses (the openai-
+          #     responses worker adapter routes gpt-5.6-* via this endpoint
+          #     — see PR #1582 / `isResponsesOnlyModel` in llm-adapter.ts);
+          #     no Copilot-specific token exchange needed in CI.
           #     On fork PRs the token is read-only and may lack inference
           #     quota; the judge then no-ops (advisory → still passes),
           #     never breaks CI.
@@ -78,12 +82,12 @@ jobs:
           #
           # Model precedence (independent of the credential):
           #   - `LORE_INVARIANT_MODEL` var set     → use it (either credential).
-          #   - else no dedicated key              → github-copilot/gpt-5-mini
+          #   - else no dedicated key              → github-copilot/gpt-5.6-luna
           #     (the token is a GitHub token; a github-copilot id is required so
-          #     the CLI sends it as Bearer to api.githubcopilot.com).
+          #     the CLI sends it as Bearer to api.githubcopilot.com/responses).
           #   - else (dedicated key, no var)       → empty → CLI's configured
           #     default worker model, authed with the dedicated key.
           # This avoids the trap of pairing a dedicated (e.g. Anthropic) key with
           # a forced github-copilot id, which would 401 and silently no-op.
-          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-copilot/gpt-5-mini' || '') }}
+          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-copilot/gpt-5.6-luna' || '') }}
           worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || github.token }}

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/lint
         with:
           lore-command: "node packages/gateway/dist/bin.cjs"
-          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-copilot/gpt-5-mini' || '') }}
+          model: ${{ vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && 'github-copilot/gpt-5.6-luna' || '') }}
           worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || github.token }}
 ```
 
@@ -78,7 +78,7 @@ The credential and the model are chosen independently.
 
 **Credential** (the `worker-api-key` input):
 
-- **Zero-secret (default).** The reference workflow falls back to the built-in `GITHUB_TOKEN` with `copilot-requests: write`, calling GitHub Copilot. The token is sent as a Bearer credential to `api.githubcopilot.com/chat/completions` — no separate Copilot token exchange is needed in CI. On fork PRs the token is read-only and may lack inference quota; the judge then no-ops (advisory → still passes) rather than breaking CI.
+- **Zero-secret (default).** The reference workflow falls back to the built-in `GITHUB_TOKEN` with `copilot-requests: write`, calling GitHub Copilot. The token is sent as a Bearer credential to `api.githubcopilot.com/responses` (the openai-responses worker adapter routes `gpt-5.6-*` via this endpoint — see PR #1582 / `isResponsesOnlyModel` in `llm-adapter.ts`) — no separate Copilot token exchange is needed in CI. On fork PRs the token is read-only and may lack inference quota; the judge then no-ops (advisory → still passes) rather than breaking CI.
 - **Dedicated key (busy repos).** Set a `LORE_WORKER_API_KEY` secret. It takes precedence over the token.
 
 **Model** (the `model` input, `provider/id`):
@@ -86,7 +86,7 @@ The credential and the model are chosen independently.
 | Situation | Model used |
 | --- | --- |
 | `LORE_INVARIANT_MODEL` repo variable is set | that value (with either credential) |
-| No dedicated key, no variable | `github-copilot/gpt-5-mini` |
+| No dedicated key, no variable | `github-copilot/gpt-5.6-luna` |
 | Dedicated key, no variable | your repo's configured default worker model |
 
 :::note


### PR DESCRIPTION
Depends on PR #1582 (openai-responses worker adapter). That PR added `buildOpenAIResponsesWorkerRequest` and the `isResponsesOnlyModel` discriminator that routes `gpt-5.6-*` to `POST https://api.githubcopilot.com/responses` (the ONLY endpoint where Copilot serves the new family; `/chat/completions` returns `unsupported_api_for_model`).

## Why

- `gpt-5.6-luna` is the cheapest non-reasoning model in the github-copilot family (per `anomalyco/models.dev#3178`), so per-judge cost drops without raising `finish_reason:"length"` / unparseable risk.
- Reasoning models (`gpt-5-mini` et al.) burn hidden reasoning tokens against `max_completion_tokens` (lore `[019ecab6]`); even with PR #1555's `JUDGE_VERDICT_MIN_BUDGET` floor, non-reasoning judges are the strictly-better default for a single-shot JSON verdict task.
- /responses shape (`instructions` + `input[]`) is closer to the prompt shape we send, so JSON parsing is more reliable than chat-completions' `{role:system, role:user}` roundtrip.

## Scope

3 files, all text-only defaults/comments:
- `.github/workflows/semantic-linter.yml` — default `model:` input + precedence-table + cross-model-validation history comment.
- `.github/actions/lint/action.yml` — the action's documented default.
- `packages/website/src/content/docs/docs/guides/semantic-linter.md` — doc table.

No test changes (text-only flip; routing logic was verified end-to-end in #1582's regression suite).

Refs: #1582, #1493 (cross-model validation corpus), `[019ecab6]`.