### PR TITLE
fix(gateway): stream Codex worker responses

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1325,7 +1325,8 @@ function buildCodexWorkerRequest(
       model: model.modelID,
       // Codex REQUIRES store:false (rejects store:true).
       store: false,
-      stream: false,
+      // ChatGPT's Codex backend rejects non-streaming requests.
+      stream: true,
       ...(temperature != null && { temperature }),
       instructions: system,
       input: [
@@ -1765,6 +1766,58 @@ function accumulateWorkerSSE(
       // Anthropic wire (incl. Vertex/Bedrock-mantle) SSE.
       return accumulateSSEResponse(response);
   }
+}
+
+/**
+ * Validate a buffered Responses worker stream before treating an empty result
+ * as a model-capability signal. The shared accumulator deliberately tolerates
+ * malformed events for foreground pass-through, but workers must fail closed:
+ * skipped deltas or a response.failed terminal are upstream failures, never
+ * evidence that the model cannot answer.
+ */
+function validateResponsesWorkerSSE(body: string): string | null {
+  let terminalStatus: string | null = null;
+
+  for (const frame of body.split(/\r?\n\r?\n/)) {
+    let event = "message";
+    const dataLines: string[] = [];
+    for (const line of frame.split(/\r?\n/)) {
+      if (line.startsWith("event:")) {
+        event = line.slice(6).trim();
+      } else if (line.startsWith("data:")) {
+        dataLines.push(line.slice(5).trimStart());
+      }
+    }
+
+    const data = dataLines.join("\n");
+    if (!data || data === "[DONE]") continue;
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(data) as Record<string, unknown>;
+    } catch {
+      return `malformed ${event || "unnamed"} event`;
+    }
+
+    if (event === "response.failed") {
+      return "response.failed terminal";
+    }
+    if (
+      event === "response.completed" ||
+      event === "response.done" ||
+      event === "response.incomplete"
+    ) {
+      const response = parsed.response as Record<string, unknown> | undefined;
+      terminalStatus =
+        typeof response?.status === "string" ? response.status : null;
+    }
+  }
+
+  if (!terminalStatus) return "missing terminal response status";
+  if (terminalStatus === "failed" || terminalStatus === "cancelled") {
+    return `terminal response status=${terminalStatus}`;
+  }
+  return null;
 }
 
 /**
@@ -2363,9 +2416,9 @@ export function createGatewayLLMClient(
                 // model.
                 if (thinkingStripped) markThinkingUnsupported(model);
 
-                // Guard: some providers (the ChatGPT/Copilot/Codex backend,
-                // DeepSeek) return an SSE stream even when stream: false was
-                // sent — sometimes WITHOUT the text/event-stream content-type.
+                // Guard: Codex workers request streaming, and some other
+                // providers stream even when stream:false was sent — sometimes
+                // WITHOUT the text/event-stream content-type.
                 // Sniff the body: if it's SSE, accumulate the whole stream via
                 // the protocol's accumulator (multi-chunk safe) instead of
                 // JSON-parsing it (which would throw on "data: {...}" / "event:
@@ -2375,6 +2428,32 @@ export function createGatewayLLMClient(
                 const ct = response.headers.get("content-type") ?? "";
                 const bodyText = await response.text();
                 const isSSE = looksLikeSSE(ct, bodyText);
+                if (
+                  isSSE &&
+                  (target.protocol === "openai-codex-responses" ||
+                    target.protocol === "openai-responses")
+                ) {
+                  const streamFailure = validateResponsesWorkerSSE(bodyText);
+                  if (streamFailure) {
+                    log.error(
+                      `worker upstream returned invalid Responses SSE — ${streamFailure}` +
+                        ` — model=${model.providerID}/${model.modelID}` +
+                        ` worker=${opts?.workerID ?? "unknown"}` +
+                        ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
+                    );
+                    span.setStatus({
+                      code: 2,
+                      message: "invalid Responses SSE",
+                    });
+                    recordWorkerFailure(
+                      opts?.sessionID ?? "_unknown",
+                      opts?.workerID ?? "unknown",
+                      "upstream-error",
+                    );
+                    lastWorkerError = `${model.providerID}/${model.modelID}: invalid Responses SSE (${streamFailure})`;
+                    return null;
+                  }
+                }
                 const rawData: Record<string, unknown> = isSSE
                   ? {}
                   : (JSON.parse(bodyText) as Record<string, unknown>);

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -60,12 +60,12 @@ export async function* parseSSEStream(
       buffer += decoder.decode(value, { stream: true });
     }
 
-    // Process complete events (delimited by blank lines: \n\n)
+    // Process complete events (blank-line delimiter; accept LF and CRLF).
     for (;;) {
-      const boundary = buffer.indexOf("\n\n");
-      if (boundary === -1) break;
-      const block = buffer.slice(0, boundary);
-      buffer = buffer.slice(boundary + 2);
+      const boundary = /\r?\n\r?\n/.exec(buffer);
+      if (!boundary) break;
+      const block = buffer.slice(0, boundary.index);
+      buffer = buffer.slice(boundary.index + boundary[0].length);
 
       // Skip empty blocks
       if (block.trim() === "") continue;
@@ -73,7 +73,7 @@ export async function* parseSSEStream(
       let eventType = "message";
       const dataLines: string[] = [];
 
-      for (const line of block.split("\n")) {
+      for (const line of block.split(/\r?\n/)) {
         if (line.startsWith("event:")) {
           eventType = line.slice(6).trim();
         } else if (line.startsWith("data:")) {
@@ -93,7 +93,7 @@ export async function* parseSSEStream(
       if (buffer.trim()) {
         let eventType = "message";
         const dataLines: string[] = [];
-        for (const line of buffer.split("\n")) {
+        for (const line of buffer.split(/\r?\n/)) {
           if (line.startsWith("event:")) {
             eventType = line.slice(6).trim();
           } else if (line.startsWith("data:")) {

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -13,6 +13,7 @@ vi.mock("../src/worker-health", async (importOriginal) => {
     recordWorkerFailure: vi.fn(actual.recordWorkerFailure),
     markWorkerPaused: vi.fn(actual.markWorkerPaused),
     markWorkerIncapable: vi.fn(actual.markWorkerIncapable),
+    recordEmptyWorkerResponse: vi.fn(actual.recordEmptyWorkerResponse),
     markFreeModelsDataBlocked: vi.fn(actual.markFreeModelsDataBlocked),
   };
 });
@@ -20,6 +21,7 @@ vi.mock("../src/worker-health", async (importOriginal) => {
 import {
   backoffMs,
   createGatewayLLMClient,
+  getLastWorkerError,
   maxRetriesFor,
   normalizeOpenAIUsage,
   resolveWorkerProtocol,
@@ -44,7 +46,11 @@ import {
 } from "../src/background-limiter";
 import { upstreamFetch } from "../src/fetch";
 import { clearAllCosts, getSessionCosts } from "../src/cost-tracker";
-import { recordWorkerFailure, markWorkerPaused } from "../src/worker-health";
+import {
+  recordWorkerFailure,
+  markWorkerPaused,
+  recordEmptyWorkerResponse,
+} from "../src/worker-health";
 import {
   markWorkerIncapable,
   markFreeModelsDataBlocked,
@@ -658,6 +664,7 @@ describe("createGatewayLLMClient.prompt", () => {
 
   afterEach(() => {
     mockFetch.mockReset();
+    vi.mocked(recordEmptyWorkerResponse).mockClear();
     clearAllCosts();
     resetBackgroundLimiter();
   });
@@ -726,19 +733,34 @@ describe("createGatewayLLMClient.prompt", () => {
       "openai-beta": "responses=experimental",
     });
 
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
     mockFetch.mockResolvedValue(
       new Response(
-        JSON.stringify({
-          output: [
-            {
-              type: "message",
-              content: [{ type: "output_text", text: "codex worker reply" }],
+        event("response.created", {
+          response: { id: "resp_worker", model: "gpt-5.1-codex-mini" },
+        }) +
+          event("response.output_item.added", {
+            output_index: 0,
+            item: { type: "message", id: "msg_worker", role: "assistant" },
+          }) +
+          event("response.output_text.delta", {
+            output_index: 0,
+            delta: "codex worker ",
+          }) +
+          event("response.output_text.delta", {
+            output_index: 0,
+            delta: "reply",
+          }) +
+          event("response.completed", {
+            response: {
+              id: "resp_worker",
+              model: "gpt-5.1-codex-mini",
+              status: "completed",
+              usage: { input_tokens: 12, output_tokens: 3 },
             },
-          ],
-          model: "gpt-5.1-codex-mini",
-          usage: { input_tokens: 12, output_tokens: 3 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
+          }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
       ),
     );
 
@@ -765,11 +787,129 @@ describe("createGatewayLLMClient.prompt", () => {
     expect(headers.originator).toBe("pi");
     const body = JSON.parse(init?.body as string) as Record<string, unknown>;
     expect(body.store).toBe(false);
+    expect(body.stream).toBe(true);
     expect(body.model).toBe("gpt-5.1-codex-mini");
     expect(Array.isArray(body.input)).toBe(true);
     // ChatGPT Codex rejects max_output_tokens — worker calls must omit it.
     expect(body.max_output_tokens).toBeUndefined();
+    const distillationCost =
+      getSessionCosts("sess-codex")?.workers.distillation;
+    expect(distillationCost?.calls).toBe(1);
+    expect(distillationCost?.cost).toBeGreaterThan(0);
   });
+
+  test.each([
+    [
+      "failed terminal",
+      `event: response.failed\ndata: ${JSON.stringify({
+        response: { status: "failed", error: { message: "upstream failed" } },
+      })}\n\n`,
+      "response.failed terminal",
+    ],
+    [
+      "malformed event",
+      "event: response.output_text.delta\ndata: {not-json}\n\n",
+      "malformed response.output_text.delta event",
+    ],
+    [
+      "missing terminal",
+      `event: response.output_text.delta\ndata: ${JSON.stringify({
+        output_index: 0,
+        delta: "partial",
+      })}\n\n`,
+      "missing terminal response status",
+    ],
+    [
+      "failed status",
+      `event: response.completed\ndata: ${JSON.stringify({
+        response: { status: "failed" },
+      })}\n\n`,
+      "terminal response status=failed",
+    ],
+    [
+      "cancelled status",
+      `event: response.completed\ndata: ${JSON.stringify({
+        response: { status: "cancelled" },
+      })}\n\n`,
+      "terminal response status=cancelled",
+    ],
+  ])(
+    "openai-codex worker classifies %s SSE as upstream-error, never model incapability",
+    async (_case, stream, diagnostic) => {
+      mockFetch.mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+      );
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "bearer", value: "jwt-token" }),
+        { providerID: "openai-codex", modelID: "gpt-5.1-codex-mini" },
+      );
+
+      const text = await client.prompt("system", "user", {
+        sessionID: "sess-codex-failed-stream",
+        workerID: "lore-distill",
+        upstreamUrl: "https://chatgpt.com/backend-api",
+        protocol: "openai-responses",
+      });
+
+      expect(text).toBeNull();
+      expect(recordWorkerFailure).toHaveBeenCalledWith(
+        "sess-codex-failed-stream",
+        "lore-distill",
+        "upstream-error",
+      );
+      expect(recordEmptyWorkerResponse).not.toHaveBeenCalled();
+      expect(markWorkerIncapable).not.toHaveBeenCalled();
+      expect(getLastWorkerError()).toContain(diagnostic);
+    },
+  );
+
+  test.each(["response.done", "response.incomplete"])(
+    "openai-codex worker accepts %s with CRLF framing",
+    async (terminalEvent) => {
+      const event = (type: string, data: Record<string, unknown>) =>
+        `event: ${type}\r\ndata: ${JSON.stringify(data)}\r\n\r\n`;
+      mockFetch.mockResolvedValue(
+        new Response(
+          event("response.output_item.added", {
+            output_index: 0,
+            item: { type: "message", id: "msg_worker", role: "assistant" },
+          }) +
+            event("response.output_text.delta", {
+              output_index: 0,
+              delta: "codex CRLF reply",
+            }) +
+            event(terminalEvent, {
+              response: {
+                status:
+                  terminalEvent === "response.incomplete"
+                    ? "incomplete"
+                    : "completed",
+              },
+            }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      );
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "bearer", value: "jwt-token" }),
+        { providerID: "openai-codex", modelID: "gpt-5.1-codex-mini" },
+      );
+
+      const text = await client.prompt("system", "user", {
+        sessionID: `sess-codex-${terminalEvent}`,
+        workerID: "lore-distill",
+        upstreamUrl: "https://chatgpt.com/backend-api",
+        protocol: "openai-responses",
+      });
+
+      expect(text).toBe("codex CRLF reply");
+      expect(recordEmptyWorkerResponse).not.toHaveBeenCalled();
+    },
+  );
 
   test("bedrock-mantle worker remaps body.model to the mantle catalog id", async () => {
     // A Bedrock session's worker (distillation/curation) routes to the session's

--- a/packages/gateway/test/stream-anthropic.test.ts
+++ b/packages/gateway/test/stream-anthropic.test.ts
@@ -98,6 +98,28 @@ describe("parseSSEStream", () => {
     expect(events).toEqual([{ event: "message_start", data: '{"x":1}' }]);
   });
 
+  test.each([1, 2, 3])(
+    "handles a CRLF delimiter split after byte %i",
+    async (split) => {
+      const prefix = 'event: message_start\r\ndata: {"x":1}';
+      const delimiter = "\r\n\r\n";
+      const events = await collect(
+        readerFromChunks([
+          prefix + delimiter.slice(0, split),
+          delimiter.slice(split),
+        ]),
+      );
+      expect(events).toEqual([{ event: "message_start", data: '{"x":1}' }]);
+    },
+  );
+
+  test("flushes a trailing CRLF block without a final blank line", async () => {
+    const events = await collect(
+      readerFromChunks(["event: message_stop\r\ndata: {}"]),
+    );
+    expect(events).toEqual([{ event: "message_stop", data: "{}" }]);
+  });
+
   test("flushes a trailing block that lacks a final blank line", async () => {
     const events = await collect(
       readerFromChunks(["event: message_stop\ndata: {}"]),


### PR DESCRIPTION
## Summary

- send `stream: true` for ChatGPT Codex worker requests, which reject non-streaming requests with `400 Stream must be set to true`
- validate buffered Responses SSE before treating an empty worker result as model incapability
- support CRLF SSE framing in the shared parser and cover every delimiter chunk boundary

## Validation

- `pnpm exec vitest run packages/gateway/test/llm-adapter.test.ts packages/gateway/test/openai-responses-stream.test.ts packages/gateway/test/stream-anthropic.test.ts packages/gateway/test/openai-codex.test.ts packages/gateway/test/worker-model.test.ts` (`281/281` passed)
- `pnpm --filter @loreai/gateway run typecheck`
- `pnpm run format:check`
- `pnpm run lint` (existing warnings only)
- adversarial review: `MERGE`
- full suite: `7240/7242` passed; the two failures reproduce outside this diff: `agents.test.ts` cannot discover a Git remote in the jj workspace, and `team-cmd.test.ts:920` uses `expect.anything()` despite its comment allowing `undefined`
