### PR TITLE
fix(gateway): scope explicit openai-responses hint to supporting providers

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -749,8 +749,29 @@ export function resolveWorkerProtocol(
   if (explicit) {
     // Per-model override beats an explicit openai hint (caller likely did
     // not know about the gpt-5.6 routing); but an explicit openai-responses
-    // hint is authoritative — caller wired it on purpose.
-    if (explicit === "openai-responses") return "openai-responses";
+    // hint is authoritative — IF the provider actually supports the
+    // Responses API. The pre-PR-#1582 behavior collapsed
+    // `openai-responses` → `openai` UNCONDITIONALLY (defensive guard
+    // against misconfigured snapshots where upstreamProviderID and
+    // protocol disagree); PR #1582 loosened that to preserve the hint
+    // UNCONDITIONALLY, which would silently misroute a misconfigured
+    // anthropic/vertex/gemini snapshot to `/v1/responses` on api.anthropic.com
+    // (404). Restore the guard: only preserve `openai-responses` when the
+    // route table says the provider supports it (real OpenAI: api.openai.com
+    // — config.ts:573-578) OR the per-model override (github-copilot +
+    // gpt-5.6-*) triggers. Other providers' openai-responses hints fall
+    // through to chat-completions (`"openai"`), matching the prior collapse.
+    if (explicit === "openai-responses") {
+      if (
+        resolveProviderRoute(providerID)?.protocol === "openai-responses" ||
+        (providerID === "github-copilot" &&
+          modelID &&
+          isResponsesOnlyModel(modelID))
+      ) {
+        return "openai-responses";
+      }
+      return "openai";
+    }
     if (
       providerID === "github-copilot" &&
       modelID &&

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -278,20 +278,68 @@ describe("resolveWorkerProtocol", () => {
     expect(resolveWorkerProtocol("anthropic", "openai")).toBe("openai");
   });
 
-  test("explicit 'openai-responses' is preserved (does NOT collapse to 'openai')", () => {
-    // As of PR B (gpt-5.6-* Responses API routing for github-copilot),
-    // `openai-responses` is a first-class worker protocol — collapsing it to
-    // `openai` would route gpt-5.6-luna to /chat/completions where Copilot
-    // returns `unsupported_api_for_model`. The explicit hint is honored.
-    expect(resolveWorkerProtocol("github-copilot", "openai-responses")).toBe(
+  test("explicit 'openai-responses' is preserved for providers that support it", () => {
+    // Real api.openai.com natively speaks /v1/responses — its route table
+    // declares `protocol: "openai-responses"` (config.ts:573-578). An
+    // explicit hint on the openai provider is honored through.
+    expect(resolveWorkerProtocol("openai", "openai-responses")).toBe(
       "openai-responses",
     );
-    // Even for an unrelated provider id (no per-model override), an explicit
-    // openai-responses hint is preserved through — caller wired it on
-    // purpose and the upstream snapshot sets the canonical protocol field.
+    // openai-codex: its route table also declares `protocol: "openai-responses"`
+    // (config.ts:581-586), and the early-return at the top of the function
+    // unconditionally maps openai-codex → openai-codex-responses.
+    // github-copilot supports /responses for the gpt-5.6-* family via the
+    // per-model override (no `protocol: "openai-responses"` in its route
+    // table entry, but `isResponsesOnlyModel(modelID)` gates it). The
+    // production call site (llm-adapter.ts:2021) ALWAYS passes modelID;
+    // the no-modelID branch is unreachable from the worker pipeline.
+    expect(
+      resolveWorkerProtocol(
+        "github-copilot",
+        "openai-responses",
+        "gpt-5.6-luna",
+      ),
+    ).toBe("openai-responses");
+    expect(
+      resolveWorkerProtocol(
+        "github-copilot",
+        "openai-responses",
+        "gpt-5.6-sol",
+      ),
+    ).toBe("openai-responses");
+  });
+
+  test("explicit 'openai-responses' collapses to 'openai' for providers that don't support it (defensive guard)", () => {
+    // Seer inline review (PR #1582#discussion_r3725297559) flagged that
+    // PR #1582's unconditional `if (explicit === "openai-responses") return
+    // "openai-responses"` weakened the pre-existing defensive collapse.
+    // A misconfigured snapshot where upstreamProviderID="anthropic" but
+    // protocol="openai-responses" would silently route to /v1/responses on
+    // api.anthropic.com (404). Restore the guard: only providers whose
+    // route table declares `protocol: "openai-responses"` (or the per-model
+    // override triggers) get the hint preserved.
     expect(resolveWorkerProtocol("anthropic", "openai-responses")).toBe(
-      "openai-responses",
+      "openai",
     );
+    expect(resolveWorkerProtocol("vertex", "openai-responses")).toBe("openai");
+    expect(resolveWorkerProtocol("google", "openai-responses")).toBe("openai");
+    expect(resolveWorkerProtocol("deepseek", "openai-responses")).toBe(
+      "openai",
+    );
+    expect(resolveWorkerProtocol("minimax", "openai-responses")).toBe("openai");
+    // github-copilot with a NON-gpt-5.6-* model (where the per-model
+    // override doesn't trigger) also collapses — the route table says
+    // `protocol: "openai"`, not "openai-responses".
+    expect(
+      resolveWorkerProtocol("github-copilot", "openai-responses", "gpt-5-mini"),
+    ).toBe("openai");
+    expect(
+      resolveWorkerProtocol(
+        "github-copilot",
+        "openai-responses",
+        "claude-sonnet-4.5",
+      ),
+    ).toBe("openai");
   });
 
   test("per-model override: github-copilot + gpt-5.6-* resolves to 'openai-responses'", () => {


### PR DESCRIPTION
## Bug

Seer inline review on PR #1582#discussion_r3725297559 (MEDIUM severity) flagged that PR #1582's `resolveWorkerProtocol` change at `llm-adapter.ts:753` unconditionally preserved `explicit === "openai-responses"` regardless of providerID. The pre-PR-#1582 behavior collapsed `openai-responses` → `openai" for any provider that wasn't openai-codex — a defensive guard against misconfigured snapshots where `upstreamProviderID` and `protocol` disagree.

## Fix

Restore the per-provider guard: only preserve explicit `openai-responses` when:
- The route table declares the provider natively supports it (real `openai` → `protocol: "openai-responses"` at `config.ts:573-578`), OR
- The per-model override triggers (`providerID === "github-copilot" && isResponsesOnlyModel(modelID)`).

Other providers' openai-responses hints fall through to `"openai"` (chat-completions), matching the pre-#1582 collapse.

## Reachability today

NONE in current production code paths. `upstreamProviderID` and `opts.protocol` come from the same `UpstreamSnapshot`, so a session with `providerID="anthropic"` always has `protocol="anthropic". The pre-#1582 collapse was strictly redundant in current code paths.

## Why restore it anyway

Future-proofing. If a future code change introduces a snapshot path where providerID and protocol disagree (translator bug, new ingress shape, etc.), the resolver would now silently misroute to `/v1/responses` on `api.anthropic.com` (404) instead of falling back to chat-completions. Pre-#1582 caught this; #1582 weakened the guard; this PR restores it.

## Tests

Two tests in `packages/gateway/test/llm-adapter.test.ts`:

1. `explicit 'openai-responses' is preserved for providers that support it`: pins real OpenAI (route-declared) + github-copilot + gpt-5.6-* (per-model override).
2. `explicit 'openai-responses' collapses to 'openai' for providers that don't support it (defensive guard)`: pins the new collapse for anthropic/vertex/google/deepseek/minimax + github-copilot with non-gpt-5.6-* models.

## Refs

- PR #1582 (openai-responses worker adapter)
- PR #1582#discussion_r3725297559 (Seer MEDIUM bug report)
- lore [019fb95e] (always address all review findings)
- lore [019fb858] (always check inline review comments before merge)