### PR TITLE
fix(cli): make data previews side-effect free

### DIFF
--- a/packages/gateway/src/cli/commands/data.ts
+++ b/packages/gateway/src/cli/commands/data.ts
@@ -26,9 +26,8 @@ import { UsageError } from "../lib/errors";
 import { runLegacyAndCollect } from "../lib/legacy-bridge";
 import { commandData, confirm } from "../data";
 
-// These commands write by default. Preview-first operations such as dedup,
-// split, and consolidate retain their legacy --yes-to-apply behavior and
-// must not be promoted into mutations by this wrapper.
+// Commands which write on their normal path. Preview-first operations remain
+// separate so a missing --yes continues to select their proven no-write path.
 export const WRITE_DATA_SUBCOMMANDS = new Set([
   "clear",
   "delete",
@@ -186,6 +185,12 @@ export const dataCommand = buildOutputCommand<
   async handler(flags, ...positionals) {
     const subcommand = positionals[0];
     const json = (flags as { json?: boolean }).json === true;
+    if (json && flags.interactive) {
+      throw new UsageError({
+        message: "--interactive cannot be used with --json.",
+        tryCommand: `lore data ${subcommand ?? "<command>"} --yes`,
+      });
+    }
     const writesByDefault =
       subcommand !== undefined &&
       WRITE_DATA_SUBCOMMANDS.has(subcommand) &&

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -2127,10 +2127,9 @@ async function cmdMove(
       const includeChildren = flags["no-children"] !== true;
 
       // Resolve session IDs via prefix matching
-      const sourceProject = data
-        .listProjects()
-        .find((project) => project.path === projectPath);
-      const allSessions = sourceProject
+      const { projectId } = await import("@loreai/core");
+      const sourceProjectId = projectId(projectPath);
+      const allSessions = sourceProjectId
         ? data.listSessions(projectPath, 10000)
         : [];
       const resolved: string[] = [];
@@ -2184,8 +2183,9 @@ async function cmdMove(
         return;
       }
 
-      const { ensureProject } = await import("@loreai/core");
-      const sourceProjectId = ensureProject(projectPath);
+      if (!sourceProjectId) {
+        throw new Error(`Project not found for sessions at ${projectPath}`);
+      }
 
       if (!skipConfirm) {
         const confirmed = await confirm(
@@ -2522,22 +2522,22 @@ async function cmdSplit(
   const minConfidence = (flags["min-confidence"] as string) ?? "high";
   const projectPath = resolve((flags.project as string) ?? process.cwd());
 
-  const sourceProject = data
-    .listProjects()
-    .find((project) => project.path === projectPath);
-  const sessions = sourceProject ? data.listSessions(projectPath, 10000) : [];
+  const { projectId } = await import("@loreai/core");
+  const sourceProjectId = projectId(projectPath);
+  const sessions = sourceProjectId ? data.listSessions(projectPath, 10000) : [];
 
   if (!sessions.length) {
     if (!asJson) console.log("No sessions found in project.");
     return;
   }
-
-  const sourceProjectId = sourceProject?.id;
+  if (!sourceProjectId) {
+    throw new Error(`Project not found for sessions at ${projectPath}`);
+  }
 
   // Suggest targets for all sessions
   const suggestions = suggestProjectsForSessions(
     sessions.map((s) => s.session_id),
-    sourceProjectId ?? "",
+    sourceProjectId,
     projectPath,
   );
 
@@ -3220,16 +3220,14 @@ async function cmdCacheStats(
     process.exit(1);
   }
 
-  const { data, getCacheBustStats, summarizeCacheBustStats } =
+  const { getCacheBustStats, projectId, summarizeCacheBustStats } =
     await import("@loreai/core");
 
   let projectID: string | undefined;
   let scopeLabel = "all projects";
   if (flags.project) {
     const projectPath = resolve(flags.project as string);
-    projectID = data
-      .listProjects()
-      .find((project) => project.path === projectPath)?.id;
+    projectID = projectId(projectPath);
     if (!projectID) {
       console.error(`No tracked project found at ${projectPath}.`);
       process.exitCode = 1;

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -954,7 +954,7 @@ async function cmdDedup(
     projectId: getProjectId,
     embedding: emb,
   } = await import("@loreai/core");
-  const apply = !!flags.yes;
+  const apply = !!flags.yes && flags["dry-run"] !== true;
   const interactive = !!flags.interactive;
   const asJson = !!flags.json;
   const explicitProject =
@@ -988,10 +988,8 @@ async function cmdDedup(
     return;
   }
 
-  // Auto-reindex if embedding config changed (e.g. model migration)
-  // or if there are entries missing embeddings. backfillEmbeddings()
-  // calls checkConfigChange() internally — no need to call it separately.
-  if (emb.isAvailable()) {
+  // Reindexing changes persistent state, so previews never perform it.
+  if (apply && emb.isAvailable()) {
     try {
       const knowledgeCount = await emb.backfillEmbeddings();
       // Also backfill distillations — checkConfigChange() inside
@@ -2119,8 +2117,6 @@ async function cmdMove(
 
   switch (type) {
     case "session": {
-      const { ensureProject } = await import("@loreai/core");
-      const sourceProjectId = ensureProject(projectPath);
       const targetPath = await resolveTargetPath(rawTo);
       const includeChildren = flags["no-children"] !== true;
 
@@ -2176,6 +2172,9 @@ async function cmdMove(
         console.log("\nDry run — no changes made.");
         return;
       }
+
+      const { ensureProject } = await import("@loreai/core");
+      const sourceProjectId = ensureProject(projectPath);
 
       if (!skipConfirm) {
         const confirmed = await confirm(
@@ -2501,7 +2500,7 @@ async function cmdSplit(
     process.exit(1);
   }
 
-  const { data, ensureProject } = await import("@loreai/core");
+  const { data } = await import("@loreai/core");
   const { suggestProjectsForSessions } = await import("../suggest");
 
   const skipConfirm = !!flags.yes;
@@ -2512,7 +2511,6 @@ async function cmdSplit(
   const minConfidence = (flags["min-confidence"] as string) ?? "high";
   const projectPath = resolve((flags.project as string) ?? process.cwd());
 
-  const sourceProjectId = ensureProject(projectPath);
   const sessions = data.listSessions(projectPath, 10000);
 
   if (!sessions.length) {
@@ -2520,10 +2518,14 @@ async function cmdSplit(
     return;
   }
 
+  const sourceProjectId = data
+    .listProjects()
+    .find((project) => project.path === projectPath)?.id;
+
   // Suggest targets for all sessions
   const suggestions = suggestProjectsForSessions(
     sessions.map((s) => s.session_id),
-    sourceProjectId,
+    sourceProjectId ?? "",
     projectPath,
   );
 
@@ -2631,6 +2633,10 @@ async function cmdSplit(
       );
     }
     return;
+  }
+
+  if (!sourceProjectId) {
+    throw new Error(`Project not found for sessions at ${projectPath}`);
   }
 
   // --- Interactive review (item 2): let the operator inspect and confirm/skip
@@ -3202,14 +3208,21 @@ async function cmdCacheStats(
     process.exit(1);
   }
 
-  const { getCacheBustStats, summarizeCacheBustStats, ensureProject } =
+  const { data, getCacheBustStats, summarizeCacheBustStats } =
     await import("@loreai/core");
 
   let projectID: string | undefined;
   let scopeLabel = "all projects";
   if (flags.project) {
     const projectPath = resolve(flags.project as string);
-    projectID = ensureProject(projectPath);
+    projectID = data
+      .listProjects()
+      .find((project) => project.path === projectPath)?.id;
+    if (!projectID) {
+      console.error(`No tracked project found at ${projectPath}.`);
+      process.exitCode = 1;
+      return;
+    }
     scopeLabel = projectPath;
   }
 

--- a/packages/gateway/src/cli/data.ts
+++ b/packages/gateway/src/cli/data.ts
@@ -1047,6 +1047,12 @@ async function cmdDedup(
   }> = [];
 
   for (const project of projects) {
+    if (!apply && !getProjectId(project.path)) {
+      console.log(
+        `[${project.name}] No tracked project found; nothing to scan.`,
+      );
+      continue;
+    }
     let result: Awaited<ReturnType<typeof ltm.deduplicate>>;
     try {
       result = await ltm.deduplicate(project.path, { dryRun: !apply });
@@ -2121,7 +2127,12 @@ async function cmdMove(
       const includeChildren = flags["no-children"] !== true;
 
       // Resolve session IDs via prefix matching
-      const allSessions = data.listSessions(projectPath, 10000);
+      const sourceProject = data
+        .listProjects()
+        .find((project) => project.path === projectPath);
+      const allSessions = sourceProject
+        ? data.listSessions(projectPath, 10000)
+        : [];
       const resolved: string[] = [];
       for (const rawId of rawIds) {
         const match = allSessions.find((s) => s.session_id.startsWith(rawId));
@@ -2511,16 +2522,17 @@ async function cmdSplit(
   const minConfidence = (flags["min-confidence"] as string) ?? "high";
   const projectPath = resolve((flags.project as string) ?? process.cwd());
 
-  const sessions = data.listSessions(projectPath, 10000);
+  const sourceProject = data
+    .listProjects()
+    .find((project) => project.path === projectPath);
+  const sessions = sourceProject ? data.listSessions(projectPath, 10000) : [];
 
   if (!sessions.length) {
     if (!asJson) console.log("No sessions found in project.");
     return;
   }
 
-  const sourceProjectId = data
-    .listProjects()
-    .find((project) => project.path === projectPath)?.id;
+  const sourceProjectId = sourceProject?.id;
 
   // Suggest targets for all sessions
   const suggestions = suggestProjectsForSessions(

--- a/packages/gateway/test/cli-data-contract.test.ts
+++ b/packages/gateway/test/cli-data-contract.test.ts
@@ -1,14 +1,12 @@
 /**
- * Phase 3C slice 1 — typed `lore data` with variadic positional + 9 flags.
+ * Phase 3C slice 2 — typed `lore data` with variadic positional + 14 flags.
  *
  * Pins the typed wrapper for `lore data`. The legacy handler takes a
  * subcommand as `positionals[0]` plus subcommand-specific args, and
- * reads 9 flags from the values dict.
+ * reads 14 flags from the values dict.
  *
- * Slice 1 covers the read-only subcommands (list, show, cache-stats).
- * Destructive subcommands (delete, clear, merge, dedup, etc.) remain
- * in LEGACY_ROUTES via the legacy commandData dispatcher; the typed
- * variadic positional forwards them by subcommand name.
+ * The typed wrapper owns machine-mode confirmation while preserving each
+ * legacy handler's own prompt and preview behavior.
  */
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { WRITE_DATA_SUBCOMMANDS } from "../src/cli/commands/data";
@@ -250,6 +248,39 @@ describe("Phase 3C slice 1 — typed lore data (read-only)", () => {
     expect(dataImpl).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();
     expect(capturedExitCode).toBe(20);
+    vi.resetModules();
+  });
+
+  test("data --json rejects interactive flows before the legacy handler", async () => {
+    vi.resetModules();
+    const dataImpl = vi.fn(async () => {});
+    vi.doMock("../src/cli/data", () => ({ commandData: dataImpl }));
+    const { runCli } = await import("../src/cli/cli");
+    const stderrChunks: Buffer[] = [];
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk) => {
+        stderrChunks.push(
+          Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+        );
+        return true;
+      });
+    process.argv = ["node", "lore", "data", "dedup", "--interactive", "--json"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      stderrSpy.mockRestore();
+      process.exitCode = priorExitCode;
+    }
+    expect(dataImpl).not.toHaveBeenCalled();
+    expect(capturedExitCode).toBe(20);
+    expect(Buffer.concat(stderrChunks).toString("utf8")).toContain(
+      "--interactive cannot be used with --json",
+    );
     vi.resetModules();
   });
 

--- a/packages/gateway/test/data-dedup-policy.test.ts
+++ b/packages/gateway/test/data-dedup-policy.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ltm } from "@loreai/core";
+import { commandData } from "../src/cli/data";
+
+let projectDir: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "lore-data-dedup-"));
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("lore data dedup safety policy", () => {
+  test("--dry-run overrides --yes and preserves duplicate entries", async () => {
+    const first = ltm.create({
+      projectPath: projectDir,
+      category: "decision",
+      title: "Keep this duplicate",
+      content: "The same decision content.",
+      scope: "project",
+    });
+    const second = ltm.create({
+      projectPath: projectDir,
+      category: "decision",
+      title: "Keep this duplicate",
+      content: "The same decision content.",
+      scope: "project",
+    });
+
+    await commandData(["dedup"], {
+      project: projectDir,
+      yes: true,
+      "dry-run": true,
+    });
+
+    expect(ltm.get(first)).not.toBeNull();
+    expect(ltm.get(second)).not.toBeNull();
+  });
+});

--- a/packages/gateway/test/data-dedup-policy.test.ts
+++ b/packages/gateway/test/data-dedup-policy.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { data, ltm } from "@loreai/core";
+import { data, db, ensureProject, ltm, projectId } from "@loreai/core";
 import { commandData } from "../src/cli/data";
 
 let projectDir: string;
@@ -19,6 +19,53 @@ afterEach(() => {
 });
 
 describe("lore data dedup safety policy", () => {
+  test.each([
+    [
+      "move",
+      () => ({
+        project: join(projectDir, "worktree"),
+        to: projectDir,
+        "dry-run": true,
+      }),
+      () => ["move", "session", "missing-session"],
+      true,
+    ],
+    [
+      "split",
+      () => ({ project: join(projectDir, "worktree") }),
+      () => ["split"],
+      false,
+    ],
+    [
+      "cache-stats",
+      () => ({ project: join(projectDir, "worktree") }),
+      () => ["cache-stats"],
+      false,
+    ],
+  ])(
+    "%s resolves an alias without creating a project",
+    async (_name, flagsFor, argsFor, expectsFailure) => {
+      const canonicalId = ensureProject(projectDir);
+      const aliasPath = join(projectDir, "worktree");
+      db()
+        .query(
+          "INSERT INTO project_path_aliases (path, project_id) VALUES (?, ?)",
+        )
+        .run(aliasPath, canonicalId);
+      const projectCount = data.listProjects().length;
+
+      expect(projectId(aliasPath)).toBe(canonicalId);
+      const command = commandData(argsFor(), flagsFor());
+      if (expectsFailure) {
+        await expect(command).rejects.toThrow();
+      } else {
+        await command;
+      }
+
+      expect(data.listProjects()).toHaveLength(projectCount);
+    },
+  );
+
   test.each([
     [
       "move",

--- a/packages/gateway/test/data-dedup-policy.test.ts
+++ b/packages/gateway/test/data-dedup-policy.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { ltm } from "@loreai/core";
+import { data, ltm } from "@loreai/core";
 import { commandData } from "../src/cli/data";
 
 let projectDir: string;
@@ -19,21 +19,67 @@ afterEach(() => {
 });
 
 describe("lore data dedup safety policy", () => {
-  test("--dry-run overrides --yes and preserves duplicate entries", async () => {
+  test.each([
+    [
+      "move",
+      () => ({ project: projectDir, to: projectDir, "dry-run": true }),
+      ["move", "session", "missing-session"],
+      true,
+    ],
+    ["split", () => ({ project: projectDir }), ["split"], undefined],
+  ])(
+    "%s preview does not create an untracked project",
+    async (_name, flagsFor, args, expectsFailure) => {
+      expect(data.listProjects()).not.toContainEqual(
+        expect.objectContaining({ path: projectDir }),
+      );
+
+      const command = commandData(args, flagsFor());
+      if (expectsFailure) {
+        await expect(command).rejects.toThrow();
+      } else {
+        await command;
+      }
+
+      expect(data.listProjects()).not.toContainEqual(
+        expect.objectContaining({ path: projectDir }),
+      );
+    },
+  );
+
+  test("--dry-run does not create an untracked project", async () => {
+    expect(data.listProjects()).not.toContainEqual(
+      expect.objectContaining({ path: projectDir }),
+    );
+
+    await commandData(["dedup"], {
+      project: projectDir,
+      yes: true,
+      "dry-run": true,
+    });
+
+    expect(data.listProjects()).not.toContainEqual(
+      expect.objectContaining({ path: projectDir }),
+    );
+  });
+
+  test("--dry-run overrides --yes and preserves a real duplicate cluster", async () => {
     const first = ltm.create({
       projectPath: projectDir,
       category: "decision",
-      title: "Keep this duplicate",
-      content: "The same decision content.",
+      title: "Prefer idempotent writes",
+      content: "Use atomic writes for generated skill files.",
       scope: "project",
     });
     const second = ltm.create({
       projectPath: projectDir,
       category: "decision",
-      title: "Keep this duplicate",
-      content: "The same decision content.",
+      title: "Use atomic skill writes",
+      content: "Use atomic writes for generated skill files.",
       scope: "project",
     });
+
+    expect(first).not.toBe(second);
 
     await commandData(["dedup"], {
       project: projectDir,


### PR DESCRIPTION
## Summary
- prevent dedup --yes --dry-run from applying deletions or backfilling embeddings
- keep move, split, and cache-stats preview/read paths from creating project records
- reject --interactive in --json mode before the legacy handler runs

## Verification
- focused data command tests
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check

## Full suite
The gateway suite had 3,783 passing tests and four unrelated pre-existing failures: two import-auth preference cases, a cache-stability timeout, and a 502 replay fixture.