### PR TITLE
fix(lint): surface judge null-text on stderr + enable LORE_DEBUG in CI

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -113,6 +113,16 @@ runs:
         LORE_DB_PATH: ${{ steps.key.outputs.db }}
         CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
         LORE_IC_GATE: ${{ inputs.gate }}
+        # Enable log.info/log.warn to surface on stderr. The action's bash already
+        # captures stderr unconditionally (per PR #1555), but the @loreai/core
+        # logger is debug-gated — without LORE_DEBUG=1 the only stderr we ever see
+        # on a successful lint run is the per-call judging progress lines. When
+        # a judge call returns null text (routing miss, auth failure, encrypted
+        # content, etc.) the unparseable++ count surfaces in the report but the
+        # underlying cause stays silent. Surfacing it here lets the next CI run
+        # pinpoint which path failed, instead of treating "20/20 unparseable" as
+        # the symptom we guess about in PR comments.
+        LORE_DEBUG: "1"
       run: |
         set -euo pipefail
         mkdir -p "$(dirname "$LORE_DB_PATH")"

--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -1075,12 +1075,37 @@ export async function checkInvariants(input: {
       continue;
     }
     judgeCalls++;
+    if (responseText === null) {
+      // Worker returned no text at all. This is the silent failure mode that
+      // bit PR #1587's CI run (20/20 unparseable on github-copilot/gpt-5.6-luna):
+      // the call completed (no exception) but the parser got nothing back,
+      // usually because the model is not accessible on the protocol the worker
+      // routed to (e.g. github-copilot/gpt-5.6-* on /chat/completions instead
+      // of /responses → upstream returns `unsupported_api_for_model`), or auth
+      // was rejected (non-Copilot bearer on api.githubcopilot.com → 400 plain
+      // text), or the response was entirely encrypted. None of these surface
+      // through `log.info` because the logger is debug-gated, so a successful
+      // CI run reporting "20/20 unparseable" used to give us no actionable
+      // signal. Log at `notice` (always visible on stderr, sink warn severity)
+      // — never `error` (this is expected failure-mode recovery, not an outage).
+      log.notice(
+        `invariant-check: judge returned null text for ${input.model?.providerID ?? "?"}/${input.model?.modelID ?? "?"} — likely cause: model not accessible on the routed protocol, auth rejected, or encrypted-only response (no parseable text in any output item)`,
+      );
+      unparseable++;
+      continue;
+    }
     const verdict = parseInvariantVerdict(responseText);
     if (!verdict) {
-      // Response was not parseable into a verdict (prose instead of JSON, a
-      // truncated object, etc.). Degrade safely to "no finding" — but COUNT it,
-      // so a systemically-broken judge is visible rather than silently
-      // indistinguishable from a genuine clean run.
+      // Response was a string but not parseable into a verdict (prose instead of
+      // JSON, a truncated object, a fenced markdown wrapper the heuristic
+      // couldn't peel, etc.). Degrade safely to "no finding" — but COUNT it, so
+      // a systemically-broken judge is visible rather than silently
+      // indistinguishable from a genuine clean run. Debug-gated because this
+      // is a model-behavior signal, not actionable for the operator — once
+      // LORE_DEBUG=1 is set the truncated text is logged for offline triage.
+      log.info(
+        `invariant-check: judge returned unparseable text for ${input.model?.providerID ?? "?"}/${input.model?.modelID ?? "?"}: ${responseText.slice(0, 200)}`,
+      );
       unparseable++;
       continue;
     }

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -3,6 +3,7 @@ import { db } from "../src/db";
 import { storeEmbedding } from "../src/db/vec-store";
 import * as embedding from "../src/embedding";
 import * as ltm from "../src/ltm";
+import * as log from "../src/log";
 import {
   changedFiles,
   checkInvariants,
@@ -807,6 +808,50 @@ describe("checkInvariants (funnel, stubbed LLM)", () => {
     expect(result.judgeCalls).toBe(1);
     expect(result.unparseable).toBe(1);
     expect(result.findings).toHaveLength(0); // safe degrade, no crash
+  });
+
+  it("emits a notice log when the judge returns null text (so 20/20 unparseable in CI is actionable)", async () => {
+    // Regression for PR #1587's CI run (run 31099868171): github-copilot/gpt-5.6-luna
+    // routed to /chat/completions (instead of /responses) returned
+    // `unsupported_api_for_model` as plain JSON, the parser walked
+    // output[].content[].text (empty) → null text, and the CLI silently
+    // counted all 20 calls as unparseable with NO stderr detail to diagnose
+    // the routing miss. The fix: when `responseText === null` after a
+    // successful call (no exception), surface a `log.notice` so the operator
+    // sees the model + provider + likely cause on the next CI run, even
+    // without LORE_DEBUG=1.
+    const project = "/tmp/ic-test-proj-null-text";
+    await seed(
+      project,
+      "sqlite boundary",
+      "node:sqlite must never be imported outside driver.node.ts",
+      v(1, 0, 0),
+    );
+    vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([v(1, 0, 0)]);
+    // Judge completes (no throw) but returns null text — the "silent failure"
+    // shape: the worker pipeline swallowed an empty/encrypted/incompatible
+    // response and the parser got nothing back.
+    const { llm } = stubLLM(() => null);
+    const noticeSpy = vi.spyOn(log, "notice").mockImplementation(() => {});
+
+    const result = await checkInvariants({
+      projectPath: project,
+      hunks: [{ file: "src/other.ts", text: '@@\n+import "node:sqlite"' }],
+      range: FAKE_RANGE,
+      llm,
+      sessionID: "s-null-text",
+      model: { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+    });
+
+    expect(result.unparseable).toBe(1);
+    expect(result.findings).toHaveLength(0); // safe degrade, no crash
+    // The notice log names the model so an operator staring at "20/20 unparseable"
+    // in CI stderr can immediately identify the routing/compat issue.
+    expect(noticeSpy).toHaveBeenCalledTimes(1);
+    const call = noticeSpy.mock.calls[0][0] as string;
+    expect(call).toContain("github-copilot/gpt-5.6-luna");
+    expect(call).toContain("null text");
+    noticeSpy.mockRestore();
   });
 
   it("prose-wrapped JSON verdict still flags (prose-tolerant parse)", async () => {


### PR DESCRIPTION
## Problem

PR #1587 CI run 31099868171 reported "20/20 unparseable" on github-copilot/gpt-5.6-luna with **no actionable stderr**. Every judge call completed (no exception) but the parser got null text back, and @loreai/core's `log.info` is debug-gated — so an operator looking at "20/20 unparseable" could only guess at the routing/auth/encrypted-content cause.

PR #1555 made the bash `cat /tmp/lore-ic.err` unconditionally, so stderr is captured. But the *content* of stderr was still gated behind LORE_DEBUG=1.

## Two changes

### 1. `.github/actions/lint/action.yml` — `LORE_DEBUG: "1"`

Added to the `Resolve range + run lint` env block. The bash already captures stderr unconditionally (per PR #1555), but the logger is debug-gated — without LORE_DEBUG=1 the only stderr visible on success was the per-call judging progress lines. With it, every `log.info` / `log.warn` from @loreai/core surfaces too, so the next "20/20 unparseable" run shows the model, the routed protocol, and any worker-pipeline error message inline.

### 2. `packages/core/src/invariant-check.ts` — split unparseable into two cases

The previous code lumped both "worker returned null text" and "worker returned text but parser couldn't extract JSON verdict" into a single `unparseable++` branch with no logging. Split:

- `responseText === null` (worker returned no text — routing miss / auth rejection / encrypted-only) → `log.notice` (always visible on stderr, sink warn severity, **never** `log.error` per the [lore] 'expected user-actionable errors are warn not error' rule). Names the model + provider + likely cause.
- `responseText` is a string but unparseable JSON → `log.info` (debug-gated — model behavior, not operator-actionable). Logs the truncated text for offline triage once LORE_DEBUG=1 is on.

The `unparseable++` counter is preserved in both branches so a systemically-broken judge stays visible rather than silently indistinguishable from a genuine clean run.

## Regression test

`invariant-check.test.ts > "emits a notice log when the judge returns null text (so 20/20 unparseable in CI is actionable)"`. **TDD-verified per lore [019fb95e]:**
- Stash fix → test FAILS at `expect(noticeSpy).toHaveBeenCalledTimes(1)` (got 0 times)
- Restore → test PASSES (1 time, contains "github-copilot/gpt-5.6-luna" + "null text")

## Pre-merge gate

- format ✓ (717 files)
- lint ✓ (only pre-existing `typescript(unbound-method)` warnings remain)
- typecheck ✓ (all 5 packages)
- tests: **7198 passed, 227 skipped, 2 failed** in 398 test files (813s)
  - 2 failures in `packages/gateway/test/import-auth-chain.test.ts` cases (a) and (b)
  - **Pre-existing on origin/main** — verified by checking out main and running the same file: same 2 failures, 43 passed / 45 total. Not introduced by this PR.
  - Per lore `[019fab42]` "Separate PR for unrelated CI/workflow fixes; rigorous PR hygiene", these belong in a follow-up PR, not this one.

## Files

```
.github/actions/lint/action.yml            |  10 +++
packages/core/src/invariant-check.ts       |  33 +++++++-
packages/core/test/invariant-check.test.ts |  45 ++++++++++
3 files changed, 84 insertions(+), 4 deletions(-)
```