### PR TITLE
fix(gateway): continue Responses streams after recall

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1924,6 +1924,12 @@ const MIGRATIONS: string[] = [
     updated_at  INTEGER NOT NULL DEFAULT 0
   );
   `,
+  // Version 78: local credential scope for header-based session identity.
+  // Credentials may separate sessions but NEVER scope project rows.
+  `ALTER TABLE session_state ADD COLUMN credential_fingerprint TEXT NOT NULL DEFAULT '';`,
+  // Version 79: local-only routing snapshot for restart-safe explicit compaction.
+  // Auth headers are excluded before serialization by gateway forwardClientHeaders().
+  `ALTER TABLE session_state ADD COLUMN last_upstream TEXT;`,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -4855,6 +4861,9 @@ export type SessionTrackingState = {
   fingerprint?: string;
   headerSessionId?: string | null;
   headerName?: string | null;
+  credentialFingerprint?: string;
+  /** JSON-serialized non-auth routing snapshot for restart-safe compaction. */
+  lastUpstream?: string | null;
   // v24: cache warming
   resolvedConversationTTL?: string;
   warmupState?: string | null; // JSON blob
@@ -4964,6 +4973,14 @@ export function saveSessionTracking(
     sets.push("header_name = ?");
     vals.push(state.headerName);
   }
+  if (state.credentialFingerprint !== undefined) {
+    sets.push("credential_fingerprint = ?");
+    vals.push(state.credentialFingerprint);
+  }
+  if (state.lastUpstream !== undefined) {
+    sets.push("last_upstream = ?");
+    vals.push(state.lastUpstream);
+  }
   // v24: cache warming
   if (state.resolvedConversationTTL !== undefined) {
     sets.push("resolved_conversation_ttl = ?");
@@ -5057,6 +5074,8 @@ export type LoadedSessionTracking = {
   fingerprint: string;
   headerSessionId: string | null;
   headerName: string | null;
+  credentialFingerprint: string;
+  lastUpstream: string | null;
   // v24: cache warming
   resolvedConversationTTL: string;
   warmupState: string | null;
@@ -5397,7 +5416,8 @@ export function loadSessionTracking(
               ltm_cache_text, ltm_cache_tokens, ltm_pin_text, ltm_pin_tokens,
               ltm_pin_keys, stable_ltm_text, stable_ltm_tokens, recall_store,
               dedup_decisions,
-              fingerprint, header_session_id, header_name,
+               fingerprint, header_session_id, header_name, credential_fingerprint,
+               last_upstream,
               resolved_conversation_ttl, warmup_state,
               dynamic_context_cap, bust_rate_ema, inter_bust_interval_ema,
               last_layer, last_known_input, last_known_message_count,
@@ -5424,6 +5444,8 @@ export function loadSessionTracking(
     fingerprint: string;
     header_session_id: string | null;
     header_name: string | null;
+    credential_fingerprint: string;
+    last_upstream: string | null;
     resolved_conversation_ttl: string;
     warmup_state: string | null;
     dynamic_context_cap: number;
@@ -5458,6 +5480,8 @@ export function loadSessionTracking(
     fingerprint: row.fingerprint,
     headerSessionId: row.header_session_id,
     headerName: row.header_name,
+    credentialFingerprint: row.credential_fingerprint,
+    lastUpstream: row.last_upstream,
     resolvedConversationTTL: row.resolved_conversation_ttl,
     warmupState: row.warmup_state,
     dynamicContextCap: row.dynamic_context_cap,
@@ -5488,13 +5512,15 @@ export function loadSessionTracking(
  */
 export function findSessionStatesByFingerprint(
   fingerprint: string,
+  options?: { legacyUnownedOnly?: boolean },
 ): Array<{ session_id: string; message_count: number; is_subagent: number }> {
   if (!fingerprint) return [];
   return db()
     .query(
       `SELECT session_id, message_count, is_subagent
          FROM session_state
-        WHERE fingerprint = ? AND fingerprint != ''`,
+        WHERE fingerprint = ? AND fingerprint != ''
+          ${options?.legacyUnownedOnly ? "AND credential_fingerprint = ''" : ""}`,
     )
     .all(fingerprint) as Array<{
     session_id: string;
@@ -5549,10 +5575,11 @@ export function loadHeaderSessionIndex(): Array<{
   sessionId: string;
   headerSessionId: string;
   headerName: string;
+  credentialFingerprint: string;
 }> {
   const rows = db()
     .query(
-      `SELECT session_id, header_session_id, header_name
+      `SELECT session_id, header_session_id, header_name, credential_fingerprint
         FROM session_state
         WHERE header_session_id IS NOT NULL AND header_name IS NOT NULL
         ORDER BY updated_at ASC`,
@@ -5561,11 +5588,13 @@ export function loadHeaderSessionIndex(): Array<{
     session_id: string;
     header_session_id: string;
     header_name: string;
+    credential_fingerprint: string;
   }>;
   return rows.map((row) => ({
     sessionId: row.session_id,
     headerSessionId: row.header_session_id,
     headerName: row.header_name,
+    credentialFingerprint: row.credential_fingerprint,
   }));
 }
 

--- a/packages/core/src/fetch-interceptor.ts
+++ b/packages/core/src/fetch-interceptor.ts
@@ -20,6 +20,8 @@ export type FetchInterceptorConfig = {
    * Called per-request so values can change (e.g., session ID).
    */
   getHeaders: () => Record<string, string>;
+  /** Observe LLM request headers in memory before gateway routing. */
+  onRequestHeaders?: (headers: Headers) => void;
 };
 
 /**
@@ -404,6 +406,18 @@ function buildGatewayHeaders(
   return headers;
 }
 
+function observeRequestHeaders(
+  headers: Headers,
+  config: FetchInterceptorConfig,
+): void {
+  if (!config.onRequestHeaders) return;
+  try {
+    config.onRequestHeaders(headers);
+  } catch (e) {
+    log.error("fetch-interceptor: onRequestHeaders() failed:", e);
+  }
+}
+
 export function installFetchInterceptor(
   config: FetchInterceptorConfig,
 ): () => void {
@@ -454,8 +468,18 @@ export function installFetchInterceptor(
       return originalFetch(input, init);
     }
 
-    // Never intercept requests already going to the gateway
-    if (url.startsWith(gatewayBase)) return originalFetch(input, init);
+    // Never intercept requests already going to the gateway, but still observe
+    // their auth so in-process extensions can scope side-channel requests.
+    if (url.startsWith(gatewayBase)) {
+      const directHeaders = new Headers(
+        init?.headers ??
+          (typeof input !== "string" && !(input instanceof URL)
+            ? input.headers
+            : undefined),
+      );
+      observeRequestHeaders(directHeaders, config);
+      return originalFetch(input, init);
+    }
 
     // Never intercept local requests (could be local LLM or gateway itself)
     const host = upstream.hostname;
@@ -485,6 +509,7 @@ export function installFetchInterceptor(
         rewrite.upstreamPath,
         config,
       );
+      observeRequestHeaders(headers, config);
       log.info(
         `fetch-interceptor: ${upstream.host}${upstream.pathname} → gateway`,
       );
@@ -508,6 +533,7 @@ export function installFetchInterceptor(
           rewrite.upstreamPath,
           config,
         );
+        observeRequestHeaders(headers, config);
         log.info(
           `fetch-interceptor: ${upstream.host}${upstream.pathname} → gateway (body-detected ${detected})`,
         );

--- a/packages/core/src/gradient.ts
+++ b/packages/core/src/gradient.ts
@@ -55,7 +55,7 @@ function estimateParts(parts: LorePart[]): number {
 }
 
 function estimateMessage(msg: MessageWithParts): number {
-  return estimateParts(msg.parts) + 20; // role/metadata overhead
+  return estimateParts(msg.parts) + (msg.hiddenInputTokens ?? 0) + 20;
 }
 
 // Cached model context limit — set by system transform hook, used by message transform
@@ -4022,6 +4022,7 @@ function transformInner(input: {
   const currentTurn = input.messages.slice(nuclearTurnStart).map((m) => ({
     info: m.info,
     parts: cleanParts(m.parts),
+    hiddenInputTokens: m.hiddenInputTokens,
   }));
   const currentTurnTokens = currentTurn.reduce(
     (sum, m) => sum + estimateMessage(m),
@@ -4039,6 +4040,7 @@ function transformInner(input: {
     olderMessages.unshift({
       info: msg.info,
       parts: cleanParts(msg.parts),
+      hiddenInputTokens: msg.hiddenInputTokens,
     });
     olderTokens += est;
   }

--- a/packages/core/src/import/auth/opencode.ts
+++ b/packages/core/src/import/auth/opencode.ts
@@ -91,7 +91,7 @@ function normalizeProvider(key: string): string {
  * usable config is found — callers preserve the original iteration order in
  * that case.
  */
-export function getOpenCodeActiveProvider(): string | null {
+export function getOpenCodeActiveProvider(projectDir = cwd()): string | null {
   // OpenCode's documented config precedence (from opencode.ai/docs/config):
   // managed > project > user config > remote > built-in defaults. For
   // `lore import` we read only the two on-disk sources (managed/remote don't
@@ -100,7 +100,7 @@ export function getOpenCodeActiveProvider(): string | null {
   // project-local override would be silently shadowed by a stale global
   // setting — and the importer would route against the wrong provider.
   const candidates = [
-    join(cwd(), "opencode.json"),
+    join(projectDir, "opencode.json"),
     join(xdgConfigHome(), "opencode", "opencode.json"),
   ];
   for (const cfgPath of candidates) {

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -73,6 +73,8 @@ export type RecallInput = {
   knowledgeEnabled?: boolean;
   /** Optional LLM client for query expansion (if `config.search.queryExpansion`). */
   llm?: LLMClient;
+  /** Abort in-flight query expansion when the owning client disconnects. */
+  signal?: AbortSignal;
   /** Search config — provides recallLimit, queryExpansion, ftsWeights, etc. */
   searchConfig?: LoreConfig["search"];
   /**
@@ -764,6 +766,26 @@ function renderResultLine(
 export async function searchRecall(
   input: RecallInput,
 ): Promise<ScoredTaggedResult[]> {
+  input.signal?.throwIfAborted();
+  const abortable = async <T>(promise: Promise<T>): Promise<T> => {
+    const signal = input.signal;
+    if (!signal) return promise;
+    signal.throwIfAborted();
+    return new Promise<T>((resolve, reject) => {
+      const onAbort = (): void => reject(signal.reason);
+      signal.addEventListener("abort", onAbort, { once: true });
+      void promise.then(
+        (value) => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(value);
+        },
+        (err) => {
+          signal.removeEventListener("abort", onAbort);
+          reject(err);
+        },
+      );
+    });
+  };
   const {
     query,
     scope = "all",
@@ -808,10 +830,14 @@ export async function searchRecall(
     queryTermCount <= expansionMaxTerms
   ) {
     try {
-      queries = await timer.await(
-        expandQuery(llm, query, undefined, sessionID),
+      queries = await abortable(
+        timer.await(
+          expandQuery(llm, query, undefined, sessionID, input.signal),
+        ),
       );
+      input.signal?.throwIfAborted();
     } catch (err) {
+      if (input.signal?.aborted) throw input.signal.reason;
       log.info("recall: query expansion failed, using original:", err);
     }
   }
@@ -861,18 +887,23 @@ export async function searchRecall(
   let primaryListEnd = 0;
 
   for (const q of queries) {
+    input.signal?.throwIfAborted();
     const knowledgeResults: ltm.ScoredKnowledgeEntry[] = [];
     if (knowledgeEnabled && scope !== "session") {
       try {
+        input.signal?.throwIfAborted();
         knowledgeResults.push(
-          ...(await ltm.searchScored({
-            query: q,
-            projectPath,
-            limit,
-            termWeights: idfWeights,
-          })),
+          ...(await abortable(
+            ltm.searchScored({
+              query: q,
+              projectPath,
+              limit,
+              termWeights: idfWeights,
+            }),
+          )),
         );
       } catch (err) {
+        if (input.signal?.aborted) throw input.signal.reason;
         log.error("recall: knowledge search failed:", err);
       }
     }
@@ -880,16 +911,20 @@ export async function searchRecall(
     const distillationResults: ScoredDistillation[] = [];
     if (scope !== "knowledge") {
       try {
+        input.signal?.throwIfAborted();
         distillationResults.push(
-          ...(await searchDistillationsScored({
-            projectPath,
-            query: q,
-            sessionID: scope === "session" ? sessionID : undefined,
-            limit,
-            termWeights: idfWeights,
-          })),
+          ...(await abortable(
+            searchDistillationsScored({
+              projectPath,
+              query: q,
+              sessionID: scope === "session" ? sessionID : undefined,
+              limit,
+              termWeights: idfWeights,
+            }),
+          )),
         );
       } catch (err) {
+        if (input.signal?.aborted) throw input.signal.reason;
         log.error("recall: distillation search failed:", err);
       }
     }
@@ -897,16 +932,20 @@ export async function searchRecall(
     const temporalResults: temporal.ScoredTemporalMessage[] = [];
     if (scope !== "knowledge") {
       try {
+        input.signal?.throwIfAborted();
         temporalResults.push(
-          ...(await temporal.searchScored({
-            projectPath,
-            query: q,
-            sessionID: scope === "session" ? sessionID : undefined,
-            limit,
-            termWeights: idfWeights,
-          })),
+          ...(await abortable(
+            temporal.searchScored({
+              projectPath,
+              query: q,
+              sessionID: scope === "session" ? sessionID : undefined,
+              limit,
+              termWeights: idfWeights,
+            }),
+          )),
         );
       } catch (err) {
+        if (input.signal?.aborted) throw input.signal.reason;
         log.error("recall: temporal search failed:", err);
       }
     }
@@ -1022,9 +1061,8 @@ export async function searchRecall(
   // Vector search on the original query (not expansions — avoid redundant embeds).
   if (embedding.isAvailable() && scope !== "session") {
     try {
-      const [queryVec] = await timer.await(
-        embedding.embed([query], "query"),
-        "embed",
+      const [queryVec] = await abortable(
+        timer.await(embedding.embed([query], "query"), "embed"),
       );
 
       // Knowledge vector search
@@ -1037,16 +1075,16 @@ export async function searchRecall(
         // vector path mirrors the main, project-scoped search. Mirrors the
         // entity-vector visibility filter below.
         const knowledgePid = ensureProject(projectPath);
-        const vectorHits = await timer.await(
-          embedding.vectorSearch(queryVec, limit),
-          "vectorSearch",
+        const vectorHits = await abortable(
+          timer.await(embedding.vectorSearch(queryVec, limit), "vectorSearch"),
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit ltm.get().
-        const entryMap = await timer.await(
-          ltm.getManyOffloaded(vectorHits.map((h) => h.id)),
+        const entryMap = await abortable(
+          timer.await(ltm.getManyOffloaded(vectorHits.map((h) => h.id))),
         );
         const vectorTagged: TaggedResult[] = [];
         for (const hit of vectorHits) {
+          input.signal?.throwIfAborted();
           const entry = entryMap.get(hit.id);
           if (entry) {
             const visible =
@@ -1075,15 +1113,19 @@ export async function searchRecall(
 
       // Distillation vector search
       if (scope !== "knowledge") {
-        const distVectorHits = await timer.await(
-          embedding.vectorSearchDistillations(queryVec, limit),
-          "vectorSearch",
+        const distVectorHits = await abortable(
+          timer.await(
+            embedding.vectorSearchDistillations(queryVec, limit),
+            "vectorSearch",
+          ),
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit point reads.
-        const distMap = await timer.await(
-          hydrateVectorRows<Distillation>(
-            distVectorHits,
-            "SELECT id, observations, generation, created_at, session_id, c_norm, r_compression FROM distillations WHERE id IN",
+        const distMap = await abortable(
+          timer.await(
+            hydrateVectorRows<Distillation>(
+              distVectorHits,
+              "SELECT id, observations, generation, created_at, session_id, c_norm, r_compression FROM distillations WHERE id IN",
+            ),
           ),
         );
         const distVectorTagged: TaggedResult[] = distVectorHits
@@ -1108,15 +1150,19 @@ export async function searchRecall(
       // Temporal vector search (includes distilled — embeddings preserved by markDistilled)
       if (scope !== "knowledge") {
         const pid = ensureProject(projectPath);
-        const temporalVectorHits = await timer.await(
-          embedding.vectorSearchTemporal(queryVec, pid, limit),
-          "vectorSearch",
+        const temporalVectorHits = await abortable(
+          timer.await(
+            embedding.vectorSearchTemporal(queryVec, pid, limit),
+            "vectorSearch",
+          ),
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit point reads.
-        const temporalMap = await timer.await(
-          hydrateVectorRows<temporal.TemporalMessage>(
-            temporalVectorHits,
-            "SELECT id, project_id, session_id, role, content, tokens, distilled, created_at, metadata FROM temporal_messages WHERE id IN",
+        const temporalMap = await abortable(
+          timer.await(
+            hydrateVectorRows<temporal.TemporalMessage>(
+              temporalVectorHits,
+              "SELECT id, project_id, session_id, role, content, tokens, distilled, created_at, metadata FROM temporal_messages WHERE id IN",
+            ),
           ),
         );
         const temporalVectorTagged: TaggedResult[] = temporalVectorHits
@@ -1150,15 +1196,19 @@ export async function searchRecall(
         // user references by name from another project resolves semantically
         // too. `infra` stays project-scoped.
         const entPid = ensureProject(projectPath);
-        const entityVectorHits = await timer.await(
-          embedding.vectorSearchEntities(queryVec, limit),
-          "vectorSearch",
+        const entityVectorHits = await abortable(
+          timer.await(
+            embedding.vectorSearchEntities(queryVec, limit),
+            "vectorSearch",
+          ),
         );
         // Batch-hydrate hits off-thread (#966) instead of N per-hit
         // getWithAliases() calls (entity row + alias load each).
-        const entMap = await timer.await(
-          entities.getManyWithAliasesOffloaded(
-            entityVectorHits.map((h) => h.id),
+        const entMap = await abortable(
+          timer.await(
+            entities.getManyWithAliasesOffloaded(
+              entityVectorHits.map((h) => h.id),
+            ),
           ),
         );
         const entityVectorTagged: TaggedResult[] = entityVectorHits
@@ -1186,19 +1236,23 @@ export async function searchRecall(
         }
       }
     } catch (err) {
+      if (input.signal?.aborted) throw input.signal.reason;
       log.info("recall: vector search failed:", err);
     }
   }
 
   // lat.md section search
   if (scope !== "session" && latReader.hasLatDir(projectPath)) {
+    input.signal?.throwIfAborted();
     try {
-      const latResults = await latReader.searchScored({
-        query,
-        projectPath,
-        limit,
-        termWeights: idfWeights,
-      });
+      const latResults = await abortable(
+        latReader.searchScored({
+          query,
+          projectPath,
+          limit,
+          termWeights: idfWeights,
+        }),
+      );
       if (latResults.length) {
         allRrfLists.push({
           items: latResults.map((item) => ({
@@ -1210,19 +1264,23 @@ export async function searchRecall(
         });
       }
     } catch (err) {
+      if (input.signal?.aborted) throw input.signal.reason;
       log.info("recall: lat.md section search failed:", err);
     }
   }
 
   // Cross-project knowledge discovery — only in "all" scope.
   if (knowledgeEnabled && scope === "all") {
+    input.signal?.throwIfAborted();
     try {
-      const crossProjectResults = await ltm.searchScoredOtherProjects({
-        query,
-        excludeProjectPath: projectPath,
-        limit,
-        termWeights: idfWeights,
-      });
+      const crossProjectResults = await abortable(
+        ltm.searchScoredOtherProjects({
+          query,
+          excludeProjectPath: projectPath,
+          limit,
+          termWeights: idfWeights,
+        }),
+      );
       if (crossProjectResults.length) {
         allRrfLists.push({
           items: crossProjectResults.map((item: ltm.ScoredKnowledgeEntry) => {
@@ -1239,6 +1297,7 @@ export async function searchRecall(
         });
       }
     } catch (err) {
+      if (input.signal?.aborted) throw input.signal.reason;
       log.info("recall: cross-project knowledge search failed:", err);
     }
   }
@@ -1249,9 +1308,10 @@ export async function searchRecall(
   // alias query-expansion above. Cross-session/cross-project, so excluded from
   // "session" and "knowledge" scopes.
   if (scope === "all" || scope === "project") {
+    input.signal?.throwIfAborted();
     try {
-      const entityResults = await timer.await(
-        entities.searchAsync({ query, projectPath, limit }),
+      const entityResults = await abortable(
+        timer.await(entities.searchAsync({ query, projectPath, limit })),
       );
       if (entityResults.length) {
         allRrfLists.push({
@@ -1263,6 +1323,7 @@ export async function searchRecall(
         });
       }
     } catch (err) {
+      if (input.signal?.aborted) throw input.signal.reason;
       log.info("recall: entity search failed (non-fatal):", err);
     }
   }
@@ -1274,13 +1335,16 @@ export async function searchRecall(
   // working elsewhere — is otherwise unreachable. Surface those here. Same
   // `e:` key as the entity list so RRF merges them. `infra` stays excluded.
   if (scope === "all") {
+    input.signal?.throwIfAborted();
     try {
-      const crossRepos = await timer.await(
-        entities.searchCrossProjectReposAsync({
-          query,
-          excludeProjectPath: projectPath,
-          limit,
-        }),
+      const crossRepos = await abortable(
+        timer.await(
+          entities.searchCrossProjectReposAsync({
+            query,
+            excludeProjectPath: projectPath,
+            limit,
+          }),
+        ),
       );
       if (crossRepos.length) {
         allRrfLists.push({
@@ -1292,6 +1356,7 @@ export async function searchRecall(
         });
       }
     } catch (err) {
+      if (input.signal?.aborted) throw input.signal.reason;
       log.info("recall: cross-project repo search failed (non-fatal):", err);
     }
   }
@@ -1309,6 +1374,7 @@ export async function searchRecall(
     (searchConfig?.graphExpansion ?? true) &&
     (scope === "all" || scope === "project")
   ) {
+    input.signal?.throwIfAborted();
     try {
       // Seeds = entities matched lexically/semantically (entity FTS + vector +
       // cross-repo). They were already visibility-filtered at their source, so
@@ -1342,9 +1408,11 @@ export async function searchRecall(
         // lists so RRF merges, not duplicates. The list is already empty when
         // knowledge is disabled (gated via includeKnowledge at graphExpand).
         if (expansion.knowledge.length) {
-          const knowledgeMap = await timer.await(
-            ltm.getManyByLogicalOffloaded(
-              expansion.knowledge.map((gk) => gk.logicalId),
+          const knowledgeMap = await abortable(
+            timer.await(
+              ltm.getManyByLogicalOffloaded(
+                expansion.knowledge.map((gk) => gk.logicalId),
+              ),
             ),
           );
           const graphKnowledge: TaggedResult[] = [];
@@ -1378,9 +1446,11 @@ export async function searchRecall(
         // visibility-filtered (same predicate entities.search uses). Same `e:`
         // key as the entity FTS/vector lists so RRF merges them.
         if (expansion.entities.length) {
-          const neighborMap = await timer.await(
-            entities.getManyWithAliasesOffloaded(
-              expansion.entities.map((e) => e.id),
+          const neighborMap = await abortable(
+            timer.await(
+              entities.getManyWithAliasesOffloaded(
+                expansion.entities.map((e) => e.id),
+              ),
             ),
           );
           const graphEntities: TaggedResult[] = [];
@@ -1407,6 +1477,7 @@ export async function searchRecall(
         }
       }
     } catch (err) {
+      if (input.signal?.aborted) throw input.signal.reason;
       log.info("recall: entity-graph expansion failed (non-fatal):", err);
     }
   }
@@ -1540,6 +1611,7 @@ export async function searchRecall(
   // while dropping the long tail of single-list noise.
   const maxResults = limit * 3;
   timer.emit("recall", fused.length, scope);
+  input.signal?.throwIfAborted();
   return fused.slice(0, maxResults);
 }
 
@@ -1653,9 +1725,12 @@ export function recallById(id: string): string {
 
 /** Full recall run: search every relevant source, fuse with RRF, format as markdown. */
 export async function runRecall(input: RecallInput): Promise<RecallResult> {
+  input.signal?.throwIfAborted();
   // ID-based detail retrieval — bypass search entirely.
   if (input.id) {
-    return recallById(input.id);
+    const result = recallById(input.id);
+    input.signal?.throwIfAborted();
+    return result;
   }
 
   const fused = await searchRecall(input);

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -597,30 +597,30 @@ export async function expandQuery(
   query: string,
   model?: { providerID: string; modelID: string },
   sessionID?: string,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   const TIMEOUT_MS = 3000;
 
   try {
-    // Race the LLM call against a timeout
-    const responseText = await Promise.race([
-      llm.prompt(
-        QUERY_EXPANSION_SYSTEM,
-        `Input: "${query}"`,
-        // temperature: 0 trades expansion diversity for eval reproducibility
-        {
-          model,
-          workerID: "lore-query-expand",
-          thinking: false,
-          urgent: true,
-          sessionID,
-          maxTokens: 256,
-          temperature: 0,
-        },
-      ),
-      new Promise<null>((resolve) =>
-        setTimeout(() => resolve(null), TIMEOUT_MS),
-      ),
-    ]);
+    signal?.throwIfAborted();
+    const timeout = AbortSignal.timeout(TIMEOUT_MS);
+    const promptSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
+    const responseText = await llm.prompt(
+      QUERY_EXPANSION_SYSTEM,
+      `Input: "${query}"`,
+      // temperature: 0 trades expansion diversity for eval reproducibility
+      {
+        model,
+        signal: promptSignal,
+        workerID: "lore-query-expand",
+        thinking: false,
+        urgent: true,
+        sessionID,
+        maxTokens: 256,
+        temperature: 0,
+      },
+    );
+    signal?.throwIfAborted();
 
     if (!responseText) {
       log.info("query expansion timed out or failed, using original query");
@@ -642,6 +642,11 @@ export async function expandQuery(
 
     return [query, ...expanded.slice(0, 3)]; // cap at 3 expansions
   } catch (err) {
+    if (signal?.aborted) throw signal.reason;
+    if (err instanceof DOMException && err.name === "TimeoutError") {
+      log.info("query expansion timed out, using original query");
+      return [query];
+    }
     log.info("query expansion failed, using original query:", err);
     return [query];
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -193,6 +193,8 @@ export function isToolPart(p: LorePart): p is LoreToolPart {
 export type LoreMessageWithParts = {
   info: LoreMessage;
   parts: LorePart[];
+  /** Transient provider bytes omitted from parts but counted by gradient. */
+  hiddenInputTokens?: number;
 };
 
 // ---------------------------------------------------------------------------
@@ -226,6 +228,8 @@ export interface LLMClient {
     opts?: {
       /** Override model for this call. */
       model?: { providerID: string; modelID: string };
+      /** Abort in-flight work when the owning client disconnects. */
+      signal?: AbortSignal;
       /**
        * Opaque worker identifier used by the host to route the request
        * (e.g. OpenCode uses this as the session agent name).

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -119,7 +119,7 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(77);
+    expect(row.version).toBe(79);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -176,7 +176,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(77);
+    expect(ver.version).toBe(79);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh
@@ -213,7 +213,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(77);
+    expect(ver.version).toBe(79);
   });
 
   test("v56: knowledge_ref_validity table + projects.last_refcheck_at exist after recovery", () => {
@@ -1365,6 +1365,7 @@ describe("db", () => {
       recallStore: JSON.stringify([["all:q", { toolUseId: "t1" }]]),
       dedupDecisions: JSON.stringify([["m1:p1", true]]),
       lastKnownMessageCount: 137,
+      lastUpstream: JSON.stringify({ model: "gpt-test" }),
     });
     const loaded = loadSessionTracking(sid);
     expect(loaded).not.toBeNull();
@@ -1384,6 +1385,7 @@ describe("db", () => {
     expect(loaded?.dedupDecisions).toBe(JSON.stringify([["m1:p1", true]]));
     // v43: persisted for accurate calibrated-delta estimation after restart.
     expect(loaded?.lastKnownMessageCount).toBe(137);
+    expect(loaded?.lastUpstream).toBe(JSON.stringify({ model: "gpt-test" }));
   });
 
   test("stable LTM (system[1]) freeze round-trips and survives partial updates (v45)", () => {
@@ -1462,12 +1464,14 @@ describe("db", () => {
       fingerprint: "abc123hash",
       headerSessionId: "uuid-4567",
       headerName: "x-claude-code-session-id",
+      credentialFingerprint: "0123456789abcdef",
     });
     const loaded = loadSessionTracking(sid);
     expect(loaded).not.toBeNull();
     expect(loaded?.fingerprint).toBe("abc123hash");
     expect(loaded?.headerSessionId).toBe("uuid-4567");
     expect(loaded?.headerName).toBe("x-claude-code-session-id");
+    expect(loaded?.credentialFingerprint).toBe("0123456789abcdef");
   });
 
   test("saveSessionTracking v24 cache warming round-trip", () => {
@@ -1541,6 +1545,7 @@ describe("db", () => {
     expect(loaded?.fingerprint).toBe("");
     expect(loaded?.headerSessionId).toBeNull();
     expect(loaded?.headerName).toBeNull();
+    expect(loaded?.credentialFingerprint).toBe("");
     expect(loaded?.resolvedConversationTTL).toBe("5m");
     expect(loaded?.warmupState).toBeNull();
     expect(loaded?.dynamicContextCap).toBe(0);
@@ -1610,10 +1615,12 @@ describe("db", () => {
     saveSessionTracking(sid1, {
       headerSessionId: "uuid-aaa",
       headerName: "x-claude-code-session-id",
+      credentialFingerprint: "credential-a",
     });
     saveSessionTracking(sid2, {
       headerSessionId: "uuid-bbb",
       headerName: "x-session-affinity",
+      credentialFingerprint: "credential-b",
     });
     // Session without headers should NOT appear
     const sid3 = `test-hsi-3-${crypto.randomUUID()}`;
@@ -1627,9 +1634,11 @@ describe("db", () => {
     expect(found1).toBeDefined();
     expect(found1?.headerSessionId).toBe("uuid-aaa");
     expect(found1?.headerName).toBe("x-claude-code-session-id");
+    expect(found1?.credentialFingerprint).toBe("credential-a");
     expect(found2).toBeDefined();
     expect(found2?.headerSessionId).toBe("uuid-bbb");
     expect(found2?.headerName).toBe("x-session-affinity");
+    expect(found2?.credentialFingerprint).toBe("credential-b");
     expect(found3).toBeUndefined();
   });
 
@@ -2118,6 +2127,26 @@ describe("db", () => {
 
       // Empty query never matches the empty-fingerprint rows.
       expect(findSessionStatesByFingerprint("")).toEqual([]);
+    });
+
+    test("findSessionStatesByFingerprint can restrict legacy candidates to unowned rows", () => {
+      const fp = `legacy-fp-${crypto.randomUUID().slice(0, 8)}`;
+      const unowned = `legacy-unowned-${crypto.randomUUID()}`;
+      const owned = `legacy-owned-${crypto.randomUUID()}`;
+      saveSessionTracking(unowned, {
+        fingerprint: fp,
+        credentialFingerprint: "",
+      });
+      saveSessionTracking(owned, {
+        fingerprint: fp,
+        credentialFingerprint: "credential-a",
+      });
+
+      expect(
+        findSessionStatesByFingerprint(fp, { legacyUnownedOnly: true }).map(
+          (row) => row.session_id,
+        ),
+      ).toEqual([unowned]);
     });
 
     test("countMatchingTemporalIds counts only same-project, same-session ids", () => {

--- a/packages/core/test/fetch-interceptor-install.test.ts
+++ b/packages/core/test/fetch-interceptor-install.test.ts
@@ -20,9 +20,13 @@ describe("installFetchInterceptor — end-to-end routing", () => {
   let cleanup: () => void;
   let captured: Captured | null;
   let realFetch: typeof globalThis.fetch;
+  let observedAuthorization: string | null;
+  let observedApiKey: string | null;
 
   beforeEach(() => {
     captured = null;
+    observedAuthorization = null;
+    observedApiKey = null;
     // Stub the underlying fetch so the interceptor calls into our capture.
     realFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       captured = {
@@ -44,6 +48,10 @@ describe("installFetchInterceptor — end-to-end routing", () => {
         "x-lore-session-id": "sess-123",
         "x-lore-project": "/home/me/proj",
       }),
+      onRequestHeaders: (headers) => {
+        observedAuthorization = headers.get("authorization");
+        observedApiKey = headers.get("x-api-key");
+      },
     });
   });
 
@@ -90,6 +98,32 @@ describe("installFetchInterceptor — end-to-end routing", () => {
       expect(headerVal("authorization")).toBe("Bearer sk-test");
       expect(headerVal("x-lore-session-id")).toBe("sess-123");
       expect(headerVal("x-lore-project")).toBe("/home/me/proj");
+      expect(observedAuthorization).toBe("Bearer sk-test");
+    });
+
+    test("observes auth on requests already targeting the gateway", async () => {
+      await fetch(`${GATEWAY}/v1/messages`, {
+        method: "POST",
+        headers: { authorization: "Bearer direct" },
+        body: JSON.stringify({ model: "claude", messages: [] }),
+      });
+      expect(observedAuthorization).toBe("Bearer direct");
+      expect(captured?.url).toBe(`${GATEWAY}/v1/messages`);
+    });
+
+    test("observes both auth schemes without altering either", async () => {
+      await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secondary",
+          "x-api-key": "primary-key",
+        },
+        body: JSON.stringify({ model: "claude", messages: [] }),
+      });
+      expect(observedApiKey).toBe("primary-key");
+      expect(observedAuthorization).toBe("Bearer secondary");
+      expect(headerVal("x-api-key")).toBe("primary-key");
+      expect(headerVal("authorization")).toBe("Bearer secondary");
     });
 
     test("forwards the original body intact", async () => {

--- a/packages/core/test/import/auth.test.ts
+++ b/packages/core/test/import/auth.test.ts
@@ -382,13 +382,14 @@ describe("getOpenCodeActiveProvider", () => {
     // or the global setting shadows the project override. Seer flagged this
     // as a HIGH-severity bug; the fix is to swap the candidate order.
     const globalCfg = configFile();
-    const projectCfg = join(process.cwd(), "opencode.json");
+    const projectDir = join(tmp, "project");
+    const projectCfg = join(projectDir, "opencode.json");
     writeJson(globalCfg, { model: "anthropic/claude-sonnet-5" });
     writeJson(projectCfg, { model: "openrouter/anthropic/claude-sonnet-5" });
-    expect(getOpenCodeActiveProvider()).toBe("openrouter");
+    expect(getOpenCodeActiveProvider(projectDir)).toBe("openrouter");
     // Flip: project overrides global regardless of file mtime.
     writeJson(projectCfg, { model: "anthropic/claude-haiku-4-5" });
-    expect(getOpenCodeActiveProvider()).toBe("anthropic");
+    expect(getOpenCodeActiveProvider(projectDir)).toBe("anthropic");
   });
 });
 

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 77", () => {
+  test("schema version is 79", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(77);
+    expect(v.version).toBe(79);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {

--- a/packages/core/test/recall-readpath-offload.test.ts
+++ b/packages/core/test/recall-readpath-offload.test.ts
@@ -3,8 +3,11 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { db, ensureProject } from "../src/db";
 import * as embedding from "../src/embedding";
 import * as entities from "../src/entities";
+import * as latReader from "../src/lat-reader";
 import * as ltm from "../src/ltm";
-import { searchRecall } from "../src/recall";
+import * as readOffload from "../src/read-offload";
+import * as temporal from "../src/temporal";
+import { runRecall, searchRecall } from "../src/recall";
 
 // PR3 (#966): recall's entity FTS scans and per-vector-hit single-row
 // hydration are routed off the main event loop. Hydration loops are now a
@@ -432,5 +435,569 @@ describe("recall vector-hit hydration is batched + offloaded (#966)", () => {
       .map((r) => r.item.item.id);
     expect(entIds).toContain(visible.id);
     expect(entIds).not.toContain(hidden.id);
+  });
+
+  test("aborts while an embedding worker is still pending", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    embedSpy.mockImplementation(() => {
+      started.resolve();
+      return new Promise(() => {});
+    });
+
+    const pending = searchRecall({
+      query: "totallyunrelatedtoken",
+      projectPath: PROJ,
+      scope: "all",
+      signal: controller.signal,
+    });
+    await started.promise;
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(kSpy).not.toHaveBeenCalled();
+    expect(dSpy).not.toHaveBeenCalled();
+    expect(tSpy).not.toHaveBeenCalled();
+    expect(eSpy).not.toHaveBeenCalled();
+  });
+
+  test("aborts while a primary knowledge search is still pending", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    const knowledgeSpy = vi
+      .spyOn(ltm, "searchScored")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(embedSpy).not.toHaveBeenCalled();
+    } finally {
+      knowledgeSpy.mockRestore();
+    }
+  });
+
+  test("aborts while temporal FTS is pending and never starts embedding", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    const knowledgeSpy = vi.spyOn(ltm, "searchScored").mockResolvedValue([]);
+    const temporalSpy = vi
+      .spyOn(temporal, "searchScored")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(embedSpy).not.toHaveBeenCalled();
+    } finally {
+      knowledgeSpy.mockRestore();
+      temporalSpy.mockRestore();
+    }
+  });
+
+  test("aborts while distillation FTS is pending and never starts temporal FTS", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    const knowledgeSpy = vi.spyOn(ltm, "searchScored").mockResolvedValue([]);
+    const offloadSpy = vi
+      .spyOn(readOffload, "offloadAllOrTimeout")
+      .mockImplementation((sql) => {
+        if (sql.includes("distillation_fts")) {
+          started.resolve();
+          return new Promise(() => {});
+        }
+        return Promise.resolve([]);
+      });
+    const temporalSpy = vi.spyOn(temporal, "searchScored");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(temporalSpy).not.toHaveBeenCalled();
+    } finally {
+      knowledgeSpy.mockRestore();
+      offloadSpy.mockRestore();
+      temporalSpy.mockRestore();
+    }
+  });
+
+  test("aborts while LAT search is pending and never starts cross-project knowledge", async () => {
+    const controller = new AbortController();
+    availableSpy.mockReturnValue(false);
+    const started = Promise.withResolvers<void>();
+    const hasLatSpy = vi.spyOn(latReader, "hasLatDir").mockReturnValue(true);
+    const latSpy = vi
+      .spyOn(latReader, "searchScored")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    const crossProjectSpy = vi.spyOn(ltm, "searchScoredOtherProjects");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(crossProjectSpy).not.toHaveBeenCalled();
+    } finally {
+      hasLatSpy.mockRestore();
+      latSpy.mockRestore();
+      crossProjectSpy.mockRestore();
+    }
+  });
+
+  test("aborts while cross-project knowledge is pending and never starts entity search", async () => {
+    const controller = new AbortController();
+    availableSpy.mockReturnValue(false);
+    const started = Promise.withResolvers<void>();
+    const crossProjectSpy = vi
+      .spyOn(ltm, "searchScoredOtherProjects")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    const entitySpy = vi.spyOn(entities, "searchAsync");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(entitySpy).not.toHaveBeenCalled();
+    } finally {
+      crossProjectSpy.mockRestore();
+      entitySpy.mockRestore();
+    }
+  });
+
+  test("checks cancellation again after synchronous ID detail retrieval", async () => {
+    const controller = new AbortController();
+    const getSpy = vi.spyOn(ltm, "get").mockImplementation(() => {
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+      return null;
+    });
+    try {
+      await expect(
+        runRecall({
+          query: "",
+          id: "k:missing",
+          projectPath: PROJ,
+          signal: controller.signal,
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(getSpy).toHaveBeenCalledWith("missing");
+    } finally {
+      getSpy.mockRestore();
+    }
+  });
+
+  test("aborts while knowledge vector search is pending and never starts hydration", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    kSpy.mockImplementation(() => {
+      started.resolve();
+      return new Promise(() => {});
+    });
+    const hydrateSpy = vi.spyOn(ltm, "getManyOffloaded");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(hydrateSpy).not.toHaveBeenCalled();
+      expect(dSpy).not.toHaveBeenCalled();
+    } finally {
+      hydrateSpy.mockRestore();
+    }
+  });
+
+  test("aborts while knowledge vector hydration is pending and never starts distillation vectors", async () => {
+    const controller = new AbortController();
+    kSpy.mockResolvedValue([{ id: "knowledge-hit", similarity: 0.9 }]);
+    const started = Promise.withResolvers<void>();
+    const hydrateSpy = vi
+      .spyOn(ltm, "getManyOffloaded")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(dSpy).not.toHaveBeenCalled();
+    } finally {
+      hydrateSpy.mockRestore();
+    }
+  });
+
+  test("aborts while distillation vector search is pending and never starts temporal vectors", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    dSpy.mockImplementation(() => {
+      started.resolve();
+      return new Promise(() => {});
+    });
+    const pending = searchRecall({
+      query: "totallyunrelatedtoken",
+      projectPath: PROJ,
+      scope: "all",
+      knowledgeEnabled: false,
+      signal: controller.signal,
+    });
+    await started.promise;
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(tSpy).not.toHaveBeenCalled();
+  });
+
+  test("aborts while distillation vector hydration is pending and never starts temporal vectors", async () => {
+    const controller = new AbortController();
+    dSpy.mockResolvedValue([{ id: "distillation-hit", similarity: 0.9 }]);
+    const started = Promise.withResolvers<void>();
+    const originalOffload = readOffload.offloadAll;
+    const offloadSpy = vi
+      .spyOn(readOffload, "offloadAll")
+      .mockImplementation((sql, params) => {
+        if (sql.includes("FROM distillations WHERE id IN")) {
+          started.resolve();
+          return new Promise(() => {});
+        }
+        return originalOffload(sql, params);
+      });
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        knowledgeEnabled: false,
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(tSpy).not.toHaveBeenCalled();
+    } finally {
+      offloadSpy.mockRestore();
+    }
+  });
+
+  test("aborts while temporal vector search is pending and never starts entity vectors", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    tSpy.mockImplementation(() => {
+      started.resolve();
+      return new Promise(() => {});
+    });
+    const pending = searchRecall({
+      query: "totallyunrelatedtoken",
+      projectPath: PROJ,
+      scope: "all",
+      knowledgeEnabled: false,
+      signal: controller.signal,
+    });
+    await started.promise;
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(eSpy).not.toHaveBeenCalled();
+  });
+
+  test("aborts while temporal vector hydration is pending and never starts entity vectors", async () => {
+    const controller = new AbortController();
+    tSpy.mockResolvedValue([{ id: "temporal-hit", similarity: 0.9 }]);
+    const started = Promise.withResolvers<void>();
+    const originalOffload = readOffload.offloadAll;
+    const offloadSpy = vi
+      .spyOn(readOffload, "offloadAll")
+      .mockImplementation((sql, params) => {
+        if (sql.includes("FROM temporal_messages WHERE id IN")) {
+          started.resolve();
+          return new Promise(() => {});
+        }
+        return originalOffload(sql, params);
+      });
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        knowledgeEnabled: false,
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(eSpy).not.toHaveBeenCalled();
+    } finally {
+      offloadSpy.mockRestore();
+    }
+  });
+
+  test("aborts while entity vector search is pending and never starts entity hydration", async () => {
+    const controller = new AbortController();
+    const started = Promise.withResolvers<void>();
+    eSpy.mockImplementation(() => {
+      started.resolve();
+      return new Promise(() => {});
+    });
+    const hydrateSpy = vi.spyOn(entities, "getManyWithAliasesOffloaded");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        knowledgeEnabled: false,
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(hydrateSpy).not.toHaveBeenCalled();
+    } finally {
+      hydrateSpy.mockRestore();
+    }
+  });
+
+  test("aborts while entity vector hydration is pending and never starts LAT search", async () => {
+    const controller = new AbortController();
+    eSpy.mockResolvedValue([{ id: "entity-hit", similarity: 0.9 }]);
+    const started = Promise.withResolvers<void>();
+    const hydrateSpy = vi
+      .spyOn(entities, "getManyWithAliasesOffloaded")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    const hasLatSpy = vi.spyOn(latReader, "hasLatDir");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        knowledgeEnabled: false,
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(hasLatSpy).not.toHaveBeenCalled();
+    } finally {
+      hydrateSpy.mockRestore();
+      hasLatSpy.mockRestore();
+    }
+  });
+
+  test("aborts while entity search is pending and never starts cross-repo search", async () => {
+    const controller = new AbortController();
+    availableSpy.mockReturnValue(false);
+    const started = Promise.withResolvers<void>();
+    const entitySpy = vi
+      .spyOn(entities, "searchAsync")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    const crossRepoSpy = vi.spyOn(entities, "searchCrossProjectReposAsync");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(crossRepoSpy).not.toHaveBeenCalled();
+    } finally {
+      entitySpy.mockRestore();
+      crossRepoSpy.mockRestore();
+    }
+  });
+
+  test("aborts while cross-repo search is pending and never starts graph expansion", async () => {
+    const controller = new AbortController();
+    availableSpy.mockReturnValue(false);
+    const started = Promise.withResolvers<void>();
+    const entitySpy = vi.spyOn(entities, "searchAsync").mockResolvedValue([]);
+    const crossRepoSpy = vi
+      .spyOn(entities, "searchCrossProjectReposAsync")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    const graphSpy = vi.spyOn(entities, "graphExpand");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(graphSpy).not.toHaveBeenCalled();
+    } finally {
+      entitySpy.mockRestore();
+      crossRepoSpy.mockRestore();
+      graphSpy.mockRestore();
+    }
+  });
+
+  test("aborts while graph knowledge hydration is pending and never starts neighbor hydration", async () => {
+    const controller = new AbortController();
+    availableSpy.mockReturnValue(false);
+    const seed = entities.create({
+      projectPath: PROJ,
+      entityType: "service",
+      canonicalName: "Graph Cancellation Seed",
+    });
+    const seedEntity = entities.getWithAliases(seed.id);
+    expect(seedEntity).not.toBeNull();
+    if (!seedEntity) throw new Error("graph seed was not created");
+    const entitySpy = vi
+      .spyOn(entities, "searchAsync")
+      .mockResolvedValue([seedEntity]);
+    const crossRepoSpy = vi
+      .spyOn(entities, "searchCrossProjectReposAsync")
+      .mockResolvedValue([]);
+    const graphSpy = vi.spyOn(entities, "graphExpand").mockReturnValue({
+      knowledge: [{ logicalId: "logical-hit", score: 1, depth: 1, reach: 1 }],
+      entities: [{ id: "neighbor-hit", score: 1, depth: 1 }],
+    });
+    const started = Promise.withResolvers<void>();
+    const knowledgeHydrateSpy = vi
+      .spyOn(ltm, "getManyByLogicalOffloaded")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    const entityHydrateSpy = vi.spyOn(entities, "getManyWithAliasesOffloaded");
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(entityHydrateSpy).not.toHaveBeenCalled();
+    } finally {
+      entitySpy.mockRestore();
+      crossRepoSpy.mockRestore();
+      graphSpy.mockRestore();
+      knowledgeHydrateSpy.mockRestore();
+      entityHydrateSpy.mockRestore();
+    }
+  });
+
+  test("aborts while graph neighbor hydration is pending", async () => {
+    const controller = new AbortController();
+    availableSpy.mockReturnValue(false);
+    const seed = entities.create({
+      projectPath: PROJ,
+      entityType: "service",
+      canonicalName: "Graph Neighbor Cancellation Seed",
+    });
+    const seedEntity = entities.getWithAliases(seed.id);
+    expect(seedEntity).not.toBeNull();
+    if (!seedEntity) throw new Error("graph seed was not created");
+    const entitySpy = vi
+      .spyOn(entities, "searchAsync")
+      .mockResolvedValue([seedEntity]);
+    const crossRepoSpy = vi
+      .spyOn(entities, "searchCrossProjectReposAsync")
+      .mockResolvedValue([]);
+    const graphSpy = vi.spyOn(entities, "graphExpand").mockReturnValue({
+      knowledge: [],
+      entities: [{ id: "neighbor-hit", score: 1, depth: 1 }],
+    });
+    const started = Promise.withResolvers<void>();
+    const entityHydrateSpy = vi
+      .spyOn(entities, "getManyWithAliasesOffloaded")
+      .mockImplementation(() => {
+        started.resolve();
+        return new Promise(() => {});
+      });
+    try {
+      const pending = searchRecall({
+        query: "totallyunrelatedtoken",
+        projectPath: PROJ,
+        scope: "all",
+        signal: controller.signal,
+      });
+      await started.promise;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      entitySpy.mockRestore();
+      crossRepoSpy.mockRestore();
+      graphSpy.mockRestore();
+      entityHydrateSpy.mockRestore();
+    }
   });
 });

--- a/packages/core/test/search.test.ts
+++ b/packages/core/test/search.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect, beforeEach, vi } from "vitest";
 import {
   ftsQuery,
   ftsQueryOr,
@@ -12,8 +12,39 @@ import {
   exactTermMatchRank,
   termIDF,
   runRelaxedSearchAsync,
+  expandQuery,
 } from "../src/search";
 import { db, ensureProject } from "../src/db";
+import type { LLMClient } from "../src/types";
+
+describe("expandQuery", () => {
+  test("aborts the worker when the expansion deadline expires", async () => {
+    vi.useFakeTimers();
+    let aborted = false;
+    const llm: LLMClient = {
+      prompt: async (_system, _user, opts) =>
+        new Promise<string | null>((_resolve, reject) => {
+          opts?.signal?.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              reject(opts.signal?.reason);
+            },
+            { once: true },
+          );
+        }),
+    };
+
+    try {
+      const pending = expandQuery(llm, "architecture");
+      await vi.advanceTimersByTimeAsync(3_000);
+      await expect(pending).resolves.toEqual(["architecture"]);
+      expect(aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe("search", () => {
   describe("ftsQuery (AND semantics)", () => {

--- a/packages/gateway/src/fetch.ts
+++ b/packages/gateway/src/fetch.ts
@@ -94,6 +94,10 @@ function nodeHttpFetch(
   init?: RequestInit,
 ): Promise<Response> {
   return new Promise((resolve, reject) => {
+    if (init?.signal?.aborted) {
+      reject(init.signal.reason);
+      return;
+    }
     const url = new URL(
       typeof input === "string"
         ? input
@@ -168,7 +172,17 @@ function nodeHttpFetch(
       },
     );
 
+    const onAbort = (): void => {
+      const reason =
+        init?.signal?.reason ?? new DOMException("Aborted", "AbortError");
+      req.destroy(reason);
+    };
+    init?.signal?.addEventListener("abort", onAbort, { once: true });
+
     req.on("error", reject);
+    req.on("close", () => {
+      init?.signal?.removeEventListener("abort", onAbort);
+    });
 
     if (init?.body) {
       req.write(init.body);

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -584,8 +584,57 @@ export function backoffMs(
   return base + Math.random() * 0.25 * base;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+export function abortableSleep(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function readWorkerResponseText(
+  response: Response,
+  signal?: AbortSignal,
+  maxBytes = 64 * 1024,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  const onAbort = (): void => {
+    void reader.cancel(signal?.reason).catch(() => {});
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    while (bytes < maxBytes) {
+      signal?.throwIfAborted();
+      const { done, value } = await reader.read();
+      signal?.throwIfAborted();
+      if (done) break;
+      if (!value) continue;
+      const chunk = value.subarray(0, maxBytes - bytes);
+      chunks.push(chunk);
+      bytes += chunk.byteLength;
+    }
+  } catch (_err) {
+    if (signal?.aborted) throw signal.reason;
+    return "(no body)";
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    void reader.cancel().catch(() => {});
+  }
+  return new TextDecoder().decode(Buffer.concat(chunks));
 }
 
 // ---------------------------------------------------------------------------
@@ -2375,12 +2424,14 @@ export function createGatewayLLMClient(
                 response = await upstreamFetch(req.url, {
                   method: "POST",
                   headers: req.headers,
+                  signal: opts?.signal,
                   // The request body may carry `thinking:{type:"disabled"}` for
                   // Claude workers (built above) to SUPPRESS thinking — it never
                   // ENABLES it. opts.thinking is not forwarded.
                   body: req.body,
                 });
               } catch (e) {
+                if (opts?.signal?.aborted) throw opts.signal.reason;
                 // Network/fetch error — retry if attempts remain
                 if (attempt < maxRetries) {
                   const delay = backoffMs(attempt, null);
@@ -2389,7 +2440,7 @@ export function createGatewayLLMClient(
                   log.warn(
                     `worker request network error (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms`,
                   );
-                  await sleep(delay);
+                  await abortableSleep(delay, opts?.signal);
                   continue;
                 }
                 // Enrich span before rethrowing
@@ -2426,7 +2477,10 @@ export function createGatewayLLMClient(
                 // success, so the JSON error-envelope check below never applies
                 // to it (bodyErrCode stays null → the block is skipped).
                 const ct = response.headers.get("content-type") ?? "";
-                const bodyText = await response.text();
+                const bodyText = await readWorkerResponseText(
+                  response,
+                  opts?.signal,
+                );
                 const isSSE = looksLikeSSE(ct, bodyText);
                 if (
                   isSSE &&
@@ -2492,7 +2546,7 @@ export function createGatewayLLMClient(
                         `error (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms ` +
                         `— model=${model.providerID}/${model.modelID} worker=${opts?.workerID ?? "unknown"}`,
                     );
-                    await sleep(delay);
+                    await abortableSleep(delay, opts?.signal);
                     continue;
                   }
                   // Exhausted. Mirror the HTTP-level exhaustion path for full
@@ -2792,7 +2846,10 @@ export function createGatewayLLMClient(
 
               // --- Auth error: 401/403 — mark stale, re-resolve, retry once ---
               if (AUTH_ERROR_CODES.has(response.status)) {
-                const text = await response.text().catch(() => "(no body)");
+                const text = await readWorkerResponseText(
+                  response,
+                  opts?.signal,
+                );
 
                 // Always record the auth failure so the worker-health ladder
                 // sees it even for session-less paths (the adapter is the
@@ -2925,7 +2982,10 @@ export function createGatewayLLMClient(
               //    so the distiller/curator stop retrying every turn (a probe
               //    is allowed once per circuit interval to detect a top-up).
               if (INSUFFICIENT_CREDIT_CODES.has(response.status)) {
-                const text = await response.text().catch(() => "(no body)");
+                const text = await readWorkerResponseText(
+                  response,
+                  opts?.signal,
+                );
                 log.warn(
                   `worker upstream insufficient credit: ${response.status} ${response.statusText}` +
                     ` — model=${model.providerID}/${model.modelID}` +
@@ -2952,7 +3012,10 @@ export function createGatewayLLMClient(
 
               // Non-transient error — fail immediately, no retry
               if (!TRANSIENT_CODES.has(response.status)) {
-                const text = await response.text().catch(() => "(no body)");
+                const text = await readWorkerResponseText(
+                  response,
+                  opts?.signal,
+                );
 
                 // 400 + a beta-related complaint → the request carries a beta
                 // header the model/subscription doesn't support. The upfront
@@ -3213,7 +3276,7 @@ export function createGatewayLLMClient(
                       ? ` (retry-after: ${Math.round(retryAfter / 1000)}s)`
                       : ""),
                 );
-                await sleep(delay);
+                await abortableSleep(delay, opts?.signal);
                 continue;
               }
 
@@ -3227,7 +3290,7 @@ export function createGatewayLLMClient(
               // LORE_DEBUG) to avoid alarming red `[lore]` noise; non-urgent
               // background exhaustion stays at `error` since it can indicate a
               // sustained problem worth investigating.
-              const text = await response.text().catch(() => "(no body)");
+              const text = await readWorkerResponseText(response, opts?.signal);
               const exhaustionMsg =
                 `worker upstream request failed after ${maxRetries + 1} attempts: ${response.status} ${response.statusText}` +
                 ` — url=${target.url} model=${model.providerID}/${model.modelID}` +
@@ -3293,6 +3356,7 @@ export function createGatewayLLMClient(
         // Client disconnect / abort is benign — downgrade from error to info
         // to avoid Sentry noise from normal connection lifecycle events.
         const isAbort = e instanceof DOMException && e.name === "AbortError";
+        if (isAbort && opts?.signal?.aborted) throw e;
         // Network/timeout error — no response was received. Record here so the
         // adapter remains the single owner of transport-failure attribution
         // (core workers no longer record on a null return).

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -12,6 +12,7 @@
  *  3. Normal conversation turns → full pipeline.
  */
 import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import type { LoreMessageWithParts, LLMClient } from "@loreai/core";
 import { asString, estimateTokens as coreEstimateTokens } from "@loreai/core";
 import {
@@ -96,6 +97,7 @@ import type {
   GatewayToolUseBlock,
   GatewayToolResultBlock,
   GatewayUsage,
+  StoredRecall,
   SessionState,
   UpstreamSnapshot,
   WarmupState,
@@ -327,14 +329,17 @@ import {
   runRecallFollowUpJSON,
   runRecallFollowUpStreamAccumulated,
   type RecallFollowUpCtx,
-  buildRecallMarker,
-  recallStoreKey,
+  buildRecallAnchor,
+  parseRecallAnchor,
+  buildAnchoredRecallMarker,
   expandRecallMarkers,
   cleanupRecallStore,
   replaceRecallWithMarker,
   isRecallMarker,
   serializeRecallStore,
+  addRecallStoreEntry,
   deserializeRecallStore,
+  recallAnchorContext,
 } from "./recall";
 import { upstreamFetch } from "./fetch";
 import {
@@ -735,12 +740,43 @@ export function rebindActiveSession(
 
 /**
  * Reverse lookup: maps header-based session ID values to internal session IDs.
- * Key: `headerName:headerValue` (e.g. `x-claude-code-session-id:uuid-1234`).
+ * Key: `credentialFingerprint\x1fheaderName\x1fheaderValue`.
  * Value: internal session ID (the key in `sessions`).
  *
  * Populated for both Tier 1 (known headers) and Tier 2 (learned headers).
  */
 const headerSessionIndex = new Map<string, string>();
+const SESSION_INDEX_SEPARATOR = "\x1f";
+
+function requestCredentialFingerprint(headers: Record<string, string>): string {
+  const credential = extractAuth(headers);
+  return credential ? authFingerprint(credential) : "";
+}
+
+function sessionIndexKey(
+  credentialFingerprint: string,
+  headerName: string,
+  headerValue: string,
+): string {
+  return [credentialFingerprint, headerName, headerValue].join(
+    SESSION_INDEX_SEPARATOR,
+  );
+}
+
+function parseSessionIndexKey(key: string): {
+  credentialFingerprint: string;
+  headerName: string;
+  headerValue: string;
+} | null {
+  const first = key.indexOf(SESSION_INDEX_SEPARATOR);
+  const second = key.indexOf(SESSION_INDEX_SEPARATOR, first + 1);
+  if (first < 0 || second < 0) return null;
+  return {
+    credentialFingerprint: key.slice(0, first),
+    headerName: key.slice(first + 1, second),
+    headerValue: key.slice(second + 1),
+  };
+}
 
 /**
  * Per-session LTM cache for byte-stability of **context-bound** entries
@@ -3018,7 +3054,11 @@ async function initIfNeeded(
   try {
     const headerEntries = loadHeaderSessionIndex();
     for (const entry of headerEntries) {
-      const indexKey = `${entry.headerName}:${entry.headerSessionId}`;
+      const indexKey = sessionIndexKey(
+        entry.credentialFingerprint,
+        entry.headerName,
+        entry.headerSessionId,
+      );
       headerSessionIndex.set(indexKey, entry.sessionId);
     }
     if (headerEntries.length > 0) {
@@ -3612,6 +3652,7 @@ function getOrCreateSession(
   sessionID: string,
   projectPath: string,
   pathSource: ProjectPathResult["source"] = "cwd",
+  credentialFingerprint = "",
 ): SessionState {
   let state = sessions.get(sessionID);
   if (!state) {
@@ -3650,6 +3691,8 @@ function getOrCreateSession(
           ? true
           : pathSource === "cwd",
       fingerprint: persisted?.fingerprint || "",
+      credentialFingerprint:
+        persisted?.credentialFingerprint || credentialFingerprint,
       lastRequestTime: Date.now(),
       lastUserTurnTime: 0,
       messageCount: persisted?.messageCount ?? 0,
@@ -3672,7 +3715,11 @@ function getOrCreateSession(
       state.headerSessionId = persisted.headerSessionId;
       state.headerName = persisted.headerName;
       // Rebuild headerSessionIndex for this session
-      const indexKey = `${persisted.headerName}:${persisted.headerSessionId}`;
+      const indexKey = sessionIndexKey(
+        persisted.credentialFingerprint,
+        persisted.headerName,
+        persisted.headerSessionId,
+      );
       headerSessionIndex.set(indexKey, sessionID);
     }
 
@@ -3739,6 +3786,43 @@ function getOrCreateSession(
     // leaking upstream as raw marker text and rewriting that message.
     if (persisted?.recallStore != null) {
       state.recallStore = deserializeRecallStore(persisted.recallStore);
+    }
+    if (persisted?.lastUpstream != null) {
+      try {
+        const parsed = JSON.parse(persisted.lastUpstream) as unknown;
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof (parsed as UpstreamSnapshot).url === "string" &&
+          [
+            "anthropic",
+            "openai",
+            "openai-responses",
+            "vertex",
+            "gemini",
+          ].includes((parsed as UpstreamSnapshot).protocol) &&
+          typeof (parsed as UpstreamSnapshot).model === "string" &&
+          (parsed as UpstreamSnapshot).model.length > 0 &&
+          (parsed as UpstreamSnapshot).headers &&
+          typeof (parsed as UpstreamSnapshot).headers === "object" &&
+          !Array.isArray((parsed as UpstreamSnapshot).headers) &&
+          Object.values((parsed as UpstreamSnapshot).headers).every(
+            (value) => typeof value === "string",
+          )
+        ) {
+          state.lastUpstream = parsed as UpstreamSnapshot;
+          if (state.lastUpstream.providerID) {
+            state.upstreamByProvider.set(
+              state.lastUpstream.providerID,
+              state.lastUpstream,
+            );
+          }
+        }
+      } catch {
+        log.warn(
+          `corrupt last upstream for session ${sessionID.slice(0, 16)}, ignoring`,
+        );
+      }
     }
     if (persisted?.ltmPinText != null && persisted.ltmPinTokens != null) {
       let entryKeys: string[] | undefined;
@@ -3934,16 +4018,32 @@ async function adoptByFingerprint(input: {
   if (!projectPath) return null;
 
   const cred = extractAuth(req.rawHeaders);
-  const fingerprint = await fingerprintMessages(
-    req.messages.map((m) => ({ role: m.role, content: m.content })),
-    { authSuffix: cred ? authFingerprint(cred) : "" },
-  );
+  const credentialFingerprint = cred ? authFingerprint(cred) : "";
+  const fingerprintInput = req.messages.map((m) => ({
+    role: m.role,
+    content: m.content,
+  }));
+  const fingerprint = await fingerprintMessages(fingerprintInput, {
+    authSuffix: cred ? authFingerprint(cred) : "",
+  });
 
   const reqIsSubagent = !!headers["x-parent-session-id"];
-  const candidates = findSessionStatesByFingerprint(fingerprint).filter(
+  const candidates = findSessionStatesByFingerprint(fingerprint);
+  if (cred) {
+    // v78 added the credential suffix to conversation fingerprints. Legacy
+    // candidates have the old unsuffixed fingerprint and no persisted owner;
+    // they still require the same project-scoped multi-message overlap below.
+    const legacyFingerprint = await fingerprintMessages(fingerprintInput);
+    candidates.push(
+      ...findSessionStatesByFingerprint(legacyFingerprint, {
+        legacyUnownedOnly: true,
+      }),
+    );
+  }
+  const eligibleCandidates = candidates.filter(
     (c) => (c.is_subagent === 1) === reqIsSubagent,
   );
-  if (candidates.length === 0) return null;
+  if (eligibleCandidates.length === 0) return null;
 
   // Hash the leading user messages by their absolute index (the only
   // position-stable IDs in temporal storage). NOTE: identifySession runs before
@@ -3967,7 +4067,11 @@ async function adoptByFingerprint(input: {
   const pid = ensureProject(projectPath);
   const minOverlap = Math.max(ADOPT_MIN_OVERLAP, Math.ceil(probedUsers * 0.5));
   let best: { sid: string; overlap: number; countDiff: number } | null = null;
-  for (const c of candidates) {
+  // temporal_messages.id is globally unique, so valid rows cannot give two
+  // sessions the same positive overlap set. Keep the tie guard as defense in
+  // depth for a corrupt/imported database rather than selecting by row order.
+  let ambiguousBest = false;
+  for (const c of eligibleCandidates) {
     // Fork guard (mirrors the in-memory Tier-3 scan): a count that dropped far
     // below the stored count is a fork, not a resume.
     if (msgCount - c.message_count < -MESSAGE_COUNT_PROXIMITY_THRESHOLD) {
@@ -3982,17 +4086,24 @@ async function adoptByFingerprint(input: {
       (overlap === best.overlap && countDiff < best.countDiff)
     ) {
       best = { sid: c.session_id, overlap, countDiff };
+      ambiguousBest = false;
+    } else if (overlap === best.overlap && countDiff === best.countDiff) {
+      ambiguousBest = true;
     }
   }
-  if (!best) return null;
+  if (!best || ambiguousBest) return null;
 
   // When a known header is present, rebind it → adopted sid so future turns
   // identify via the Tier 1 fast path (and stop re-confirming overlap).
   if (known) {
-    headerSessionIndex.set(`${known.headerName}:${known.sessionId}`, best.sid);
+    headerSessionIndex.set(
+      sessionIndexKey(credentialFingerprint, known.headerName, known.sessionId),
+      best.sid,
+    );
     saveSessionTracking(best.sid, {
       headerSessionId: known.sessionId,
       headerName: known.headerName,
+      credentialFingerprint,
     });
   }
   log.info(
@@ -4008,6 +4119,7 @@ async function identifySession(
   projectPath: string,
 ): Promise<{ sessionID: string; isNew: boolean; tier: 1 | 2 | 2.5 | 3 }> {
   const headers = req.rawHeaders;
+  const credentialFingerprint = requestCredentialFingerprint(headers);
 
   // --- Tier 1: Known headers ---
   // Sub-agent requests (carrying x-parent-session-id) are NOT merged into the
@@ -4017,12 +4129,20 @@ async function identifySession(
 
   const known = extractKnownSessionHeader(headers);
   if (known) {
-    const indexKey = `${known.headerName}:${known.sessionId}`;
+    const indexKey = sessionIndexKey(
+      credentialFingerprint,
+      known.headerName,
+      known.sessionId,
+    );
     let existingSid = headerSessionIndex.get(indexKey);
     if (!existingSid) {
       for (const entry of loadHeaderSessionIndex()) {
         headerSessionIndex.set(
-          `${entry.headerName}:${entry.headerSessionId}`,
+          sessionIndexKey(
+            entry.credentialFingerprint,
+            entry.headerName,
+            entry.headerSessionId,
+          ),
           entry.sessionId,
         );
       }
@@ -4043,7 +4163,11 @@ async function identifySession(
       if (fallbackName === known.headerName) continue; // skip the primary
       const fallbackValue = headers[fallbackName];
       if (!fallbackValue) continue;
-      const fallbackKey = `${fallbackName}:${fallbackValue}`;
+      const fallbackKey = sessionIndexKey(
+        credentialFingerprint,
+        fallbackName,
+        fallbackValue,
+      );
       const fallbackSid = headerSessionIndex.get(fallbackKey);
       if (fallbackSid) {
         // Migrate: index under the new (higher-priority) header.
@@ -4051,12 +4175,14 @@ async function identifySession(
         saveSessionTracking(fallbackSid, {
           headerSessionId: known.sessionId,
           headerName: known.headerName,
+          credentialFingerprint,
         });
         // Update in-memory state if present.
         const inMemory = sessions.get(fallbackSid);
         if (inMemory) {
           inMemory.headerSessionId = known.sessionId;
           inMemory.headerName = known.headerName;
+          inMemory.credentialFingerprint = credentialFingerprint;
         }
         log.info(
           `session ${fallbackSid.slice(0, 16)}: migrated from ${fallbackName} to ${known.headerName}`,
@@ -4075,6 +4201,7 @@ async function identifySession(
     const predecessor = !isRotationEligible(known.headerName)
       ? null
       : findRotationPredecessor(
+          credentialFingerprint,
           known.headerName,
           known.sessionId,
           headerSessionIndex,
@@ -4125,6 +4252,7 @@ async function identifySession(
           saveSessionTracking(sessionID, {
             headerSessionId: known.sessionId,
             headerName: known.headerName,
+            credentialFingerprint,
           });
           // The old predecessor's index entry is intentionally preserved — the
           // old session is still valid and may receive requests with its nanoid.
@@ -4138,7 +4266,11 @@ async function identifySession(
 
     if (predecessor) {
       // Resume the old session with the new header value.
-      const oldKey = `${known.headerName}:${predecessor.oldHeaderValue}`;
+      const oldKey = sessionIndexKey(
+        credentialFingerprint,
+        known.headerName,
+        predecessor.oldHeaderValue,
+      );
       headerSessionIndex.delete(oldKey);
       headerSessionIndex.set(indexKey, predecessor.sid);
 
@@ -4147,12 +4279,14 @@ async function identifySession(
       if (inMemory) {
         inMemory.headerSessionId = known.sessionId;
         inMemory.headerName = known.headerName;
+        inMemory.credentialFingerprint = credentialFingerprint;
       }
 
       // Persist the new header mapping immediately.
       saveSessionTracking(predecessor.sid, {
         headerSessionId: known.sessionId,
         headerName: known.headerName,
+        credentialFingerprint,
       });
 
       log.info(
@@ -4181,6 +4315,7 @@ async function identifySession(
     saveSessionTracking(sessionID, {
       headerSessionId: known.sessionId,
       headerName: known.headerName,
+      credentialFingerprint,
     });
     return { sessionID, isNew: true, tier: 1 };
   }
@@ -4190,6 +4325,7 @@ async function identifySession(
   // a header value in the current request.
   for (const [sid, state] of sessions) {
     if (!state.headerSessionId || !state.headerName) continue;
+    if ((state.credentialFingerprint ?? "") !== credentialFingerprint) continue;
     const currentValue = headers[state.headerName];
     if (currentValue && currentValue === state.headerSessionId) {
       return { sessionID: sid, isNew: false, tier: 2 };
@@ -4202,7 +4338,11 @@ async function identifySession(
   // but less authoritative than explicit headers (Tier 1).
   const markerSid = extractSessionMarker(req.messages);
   if (markerSid) {
-    const markerKey = `context-marker:${markerSid}`;
+    const markerKey = sessionIndexKey(
+      credentialFingerprint,
+      "context-marker",
+      markerSid,
+    );
     const existingSid = headerSessionIndex.get(markerKey);
     if (existingSid) {
       return { sessionID: existingSid, isNew: false, tier: 2.5 as const };
@@ -4253,12 +4393,17 @@ async function identifySession(
         state.headerSessionId = result.promoted.value;
         state.headerName = result.promoted.name;
         // Index the promoted header for future Tier 2 lookups.
-        const indexKey = `${result.promoted.name}:${result.promoted.value}`;
+        const indexKey = sessionIndexKey(
+          credentialFingerprint,
+          result.promoted.name,
+          result.promoted.value,
+        );
         headerSessionIndex.set(indexKey, bestMatch.sid);
         // Persist immediately — rare event, critical for post-restart correlation
         saveSessionTracking(bestMatch.sid, {
           headerSessionId: result.promoted.value,
           headerName: result.promoted.name,
+          credentialFingerprint,
         });
         log.info(
           `session ${bestMatch.sid.slice(0, 16)}: promoted header ${result.promoted.name} for Tier 2 identification`,
@@ -4321,6 +4466,7 @@ async function forwardToUpstream(
   config: GatewayConfig,
   interceptor?: UpstreamInterceptor,
   cache?: AnthropicCacheOptions,
+  signal?: AbortSignal,
 ): Promise<UpstreamResult> {
   let url: string;
   let headers: Record<string, string>;
@@ -4726,6 +4872,7 @@ async function forwardToUpstream(
           method: "POST",
           headers,
           body: upstreamBody,
+          signal,
         }),
     );
     return { response, serializedBody, effectiveProtocol };
@@ -4735,6 +4882,7 @@ async function forwardToUpstream(
     method: "POST",
     headers,
     body: upstreamBody,
+    signal,
   });
   return { response, serializedBody, effectiveProtocol };
 }
@@ -4788,6 +4936,8 @@ function buildStreamingResponse(
   upstreamResponse: Response,
   onComplete: (response: GatewayResponse) => void,
   recallContext?: {
+    /** Original client transcript used for replay-anchor provenance. */
+    clientMessages: GatewayMessage[];
     modifiedReq: GatewayRequest;
     config: GatewayConfig;
     sessionState: SessionState;
@@ -4841,6 +4991,7 @@ function buildStreamingResponse(
     recallAccum ??
     createStreamAccumulator({ scaleClientUsage: true, maxReportedUsage });
   const encoder = new TextEncoder();
+  const recallVisibleContent: GatewayContentBlock[] = [];
   // Start of the client-facing stream — used to flag aborts that happen after
   // a long in-flight time (a host-pressure signal; see the abort catch below).
   const streamStartMs = Date.now();
@@ -4900,7 +5051,6 @@ function buildStreamingResponse(
         if (keepaliveTimer) clearTimeout(keepaliveTimer);
         keepaliveTimer = null;
       };
-
       try {
         // Parse and forward upstream SSE events
         if (!upstreamResponse.body) {
@@ -5039,14 +5189,51 @@ function buildStreamingResponse(
             const scope = input.scope ?? "all";
 
             // Store recall result for marker round-trip expansion
-            const storeKey = recallStoreKey(input.query, scope, input.id);
+            const anchorId = crypto.randomUUID();
+            const storeKey = `anchor:${anchorId}`;
             const position = currentResp.content.indexOf(recallBlock);
-            recallContext.sessionState.recallStore.set(storeKey, {
-              toolUseId: recallBlock.id,
-              input,
-              position,
-              result,
-            });
+            const markerPrefix = recallContext.clientSpeaksAnthropic
+              ? currentResp.content.filter(
+                  (block) =>
+                    block.type !== "tool_use" || block.id !== recallBlock.id,
+                )
+              : currentResp.content.slice(0, position);
+            const anchorContextId = recallAnchorContext(
+              recallContext.clientMessages,
+              recallContext.clientMessages.length,
+              [...recallVisibleContent, ...markerPrefix],
+            );
+            const companionToolUses = currentResp.content.flatMap(
+              (block, index) => {
+                if (block.type !== "tool_use" || block.id === recallBlock.id) {
+                  return [];
+                }
+                return [
+                  {
+                    id: block.id,
+                    name: block.name,
+                    input: block.input,
+                    side:
+                      recallContext.clientSpeaksAnthropic || index < position
+                        ? ("before" as const)
+                        : ("after" as const),
+                  },
+                ];
+              },
+            );
+            addRecallStoreEntry(
+              recallContext.sessionState.recallStore,
+              storeKey,
+              {
+                toolUseId: recallBlock.id,
+                anchorId,
+                anchorContextId,
+                input,
+                position,
+                result,
+                ...(companionToolUses.length > 0 ? { companionToolUses } : {}),
+              },
+            );
             // Persist the store (v46) so the marker still expands byte-identically
             // after a gateway restart instead of leaking raw marker text upstream.
             saveSessionTracking(recallContext.sessionState.sessionID, {
@@ -5068,7 +5255,26 @@ function buildStreamingResponse(
             // across turns (the client's persisted transcript has SOMETHING for
             // expandRecallMarkers to find next turn, fixing the silent-recall-loss bug
             // that would result from dropping the marker entirely for these clients).
-            const markerText = buildRecallMarker(input.query, scope, input.id);
+            const markerText = buildAnchoredRecallMarker(
+              input.query,
+              scope,
+              input.id,
+              anchorId,
+            );
+            if (recallContext.clientSpeaksAnthropic) {
+              recallVisibleContent.push(...markerPrefix, {
+                type: "text",
+                text: markerText,
+              });
+            } else {
+              recallVisibleContent.push(
+                ...currentResp.content.map((block) =>
+                  block.type === "tool_use" && block.id === recallBlock.id
+                    ? { type: "text" as const, text: markerText }
+                    : block,
+                ),
+              );
+            }
             let syntheticMarker: string;
             if (recallContext.clientSpeaksAnthropic) {
               const syntheticMessageId = `lore_marker_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
@@ -5157,7 +5363,10 @@ function buildStreamingResponse(
                 safeEnqueue(encoder.encode(heldBack));
               }
 
-              const markerResp = replaceRecallWithMarker(currentResp);
+              const markerResp = replaceRecallWithMarker(
+                currentResp,
+                new Map([[recallBlock.id, markerText]]),
+              );
               clearKeepalive();
               onComplete(markerResp);
               safeClose();
@@ -5177,11 +5386,17 @@ function buildStreamingResponse(
             // recall result makes the prefix diverge from the next real turn,
             // so the cache write would be wasted money.
             const streamingRecallCtx: RecallFollowUpCtx = {
-              forward: (r) =>
-                forwardToUpstream(r, recallContext.config, undefined, {
-                  ...recallContext.cacheOptions,
-                  cacheConversation: false,
-                }),
+              forward: (r, signal) =>
+                forwardToUpstream(
+                  r,
+                  recallContext.config,
+                  undefined,
+                  {
+                    ...recallContext.cacheOptions,
+                    cacheConversation: false,
+                  },
+                  signal,
+                ),
               // JSON parsing is unused on the streaming path (assertSSEResponse
               // guarantees an SSE body); provide a guard that throws if reached.
               parseJSON: () => {
@@ -5215,7 +5430,10 @@ function buildStreamingResponse(
               if (heldBack) {
                 safeEnqueue(encoder.encode(heldBack));
               }
-              const markerResp = replaceRecallWithMarker(currentResp);
+              const markerResp = replaceRecallWithMarker(
+                currentResp,
+                new Map([[recallBlock.id, markerText]]),
+              );
               clearKeepalive();
               onComplete(markerResp);
               safeClose();
@@ -5247,7 +5465,10 @@ function buildStreamingResponse(
               if (heldBack) {
                 safeEnqueue(encoder.encode(heldBack));
               }
-              const markerResp = replaceRecallWithMarker(currentResp);
+              const markerResp = replaceRecallWithMarker(
+                currentResp,
+                new Map([[recallBlock.id, markerText]]),
+              );
               clearKeepalive();
               onComplete(markerResp);
               safeClose();
@@ -5345,6 +5566,7 @@ function buildStreamingResponse(
 
             const markerResp = replaceRecallWithMarker(
               contAccum.hasRecall() ? contAccum.getResponse() : currentResp,
+              new Map([[recallBlock.id, markerText]]),
             );
             clearKeepalive();
             onComplete(markerResp);
@@ -5437,59 +5659,761 @@ export function streamResponsesRecallAware(
   opts: {
     onComplete: (response: GatewayResponse) => void;
     sessionID?: string;
+    maxRecallDepth?: number;
+    maxDeferredBytes?: number;
+    maxHiddenRecallBytes?: number;
+    maxRetainedStateBytes?: number;
+    maxStreamBytes?: number;
+    maxSSEFrames?: number;
     /**
      * Called when a `recall` function_call is fully parsed. Runs the recall
      * (LTM search + optional LLM result) and returns the pieces needed to
      * deliver the marker + continuation to the client:
-     *  - `markerText`: the `buildRecallMarker(...)` text emission.
      *  - `resultText`: the raw recall result string (for the follow-up).
-     * Return null to abort (emits a marker-only response).
      */
     onRecall: (input: {
       query: string;
       scope?: string;
       id?: string;
+      outputIndex: number;
       toolUseId: string;
+      /** Position in the normalized GatewayResponse content array. */
+      contentPosition: number;
       /** The accumulated response INCLUDING the recall tool_use, so the caller
        *  can build the follow-up request from the same accumulation the
        *  streamer uses. */
       acc: GatewayResponse;
+      signal: AbortSignal;
     }) => Promise<{
-      markerText: string;
+      anchorText: string;
       resultText: string;
-    } | null>;
+      commit?: () => void;
+      rollback?: () => void;
+    }>;
     /** Streaming follow-up stage: build + forward + assert-SSE + reader. */
     runFollowUp: (ctx: {
-      markerText: string;
+      anchorText: string;
       resultText: string;
       acc: GatewayResponse;
+      toolUseId: string;
+      contentPosition: number;
+      signal: AbortSignal;
     }) => Promise<{
       reader: ReadableStreamDefaultReader<Uint8Array>;
     }>;
   },
 ): Response {
   const state = makeResponsesAccState();
+  const syntheticIdentities = new Set<string>();
+  const responseLifecycles = new WeakMap<
+    ResponsesAccState,
+    { created: boolean; terminal: boolean }
+  >();
+  const responseLifecycleFor = (
+    acc: ResponsesAccState,
+  ): { created: boolean; terminal: boolean } => {
+    let lifecycle = responseLifecycles.get(acc);
+    if (!lifecycle) {
+      lifecycle = { created: false, terminal: false };
+      responseLifecycles.set(acc, lifecycle);
+    }
+    return lifecycle;
+  };
+  type OutputLifecycle = {
+    argumentsDone: boolean;
+    outputDone: boolean;
+    content: Map<
+      number,
+      {
+        kind?: string;
+        valueSeen: boolean;
+        valueDone: boolean;
+        finalValue?: string;
+        partFinalValue?: string;
+        partAdded: boolean;
+        partDone: boolean;
+      }
+    >;
+  };
+  const outputLifecycles = new WeakMap<
+    ResponsesAccState,
+    Map<number, OutputLifecycle>
+  >();
+  const lifecyclesFor = (
+    acc: ResponsesAccState,
+  ): Map<number, OutputLifecycle> => {
+    let lifecycles = outputLifecycles.get(acc);
+    if (!lifecycles) {
+      lifecycles = new Map();
+      outputLifecycles.set(acc, lifecycles);
+    }
+    return lifecycles;
+  };
+  let transactionBaseline: ResponsesAccState | undefined;
+  const transactionRollbacks: Array<() => void> = [];
+  const restoreTransactionBaseline = (): void => {
+    if (!transactionBaseline) return;
+    state.id = transactionBaseline.id;
+    state.model = transactionBaseline.model;
+    state.stopReason = transactionBaseline.stopReason;
+    state.terminalEvent = transactionBaseline.terminalEvent;
+    state.usage = { ...transactionBaseline.usage };
+    state.items = new Map(transactionBaseline.items);
+    state.rawItems = new Map(transactionBaseline.rawItems);
+    transactionBaseline = undefined;
+  };
+  const rollbackTransaction = (): void => {
+    restoreTransactionBaseline();
+    for (const rollback of transactionRollbacks.splice(0).reverse()) {
+      try {
+        rollback();
+      } catch (err) {
+        log.error("recall transaction rollback failed:", err);
+      }
+    }
+  };
   const encoder = new TextEncoder();
   const sessionID = opts.sessionID;
+  const maxRecallDepth = opts.maxRecallDepth ?? MAX_RECALL_DEPTH;
+  const maxDeferredBytes = opts.maxDeferredBytes ?? 1024 * 1024;
+  const maxHiddenRecallBytes = opts.maxHiddenRecallBytes ?? maxDeferredBytes;
+  const maxRetainedStateBytes = opts.maxRetainedStateBytes ?? 16 * 1024 * 1024;
+  const maxStreamBytes = opts.maxStreamBytes ?? 64 * 1024 * 1024;
+  let retainedStateBytes = 0;
+  let streamBytes = 0;
+  let hiddenRecallBytes = 0;
+  const maxSSEFrames = opts.maxSSEFrames ?? 100_000;
+  const frameCounter = { count: 0 };
+  const sseInactivityMs = 120_000;
+
+  const parseRecallArguments = (
+    value: unknown,
+  ): { query: string; scope?: string; id?: string } => {
+    if (typeof value !== "string") {
+      throw new Error(
+        "invalid recall function arguments: expected JSON string",
+      );
+    }
+    let input: unknown;
+    try {
+      input = JSON.parse(value);
+    } catch {
+      throw new Error("invalid recall function arguments: malformed JSON");
+    }
+    if (!input || typeof input !== "object" || Array.isArray(input)) {
+      throw new Error("invalid recall function arguments: expected object");
+    }
+    const record = input as Record<string, unknown>;
+    const allowed = new Set(["query", "scope", "id"]);
+    const unknown = Object.keys(record).find((key) => !allowed.has(key));
+    if (unknown) {
+      throw new Error(
+        `invalid recall function arguments: unknown property "${unknown}"`,
+      );
+    }
+    if (record.query !== undefined && typeof record.query !== "string") {
+      throw new Error(
+        "invalid recall function arguments: query must be a string",
+      );
+    }
+    if (
+      record.id !== undefined &&
+      record.id !== null &&
+      typeof record.id !== "string"
+    ) {
+      throw new Error("invalid recall function arguments: id must be a string");
+    }
+    if (
+      record.scope !== undefined &&
+      record.scope !== null &&
+      typeof record.scope !== "string"
+    ) {
+      throw new Error(
+        "invalid recall function arguments: scope must be a string",
+      );
+    }
+    const query = record.query ?? "";
+    const id = record.id || undefined;
+    if (!query.trim() && !id) {
+      throw new Error(
+        "invalid recall function arguments: query or id is required",
+      );
+    }
+    const scope = record.scope || undefined;
+    if (
+      scope &&
+      scope !== "all" &&
+      scope !== "session" &&
+      scope !== "project" &&
+      scope !== "knowledge"
+    ) {
+      throw new Error("invalid recall function arguments: unsupported scope");
+    }
+    return { query, ...(scope ? { scope } : {}), ...(id ? { id } : {}) };
+  };
+
+  const mergeUsage = (target: GatewayUsage, source: GatewayUsage): void => {
+    target.inputTokens += source.inputTokens;
+    target.outputTokens += source.outputTokens;
+    if (source.cacheReadInputTokens != null) {
+      target.cacheReadInputTokens =
+        (target.cacheReadInputTokens ?? 0) + source.cacheReadInputTokens;
+    }
+    if (source.cacheCreationInputTokens != null) {
+      target.cacheCreationInputTokens =
+        (target.cacheCreationInputTokens ?? 0) +
+        source.cacheCreationInputTokens;
+    }
+  };
 
   let cancelled = false;
+  let terminalDelivered = false;
+  const abortController = new AbortController();
+  const signal = abortController.signal;
   let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+
+  const outputIndexForEvent = (
+    event: string,
+    parsed: Record<string, unknown>,
+    state: ResponsesAccState,
+  ): number | undefined => {
+    const requiresOutputIndex =
+      /^response\.(?:output_item|output_text|function_call_arguments|content_part|reasoning_summary|refusal)/.test(
+        event,
+      );
+    const hasOutputIndex = Object.hasOwn(parsed, "output_index");
+    if (!requiresOutputIndex && !hasOutputIndex) return undefined;
+    const index = parsed.output_index;
+    if (!Number.isSafeInteger(index) || (index as number) < 0) {
+      throw new Error(`invalid Responses output_index for ${event}`);
+    }
+    const outputIndex = index as number;
+    const lifecycles = lifecyclesFor(state);
+    const lifecycle = lifecycles.get(outputIndex);
+    if (lifecycle?.outputDone && event !== "response.output_item.added") {
+      throw new Error(
+        `Responses event after output_item.done for index ${outputIndex}`,
+      );
+    }
+    if (event === "response.output_item.added") {
+      if (state.rawItems.has(outputIndex)) {
+        throw new Error(`duplicate Responses output_index ${outputIndex}`);
+      }
+      const item = parsed.item as Record<string, unknown> | undefined;
+      if (
+        !item ||
+        typeof item.type !== "string" ||
+        typeof item.id !== "string" ||
+        item.id.length === 0 ||
+        (item.type === "function_call" &&
+          (typeof item.call_id !== "string" ||
+            item.call_id.length === 0 ||
+            typeof item.name !== "string" ||
+            item.name.length === 0))
+      ) {
+        throw new Error(
+          `incomplete Responses output_item.added identity for index ${outputIndex}`,
+        );
+      }
+      if (item.type === "function_call" && item.id === item.call_id) {
+        throw new Error("duplicate Responses identity within output item");
+      }
+      const identities = [item.id, item.call_id].filter(
+        (value): value is string => typeof value === "string",
+      );
+      if (identities.some((identity) => syntheticIdentities.has(identity))) {
+        throw new Error("duplicate synthetic Responses item identity");
+      }
+      for (const [existingIndex, existing] of state.rawItems) {
+        const newIdentities = [item.id, item.call_id].filter(
+          (value): value is string => typeof value === "string",
+        );
+        const existingIdentities = new Set(
+          [existing.id, existing.call_id].filter(
+            (value): value is string => typeof value === "string",
+          ),
+        );
+        if (
+          existingIndex !== outputIndex &&
+          newIdentities.some((identity) => existingIdentities.has(identity))
+        ) {
+          throw new Error("duplicate Responses item identity");
+        }
+      }
+      lifecycles.set(outputIndex, {
+        argumentsDone: item.type !== "function_call",
+        outputDone: false,
+        content: new Map(),
+      });
+    } else if (!state.rawItems.has(outputIndex)) {
+      throw new Error(
+        `Responses ${event} arrived before output_item.added for index ${outputIndex}`,
+      );
+    } else {
+      const declared = state.rawItems.get(outputIndex);
+      if (!lifecycle) {
+        throw new Error(`missing Responses lifecycle for index ${outputIndex}`);
+      }
+      const item = parsed.item as Record<string, unknown> | undefined;
+      if (
+        event === "response.output_item.done" &&
+        (!item ||
+          item.type !== declared?.type ||
+          item.id !== declared?.id ||
+          item.call_id !== declared?.call_id ||
+          item.name !== declared?.name)
+      ) {
+        throw new Error(
+          `Responses output_item.done changed item identity for index ${outputIndex}`,
+        );
+      }
+      const declaredType = declared?.type;
+      const itemId = parsed.item_id;
+      if (
+        event !== "response.output_item.done" &&
+        (typeof itemId !== "string" || itemId !== declared?.id)
+      ) {
+        throw new Error(
+          `Responses ${event} changed item_id for index ${outputIndex}`,
+        );
+      }
+      if (
+        (event.startsWith("response.output_text") ||
+          event.startsWith("response.content_part") ||
+          event.startsWith("response.refusal")) &&
+        (!Number.isSafeInteger(parsed.content_index) ||
+          (parsed.content_index as number) < 0)
+      ) {
+        throw new Error(`invalid Responses content_index for ${event}`);
+      }
+      if (
+        event.startsWith("response.output_text") ||
+        event.startsWith("response.content_part") ||
+        event.startsWith("response.refusal")
+      ) {
+        const contentIndex = parsed.content_index as number;
+        const contentState = lifecycle.content.get(contentIndex) ?? {
+          valueSeen: false,
+          valueDone: false,
+          partAdded: false,
+          partDone: false,
+        };
+        const expectedKind = event.startsWith("response.output_text")
+          ? "output_text"
+          : event.startsWith("response.refusal")
+            ? "refusal"
+            : undefined;
+        const part = parsed.part as Record<string, unknown> | undefined;
+        const partKind =
+          event.startsWith("response.content_part") &&
+          typeof part?.type === "string"
+            ? part.type
+            : undefined;
+        const kind = expectedKind ?? partKind;
+        if (!kind || (contentState.kind && contentState.kind !== kind)) {
+          throw new Error(
+            `Responses ${event} changed content type for index ${outputIndex}:${contentIndex}`,
+          );
+        }
+        contentState.kind = kind;
+        if (event === "response.content_part.added") {
+          if (contentState.partAdded) {
+            throw new Error(
+              `duplicate Responses content_part.added for index ${outputIndex}:${contentIndex}`,
+            );
+          }
+          contentState.partAdded = true;
+        } else if (event === "response.content_part.done") {
+          if (!contentState.partAdded || contentState.partDone) {
+            throw new Error(
+              `invalid Responses content_part.done for index ${outputIndex}:${contentIndex}`,
+            );
+          }
+          contentState.partDone = true;
+          const partValue = kind === "output_text" ? part?.text : part?.refusal;
+          if (typeof partValue !== "string") {
+            throw new Error(`invalid Responses ${event} final value`);
+          }
+          contentState.partFinalValue = partValue;
+          if (
+            contentState.finalValue !== undefined &&
+            contentState.finalValue !== partValue
+          ) {
+            throw new Error(
+              `Responses content_part.done changed content for index ${outputIndex}:${contentIndex}`,
+            );
+          }
+        } else {
+          if (contentState.valueDone) {
+            throw new Error(
+              `Responses content changed after completion for index ${outputIndex}:${contentIndex}`,
+            );
+          }
+          contentState.valueSeen = true;
+          if (event.endsWith(".done")) {
+            const finalValue =
+              kind === "output_text" ? parsed.text : parsed.refusal;
+            if (typeof finalValue !== "string") {
+              throw new Error(`invalid Responses ${event} final value`);
+            }
+            contentState.valueDone = true;
+            contentState.finalValue = finalValue;
+            if (
+              contentState.partFinalValue !== undefined &&
+              contentState.partFinalValue !== finalValue
+            ) {
+              throw new Error(
+                `Responses ${event} changed content part for index ${outputIndex}:${contentIndex}`,
+              );
+            }
+          }
+        }
+        lifecycle.content.set(contentIndex, contentState);
+      }
+      if (
+        event.startsWith("response.reasoning_summary") &&
+        (!Number.isSafeInteger(parsed.summary_index) ||
+          (parsed.summary_index as number) < 0)
+      ) {
+        throw new Error(`invalid Responses summary_index for ${event}`);
+      }
+      if (
+        ((event.startsWith("response.output_text") ||
+          event.startsWith("response.content_part") ||
+          event.startsWith("response.refusal")) &&
+          declaredType !== "message") ||
+        (event.startsWith("response.reasoning_summary") &&
+          declaredType !== "reasoning") ||
+        (event.startsWith("response.function_call_arguments") &&
+          declaredType !== "function_call")
+      ) {
+        throw new Error(
+          `Responses ${event} does not match item type ${String(declaredType)}`,
+        );
+      }
+      if (event === "response.function_call_arguments.done") {
+        if (lifecycle.argumentsDone) {
+          throw new Error(
+            `duplicate Responses function arguments completion for index ${outputIndex}`,
+          );
+        }
+        lifecycle.argumentsDone = true;
+      } else if (
+        event.startsWith("response.function_call_arguments") &&
+        lifecycle.argumentsDone
+      ) {
+        throw new Error(
+          `Responses function arguments changed after completion for index ${outputIndex}`,
+        );
+      }
+      if (event === "response.output_item.done") {
+        if (declaredType === "function_call" && !lifecycle.argumentsDone) {
+          throw new Error(
+            `Responses function call completed before arguments for index ${outputIndex}`,
+          );
+        }
+        if (declaredType === "function_call") {
+          const normalized = state.items.get(outputIndex);
+          if (
+            normalized?.type !== "tool_use" ||
+            typeof item?.arguments !== "string" ||
+            item.arguments !== normalized.args
+          ) {
+            throw new Error(
+              `Responses output_item.done changed arguments for index ${outputIndex}`,
+            );
+          }
+        }
+        if (declaredType === "message") {
+          const finalContent = item?.content;
+          if (!Array.isArray(finalContent)) {
+            throw new Error(
+              `Responses message completed without content for index ${outputIndex}`,
+            );
+          }
+          for (const [contentIndex, contentState] of lifecycle.content) {
+            const finalPart = finalContent[contentIndex] as
+              | Record<string, unknown>
+              | undefined;
+            if (!finalPart || finalPart.type !== contentState.kind) {
+              throw new Error(
+                `Responses output_item.done changed content type for index ${outputIndex}:${contentIndex}`,
+              );
+            }
+            if (contentState.valueSeen && !contentState.valueDone) {
+              throw new Error(
+                `Responses content ended before completion for index ${outputIndex}:${contentIndex}`,
+              );
+            }
+            if (contentState.partAdded && !contentState.partDone) {
+              throw new Error(
+                `Responses content part ended before completion for index ${outputIndex}:${contentIndex}`,
+              );
+            }
+            const finalValue =
+              contentState.kind === "output_text"
+                ? finalPart.text
+                : finalPart.refusal;
+            if (
+              contentState.finalValue !== undefined &&
+              finalValue !== contentState.finalValue
+            ) {
+              throw new Error(
+                `Responses output_item.done changed content for index ${outputIndex}:${contentIndex}`,
+              );
+            }
+          }
+        }
+        lifecycle.outputDone = true;
+      }
+    }
+    return outputIndex;
+  };
+  const validateResponseLifecycle = (
+    acc: ResponsesAccState,
+    event: string,
+    parsed: Record<string, unknown>,
+  ): void => {
+    const lifecycle = responseLifecycleFor(acc);
+    if (lifecycle.terminal) {
+      throw new Error(`Responses event after terminal: ${event}`);
+    }
+    if (event === "response.created") {
+      if (lifecycle.created) throw new Error("duplicate response.created");
+      const response = parsed.response as Record<string, unknown> | undefined;
+      if (!response || typeof response.id !== "string" || !response.id) {
+        throw new Error("response.created missing response identity");
+      }
+      lifecycle.created = true;
+      return;
+    }
+    if (!lifecycle.created && event.startsWith("response.")) {
+      throw new Error(`Responses event before response.created: ${event}`);
+    }
+    if (event === "response.in_progress") {
+      const response = parsed.response as Record<string, unknown> | undefined;
+      if (acc.id && response?.id !== undefined && response.id !== acc.id) {
+        throw new Error(
+          "Responses in-progress event changed response identity",
+        );
+      }
+    }
+    if (
+      event === "response.completed" ||
+      event === "response.done" ||
+      event === "response.incomplete" ||
+      event === "response.failed"
+    ) {
+      const response = parsed.response as Record<string, unknown> | undefined;
+      if (acc.id && response?.id !== acc.id) {
+        throw new Error("Responses terminal event changed response identity");
+      }
+      lifecycle.terminal = true;
+    }
+  };
+  const assertOutputLifecyclesComplete = (acc: ResponsesAccState): void => {
+    const lifecycles = lifecyclesFor(acc);
+    for (const index of acc.rawItems.keys()) {
+      if (!lifecycles.get(index)?.outputDone) {
+        throw new Error(
+          `Responses stream ended before output_item.done for index ${index}`,
+        );
+      }
+    }
+  };
+  const assertTerminalOutputMatches = (
+    acc: ResponsesAccState,
+    parsed: Record<string, unknown>,
+  ): void => {
+    const response = parsed.response as Record<string, unknown> | undefined;
+    if (!response) throw new Error("Responses terminal event missing response");
+    if (acc.id && response.id !== acc.id) {
+      throw new Error("Responses terminal event changed response identity");
+    }
+    if (response.output === undefined) return;
+    if (!Array.isArray(response.output)) {
+      throw new Error("Responses terminal output must be an array");
+    }
+    const actualOutput = response.output.filter(
+      (item): item is Record<string, unknown> =>
+        !!item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type !== "item_reference",
+    );
+    const expected = [...acc.rawItems.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([, item]) => item)
+      .filter((item) => item.type !== "item_reference");
+    if (actualOutput.length !== expected.length) {
+      throw new Error("Responses terminal output changed item count");
+    }
+    for (let i = 0; i < expected.length; i++) {
+      const actual = actualOutput[i];
+      const streamed = expected[i];
+      if (
+        !actual ||
+        actual.type !== streamed.type ||
+        actual.id !== streamed.id ||
+        actual.call_id !== streamed.call_id ||
+        (streamed.type === "message" &&
+          !isDeepStrictEqual(actual.content, streamed.content)) ||
+        (streamed.type === "function_call" &&
+          actual.arguments !== streamed.arguments)
+      ) {
+        throw new Error("Responses terminal output changed streamed item");
+      }
+    }
+  };
+  const reserveSyntheticIdentity = (
+    syntheticId: string,
+    states: readonly ResponsesAccState[],
+  ): void => {
+    if (
+      syntheticIdentities.has(syntheticId) ||
+      states.some(
+        (acc) =>
+          [...acc.items.values()].some(
+            (item) =>
+              item.id === syntheticId ||
+              (item.type === "tool_use" && item.callId === syntheticId),
+          ) ||
+          [...acc.rawItems.values()].some(
+            (item) => item.id === syntheticId || item.call_id === syntheticId,
+          ),
+      )
+    ) {
+      throw new Error("duplicate synthetic Responses item identity");
+    }
+    syntheticIdentities.add(syntheticId);
+  };
 
   // --- Keepalive (same as streamResponsesPassthrough) ---
   const KEEPALIVE_INACTIVITY_MS = 30_000;
   const keepaliveComment = encoder.encode(`: keepalive\n\n`);
   let keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
   let completed = false;
-  let terminalSeen = false;
+  let completionAttempted = false;
+  let nextSequenceNumber = 0;
 
-  const finish = (resp: GatewayResponse): void => {
-    if (completed) return;
-    completed = true;
+  const sequenceChunk = (chunk: Uint8Array): Uint8Array => {
+    const text = new TextDecoder().decode(chunk);
+    if (!text.startsWith("event: ")) return chunk;
+    let output = "";
+    for (const frame of text.split("\n\n")) {
+      if (!frame) continue;
+      const lines = frame.split("\n");
+      const eventLine = lines.find((line) => line.startsWith("event: "));
+      const dataLines = lines.filter((line) => line.startsWith("data: "));
+      if (!eventLine || dataLines.length === 0) {
+        output += `${frame}\n\n`;
+        continue;
+      }
+      const event = eventLine.slice("event: ".length);
+      const data = dataLines
+        .map((line) => line.slice("data: ".length))
+        .join("\n");
+      try {
+        const parsed = JSON.parse(data) as Record<string, unknown>;
+        output += formatResponsesEvent(
+          event,
+          JSON.stringify({ ...parsed, sequence_number: nextSequenceNumber++ }),
+        );
+      } catch {
+        output += `${frame}\n\n`;
+      }
+    }
+    return encoder.encode(output);
+  };
+
+  const finish = (resp: GatewayResponse): boolean => {
+    if (completionAttempted) return completed;
+    completionAttempted = true;
     try {
       opts.onComplete(resp);
+      completed = true;
+      return true;
     } catch (err) {
       log.error("openai-responses recall-aware onComplete error:", err);
+      return false;
     }
+  };
+  const settleRecall = async (
+    input: Parameters<typeof opts.onRecall>[0],
+  ): ReturnType<typeof opts.onRecall> => {
+    const operation = opts.onRecall(input);
+    const onLateResult = async (): Promise<void> => {
+      try {
+        const late = await operation;
+        late.rollback?.();
+      } catch {
+        // The aborted request no longer observes the callback result.
+      }
+    };
+    if (signal.aborted) {
+      void onLateResult();
+      throw signal.reason;
+    }
+    let rejectAbort: ((reason: unknown) => void) | undefined;
+    const abort = new Promise<never>((_, reject) => {
+      rejectAbort = reject;
+    });
+    const onAbort = (): void => rejectAbort?.(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    let result: Awaited<ReturnType<typeof opts.onRecall>>;
+    try {
+      result = await Promise.race([operation, abort]);
+    } catch (err) {
+      if (signal.aborted) void onLateResult();
+      throw err;
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+    }
+    if (signal.aborted) {
+      try {
+        result.rollback?.();
+      } catch (err) {
+        log.error("late recall rollback failed:", err);
+      }
+      throw signal.reason;
+    }
+    return result;
+  };
+  const settleFollowUp = async (
+    input: Parameters<typeof opts.runFollowUp>[0],
+  ): ReturnType<typeof opts.runFollowUp> => {
+    const operation = opts.runFollowUp(input);
+    const cancelLateReader = async (): Promise<void> => {
+      try {
+        const late = await operation;
+        await late.reader.cancel();
+      } catch {
+        // The aborted request no longer observes the callback result.
+      }
+    };
+    if (signal.aborted) {
+      void cancelLateReader();
+      throw signal.reason;
+    }
+    let rejectAbort: ((reason: unknown) => void) | undefined;
+    const abort = new Promise<never>((_, reject) => {
+      rejectAbort = reject;
+    });
+    const onAbort = (): void => rejectAbort?.(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    let result: Awaited<ReturnType<typeof opts.runFollowUp>>;
+    try {
+      result = await Promise.race([operation, abort]);
+    } catch (err) {
+      if (signal.aborted) void cancelLateReader();
+      throw err;
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+    }
+    if (signal.aborted) {
+      void result.reader.cancel().catch(() => {});
+      throw signal.reason;
+    }
+    return result;
   };
 
   /**
@@ -5578,44 +6502,33 @@ export function streamResponsesRecallAware(
    * Rebuild the terminal `response.completed` event from the given completion
    * state (used instead of the suppressed original when recall was detected).
    */
-  function buildCompleted(res: GatewayResponse): string {
-    const finalOutput: Array<Record<string, unknown>> = [];
-    for (const block of res.content) {
-      if (block.type === "text") {
-        finalOutput.push({
-          type: "message",
-          id: `msg_${state.id || "resp"}_${finalOutput.length}`,
-          role: "assistant",
-          status: "completed",
-          content: [{ type: "output_text", text: block.text, annotations: [] }],
-        });
-      } else if (block.type === "tool_use") {
-        finalOutput.push({
-          type: "function_call",
-          id: `fc_${block.id}`,
-          call_id: block.id,
-          name: block.name,
-          arguments: JSON.stringify(block.input),
-          status: "completed",
-        });
-      }
-    }
+  function buildTerminal(res: GatewayResponse): string {
+    const finalOutput = buildOutputItems();
     const finalStatus = mapStatusFromStopReason(res.stopReason);
     const ru = res.usage ?? ZERO_USAGE;
+    const inclusiveInputTokens =
+      ru.inputTokens +
+      (ru.cacheReadInputTokens ?? 0) +
+      (ru.cacheCreationInputTokens ?? 0);
     const usageData: Record<string, unknown> = {
-      input_tokens: ru.inputTokens,
+      input_tokens: inclusiveInputTokens,
       output_tokens: ru.outputTokens,
-      total_tokens: ru.inputTokens + ru.outputTokens,
+      total_tokens: inclusiveInputTokens + ru.outputTokens,
     };
-    if (ru.cacheReadInputTokens != null) {
-      usageData.prompt_tokens_details = {
-        cached_tokens: ru.cacheReadInputTokens,
+    if (
+      ru.cacheReadInputTokens != null ||
+      ru.cacheCreationInputTokens != null
+    ) {
+      usageData.input_tokens_details = {
+        cached_tokens: ru.cacheReadInputTokens ?? 0,
+        cache_write_tokens: ru.cacheCreationInputTokens ?? 0,
       };
     }
+    const terminalEvent = state.terminalEvent ?? "response.completed";
     return formatResponsesEvent(
-      "response.completed",
+      terminalEvent,
       JSON.stringify({
-        type: "response.completed",
+        type: terminalEvent,
         response: {
           id: state.id,
           object: "response",
@@ -5629,419 +6542,962 @@ export function streamResponsesRecallAware(
     );
   }
 
+  function buildOutputItems(
+    hiddenIndices: ReadonlySet<number> = new Set(),
+  ): Array<Record<string, unknown>> {
+    const finalOutput: Array<Record<string, unknown>> = [];
+    const sortedIndices = [
+      ...new Set([...state.rawItems.keys(), ...state.items.keys()]),
+    ].sort((a, b) => a - b);
+    for (const index of sortedIndices) {
+      if (hiddenIndices.has(index)) continue;
+      const item = state.items.get(index);
+      if (!item) {
+        const rawItem = state.rawItems.get(index);
+        if (rawItem && rawItem.type !== "item_reference") {
+          finalOutput.push(rawItem);
+        }
+        continue;
+      }
+      if (item.type === "text") {
+        if (item.content) {
+          const raw = state.rawItems.get(index);
+          finalOutput.push({
+            ...(raw ?? {
+              type: "message",
+              id: item.id,
+              role: "assistant",
+              status: "completed",
+            }),
+            content: item.content,
+          });
+          continue;
+        }
+        if (item.refusal !== undefined) {
+          finalOutput.push({
+            type: "message",
+            id: item.id,
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "refusal", refusal: item.refusal }],
+          });
+          continue;
+        }
+        finalOutput.push({
+          type: "message",
+          id: item.id,
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: item.text, annotations: [] }],
+        });
+      } else {
+        finalOutput.push({
+          type: "function_call",
+          id: item.id,
+          call_id: item.callId,
+          name: item.name,
+          arguments: item.args,
+          status: "completed",
+        });
+      }
+    }
+    return finalOutput;
+  }
+
+  let resumeDemand: (() => void) | undefined;
   const stream = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      const safeEnqueue = (chunk: Uint8Array): boolean => {
-        if (cancelled) return false;
-        try {
-          controller.enqueue(chunk);
-          return true;
-        } catch {
-          cancelled = true;
-          return false;
-        }
-      };
-      const safeClose = (): void => {
-        if (cancelled) return;
-        try {
-          controller.close();
-        } catch {
-          // Already closed/cancelled
-        }
-      };
-
-      const resetKeepalive = (): void => {
-        if (keepaliveTimer) clearTimeout(keepaliveTimer);
-        keepaliveTimer = setTimeout(function tick() {
-          if (cancelled) return;
-          safeEnqueue(keepaliveComment);
-          keepaliveTimer = setTimeout(tick, KEEPALIVE_INACTIVITY_MS);
-        }, KEEPALIVE_INACTIVITY_MS);
-      };
-      const clearKeepalive = (): void => {
-        if (keepaliveTimer) clearTimeout(keepaliveTimer);
-        keepaliveTimer = null;
-      };
-
-      try {
-        if (!upstreamResponse.body) {
-          throw new Error("Upstream response has no body");
-        }
-        const reader = upstreamResponse.body.getReader();
-        activeReader = reader;
-
-        // --- Recall interception state ---
-        // `output_index` values whose item is a suppressed `recall` function_call.
-        const recallIndices = new Set<number>();
-        // Set of recall indices whose full args have been collected (so we run
-        // the recall exactly once per recall call).
-        const recallExecuted = new Set<number>();
-        const recallToolUseIds = new Map<number, string>();
-        // Ordered list of parsed recall invocations: { outputIndex, block }.
-        const pendingRecalls: Array<{
-          outputIndex: number;
-          toolUseId: string;
-          query: string;
-          scope?: string;
-          id?: string;
-        }> = [];
-        // Whether any NON-recall function_call appeared (mixed-tools case).
-        let otherToolSeen = false;
-
-        resetKeepalive();
-        for await (const { event, data } of parseSSEStream(reader)) {
-          resetKeepalive(); // upstream alive — reset inactivity timer
-
-          if (!data || data === "[DONE]") continue;
-
-          let parsed: Record<string, unknown>;
+    start(controller) {
+      void (async () => {
+        const waitForDemand = async (): Promise<void> => {
+          while (!cancelled && (controller.desiredSize ?? 1) <= 0) {
+            await new Promise<void>((resolve) => {
+              resumeDemand = resolve;
+            });
+          }
+        };
+        const safeEnqueue = async (chunk: Uint8Array): Promise<boolean> => {
+          if (cancelled) return false;
+          await waitForDemand();
+          if (cancelled) return false;
           try {
-            parsed = JSON.parse(data) as Record<string, unknown>;
+            controller.enqueue(sequenceChunk(chunk));
+            return true;
           } catch {
-            // Non-JSON (keepalive etc.) — forward as-is
-            if (event !== "message") {
-              safeEnqueue(encoder.encode(formatResponsesEvent(event, data)));
-            }
-            continue;
+            cancelled = true;
+            return false;
           }
+        };
+        const safeClose = (): void => {
+          if (cancelled) return;
+          try {
+            controller.close();
+          } catch {
+            // Already closed/cancelled
+          }
+        };
 
-          const outputIndex = parsed.output_index as number | undefined;
+        const resetKeepalive = (): void => {
+          if (keepaliveTimer) clearTimeout(keepaliveTimer);
+          keepaliveTimer = setTimeout(function tick() {
+            if (cancelled) return;
+            if ((controller.desiredSize ?? 1) > 0) {
+              void safeEnqueue(keepaliveComment);
+            }
+            keepaliveTimer = setTimeout(tick, KEEPALIVE_INACTIVITY_MS);
+          }, KEEPALIVE_INACTIVITY_MS);
+        };
+        const clearKeepalive = (): void => {
+          if (keepaliveTimer) clearTimeout(keepaliveTimer);
+          keepaliveTimer = null;
+        };
+        let principalReader: ReadableStreamDefaultReader<Uint8Array> | null =
+          null;
+        // Recall items are gateway-internal and must stay hidden on every exit,
+        // including failures raised before marker replacement.
+        const recallIndices = new Set<number>();
+        const referenceIndices = new Set<number>();
 
-          // Detect a recall function_call item from its `added` event.
-          if (
-            event === "response.output_item.added" &&
-            outputIndex !== undefined
-          ) {
-            const item = parsed.item as Record<string, unknown> | undefined;
-            const isRecallCall =
-              item?.type === "function_call" && item?.name === "recall";
-            if (isRecallCall) {
-              recallIndices.add(outputIndex);
-              const toolUseId = item?.call_id ?? item?.id;
-              if (typeof toolUseId === "string") {
-                recallToolUseIds.set(outputIndex, toolUseId);
+        try {
+          if (!upstreamResponse.body) {
+            throw new Error("Upstream response has no body");
+          }
+          const reader = upstreamResponse.body.getReader();
+          principalReader = reader;
+          activeReader = reader;
+
+          // --- Recall interception state ---
+          // `output_index` values whose item is a suppressed `recall` function_call.
+          const parsedRecallInputs = new Map<
+            number,
+            { query: string; scope?: string; id?: string }
+          >();
+          // Ordered list of parsed recall invocations: { outputIndex, block }.
+          const pendingRecalls: Array<{
+            outputIndex: number;
+            contentPosition: number;
+            query: string;
+            scope?: string;
+            id?: string;
+            toolUseId: string;
+          }> = [];
+          // Whether any NON-recall function_call appeared (mixed-tools case).
+          let otherToolSeen = false;
+          const deferredEvents: Uint8Array[] = [];
+          let deferredBytes = 0;
+
+          resetKeepalive();
+          for await (const { event, data } of parseSSEStream(reader, {
+            maxFrames: maxSSEFrames,
+            inactivityMs: sseInactivityMs,
+            signal,
+            frameCounter,
+          })) {
+            resetKeepalive(); // upstream alive — reset inactivity timer
+
+            if (!data || data === "[DONE]") continue;
+            streamBytes += encoder.encode(
+              formatResponsesEvent(event, data),
+            ).byteLength;
+            if (streamBytes > maxStreamBytes) {
+              throw new Error("Responses stream exceeded byte limit");
+            }
+
+            let parsed: Record<string, unknown>;
+            try {
+              parsed = JSON.parse(data) as Record<string, unknown>;
+            } catch {
+              if (event.startsWith("response.")) {
+                throw new Error(`malformed JSON in Responses event ${event}`);
               }
-            } else if (item?.type === "function_call") {
-              otherToolSeen = true;
+              // Non-JSON keepalive/comment event — forward as-is.
+              if (recallIndices.size === 0 && event !== "message") {
+                await safeEnqueue(
+                  encoder.encode(formatResponsesEvent(event, data)),
+                );
+              }
+              continue;
             }
-          }
+            if (parsed.type !== event) {
+              throw new Error(`Responses payload type does not match ${event}`);
+            }
+            validateResponseLifecycle(state, event, parsed);
 
-          const isRecallEvent =
-            outputIndex !== undefined && recallIndices.has(outputIndex);
-
-          // Always accumulate into the internal state for postResponse.
-          applyResponsesEvent(state, event, parsed);
-
-          // Suppress all events belonging to a recall item.
-          if (isRecallEvent && outputIndex !== undefined) {
-            // Collect the recall arguments once the function_call_arguments.done
-            // arrives for a recall index.
+            const rawOutputIndex = parsed.output_index;
+            const addedItem = parsed.item as
+              | Record<string, unknown>
+              | undefined;
             if (
-              event === "response.function_call_arguments.done" &&
-              !recallExecuted.has(outputIndex)
+              event === "response.output_item.added" &&
+              addedItem?.type === "item_reference"
             ) {
-              const args = parsed.arguments as string | undefined;
-              let input: Record<string, unknown> = {};
-              if (args) {
-                try {
-                  input = JSON.parse(args) as Record<string, unknown>;
-                } catch {
-                  /* keep empty */
-                }
-              }
-              const query = asString(input.query);
-              pendingRecalls.push({
-                outputIndex,
-                toolUseId:
-                  recallToolUseIds.get(outputIndex) ?? String(outputIndex),
-                query,
-                scope: asString(input.scope) || undefined,
-                id: asString(input.id) || undefined,
-              });
-              recallExecuted.add(outputIndex);
-            }
-            // Don't forward recall-item events to the client.
-            continue;
-          }
-
-          // Terminal events: handle recall interception before forwarding.
-          if (
-            event === "response.completed" ||
-            event === "response.done" ||
-            event === "response.incomplete"
-          ) {
-            if (pendingRecalls.length === 0) {
-              // No recall — forward the terminal event verbatim.
-              terminalSeen = true;
               if (
-                !safeEnqueue(encoder.encode(formatResponsesEvent(event, data)))
-              )
-                break;
+                !Number.isSafeInteger(rawOutputIndex) ||
+                (rawOutputIndex as number) < 0
+              ) {
+                throw new Error(
+                  "invalid Responses output_index for item_reference",
+                );
+              }
+              referenceIndices.add(rawOutputIndex as number);
+              continue;
+            }
+            if (
+              Number.isSafeInteger(rawOutputIndex) &&
+              referenceIndices.has(rawOutputIndex as number)
+            ) {
               continue;
             }
 
-            // Recall was detected. Drive the recall loop.
-            // Marker items already emitted at non-conflicting output indices.
-            let markerTexts: string[] = [];
-            // Continuation items accumulated from a recall-only follow-up, in
-            // their OWN state (never merged into `state` to avoid index
-            // collisions). undefined when no follow-up ran (e.g. mixed tools).
-            let appliedContinuation: ResponsesAccState | undefined;
-            // Offset applied to continuation items when merging into `state`:
-            // the marker slot + 1 (next free position).
-            let contIndexBase = 0;
-
-            for (const recall of pendingRecalls) {
-              const recallAcc = finalizeResponsesAcc(state);
-              const executed = await opts.onRecall({
-                query: recall.query,
-                scope: recall.scope,
-                id: recall.id,
-                toolUseId: recall.toolUseId,
-                acc: recallAcc,
-              });
-              if (!executed) {
-                // Abort path — emit nothing more; rely on the final rebuild.
-                continue;
+            const outputIndex = outputIndexForEvent(event, parsed, state);
+            if (outputIndex !== undefined) {
+              retainedStateBytes += encoder.encode(data).byteLength;
+              if (retainedStateBytes > maxRetainedStateBytes) {
+                throw new Error("Responses retained state exceeded byte limit");
               }
-              markerTexts.push(executed.markerText);
+            }
 
-              // Emit a synthetic marker output_text item at a non-conflicting
-              // output_index (reuse the suppressed recall index slot — the item
-              // is absent from the client, so its position is free).
+            // Detect a recall function_call item from its `added` event.
+            if (
+              event === "response.output_item.added" &&
+              outputIndex !== undefined
+            ) {
+              const item = parsed.item as Record<string, unknown> | undefined;
+              const isRecallCall =
+                item?.type === "function_call" && item?.name === "recall";
+              if (isRecallCall) {
+                recallIndices.add(outputIndex);
+              } else if (item?.type === "function_call") {
+                otherToolSeen = true;
+              }
+            }
+
+            const isRecallEvent =
+              outputIndex !== undefined && recallIndices.has(outputIndex);
+
+            // Always accumulate into the internal state for postResponse.
+            applyResponsesEvent(state, event, parsed);
+
+            // Suppress all events belonging to a recall item, but still count
+            // them so malformed argument streams cannot grow without bound.
+            if (isRecallEvent && outputIndex !== undefined) {
+              const hiddenBytes = encoder.encode(
+                formatResponsesEvent(event, data),
+              ).byteLength;
+              deferredBytes += hiddenBytes;
+              hiddenRecallBytes += hiddenBytes;
               if (
-                !safeEnqueue(
-                  encoder.encode(
-                    emitTextItem(
-                      recall.outputIndex,
-                      executed.markerText,
-                      `msg_${state.id || "lore"}_${recall.outputIndex}`,
-                    ),
-                  ),
+                deferredBytes > maxDeferredBytes ||
+                hiddenRecallBytes > maxHiddenRecallBytes
+              ) {
+                throw new Error("recall stream exceeded deferred event limit");
+              }
+              if (event === "response.function_call_arguments.done") {
+                parsedRecallInputs.set(
+                  outputIndex,
+                  parseRecallArguments(parsed.arguments),
+                );
+              }
+              if (event === "response.output_item.done") {
+                const input = parsedRecallInputs.get(outputIndex);
+                if (!input) {
+                  throw new Error(
+                    `recall output completed before arguments for index ${outputIndex}`,
+                  );
+                }
+                const query = input.query;
+                const recallItem = state.items.get(outputIndex);
+                const recallToolUseId =
+                  recallItem?.type === "tool_use" ? recallItem.callId : "";
+                const contentPosition = finalizeResponsesAcc(
+                  state,
+                ).content.findIndex(
+                  (block) =>
+                    block.type === "tool_use" && block.id === recallToolUseId,
+                );
+                pendingRecalls.push({
+                  outputIndex,
+                  contentPosition,
+                  query,
+                  scope: input.scope,
+                  id: input.id,
+                  toolUseId: recallToolUseId,
+                });
+                parsedRecallInputs.delete(outputIndex);
+              }
+              // Don't forward recall-item events to the client.
+              continue;
+            }
+
+            // Terminal events: handle recall interception before forwarding.
+            if (
+              event === "response.completed" ||
+              event === "response.done" ||
+              event === "response.incomplete" ||
+              event === "response.failed"
+            ) {
+              assertOutputLifecyclesComplete(state);
+              assertTerminalOutputMatches(state, parsed);
+              if (pendingRecalls.length === 0) {
+                if (recallIndices.size > 0) {
+                  throw new Error(
+                    "recall stream ended before function arguments completed",
+                  );
+                }
+                // No recall — forward the terminal event verbatim.
+                if (
+                  !(await safeEnqueue(
+                    encoder.encode(formatResponsesEvent(event, data)),
+                  ))
                 )
-              ) {
-                break;
+                  break;
+                void reader.cancel().catch(() => {});
+                principalReader = null;
+                clearKeepalive();
+                finish(finalizeResponsesAcc(state));
+                safeClose();
+                return;
+              }
+              if (state.terminalEvent === "response.failed") {
+                throw new Error("recall principal returned response.failed");
+              }
+              if (state.terminalEvent === "response.incomplete") {
+                throw new Error(
+                  "incomplete recall principal cannot execute recall",
+                );
               }
 
-              if (
-                !otherToolSeen &&
-                recall === pendingRecalls[pendingRecalls.length - 1]
-              ) {
-                // Recall-only: run the streaming follow-up and pipe the
-                // continuation inline before the final completion.
-                try {
-                  const follow = await opts.runFollowUp({
-                    markerText: executed.markerText,
-                    resultText: executed.resultText,
-                    acc: recallAcc,
+              // Recall was detected. Drive the recall loop.
+              if (pendingRecalls.length > 1) {
+                throw new Error(
+                  "parallel recall calls require a multi-result continuation",
+                );
+              }
+              if (pendingRecalls.length > maxRecallDepth) {
+                throw new Error(
+                  `recall depth exhausted (${maxRecallDepth}) in Responses stream`,
+                );
+              }
+              const anchorTexts: string[] = [];
+              transactionBaseline = {
+                ...state,
+                usage: { ...state.usage },
+                items: new Map(state.items),
+                rawItems: new Map(state.rawItems),
+              };
+              const pendingCommits: Array<() => void> = [];
+              const transactionalEvents: Uint8Array[] = [];
+              let transactionalBytes = 0;
+              const queueTransactional = (chunk: Uint8Array): void => {
+                transactionalBytes += chunk.byteLength;
+                if (transactionalBytes > maxDeferredBytes) {
+                  throw new Error(
+                    "recall continuation exceeded deferred event limit",
+                  );
+                }
+                transactionalEvents.push(chunk);
+              };
+              for (const recall of pendingRecalls) {
+                const syntheticId = `msg_${state.id || "lore"}_${recall.outputIndex}`;
+                reserveSyntheticIdentity(syntheticId, [state]);
+                const recallAcc = finalizeResponsesAcc(state);
+                const executed = await settleRecall({
+                  query: recall.query,
+                  scope: recall.scope,
+                  id: recall.id,
+                  outputIndex: recall.outputIndex,
+                  toolUseId: recall.toolUseId,
+                  contentPosition: recall.contentPosition,
+                  acc: recallAcc,
+                  signal,
+                });
+                anchorTexts.push(executed.anchorText);
+                if (executed.commit) pendingCommits.push(executed.commit);
+                if (executed.rollback) {
+                  transactionRollbacks.push(executed.rollback);
+                }
+                const anchorChunk = encoder.encode(
+                  emitTextItem(
+                    recall.outputIndex,
+                    executed.anchorText,
+                    syntheticId,
+                  ),
+                );
+                if (otherToolSeen) {
+                  state.items.set(recall.outputIndex, {
+                    type: "text",
+                    id: `msg_${state.id || "lore"}_${recall.outputIndex}`,
+                    text: executed.anchorText,
                   });
-                  activeReader = follow.reader;
-                  // Accumulate the continuation into its OWN state so indices
-                  // never collide with the marker/reply items in `state`.
-                  const contState = makeResponsesAccState();
-                  // Continue the output_index numbering past all suppressed
-                  // markers and the currently-emitted marker.
-                  let contIndex = recall.outputIndex + 1;
-                  contIndexBase = contIndex;
-                  for await (const { event: ce, data: cd } of parseSSEStream(
-                    follow.reader,
-                  )) {
-                    if (cancelled) break;
-                    if (!cd || cd === "[DONE]") continue;
-                    let cparsed: Record<string, unknown>;
-                    try {
-                      cparsed = JSON.parse(cd) as Record<string, unknown>;
-                    } catch {
-                      if (ce !== "message") {
-                        safeEnqueue(
-                          encoder.encode(formatResponsesEvent(ce, cd)),
+                  queueTransactional(anchorChunk);
+                  for (const chunk of deferredEvents) queueTransactional(chunk);
+                } else {
+                  queueTransactional(anchorChunk);
+                  for (const chunk of deferredEvents) queueTransactional(chunk);
+                }
+                deferredEvents.length = 0;
+                deferredBytes = 0;
+
+                if (
+                  !otherToolSeen &&
+                  recall === pendingRecalls[pendingRecalls.length - 1]
+                ) {
+                  // Recall-only: run the streaming follow-up and pipe the
+                  // continuation inline before the final completion.
+                  try {
+                    signal.throwIfAborted();
+                    let follow = await settleFollowUp({
+                      anchorText: executed.anchorText,
+                      resultText: executed.resultText,
+                      acc: recallAcc,
+                      toolUseId: recall.toolUseId,
+                      contentPosition: recall.contentPosition,
+                      signal,
+                    });
+                    let recallDepth = pendingRecalls.length;
+                    for (;;) {
+                      activeReader = follow.reader;
+                      const contState = makeResponsesAccState();
+                      const contRecallIndices = new Set<number>();
+                      const contReferenceIndices = new Set<number>();
+                      const contRecallInputs = new Map<
+                        number,
+                        { query: string; scope?: string; id?: string }
+                      >();
+                      const contPending: typeof pendingRecalls = [];
+                      const heldContinuationEvents: Uint8Array[] = [];
+                      let heldContinuationBytes = 0;
+                      let continuationRecallBytes = 0;
+                      let contOtherTool = false;
+                      let continuationCompleted = false;
+                      let continuationFailed = false;
+                      const contIndex =
+                        Math.max(
+                          -1,
+                          ...state.rawItems.keys(),
+                          ...state.items.keys(),
+                        ) + 1;
+                      try {
+                        for await (const {
+                          event: ce,
+                          data: cd,
+                        } of parseSSEStream(follow.reader, {
+                          maxFrames: maxSSEFrames,
+                          inactivityMs: sseInactivityMs,
+                          signal,
+                          frameCounter,
+                        })) {
+                          if (cancelled) break;
+                          if (!cd || cd === "[DONE]") continue;
+                          streamBytes += encoder.encode(
+                            formatResponsesEvent(ce, cd),
+                          ).byteLength;
+                          if (streamBytes > maxStreamBytes) {
+                            throw new Error(
+                              "Responses stream exceeded byte limit",
+                            );
+                          }
+                          let cparsed: Record<string, unknown>;
+                          try {
+                            cparsed = JSON.parse(cd) as Record<string, unknown>;
+                          } catch {
+                            if (ce.startsWith("response.")) {
+                              throw new Error(
+                                `malformed JSON in Responses event ${ce}`,
+                              );
+                            }
+                            if (
+                              contRecallIndices.size === 0 &&
+                              ce !== "message"
+                            ) {
+                              queueTransactional(
+                                encoder.encode(formatResponsesEvent(ce, cd)),
+                              );
+                            }
+                            continue;
+                          }
+                          if (cparsed.type !== ce) {
+                            throw new Error(
+                              `Responses payload type does not match ${ce}`,
+                            );
+                          }
+                          validateResponseLifecycle(contState, ce, cparsed);
+                          const rawContinuationIndex = cparsed.output_index;
+                          const addedContinuationItem = cparsed.item as
+                            | Record<string, unknown>
+                            | undefined;
+                          if (
+                            ce === "response.output_item.added" &&
+                            addedContinuationItem?.type === "item_reference"
+                          ) {
+                            if (
+                              !Number.isSafeInteger(rawContinuationIndex) ||
+                              (rawContinuationIndex as number) < 0
+                            ) {
+                              throw new Error(
+                                "invalid Responses output_index for item_reference",
+                              );
+                            }
+                            contReferenceIndices.add(
+                              rawContinuationIndex as number,
+                            );
+                            continue;
+                          }
+                          if (
+                            Number.isSafeInteger(rawContinuationIndex) &&
+                            contReferenceIndices.has(
+                              rawContinuationIndex as number,
+                            )
+                          ) {
+                            continue;
+                          }
+                          const ci = outputIndexForEvent(
+                            ce,
+                            cparsed,
+                            contState,
+                          );
+                          if (ci !== undefined) {
+                            retainedStateBytes += encoder.encode(cd).byteLength;
+                            if (retainedStateBytes > maxRetainedStateBytes) {
+                              throw new Error(
+                                "Responses retained state exceeded byte limit",
+                              );
+                            }
+                          }
+                          if (
+                            ce === "response.output_item.added" &&
+                            ci !== undefined
+                          ) {
+                            const item = cparsed.item as
+                              | Record<string, unknown>
+                              | undefined;
+                            if (
+                              item?.type === "function_call" &&
+                              item.name === RECALL_TOOL_NAME
+                            ) {
+                              contRecallIndices.add(ci);
+                            } else if (item?.type === "function_call") {
+                              contOtherTool = true;
+                            }
+                          }
+                          applyResponsesEvent(contState, ce, cparsed);
+                          const isContRecall =
+                            ci !== undefined && contRecallIndices.has(ci);
+                          if (isContRecall) {
+                            const hiddenBytes = encoder.encode(
+                              formatResponsesEvent(ce, cd),
+                            ).byteLength;
+                            continuationRecallBytes += hiddenBytes;
+                            hiddenRecallBytes += hiddenBytes;
+                            if (
+                              continuationRecallBytes > maxDeferredBytes ||
+                              hiddenRecallBytes > maxHiddenRecallBytes
+                            ) {
+                              throw new Error(
+                                "recall continuation exceeded deferred event limit",
+                              );
+                            }
+                            if (
+                              ce === "response.function_call_arguments.done"
+                            ) {
+                              contRecallInputs.set(
+                                ci,
+                                parseRecallArguments(cparsed.arguments),
+                              );
+                            }
+                            if (ce === "response.output_item.done") {
+                              const input = contRecallInputs.get(ci);
+                              if (!input) {
+                                throw new Error(
+                                  `recall continuation completed before arguments for index ${ci}`,
+                                );
+                              }
+                              const item = contState.items.get(ci);
+                              const toolUseId =
+                                item?.type === "tool_use" ? item.callId : "";
+                              const contentPosition = finalizeResponsesAcc(
+                                contState,
+                              ).content.findIndex(
+                                (block) =>
+                                  block.type === "tool_use" &&
+                                  block.id === toolUseId,
+                              );
+                              contPending.push({
+                                outputIndex: ci,
+                                contentPosition,
+                                query: input.query,
+                                scope: input.scope,
+                                id: input.id,
+                                toolUseId,
+                              });
+                              contRecallInputs.delete(ci);
+                            }
+                            continue;
+                          }
+                          if (
+                            ce === "response.completed" ||
+                            ce === "response.done" ||
+                            ce === "response.incomplete" ||
+                            ce === "response.failed"
+                          ) {
+                            assertOutputLifecyclesComplete(contState);
+                            assertTerminalOutputMatches(contState, cparsed);
+                            continuationCompleted =
+                              contState.terminalEvent !== undefined;
+                            continuationFailed =
+                              contState.terminalEvent === "response.failed";
+                            break;
+                          }
+                          if (
+                            ce === "response.created" ||
+                            ce === "response.in_progress"
+                          ) {
+                            continue;
+                          }
+                          if (ci !== undefined) {
+                            const shifted = encoder.encode(
+                              formatResponsesEvent(
+                                ce,
+                                JSON.stringify({
+                                  ...cparsed,
+                                  output_index: ci + contIndex,
+                                }),
+                              ),
+                            );
+                            if (contRecallIndices.size > 0) {
+                              heldContinuationBytes += shifted.byteLength;
+                              if (heldContinuationBytes > maxDeferredBytes) {
+                                throw new Error(
+                                  "recall continuation exceeded deferred event limit",
+                                );
+                              }
+                              heldContinuationEvents.push(shifted);
+                            } else queueTransactional(shifted);
+                          } else if (ce !== "message") {
+                            const chunk = encoder.encode(
+                              formatResponsesEvent(ce, cd),
+                            );
+                            if (contRecallIndices.size > 0) {
+                              heldContinuationBytes += chunk.byteLength;
+                              if (heldContinuationBytes > maxDeferredBytes) {
+                                throw new Error(
+                                  "recall continuation exceeded deferred event limit",
+                                );
+                              }
+                              heldContinuationEvents.push(chunk);
+                            } else queueTransactional(chunk);
+                          }
+                        }
+                      } finally {
+                        void follow.reader.cancel().catch(() => {});
+                      }
+                      const mergeContinuation = (): void => {
+                        for (const item of contState.rawItems.values()) {
+                          const itemIdentities = [item.id, item.call_id].filter(
+                            (value): value is string =>
+                              typeof value === "string",
+                          );
+                          for (const existing of state.items.values()) {
+                            const existingIdentities = new Set(
+                              [
+                                existing.id,
+                                existing.type === "tool_use"
+                                  ? existing.callId
+                                  : undefined,
+                              ].filter(
+                                (value): value is string =>
+                                  typeof value === "string",
+                              ),
+                            );
+                            if (
+                              itemIdentities.some((identity) =>
+                                existingIdentities.has(identity),
+                              )
+                            ) {
+                              throw new Error(
+                                "duplicate Responses item identity across continuation",
+                              );
+                            }
+                          }
+                          for (const existing of state.rawItems.values()) {
+                            const existingIdentities = new Set(
+                              [existing.id, existing.call_id].filter(
+                                (value): value is string =>
+                                  typeof value === "string",
+                              ),
+                            );
+                            if (
+                              itemIdentities.some((identity) =>
+                                existingIdentities.has(identity),
+                              )
+                            ) {
+                              throw new Error(
+                                "duplicate Responses item identity across continuation",
+                              );
+                            }
+                          }
+                        }
+                        for (const [idx, item] of contState.items) {
+                          state.items.set(idx + contIndex, item);
+                        }
+                        for (const [idx, item] of contState.rawItems) {
+                          state.rawItems.set(idx + contIndex, item);
+                        }
+                        mergeUsage(state.usage, contState.usage);
+                      };
+                      if (continuationFailed) {
+                        throw new Error(
+                          "recall follow-up returned response.failed",
                         );
                       }
-                      continue;
-                    }
-                    // Accumulate continuation into contState for the final rebuild.
-                    applyResponsesEvent(contState, ce, cparsed);
-                    const ci = cparsed.output_index as number | undefined;
-                    // Re-index continuation items so they don't collide with the
-                    // marker text item(s) already emitted. The continuation's own
-                    // output numbering starts at 0; shift every index by
-                    // contIndex (the next free slot after the marker).
-                    if (ci !== undefined) {
-                      const shifted = {
-                        ...cparsed,
-                        output_index: ci + contIndex,
-                      };
                       if (
-                        !safeEnqueue(
+                        !continuationCompleted ||
+                        contState.items.size === 0
+                      ) {
+                        throw new Error(
+                          "recall follow-up ended without a completed response containing output",
+                        );
+                      }
+                      if (contRecallIndices.size !== contPending.length) {
+                        throw new Error(
+                          "recall follow-up ended before function arguments completed",
+                        );
+                      }
+                      if (contPending.length > 1) {
+                        throw new Error(
+                          "parallel recall calls require a multi-result continuation",
+                        );
+                      }
+                      if (
+                        contState.terminalEvent === "response.incomplete" &&
+                        contPending.length > 0
+                      ) {
+                        throw new Error(
+                          "incomplete recall continuation cannot execute another recall",
+                        );
+                      }
+                      let nextRecall: (typeof contPending)[number] | undefined;
+                      let nextExecuted:
+                        | {
+                            anchorText: string;
+                            resultText: string;
+                            commit?: () => void;
+                            rollback?: () => void;
+                          }
+                        | undefined;
+                      let nextAcc: GatewayResponse | undefined;
+                      if (contPending.length === 1) {
+                        if (recallDepth >= maxRecallDepth) {
+                          throw new Error(
+                            `recall depth exhausted (${maxRecallDepth}) in Responses continuation`,
+                          );
+                        }
+                        recallDepth++;
+                        nextRecall = contPending[0];
+                        nextAcc = finalizeResponsesAcc(contState);
+                        const nextSyntheticId = `msg_${state.id || "lore"}_${nextRecall.outputIndex + contIndex}`;
+                        reserveSyntheticIdentity(nextSyntheticId, [
+                          state,
+                          contState,
+                        ]);
+                        nextExecuted = await settleRecall({
+                          ...nextRecall,
+                          acc: nextAcc,
+                          signal,
+                        });
+                        if (nextExecuted.commit) {
+                          pendingCommits.push(nextExecuted.commit);
+                        }
+                        if (nextExecuted.rollback) {
+                          transactionRollbacks.push(nextExecuted.rollback);
+                        }
+                        const nextRecallIndex = nextRecall.outputIndex;
+                        contState.items.set(nextRecallIndex, {
+                          type: "text",
+                          id: nextSyntheticId,
+                          text: nextExecuted.anchorText,
+                        });
+                        queueTransactional(
                           encoder.encode(
-                            formatResponsesEvent(ce, JSON.stringify(shifted)),
+                            emitTextItem(
+                              nextRecall.outputIndex + contIndex,
+                              nextExecuted.anchorText,
+                            ),
                           ),
-                        )
-                      ) {
+                        );
+                      }
+                      for (const chunk of heldContinuationEvents) {
+                        queueTransactional(chunk);
+                      }
+                      mergeContinuation();
+                      if (!nextRecall || !nextExecuted || contOtherTool) {
+                        state.stopReason = contState.stopReason;
+                        state.terminalEvent = contState.terminalEvent;
                         break;
                       }
-                    } else if (ce !== "message") {
-                      // Follow-up terminal events stop the continuation loop —
-                      // we rebuild the terminal (response.completed) below.
-                      if (
-                        ce === "response.completed" ||
-                        ce === "response.done" ||
-                        ce === "response.incomplete" ||
-                        ce === "response.failed"
-                      ) {
-                        break;
-                      }
-                      // Follow-up lifecycle events must never reach the client:
-                      // the principal stream already emitted response.created /
-                      // response.in_progress, and we rebuild the terminal below.
-                      // Forwarding them would duplicate init/terminal events and
-                      // violate the Responses SSE protocol.
-                      if (
-                        ce === "response.created" ||
-                        ce === "response.in_progress"
-                      ) {
-                        continue;
-                      }
-                      if (
-                        !safeEnqueue(
-                          encoder.encode(formatResponsesEvent(ce, cd)),
-                        )
-                      )
-                        break;
+                      follow = await settleFollowUp({
+                        anchorText: nextExecuted.anchorText,
+                        resultText: nextExecuted.resultText,
+                        acc: nextAcc ?? finalizeResponsesAcc(contState),
+                        toolUseId: nextRecall.toolUseId,
+                        contentPosition: nextRecall.contentPosition,
+                        signal,
+                      });
                     }
-                    // Terminal for continuation — we rebuild below, so stop here.
-                    if (
-                      ce === "response.completed" ||
-                      ce === "response.done" ||
-                      ce === "response.incomplete" ||
-                      ce === "response.failed"
-                    ) {
-                      break;
-                    }
+                    state.items.set(recall.outputIndex, {
+                      type: "text",
+                      id: `msg_${state.id || "lore"}_${recall.outputIndex}`,
+                      text: executed.anchorText,
+                    });
+                  } catch (err) {
+                    log.error(
+                      `recall follow-up stream error${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}:`,
+                      err,
+                    );
+                    throw err;
                   }
-                  appliedContinuation = contState;
-                  // The follow-up has reached its terminal event; cancel its
-                  // reader so the upstream body is released promptly.
-                  void follow.reader.cancel().catch(() => {});
-                } catch (err) {
-                  log.error(
-                    `recall follow-up stream error${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}:`,
-                    err,
+                }
+              }
+
+              // Rebuild the terminal response.completed reflecting only the
+              // continuation (recall-only) or the client-owned tools (mixed).
+              const finalResp = finalizeResponsesAcc(state);
+              let anchorIndex = 0;
+              const visibleResp = {
+                ...finalResp,
+                content: finalResp.content.map((block) => {
+                  if (block.type !== "tool_use" || block.name !== "recall") {
+                    return block;
+                  }
+                  return {
+                    type: "text" as const,
+                    text: anchorTexts[anchorIndex++] ?? "",
+                  };
+                }),
+              };
+              clearKeepalive();
+              for (const chunk of transactionalEvents) {
+                if (!(await safeEnqueue(chunk))) {
+                  throw new Error(
+                    "client disconnected while delivering recall continuation",
                   );
                 }
               }
-            }
-
-            // Merge the continuation (if any) into `state` at the correct
-            // offset. The continuation's `contState.items` are keyed by its
-            // OWN 0-based output indices; shift each by contIndex (the marker
-            // slot + 1, the next free position after the emitted marker item)
-            // when a recall-only follow-up ran.
-            if (appliedContinuation) {
-              const offset = contIndexBase;
-              // Shift continuation usage accumulation onto the total for the
-              // internal postResponse response (usage is index-independent).
-              state.usage.inputTokens += appliedContinuation.usage.inputTokens;
-              state.usage.outputTokens +=
-                appliedContinuation.usage.outputTokens;
-              state.usage.cacheReadInputTokens =
-                (state.usage.cacheReadInputTokens ?? 0) +
-                (appliedContinuation.usage.cacheReadInputTokens ?? 0);
-              state.usage.cacheCreationInputTokens =
-                (state.usage.cacheCreationInputTokens ?? 0) +
-                (appliedContinuation.usage.cacheCreationInputTokens ?? 0);
-              for (const [idx, item] of appliedContinuation.items) {
-                state.items.set(idx + offset, item);
+              if (
+                !(await safeEnqueue(encoder.encode(buildTerminal(visibleResp))))
+              ) {
+                throw new Error(
+                  "client disconnected while delivering recall terminal",
+                );
               }
-              // Merge stop reason from the continuation (it is the final leg).
-              if (appliedContinuation.stopReason) {
-                state.stopReason = appliedContinuation.stopReason;
+              terminalDelivered = true;
+              if (cancelled) throw signal.reason;
+              if (!finish(visibleResp)) {
+                throw new Error("recall onComplete failed after delivery");
               }
-            }
-
-            // Rebuild the terminal response.completed reflecting marker +
-            // continuation (recall-only) OR marker + other tools (mixed).
-            const finalResp = finalizeResponsesAcc(state);
-            // Replace ONLY the recall tool_use(s) with their marker text, so
-            // non-recall tool_use (which the client must act on) is preserved.
-            const markedResp = {
-              ...finalResp,
-              content: [
-                ...finalResp.content.filter(
-                  (b) => b.type !== "tool_use" || b.name !== "recall",
-                ),
-                ...markerTexts.map((t) => ({ type: "text" as const, text: t })),
-              ],
-            };
-            clearKeepalive();
-            finish(markedResp);
-            if (!safeEnqueue(encoder.encode(buildCompleted(markedResp)))) {
+              for (const commit of pendingCommits.splice(0)) commit();
+              transactionRollbacks.length = 0;
+              transactionBaseline = undefined;
+              void reader.cancel().catch(() => {});
+              principalReader = null;
               safeClose();
               return;
             }
+
+            // Non-terminal, non-recall event: forward verbatim.
+            const chunk = encoder.encode(formatResponsesEvent(event, data));
+            if (recallIndices.size > 0) {
+              deferredBytes += chunk.byteLength;
+              if (deferredBytes > maxDeferredBytes) {
+                throw new Error("recall stream exceeded deferred event limit");
+              }
+              deferredEvents.push(chunk);
+            } else if (!(await safeEnqueue(chunk))) {
+              break;
+            }
+          }
+
+          throw new Error(
+            "upstream Responses stream ended without a terminal event",
+          );
+        } catch (err) {
+          rollbackTransaction();
+          if (principalReader) {
+            void principalReader.cancel().catch(() => {});
+          }
+          principalReader = null;
+          clearKeepalive();
+          if (terminalDelivered) {
             safeClose();
             return;
           }
-
-          // Non-terminal, non-recall event: forward verbatim.
-          if (!safeEnqueue(encoder.encode(formatResponsesEvent(event, data)))) {
-            break;
+          const isAbort =
+            err instanceof DOMException && err.name === "AbortError";
+          if (isAbort) {
+            log.info(
+              `openai-responses recall-aware stream aborted${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
+            );
+            if (cancelled || signal.aborted) {
+              safeClose();
+              return;
+            }
+          } else {
+            log.error(
+              `openai-responses recall-aware stream error${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}:`,
+              err,
+            );
           }
-        }
-
-        // Stream ended without a terminal event (e.g. reader closed early).
-        if (!terminalSeen) {
-          clearKeepalive();
-          finish(finalizeResponsesAcc(state));
-        }
-        safeClose();
-      } catch (err) {
-        clearKeepalive();
-        const isAbort =
-          err instanceof DOMException && err.name === "AbortError";
-        if (isAbort) {
-          log.info(
-            `openai-responses recall-aware stream aborted${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
-          );
-        } else {
-          log.error(
-            `openai-responses recall-aware stream error${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}:`,
-            err,
-          );
-        }
-        safeEnqueue(
-          encoder.encode(
-            formatResponsesEvent(
-              "response.failed",
-              JSON.stringify({
-                type: "response.failed",
-                response: {
-                  id: state.id || "resp_error",
-                  object: "response",
-                  created_at: Math.floor(Date.now() / 1000),
-                  model: state.model,
-                  status: "failed",
-                  output: [],
-                  usage: null,
-                  error: {
-                    type: "server_error",
-                    message:
-                      err instanceof Error
-                        ? err.message
-                        : "upstream stream error",
+          await safeEnqueue(
+            encoder.encode(
+              formatResponsesEvent(
+                "response.failed",
+                JSON.stringify({
+                  type: "response.failed",
+                  response: {
+                    id: state.id || "resp_error",
+                    object: "response",
+                    created_at: Math.floor(Date.now() / 1000),
+                    model: state.model,
+                    status: "failed",
+                    output: buildOutputItems(recallIndices),
+                    usage: null,
+                    error: {
+                      type: "server_error",
+                      message:
+                        "Lore could not continue the response after recall",
+                    },
                   },
-                },
-              }),
+                }),
+              ),
             ),
-          ),
-        );
-        finish(finalizeResponsesAcc(state));
-        safeClose();
-      }
+          );
+          const failedResponse = finalizeResponsesAcc(state);
+          failedResponse.content = failedResponse.content.filter(
+            (block) =>
+              (block.type !== "tool_use" || block.name !== RECALL_TOOL_NAME) &&
+              (block.type !== "text" || !parseRecallAnchor(block.text)),
+          );
+          failedResponse.rawOutputItems = failedResponse.rawOutputItems?.filter(
+            (item) =>
+              item.type !== "function_call" || item.name !== RECALL_TOOL_NAME,
+          );
+          finish(failedResponse);
+          safeClose();
+        }
+      })();
     },
 
+    pull() {
+      resumeDemand?.();
+      resumeDemand = undefined;
+    },
     cancel() {
+      resumeDemand?.();
+      resumeDemand = undefined;
       cancelled = true;
+      rollbackTransaction();
+      abortController.abort(
+        new DOMException("Responses client disconnected", "AbortError"),
+      );
       if (keepaliveTimer) clearTimeout(keepaliveTimer);
       try {
         if (activeReader) {
@@ -6206,9 +7662,12 @@ export function accumulateResponsesNonStreamJSON(
 ): GatewayResponse {
   const content: GatewayContentBlock[] = [];
   const output = json.output as Array<Record<string, unknown>> | undefined;
+  const replayableOutput = output?.filter(
+    (item) => item.type !== "item_reference",
+  );
 
-  if (output) {
-    for (const item of output) {
+  if (replayableOutput) {
+    for (const item of replayableOutput) {
       if (item.type === "message") {
         const msgContent = item.content as
           | Array<Record<string, unknown>>
@@ -6258,6 +7717,7 @@ export function accumulateResponsesNonStreamJSON(
     id: asString(json.id),
     model: asString(json.model),
     content,
+    rawOutputItems: replayableOutput,
     stopReason,
     usage: {
       inputTokens: disjointOpenAIInputTokens(
@@ -6270,6 +7730,117 @@ export function accumulateResponsesNonStreamJSON(
       cacheCreationInputTokens: inputTokensDetails?.cache_write_tokens,
     },
   };
+}
+
+/** @internal Exported for end-to-end replay tests. */
+export function responsesProvenanceContent(
+  response: GatewayResponse,
+  replacements: ReadonlyMap<string, string> = new Map(),
+  stopBeforeToolUseId?: string,
+): GatewayContentBlock[] {
+  if (!response.rawOutputItems?.length) {
+    const content: GatewayContentBlock[] = [];
+    for (const block of response.content) {
+      if (block.type === "tool_use") {
+        if (block.id === stopBeforeToolUseId) break;
+        const replacement = replacements.get(block.id);
+        content.push(replacement ? { type: "text", text: replacement } : block);
+      } else {
+        content.push(block);
+      }
+    }
+    return content;
+  }
+
+  const content: GatewayContentBlock[] = [];
+  const textBlocks = response.content.filter(
+    (block): block is Extract<GatewayContentBlock, { type: "text" }> =>
+      block.type === "text",
+  );
+  let textIndex = 0;
+  for (const raw of response.rawOutputItems) {
+    if (raw.type === "item_reference") continue;
+    if (raw.type === "reasoning") {
+      content.push({ type: "opaque", raw, responsesItem: true });
+      continue;
+    }
+    if (raw.type === "message") {
+      const parts = Array.isArray(raw.content)
+        ? (raw.content as Array<Record<string, unknown>>)
+        : [];
+      for (const part of parts) {
+        content.push({
+          type: "opaque",
+          raw: { ...raw, content: [part] },
+          responsesItem: true,
+        });
+        if (part.type === "output_text" && typeof part.text === "string") {
+          textIndex++;
+        }
+      }
+      if (parts.length === 0 && textBlocks[textIndex]) {
+        content.push(textBlocks[textIndex++]);
+      }
+      continue;
+    }
+    if (raw.type === "function_call") {
+      const toolUseId = asString(raw.call_id ?? raw.id);
+      if (toolUseId === stopBeforeToolUseId) break;
+      const replacement = replacements.get(toolUseId);
+      if (replacement) {
+        content.push({ type: "text", text: replacement });
+        continue;
+      }
+      const block = response.content.find(
+        (candidate): candidate is GatewayToolUseBlock =>
+          candidate.type === "tool_use" && candidate.id === toolUseId,
+      );
+      if (block) content.push(block);
+      continue;
+    }
+    content.push({ type: "opaque", raw, responsesItem: true });
+  }
+  return content;
+}
+
+/** @internal Preserve request-only provenance across lossless Lore transforms. */
+export function responsesProvenanceByMessageId(
+  messages: GatewayMessage[],
+  loreMessages: LoreMessageWithParts[],
+): ReadonlyMap<
+  string,
+  Pick<GatewayMessage, "content" | "provenanceContent" | "provenancePositions">
+> {
+  return new Map(
+    loreMessages.flatMap((message, index) => {
+      const original = messages[index];
+      return original?.provenanceContent
+        ? [
+            [
+              message.info.id,
+              {
+                content: original.content,
+                provenanceContent: original.provenanceContent,
+                provenancePositions: original.provenancePositions,
+              },
+            ] as const,
+          ]
+        : [];
+    }),
+  );
+}
+
+/** @internal Build the canonical anchor hash used by every Responses path. */
+export function responsesAnchorContext(
+  clientMessages: GatewayMessage[],
+  visibleContent: GatewayContentBlock[],
+  response: GatewayResponse,
+  stopBeforeToolUseId: string,
+): string {
+  return recallAnchorContext(clientMessages, clientMessages.length, [
+    ...visibleContent,
+    ...responsesProvenanceContent(response, new Map(), stopBeforeToolUseId),
+  ]);
 }
 
 /**
@@ -6926,6 +8497,9 @@ function postResponse(
     }
 
     sessionState.lastUpstream = upstreamSnapshot;
+    saveSessionTracking(sessionID, {
+      lastUpstream: JSON.stringify({ ...upstreamSnapshot, headers: {} }),
+    });
     // Store per-provider snapshot so workers/cache-warmer can look up the
     // correct URL and credentials when the session uses multiple providers.
     if (upstreamSnapshot.providerID) {
@@ -7380,6 +8954,7 @@ async function handleCompaction(
     sessionID,
     pathResult.path,
     pathResult.source,
+    requestCredentialFingerprint(req.rawHeaders),
   );
   const projectPath = resolveSessionProjectPath(
     pathResult,
@@ -7611,8 +9186,16 @@ export async function handleCompactEndpoint(
     rawHeaders[key] = value;
   });
   const gitRemote = extractGitRemoteHeader(rawHeaders);
-
-  await initIfNeeded(projectPath, config, gitRemote);
+  const credential = extractAuth(rawHeaders);
+  if (!credential) {
+    return new Response(
+      JSON.stringify({
+        error: "unauthorized",
+        message: "A provider credential is required",
+      }),
+      { status: 401, headers: { "content-type": "application/json" } },
+    );
+  }
 
   // Build a minimal GatewayRequest for session identification.
   // Only rawHeaders and messages are used by identifySession().
@@ -7646,6 +9229,29 @@ export async function handleCompactEndpoint(
     );
   }
 
+  const state = getOrCreateSession(
+    sessionID,
+    projectPath,
+    "header",
+    authFingerprint(credential),
+  );
+  if (
+    !state ||
+    state.projectPathProvisional === true ||
+    state.projectPath !== projectPath
+  ) {
+    return new Response(
+      JSON.stringify({
+        error: "project_mismatch",
+        message: "project_path does not match the authenticated session",
+      }),
+      { status: 403, headers: { "content-type": "application/json" } },
+    );
+  }
+  setSessionAuth(sessionID, credential, state.lastUpstream?.providerID);
+
+  await initIfNeeded(state.projectPath, config, gitRemote);
+
   // Cancel-when-fits policy. The gateway is the authoritative source for
   // "does this session's raw context fit in the layer-0 budget?" — the plugin
   // just relays. We resolve the session's lastUpstream to a real ModelSpec
@@ -7666,7 +9272,6 @@ export async function handleCompactEndpoint(
   // keep raw; anything above it must be summarized (or the next LLM call
   // will overflow). If we later want a tighter per-session cap, it's a
   // single constant in one place to change.
-  const state = sessions.get(sessionID);
   const cancelDecision = shouldCancelCompactionFromBudget(
     body.tokens_before,
     state?.lastUpstream,
@@ -8128,6 +9733,7 @@ async function handleConversationTurn(
     sessionID,
     pathResult.path,
     pathResult.source,
+    cred ? authFingerprint(cred) : "",
   );
   let projectPath = resolveSessionProjectPath(pathResult, sessionState, config);
 
@@ -8240,8 +9846,12 @@ async function handleConversationTurn(
       // Search the full headerSessionIndex — covers Tier 1 (known) and Tier 2 (learned) headers.
       let resolvedParent: string | undefined;
       for (const [key, loreId] of headerSessionIndex) {
-        const colonIdx = key.indexOf(":");
-        if (colonIdx >= 0 && key.slice(colonIdx + 1) === parentClientId) {
+        const parsed = parseSessionIndexKey(key);
+        if (
+          parsed?.credentialFingerprint ===
+            (sessionState.credentialFingerprint ?? "") &&
+          parsed.headerValue === parentClientId
+        ) {
           resolvedParent = loreId;
           break;
         }
@@ -8423,16 +10033,38 @@ async function handleConversationTurn(
     projectPath,
   });
 
+  // Anchor provenance must use the normalized client transcript before recall
+  // expansion mutates historical markers into synthetic tool round trips.
+  const recallClientMessages = req.messages.map((message) => ({
+    role: message.role,
+    content: [...message.content],
+    ...(message.provenanceContent
+      ? { provenanceContent: [...message.provenanceContent] }
+      : {}),
+    ...(message.provenancePositions
+      ? { provenancePositions: [...message.provenancePositions] }
+      : {}),
+  }));
+
   // --- Expand recall markers from previous turns ---
   // Scan all assistant messages for marker text blocks and restore them
   // to tool_use + tool_result pairs before forwarding upstream.
   if (sessionState.recallStore.size > 0) {
+    // Cleanup must inspect the client transcript while anchors still exist.
+    // Expanding first would make every live anchor look orphaned.
+    const recallStoreChanged = cleanupRecallStore(
+      req,
+      sessionState.recallStore,
+    );
     const expanded = expandRecallMarkers(req, sessionState.recallStore);
     if (expanded) {
       log.info(`expanded recall markers for session ${sessionID.slice(0, 16)}`);
     }
-    // Clean up orphaned store entries (markers evicted by gradient)
-    cleanupRecallStore(req, sessionState.recallStore);
+    if (recallStoreChanged) {
+      saveSessionTracking(sessionID, {
+        recallStore: serializeRecallStore(sessionState.recallStore),
+      });
+    }
   }
 
   // --- Strip context warning markers from previous turns ---
@@ -8677,6 +10309,10 @@ async function handleConversationTurn(
   // decision below (isLargeColdStart) and the gradient transform in step 7, so
   // both see identical input and agree on whether this cold session compresses.
   const loreMessages = gatewayMessagesToLore(req.messages, sessionID);
+  const provenanceByMessageId = responsesProvenanceByMessageId(
+    req.messages,
+    loreMessages,
+  );
   resolveToolResults(loreMessages);
 
   // --- 6. LTM injection (system[1] stable prefix + durable-delta context LTM) ---
@@ -9408,7 +11044,14 @@ async function handleConversationTurn(
   // loreMessagesToGateway reconstructs tool_result blocks from assistant's
   // completed/error tool parts; removeOrphanedToolResults is a safety net
   // that catches any remaining orphaned tool_result references.
-  const transformedMessages = loreMessagesToGateway(result.messages);
+  const transformedMessages = loreMessagesToGateway(
+    result.messages,
+    provenanceByMessageId,
+    result.messages.length === loreMessages.length &&
+      result.messages.every(
+        (message, index) => message.info.id === loreMessages[index]?.info.id,
+      ),
+  );
   removeOrphanedToolResults(transformedMessages);
 
   const modifiedReq: GatewayRequest = {
@@ -9434,6 +11077,15 @@ async function handleConversationTurn(
           }
         : RECALL_GATEWAY_TOOL;
     modifiedReq.tools = [...modifiedReq.tools, recallTool];
+  }
+  if (
+    modifiedReq.protocol === "openai-responses" &&
+    clientHasRecallTool(modifiedReq.tools)
+  ) {
+    modifiedReq.extras = {
+      ...modifiedReq.extras,
+      parallel_tool_calls: false,
+    };
   }
 
   // --- 8c. Synthetic project-resolution: inject probe if eligible ---
@@ -9830,6 +11482,7 @@ async function handleConversationTurn(
     let currentResp = resp;
     let recallDepth = 0;
     let currentModifiedReq = modifiedReq;
+    const responsesVisibleContent: GatewayContentBlock[] = [];
     const cumulativeUsage = { ...(resp.usage ?? ZERO_USAGE) };
     // Whether this request opted into the 1M window (context-1m beta); gates the
     // client-usage cap so a 1M-capable model the client meters against 200K is
@@ -9858,17 +11511,29 @@ async function handleConversationTurn(
       );
 
       // Store recall result for marker round-trip expansion
-      const storeKey = recallStoreKey(
-        input.query,
-        input.scope ?? "all",
-        input.id,
-      );
+      const scope = input.scope ?? "all";
+      const anchorId = crypto.randomUUID();
+      const storeKey = `anchor:${anchorId}`;
       const position = currentResp.content.indexOf(recallBlock);
-      sessionState.recallStore.set(storeKey, {
+      const anchorContextId = responsesAnchorContext(
+        recallClientMessages,
+        responsesVisibleContent,
+        currentResp,
+        recallBlock.id,
+      );
+      const companionToolUses = currentResp.content.flatMap((block, index) => {
+        if (block.type !== "tool_use" || block.id === recallBlock.id) return [];
+        const side: "before" | "after" = index < position ? "before" : "after";
+        return [{ id: block.id, name: block.name, input: block.input, side }];
+      });
+      addRecallStoreEntry(sessionState.recallStore, storeKey, {
         toolUseId: recallBlock.id,
+        anchorId,
+        anchorContextId,
         input,
         position,
         result,
+        ...(companionToolUses.length > 0 ? { companionToolUses } : {}),
       });
       // Persist the store (v46) so the marker still expands byte-identically
       // after a gateway restart instead of leaking raw marker text upstream.
@@ -9876,7 +11541,22 @@ async function handleConversationTurn(
         recallStore: serializeRecallStore(sessionState.recallStore),
       });
 
-      const markerResp = replaceRecallWithMarker(currentResp);
+      const markerText = buildAnchoredRecallMarker(
+        input.query,
+        scope,
+        input.id,
+        anchorId,
+      );
+      const markerResp = replaceRecallWithMarker(
+        currentResp,
+        new Map([[recallBlock.id, markerText]]),
+      );
+      responsesVisibleContent.push(
+        ...responsesProvenanceContent(
+          currentResp,
+          new Map([[recallBlock.id, markerText]]),
+        ),
+      );
 
       if (hasOtherToolUse(currentResp)) {
         // Mixed tools — return response with marker, client handles the rest
@@ -10036,7 +11716,17 @@ async function handleConversationTurn(
       log.warn(
         `recall depth exhausted (${MAX_RECALL_DEPTH}) — stripping remaining recall`,
       );
-      currentResp = replaceRecallWithMarker(currentResp);
+      currentResp = {
+        ...currentResp,
+        content: currentResp.content.map((block) =>
+          block.type === "tool_use" && block.name === RECALL_TOOL_NAME
+            ? {
+                type: "text" as const,
+                text: `Recall depth limit reached (${MAX_RECALL_DEPTH}).`,
+              }
+            : block,
+        ),
+      };
     }
     currentResp.usage = cumulativeUsage;
     postResponse(
@@ -10108,6 +11798,8 @@ async function handleConversationTurn(
       // client.
       if (req.protocol === "openai-responses" && !shouldInjectWarning) {
         if (hasRecallTool) {
+          let responsesRecallRequest = modifiedReq;
+          const responsesVisibleContent: GatewayContentBlock[] = [];
           return streamResponsesRecallAware(upstreamResponse, {
             onComplete: (resp) =>
               postResponse(
@@ -10119,7 +11811,16 @@ async function handleConversationTurn(
                 genAiSpan,
               ),
             sessionID: sessionState.sessionID,
-            onRecall: async ({ query, scope, id, toolUseId, acc }) => {
+            maxRecallDepth: MAX_RECALL_DEPTH,
+            onRecall: async ({
+              query,
+              scope,
+              id,
+              toolUseId,
+              contentPosition,
+              acc,
+              signal,
+            }) => {
               const alreadyInLtm = buildAlreadyInLtmIds(
                 stableLtmText,
                 pendingKnowledgeDelta,
@@ -10135,39 +11836,109 @@ async function handleConversationTurn(
                 sessionState.sessionID,
                 getLLMClient(config),
                 alreadyInLtm.size > 0 ? alreadyInLtm : undefined,
+                signal,
               );
-              const scopeVal = input.scope ?? "all";
-              const storeKey = recallStoreKey(query, scopeVal, input.id);
-              const anchorPosition = acc.content.findIndex(
-                (block) => block.type === "tool_use" && block.id === toolUseId,
+              const recallBlock = acc.content[contentPosition];
+              if (
+                recallBlock?.type !== "tool_use" ||
+                recallBlock.id !== toolUseId ||
+                recallBlock.name !== RECALL_TOOL_NAME
+              ) {
+                throw new Error(
+                  "recall execution: recall block not found in accumulated response",
+                );
+              }
+              const anchorId = crypto.randomUUID();
+              const position = contentPosition;
+              const anchorContextId = responsesAnchorContext(
+                recallClientMessages,
+                responsesVisibleContent,
+                acc,
+                recallBlock.id,
               );
-              const markerText = buildRecallMarker(query, scopeVal, input.id);
-              sessionState.recallStore.set(storeKey, {
+              const companionToolUses = acc.content.flatMap((block, index) => {
+                if (block.type !== "tool_use" || block.id === toolUseId) {
+                  return [];
+                }
+                const side: "before" | "after" =
+                  index < position ? "before" : "after";
+                return [
+                  {
+                    id: block.id,
+                    name: block.name,
+                    input: block.input,
+                    side,
+                  },
+                ];
+              });
+              const storeKey = `anchor:${anchorId}`;
+              const storedRecall = {
                 toolUseId,
-                anchorPosition,
+                anchorId,
+                anchorContextId,
                 input,
-                position: -1,
+                position,
                 result,
-              });
-              saveSessionTracking(sessionState.sessionID, {
-                recallStore: serializeRecallStore(sessionState.recallStore),
-              });
-              return { markerText, resultText: result };
+                ...(companionToolUses.length > 0 ? { companionToolUses } : {}),
+              } satisfies StoredRecall;
+              const persistStore = (): void => {
+                saveSessionTracking(sessionState.sessionID, {
+                  recallStore: serializeRecallStore(sessionState.recallStore),
+                });
+              };
+              const anchorText = buildRecallAnchor(anchorId);
+              responsesVisibleContent.push(
+                ...responsesProvenanceContent(
+                  acc,
+                  new Map([[toolUseId, anchorText]]),
+                ),
+              );
+              return {
+                anchorText,
+                resultText: result,
+                commit: () => {
+                  addRecallStoreEntry(
+                    sessionState.recallStore,
+                    storeKey,
+                    storedRecall,
+                  );
+                  persistStore();
+                },
+                rollback: () => {
+                  if (sessionState.recallStore.delete(storeKey)) persistStore();
+                },
+              };
             },
-            runFollowUp: async ({ acc, resultText }) => {
+            runFollowUp: async ({
+              acc,
+              resultText,
+              toolUseId,
+              contentPosition,
+              signal,
+            }) => {
               // Reconstruct the recall tool_use block for the follow-up request.
-              const recallBlock = findRecallToolUse(acc);
-              if (!recallBlock) {
+              const recallBlock = acc.content[contentPosition];
+              if (
+                recallBlock?.type !== "tool_use" ||
+                recallBlock.id !== toolUseId ||
+                recallBlock.name !== RECALL_TOOL_NAME
+              ) {
                 throw new Error(
                   "recall follow-up: recall block not found in accumulated response",
                 );
               }
               const followUpCtx: RecallFollowUpCtx = {
-                forward: (r) =>
-                  forwardToUpstream(r, config, undefined, {
-                    ...cacheOptions,
-                    cacheConversation: false,
-                  }),
+                forward: (r, followUpSignal) =>
+                  forwardToUpstream(
+                    r,
+                    config,
+                    undefined,
+                    {
+                      ...cacheOptions,
+                      cacheConversation: false,
+                    },
+                    followUpSignal,
+                  ),
                 parseJSON: () => {
                   throw new Error(
                     "parseJSON must not be called on the streaming recall path",
@@ -10176,16 +11947,18 @@ async function handleConversationTurn(
               };
               const follow = await runRecallFollowUpStreaming(
                 followUpCtx,
-                modifiedReq,
+                responsesRecallRequest,
                 acc,
                 resultText,
                 recallBlock,
+                signal,
               );
               if (!follow.ok) {
                 throw new Error(
-                  `recall follow-up upstream error: ${follow.status ?? "?"} ${follow.detail}`,
+                  `recall follow-up upstream error: ${follow.status ?? "?"}`,
                 );
               }
+              responsesRecallRequest = follow.followUp;
               return { reader: follow.reader };
             },
           });
@@ -10236,6 +12009,7 @@ async function handleConversationTurn(
         postResponse(req, resp, sessionState, config, requestBody, genAiSpan),
       hasRecallTool
         ? {
+            clientMessages: recallClientMessages,
             modifiedReq,
             config,
             sessionState,
@@ -10321,11 +12095,16 @@ function toolResultContent(state: {
 /** @internal Exported for tests. */
 export function loreMessagesToGateway(
   messages: LoreMessageWithParts[],
-): Array<{ role: "user" | "assistant"; content: GatewayContentBlock[] }> {
-  const out: Array<{
-    role: "user" | "assistant";
-    content: GatewayContentBlock[];
-  }> = [];
+  provenanceByMessageId: ReadonlyMap<
+    string,
+    Pick<
+      GatewayMessage,
+      "content" | "provenanceContent" | "provenancePositions"
+    >
+  > = new Map(),
+  allowProvenance = true,
+): GatewayMessage[] {
+  const out: GatewayMessage[] = [];
 
   // tool_result blocks reconstructed from the preceding assistant message's
   // completed/error tool parts. Injected at the start of the next user message.
@@ -10431,7 +12210,20 @@ export function loreMessagesToGateway(
       }
     }
 
-    out.push({ role: msg.info.role, content });
+    const message: GatewayMessage = { role: msg.info.role, content };
+    const provenance = allowProvenance
+      ? provenanceByMessageId.get(msg.info.id)
+      : undefined;
+    if (
+      provenance?.provenanceContent &&
+      JSON.stringify(content) === JSON.stringify(provenance.content)
+    ) {
+      message.provenanceContent = [...provenance.provenanceContent];
+      if (provenance.provenancePositions) {
+        message.provenancePositions = [...provenance.provenancePositions];
+      }
+    }
+    out.push(message);
   }
 
   return out;
@@ -10612,7 +12404,11 @@ function handleAmnesiaSlashCommand(
   const known = extractKnownSessionHeader(req.rawHeaders);
   let state: SessionState | undefined;
   if (known) {
-    const indexKey = `${known.headerName}:${known.sessionId}`;
+    const indexKey = sessionIndexKey(
+      requestCredentialFingerprint(req.rawHeaders),
+      known.headerName,
+      known.sessionId,
+    );
     const sid = headerSessionIndex.get(indexKey);
     if (sid) state = allSessions.get(sid);
   }
@@ -10698,7 +12494,11 @@ function handleWarmupSlashCommand(
   const known = extractKnownSessionHeader(req.rawHeaders);
   let state: SessionState | undefined;
   if (known) {
-    const indexKey = `${known.headerName}:${known.sessionId}`;
+    const indexKey = sessionIndexKey(
+      requestCredentialFingerprint(req.rawHeaders),
+      known.headerName,
+      known.sessionId,
+    );
     const sid = headerSessionIndex.get(indexKey);
     if (sid) state = allSessions.get(sid);
   }
@@ -10765,7 +12565,11 @@ async function handleCurateSlashCommand(
   let state: SessionState | undefined;
   let sessionID: string | undefined;
   if (known) {
-    const indexKey = `${known.headerName}:${known.sessionId}`;
+    const indexKey = sessionIndexKey(
+      requestCredentialFingerprint(req.rawHeaders),
+      known.headerName,
+      known.sessionId,
+    );
     const sid = headerSessionIndex.get(indexKey);
     if (sid) {
       state = allSessions.get(sid);
@@ -10777,7 +12581,9 @@ async function handleCurateSlashCommand(
   if (!sessionID) {
     // Use the most recently active session
     let latest: SessionState | undefined;
+    const credentialFingerprint = requestCredentialFingerprint(req.rawHeaders);
     for (const s of allSessions.values()) {
+      if ((s.credentialFingerprint ?? "") !== credentialFingerprint) continue;
       if (!latest || s.lastRequestTime > latest.lastRequestTime) {
         latest = s;
       }
@@ -11099,7 +12905,11 @@ export async function handleRequest(
     let priorState: SessionState | undefined;
     const known = extractKnownSessionHeader(req.rawHeaders);
     if (known) {
-      const indexKey = `${known.headerName}:${known.sessionId}`;
+      const indexKey = sessionIndexKey(
+        earlyAuth ? authFingerprint(earlyAuth) : "",
+        known.headerName,
+        known.sessionId,
+      );
       const sid = headerSessionIndex.get(indexKey);
       if (sid) priorState = sessions.get(sid);
     }

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -4,9 +4,9 @@
  * Uses a unified "Marker and Expand" strategy:
  *
  *  1. **On response (to client):** The recall `tool_use` block is replaced
- *     with a human-readable marker text block
- *     (`📚 Searching <scope> for "<query>"…`). The recall is executed
- *     internally and the result is stored in session state.
+ *     with a text marker. Responses clients receive an invisible unique anchor;
+ *     other clients receive status text plus the same anchor. The recall result
+ *     is stored in session state under that unique key.
  *
  *  2. **On request (from client):** Marker text blocks in the conversation
  *     are expanded back into the original `tool_use` + `tool_result` pairs
@@ -26,6 +26,7 @@ import {
   type RecallScope,
   type LLMClient,
 } from "@loreai/core";
+import { createHash } from "node:crypto";
 
 import type {
   GatewayTool,
@@ -33,9 +34,11 @@ import type {
   GatewayResponse,
   GatewayToolUseBlock,
   GatewayMessage,
+  GatewayContentBlock,
   RecallStore,
   StoredRecall,
 } from "./translate/types";
+import { looksLikeSSE } from "./translate/types";
 
 // ---------------------------------------------------------------------------
 // Tool definition
@@ -63,6 +66,7 @@ export const RECALL_GATEWAY_TOOL: GatewayTool = {
       },
     },
     required: ["query"],
+    additionalProperties: false,
   },
 };
 
@@ -70,6 +74,8 @@ export const RECALL_TOOL_NAME = "recall";
 
 /** Safety-net cap on recall follow-ups per client request (like any agentic loop). */
 export const MAX_RECALL_DEPTH = 10;
+export const MAX_RECALL_STORE_ENTRIES = 128;
+export const MAX_RECALL_STORE_BYTES = 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // Marker utilities — human-readable text ↔ recall tool round-trip
@@ -114,14 +120,236 @@ export function buildRecallMarker(
 }
 
 /** Regex to parse a recall marker back into query + scope. */
-const MARKER_REGEX = /📚 Searching (.+?) for "(.+?)"…/;
+const MARKER_REGEX = /^📚 Searching (.+?) for "(.+)"…$/;
 
 /** Regex to parse an id-based recall marker. */
-const ID_MARKER_REGEX = /📚 Fetching detail for (.+?)…/;
+const ID_MARKER_REGEX = /^📚 Fetching detail for (.+?)…$/;
+
+/** Invisible Responses transcript anchor. Markdown renderers omit comments. */
+const ANCHOR_REGEX =
+  /^<!-- lore-recall:([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}) -->$/;
+
+export function buildRecallAnchor(toolUseId: string): string {
+  return `<!-- lore-recall:${encodeURIComponent(toolUseId)} -->`;
+}
+
+/** Keep the visible status while assigning every replay a unique key. */
+export function buildAnchoredRecallMarker(
+  query: string,
+  scope: string,
+  id: string | undefined,
+  anchorId: string,
+): string {
+  return `${buildRecallMarker(query, scope, id)}\n${buildRecallAnchor(anchorId)}`;
+}
+
+export function parseRecallAnchor(text: string): string | null {
+  const match = ANCHOR_REGEX.exec(text);
+  return match && buildRecallAnchor(match[1]) === text ? match[1] : null;
+}
+
+function parseRecallAnchorFromText(text: string): string | null {
+  const direct = parseRecallAnchor(text);
+  if (direct) return direct;
+  const newline = text.lastIndexOf("\n");
+  if (newline < 0) return null;
+  return parseRecallAnchor(text.slice(newline + 1));
+}
+
+/** Fingerprint the complete transcript prefix that precedes a replay anchor. */
+export function recallAnchorContext(
+  messages: GatewayMessage[],
+  beforeIndex = messages.length,
+  assistantPrefix: GatewayContentBlock[] = [],
+): string {
+  const normalized: GatewayMessage[] = [];
+  const append = (message: GatewayMessage): void => {
+    const content = message.provenanceContent ?? message.content;
+    if (content.length === 0) return;
+    const previous = normalized[normalized.length - 1];
+    if (previous?.role === message.role) {
+      previous.content.push(...content);
+    } else {
+      normalized.push({ role: message.role, content: [...content] });
+    }
+  };
+  for (const message of messages.slice(0, beforeIndex)) append(message);
+  if (assistantPrefix.length > 0) {
+    append({ role: "assistant", content: assistantPrefix });
+  }
+  const hash = createHash("sha256");
+  const frame = (value: unknown): void => {
+    const payload = JSON.stringify(value);
+    hash.update(`${Buffer.byteLength(payload)}:`);
+    hash.update(payload);
+  };
+  normalized.forEach((message, index) =>
+    frame([index, message.role, message.content]),
+  );
+  return hash.digest("hex");
+}
+
+function recallMessagePrefix(
+  message: GatewayMessage,
+  visibleBlocks: number,
+): GatewayContentBlock[] {
+  if (!message.provenanceContent || !message.provenancePositions) {
+    return message.content.slice(0, visibleBlocks);
+  }
+  const end =
+    visibleBlocks < message.provenancePositions.length
+      ? message.provenancePositions[visibleBlocks]
+      : message.provenanceContent.length;
+  return message.provenanceContent.slice(0, end);
+}
+
+function replaceVisibleContentBlock(
+  message: GatewayMessage,
+  visibleIndex: number,
+  block: GatewayContentBlock,
+): void {
+  message.content[visibleIndex] = block;
+  if (!message.provenanceContent || !message.provenancePositions) return;
+  const provenanceIndex = message.provenancePositions[visibleIndex];
+  if (provenanceIndex === undefined) return;
+  const nextIndex =
+    message.provenancePositions[visibleIndex + 1] ??
+    message.provenanceContent.length;
+  message.provenanceContent.splice(
+    provenanceIndex,
+    nextIndex - provenanceIndex,
+    block,
+  );
+  const delta = 1 - (nextIndex - provenanceIndex);
+  for (let i = visibleIndex + 1; i < message.provenancePositions.length; i++) {
+    message.provenancePositions[i] += delta;
+  }
+}
+
+function truncateVisibleContent(
+  message: GatewayMessage,
+  visibleLength: number,
+): void {
+  message.content.length = visibleLength;
+  if (!message.provenanceContent || !message.provenancePositions) return;
+  const provenanceLength =
+    visibleLength < message.provenancePositions.length
+      ? message.provenancePositions[visibleLength]
+      : message.provenanceContent.length;
+  message.provenanceContent.length = provenanceLength;
+  message.provenancePositions.length = visibleLength;
+}
+
+function removeVisibleContentBlock(
+  message: GatewayMessage,
+  visibleIndex: number,
+): GatewayContentBlock {
+  const provenanceIndex = message.provenancePositions?.[visibleIndex];
+  if (
+    message.provenanceContent &&
+    message.provenancePositions &&
+    (provenanceIndex === undefined ||
+      provenanceIndex < 0 ||
+      provenanceIndex >= message.provenanceContent.length)
+  ) {
+    throw new Error("invalid visible content provenance");
+  }
+  const [block] = message.content.splice(visibleIndex, 1);
+  if (!block) throw new Error("visible content block not found");
+  if (!message.provenanceContent || !message.provenancePositions) return block;
+  if (provenanceIndex === undefined) {
+    throw new Error("invalid visible content provenance");
+  }
+  message.provenanceContent.splice(provenanceIndex, 1);
+  message.provenancePositions.splice(visibleIndex, 1);
+  for (let i = visibleIndex; i < message.provenancePositions.length; i++) {
+    message.provenancePositions[i] -= 1;
+  }
+  return block;
+}
+
+function insertVisibleContentBlocks(
+  message: GatewayMessage,
+  visibleIndex: number,
+  blocks: GatewayContentBlock[],
+): void {
+  if (blocks.length === 0) return;
+  message.content.splice(visibleIndex, 0, ...blocks);
+  if (!message.provenanceContent || !message.provenancePositions) return;
+  const provenanceIndex =
+    message.provenancePositions[visibleIndex] ??
+    message.provenanceContent.length;
+  message.provenanceContent.splice(provenanceIndex, 0, ...blocks);
+  for (let i = visibleIndex; i < message.provenancePositions.length; i++) {
+    message.provenancePositions[i] += blocks.length;
+  }
+  message.provenancePositions.splice(
+    visibleIndex,
+    0,
+    ...blocks.map((_block, index) => provenanceIndex + index),
+  );
+}
+
+type CompanionBundle = {
+  content: GatewayContentBlock[];
+  provenanceContent?: GatewayContentBlock[];
+  provenancePositions?: number[];
+};
+
+function insertCompanionBundle(
+  message: GatewayMessage,
+  visibleIndex: number,
+  bundle: CompanionBundle,
+): void {
+  if (!bundle.provenanceContent || !bundle.provenancePositions) {
+    insertVisibleContentBlocks(message, visibleIndex, bundle.content);
+    return;
+  }
+  if (!message.provenanceContent || !message.provenancePositions) {
+    message.provenanceContent = [...message.content];
+    message.provenancePositions = message.content.map((_block, index) => index);
+  }
+  message.content.splice(visibleIndex, 0, ...bundle.content);
+  const provenanceIndex =
+    message.provenancePositions[visibleIndex] ??
+    message.provenanceContent.length;
+  message.provenanceContent.splice(
+    provenanceIndex,
+    0,
+    ...bundle.provenanceContent,
+  );
+  for (let i = visibleIndex; i < message.provenancePositions.length; i++) {
+    message.provenancePositions[i] += bundle.provenanceContent.length;
+  }
+  message.provenancePositions.splice(
+    visibleIndex,
+    0,
+    ...bundle.provenancePositions.map((position) => provenanceIndex + position),
+  );
+}
 
 /** Check if a text string is a recall marker (search or detail). */
 export function isRecallMarker(text: string): boolean {
-  return parseRecallMarker(text) !== null;
+  return (
+    parseRecallMarker(text) !== null || parseRecallAnchorFromText(text) !== null
+  );
+}
+
+function storedRecallForText(
+  text: string,
+  store: RecallStore,
+): { key: string; stored: StoredRecall; canonical: boolean } | null {
+  const parsed = parseRecallMarker(text);
+  if (parsed) {
+    const key = recallStoreKey(parsed.query, parsed.scope, parsed.id);
+    const stored = store.get(key);
+    return stored ? { key, stored, canonical: false } : null;
+  }
+  const anchorId = parseRecallAnchorFromText(text);
+  if (!anchorId) return null;
+  const key = `anchor:${anchorId}`;
+  const stored = store.get(key);
+  return stored ? { key, stored, canonical: true } : null;
 }
 
 /**
@@ -157,9 +385,46 @@ export function serializeRecallStore(store: RecallStore): string {
   return JSON.stringify([...store.entries()]);
 }
 
+/** Add one record without evicting a still-live replay anchor. */
+export function addRecallStoreEntry(
+  store: RecallStore,
+  key: string,
+  value: StoredRecall,
+): void {
+  let minimumBytes = 0;
+  const countStrings = (input: unknown): void => {
+    if (minimumBytes > MAX_RECALL_STORE_BYTES) return;
+    if (typeof input === "string") {
+      minimumBytes += Buffer.byteLength(input);
+    } else if (Array.isArray(input)) {
+      for (const item of input) countStrings(item);
+    } else if (input && typeof input === "object") {
+      for (const [name, child] of Object.entries(input)) {
+        minimumBytes += Buffer.byteLength(name);
+        countStrings(child);
+      }
+    }
+  };
+  countStrings(key);
+  countStrings(value);
+  if (minimumBytes > MAX_RECALL_STORE_BYTES) {
+    throw new Error("recall store capacity exceeded");
+  }
+  const candidate = new Map(store);
+  candidate.set(key, value);
+  if (
+    candidate.size > MAX_RECALL_STORE_ENTRIES ||
+    Buffer.byteLength(serializeRecallStore(candidate)) > MAX_RECALL_STORE_BYTES
+  ) {
+    throw new Error("recall store capacity exceeded");
+  }
+  store.set(key, value);
+}
+
 /** Restore a recall store from its JSON form. Tolerant of corrupt/old blobs. */
 export function deserializeRecallStore(json: string): RecallStore {
   const store: RecallStore = new Map();
+  if (Buffer.byteLength(json) > MAX_RECALL_STORE_BYTES) return store;
   try {
     const entries = JSON.parse(json);
     if (!Array.isArray(entries)) return store;
@@ -170,10 +435,14 @@ export function deserializeRecallStore(json: string): RecallStore {
         typeof entry[0] === "string" &&
         entry[1] &&
         typeof entry[1] === "object" &&
-        typeof (entry[1] as StoredRecall).toolUseId === "string" &&
-        typeof (entry[1] as StoredRecall).result === "string"
+        isStoredRecall(entry[1]) &&
+        isValidRecallStoreEntry(entry[0], entry[1])
       ) {
-        store.set(entry[0], entry[1] as StoredRecall);
+        try {
+          addRecallStoreEntry(store, entry[0], entry[1]);
+        } catch {
+          break;
+        }
       }
     }
   } catch {
@@ -181,6 +450,79 @@ export function deserializeRecallStore(json: string): RecallStore {
     // once the recall re-executes).
   }
   return store;
+}
+
+function isValidRecallStoreEntry(key: string, item: StoredRecall): boolean {
+  if (
+    !item.toolUseId ||
+    !Number.isSafeInteger(item.position) ||
+    item.position < 0 ||
+    (item.input.scope !== undefined &&
+      item.input.scope !== "all" &&
+      item.input.scope !== "session" &&
+      item.input.scope !== "project" &&
+      item.input.scope !== "knowledge")
+  ) {
+    return false;
+  }
+  if (!key.startsWith("anchor:")) {
+    return (
+      item.anchorContextId === undefined ||
+      /^[0-9a-f]{64}$/.test(item.anchorContextId)
+    );
+  }
+  if (!item.anchorContextId || !/^[0-9a-f]{64}$/.test(item.anchorContextId)) {
+    return false;
+  }
+  const anchorId = key.slice("anchor:".length);
+  return (
+    item.anchorId === anchorId &&
+    parseRecallAnchor(buildRecallAnchor(anchorId)) === anchorId
+  );
+}
+
+function isStoredRecall(value: unknown): value is StoredRecall {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Record<string, unknown>;
+  const input = item.input as Record<string, unknown> | undefined;
+  if (
+    typeof item.toolUseId !== "string" ||
+    typeof item.result !== "string" ||
+    typeof item.position !== "number" ||
+    !input ||
+    typeof input.query !== "string" ||
+    (input.scope !== undefined && typeof input.scope !== "string") ||
+    ((item.input as Record<string, unknown>).id !== undefined &&
+      typeof (item.input as Record<string, unknown>).id !== "string")
+  ) {
+    return false;
+  }
+  if (
+    (item.anchorId !== undefined && typeof item.anchorId !== "string") ||
+    (item.anchorContextId !== undefined &&
+      typeof item.anchorContextId !== "string") ||
+    (item.companionToolUseIds !== undefined &&
+      (!Array.isArray(item.companionToolUseIds) ||
+        !item.companionToolUseIds.every((id) => typeof id === "string")))
+  ) {
+    return false;
+  }
+  if (item.companionToolUses !== undefined) {
+    if (!Array.isArray(item.companionToolUses)) return false;
+    for (const companion of item.companionToolUses) {
+      if (!companion || typeof companion !== "object") return false;
+      const record = companion as Record<string, unknown>;
+      if (
+        typeof record.id !== "string" ||
+        typeof record.name !== "string" ||
+        !("input" in record) ||
+        (record.side !== "before" && record.side !== "after")
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 /** Derive a store key from query + scope, or from id for detail lookups. */
@@ -211,6 +553,35 @@ export function expandRecallMarkers(
   store: RecallStore,
 ): boolean {
   let expanded = false;
+  const anchorValidity = new Map<string, boolean[]>();
+  const incomingMessages = structuredClone(req.messages);
+  for (let i = 0; i < incomingMessages.length; i++) {
+    const message = incomingMessages[i];
+    if (message.role !== "assistant") continue;
+    for (let j = 0; j < message.content.length; j++) {
+      const block = message.content[j];
+      if (block.type !== "text") continue;
+      const candidate = storedRecallForText(block.text, store);
+      if (!candidate) continue;
+      const valid = candidate.key.startsWith("anchor:")
+        ? candidate.stored.anchorContextId ===
+          recallAnchorContext(
+            incomingMessages,
+            i,
+            recallMessagePrefix(message, j),
+          )
+        : candidate.stored.anchorContextId === undefined ||
+          candidate.stored.anchorContextId ===
+            recallAnchorContext(
+              incomingMessages,
+              i,
+              recallMessagePrefix(message, j),
+            );
+      const occurrences = anchorValidity.get(candidate.key) ?? [];
+      occurrences.push(valid);
+      anchorValidity.set(candidate.key, occurrences);
+    }
+  }
 
   // Iterate forward; when we splice messages the index is adjusted.
   for (let i = 0; i < req.messages.length; i++) {
@@ -221,23 +592,121 @@ export function expandRecallMarkers(
     // We process one marker per assistant message per pass; the outer
     // loop will revisit if there's more than one (rare).
     let markerIdx = -1;
-    let parsed: { query: string; scope: RecallScope; id?: string } | null =
-      null;
+    let match: { key: string; stored: StoredRecall } | null = null;
     for (let j = 0; j < msg.content.length; j++) {
       const block = msg.content[j];
       if (block.type !== "text") continue;
-      parsed = parseRecallMarker(block.text);
-      if (parsed) {
+      match = storedRecallForText(block.text, store);
+      if (match) {
         markerIdx = j;
         break;
       }
     }
 
-    if (markerIdx < 0 || !parsed) continue;
+    if (markerIdx < 0 || !match) continue;
+    const { stored } = match;
+    if (!(anchorValidity.get(match.key)?.shift() ?? false)) continue;
 
-    const key = recallStoreKey(parsed.query, parsed.scope, parsed.id);
-    const stored = store.get(key);
-    if (!stored) continue; // No stored result — leave marker as-is
+    // Responses emits output text and function calls as separate input items,
+    // which parse into adjacent assistant messages. Rejoin only tool calls that
+    // were companions of the original recall. Continuation tool calls are not
+    // companions and must stay after the synthetic recall result turn.
+    const companions = stored.companionToolUses;
+    const beforeCompanions = companions?.filter(
+      (item) => item.side === "before",
+    );
+    const afterCompanions = companions?.filter((item) => item.side === "after");
+    const matchesCompanions = (
+      content: GatewayContentBlock[],
+      expected: typeof beforeCompanions,
+    ): boolean =>
+      content.filter((block) => block.type === "tool_use").length ===
+        expected?.length &&
+      content
+        .filter((block) => block.type === "tool_use")
+        .every((block, index) => {
+          const item = expected[index];
+          return (
+            block.type === "tool_use" &&
+            block.id === item.id &&
+            block.name === item.name &&
+            JSON.stringify(block.input) === JSON.stringify(item.input)
+          );
+        });
+    const takeCompanions = (message: GatewayMessage): CompanionBundle => {
+      if (
+        message.content.every((block) => block.type === "tool_use") &&
+        message.provenanceContent &&
+        message.provenancePositions
+      ) {
+        const provenanceContent = message.provenanceContent;
+        const provenancePositions = message.provenancePositions;
+        if (
+          provenancePositions.length !== message.content.length ||
+          provenancePositions.some(
+            (position, index) =>
+              !Number.isSafeInteger(position) ||
+              position < 0 ||
+              position >= provenanceContent.length ||
+              (index > 0 && position <= provenancePositions[index - 1]),
+          )
+        ) {
+          throw new Error("invalid companion provenance");
+        }
+        const bundle: CompanionBundle = {
+          content: [...message.content],
+          provenanceContent: [...provenanceContent],
+          provenancePositions: [...provenancePositions],
+        };
+        message.content.length = 0;
+        provenanceContent.length = 0;
+        provenancePositions.length = 0;
+        return bundle;
+      }
+      const moved: GatewayContentBlock[] = [];
+      for (let index = message.content.length - 1; index >= 0; index--) {
+        if (message.content[index].type === "tool_use") {
+          moved.unshift(removeVisibleContentBlock(message, index));
+        }
+      }
+      return { content: moved };
+    };
+    while ((beforeCompanions?.length ?? 0) > 0 && i > 0) {
+      const previous = req.messages[i - 1];
+      if (
+        previous.role !== "assistant" ||
+        !matchesCompanions(previous.content, beforeCompanions)
+      ) {
+        break;
+      }
+      const moved = takeCompanions(previous);
+      insertCompanionBundle(msg, 0, moved);
+      markerIdx += moved.content.length;
+      if (
+        previous.content.length === 0 &&
+        (previous.provenanceContent?.length ?? 0) === 0
+      ) {
+        req.messages.splice(i - 1, 1);
+        i -= 1;
+      }
+    }
+    while ((afterCompanions?.length ?? 0) > 0) {
+      const next = req.messages[i + 1];
+      if (
+        !next ||
+        next.role !== "assistant" ||
+        !matchesCompanions(next.content, afterCompanions)
+      ) {
+        break;
+      }
+      insertCompanionBundle(msg, msg.content.length, takeCompanions(next));
+      if (
+        next.content.length === 0 &&
+        (next.provenanceContent?.length ?? 0) === 0
+      ) {
+        req.messages.splice(i + 1, 1);
+      }
+    }
 
     // Check if there's non-tool content AFTER the marker in this message.
     // This happens when recall-only follow-up piped continuation content
@@ -247,16 +716,16 @@ export function expandRecallMarkers(
     const hasContinuationAfter = afterMarker.some((b) => b.type !== "tool_use");
 
     // Replace marker with tool_use
-    msg.content[markerIdx] = {
+    replaceVisibleContentBlock(msg, markerIdx, {
       type: "tool_use",
       id: stored.toolUseId,
       name: RECALL_TOOL_NAME,
       input: stored.input,
-    };
+    });
 
     // Truncate assistant message at the tool_use (remove continuation)
     if (hasContinuationAfter) {
-      msg.content.length = markerIdx + 1;
+      truncateVisibleContent(msg, markerIdx + 1);
     }
 
     // Build synthetic tool_result user message
@@ -287,7 +756,10 @@ export function expandRecallMarkers(
       // tool_results — matching the tool_use order in the assistant message.
       const nextMsg = req.messages[i + 1];
       if (nextMsg?.role === "user") {
-        nextMsg.content.unshift({
+        const resultIndex = msg.content
+          .slice(0, markerIdx)
+          .filter((block) => block.type === "tool_use").length;
+        nextMsg.content.splice(resultIndex, 0, {
           type: "tool_result",
           toolUseId: stored.toolUseId,
           content: [{ type: "text", text: stored.result }],
@@ -312,8 +784,8 @@ export function expandRecallMarkers(
 export function cleanupRecallStore(
   req: GatewayRequest,
   store: RecallStore,
-): void {
-  if (store.size === 0) return;
+): boolean {
+  if (store.size === 0) return false;
 
   // Collect all marker keys still present in assistant messages
   const activeKeys = new Set<string>();
@@ -321,19 +793,31 @@ export function cleanupRecallStore(
     if (msg.role !== "assistant") continue;
     for (const block of msg.content) {
       if (block.type !== "text") continue;
-      const parsed = parseRecallMarker(block.text);
-      if (parsed) {
-        activeKeys.add(recallStoreKey(parsed.query, parsed.scope, parsed.id));
+      const match = storedRecallForText(block.text, store);
+      if (
+        match &&
+        (!match.stored.anchorContextId ||
+          match.stored.anchorContextId ===
+            recallAnchorContext(
+              req.messages,
+              req.messages.indexOf(msg),
+              recallMessagePrefix(msg, msg.content.indexOf(block)),
+            ))
+      ) {
+        activeKeys.add(match.key);
       }
     }
   }
 
   // Remove entries not referenced by any current marker
+  let changed = false;
   for (const key of store.keys()) {
     if (!activeKeys.has(key)) {
       store.delete(key);
+      changed = true;
     }
   }
+  return changed;
 }
 
 // ---------------------------------------------------------------------------
@@ -402,6 +886,7 @@ export async function executeRecall(
   sessionID: string,
   llm?: LLMClient,
   alreadyInLtmIds?: ReadonlySet<string>,
+  signal?: AbortSignal,
 ): Promise<{
   result: string;
   input: { query: string; scope?: RecallScope; id?: string };
@@ -410,6 +895,7 @@ export async function executeRecall(
   const cfg = loreConfig();
 
   try {
+    signal?.throwIfAborted();
     const result = await runRecall({
       query,
       scope,
@@ -418,14 +904,17 @@ export async function executeRecall(
       sessionID,
       knowledgeEnabled: cfg.knowledge?.enabled ?? true,
       llm,
+      signal,
       searchConfig: cfg.search,
       // Genuine agent recall — record cross-project transfer metrics (#506).
       recordTransfers: true,
       ...(alreadyInLtmIds ? { alreadyInLtmIds } : {}),
     });
+    signal?.throwIfAborted();
 
     return { result, input: { query, scope, id } };
   } catch (e) {
+    if (signal?.aborted) throw signal.reason;
     log.error("gateway recall execution failed:", e);
     return {
       result: "Recall search failed. The memory system encountered an error.",
@@ -458,6 +947,7 @@ export interface RecallFollowUpCtx {
   /** Forward a follow-up request upstream and return the raw response. */
   forward: (
     req: GatewayRequest,
+    signal?: AbortSignal,
   ) => Promise<{ response: Response; effectiveProtocol: RecallProtocol }>;
   /** Parse a non-streaming (JSON) upstream response into a GatewayResponse. */
   parseJSON: (
@@ -518,12 +1008,24 @@ export function buildRecallFollowUpRequest(
   // by default.
   const prefixBlocks = resp.content.filter(
     (b) =>
-      b.type !== "text" && b.type !== "tool_use" && b.type !== "tool_result",
+      b.type !== "text" &&
+      b.type !== "tool_use" &&
+      b.type !== "tool_result" &&
+      !(b.type === "opaque" && b.responsesItem),
   );
+  const rawPrefixBlocks: GatewayContentBlock[] = (resp.rawOutputItems ?? [])
+    .filter(
+      (item) =>
+        item.type !== "function_call" &&
+        item.type !== "function_call_output" &&
+        item.type !== "item_reference",
+    )
+    .map((raw) => ({ type: "opaque", raw, responsesItem: true }));
 
   const assistantMessage: GatewayMessage = {
     role: "assistant",
     content: [
+      ...rawPrefixBlocks,
       ...prefixBlocks,
       {
         type: "tool_use",
@@ -570,13 +1072,105 @@ export function buildRecallFollowUpRequest(
  * loud, greppable error (caught by the recall try/catch → marker fallback +
  * Sentry via log.error).
  */
-function assertSSEResponse(response: Response): void {
+async function ensureSSEResponse(
+  response: Response,
+  signal?: AbortSignal,
+): Promise<Response> {
   const ct = response.headers.get("content-type") ?? "";
-  if (!ct.includes("text/event-stream")) {
-    throw new Error(
-      `recall follow-up expected SSE but got "${ct}" — stream flag/consumer mismatch`,
-    );
+  if (!response.body) {
+    throw new Error("recall follow-up (streaming) response has no body");
   }
+  if (ct.includes("text/event-stream")) return response;
+
+  // ChatGPT/Codex sometimes omits Content-Type on valid SSE responses. Sniff a
+  // tee of the body, preserving the other branch for the real stream parser.
+  const [probe, replay] = response.body.tee();
+  const reader = probe.getReader();
+  const decoder = new TextDecoder();
+  let prefix = "";
+  let probedBytes = 0;
+  const maxProbeBytes = 4096;
+  const maxProbeChunks = 64;
+  const probeSignal = signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(10_000)])
+    : AbortSignal.timeout(10_000);
+  const probeAborted = new Promise<never>((_resolve, reject) => {
+    probeSignal.addEventListener("abort", () => reject(probeSignal.reason), {
+      once: true,
+    });
+  });
+  let chunks = 0;
+  try {
+    while (probedBytes < maxProbeBytes && chunks < maxProbeChunks) {
+      const { done, value } = await Promise.race([reader.read(), probeAborted]);
+      if (done) break;
+      chunks++;
+      if (value) {
+        const remaining = maxProbeBytes - probedBytes;
+        const chunk = value.subarray(0, remaining);
+        probedBytes += chunk.byteLength;
+        prefix += decoder.decode(chunk, { stream: true });
+      }
+      let head = prefix.replace(/^\uFEFF/, "").trimStart();
+      while (head.startsWith(":")) {
+        const newline = head.indexOf("\n");
+        if (newline < 0) {
+          head = "";
+          break;
+        }
+        head = head.slice(newline + 1).trimStart();
+      }
+      if (looksLikeSSE(ct, head)) {
+        void reader.cancel();
+        return new Response(replay, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+      }
+      if (head && !"data:".startsWith(head) && !"event:".startsWith(head)) {
+        break;
+      }
+    }
+  } finally {
+    void reader.cancel();
+  }
+  void replay.cancel();
+  throw new Error(
+    `recall follow-up expected SSE but got "${ct}" and a non-SSE body`,
+  );
+}
+
+async function readResponseTextLimited(
+  response: Response,
+  maxBytes = 500,
+  signal?: AbortSignal,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+  const decoder = new TextDecoder();
+  let text = "";
+  let readBytes = 0;
+  const onAbort = (): void => {
+    void reader.cancel(signal?.reason).catch(() => {});
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    while (readBytes < maxBytes) {
+      signal?.throwIfAborted();
+      const { done, value } = await reader.read();
+      signal?.throwIfAborted();
+      if (done) break;
+      if (!value) continue;
+      const chunk = value.subarray(0, maxBytes - readBytes);
+      readBytes += chunk.byteLength;
+      text += decoder.decode(chunk, { stream: readBytes < maxBytes });
+    }
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    void reader.cancel().catch(() => {});
+  }
+  return text;
 }
 
 /**
@@ -638,6 +1232,7 @@ export async function runRecallFollowUpStreaming(
   resp: GatewayResponse,
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
+  signal?: AbortSignal,
 ): Promise<RecallFollowUpStreaming | RecallFollowUpError> {
   const followUp = buildRecallFollowUpRequest(
     originalReq,
@@ -646,16 +1241,23 @@ export async function runRecallFollowUpStreaming(
     recallToolUseBlock,
     /* stream */ true,
   );
-  const { response } = await ctx.forward(followUp);
+  const { response } = await ctx.forward(followUp, signal);
   if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    return { ok: false, status: response.status, detail: detail.slice(0, 500) };
+    let detail = "";
+    try {
+      detail = await readResponseTextLimited(response, 500, signal);
+    } catch (err) {
+      if (signal?.aborted) throw signal.reason;
+      log.warn("recall follow-up error body could not be read:", err);
+    }
+    return { ok: false, status: response.status, detail };
   }
-  assertSSEResponse(response);
-  if (!response.body) {
+  const sseResponse = await ensureSSEResponse(response, signal);
+  const body = sseResponse.body;
+  if (!body) {
     throw new Error("recall follow-up (streaming) response has no body");
   }
-  return { ok: true, reader: response.body.getReader(), followUp };
+  return { ok: true, reader: body.getReader(), followUp };
 }
 
 /**
@@ -681,8 +1283,8 @@ export async function runRecallFollowUpJSON(
   );
   const { response, effectiveProtocol } = await ctx.forward(followUp);
   if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    return { ok: false, status: response.status, detail: detail.slice(0, 500) };
+    const detail = await readResponseTextLimited(response).catch(() => "");
+    return { ok: false, status: response.status, detail };
   }
   assertJSONResponse(response);
   const continuation = await ctx.parseJSON(response, effectiveProtocol);
@@ -727,11 +1329,11 @@ export async function runRecallFollowUpStreamAccumulated(
   );
   const { response } = await ctx.forward(followUp);
   if (!response.ok) {
-    const detail = await response.text().catch(() => "");
-    return { ok: false, status: response.status, detail: detail.slice(0, 500) };
+    const detail = await readResponseTextLimited(response).catch(() => "");
+    return { ok: false, status: response.status, detail };
   }
-  assertSSEResponse(response);
-  const continuation = await ctx.parseSSE(response);
+  const sseResponse = await ensureSSEResponse(response);
+  const continuation = await ctx.parseSSE(sseResponse);
   return { ok: true, continuation, followUp };
 }
 
@@ -747,6 +1349,7 @@ export async function runRecallFollowUpStreamAccumulated(
  */
 export function replaceRecallWithMarker(
   resp: GatewayResponse,
+  markers?: ReadonlyMap<string, string>,
 ): GatewayResponse {
   return {
     ...resp,
@@ -759,7 +1362,7 @@ export function replaceRecallWithMarker(
           typeof input.id === "string" && input.id ? input.id : undefined;
         return {
           type: "text" as const,
-          text: buildRecallMarker(query, scope, id),
+          text: markers?.get(b.id) ?? buildRecallMarker(query, scope, id),
         };
       }
       return b;

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -500,13 +500,14 @@ export interface RotationCandidate {
  * for re-indexing the header mapping and persisting the change.
  */
 export function findRotationPredecessor(
+  credentialFingerprint: string,
   headerName: string,
   newHeaderValue: string,
   headerIndex: ReadonlyMap<string, string>,
   getCandidate: (sid: string) => RotationCandidate | null,
   now: number = Date.now(),
 ): { sid: string; oldHeaderValue: string } | null {
-  const headerPrefix = `${headerName}:`;
+  const headerPrefix = `${credentialFingerprint}\x1f${headerName}\x1f`;
   const newKey = headerPrefix + newHeaderValue;
   let predecessor: { sid: string; oldHeaderValue: string } | null = null;
 

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -50,13 +50,42 @@ export function formatSSEEvent(eventType: string, data: string): string {
  */
 export async function* parseSSEStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
+  opts: {
+    maxEventBytes?: number;
+    maxFrames?: number;
+    frameCounter?: { count: number };
+    inactivityMs?: number;
+    signal?: AbortSignal;
+  } = {},
 ): AsyncGenerator<{ event: string; data: string }> {
   const decoder = new TextDecoder();
   let buffer = "";
+  let bufferedBytes = 0;
+  const maxEventBytes = opts.maxEventBytes ?? 4 * 1024 * 1024;
+  const maxFrames = opts.maxFrames ?? Number.POSITIVE_INFINITY;
+  const frameCounter = opts.frameCounter ?? { count: 0 };
 
   for (;;) {
-    const { done, value } = await reader.read();
+    opts.signal?.throwIfAborted();
+    const read = reader.read();
+    let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
+    const inactivity = new Promise<never>((_resolve, reject) => {
+      if (!opts.inactivityMs) return;
+      inactivityTimer = setTimeout(
+        () => reject(new Error("SSE stream inactivity deadline exceeded")),
+        opts.inactivityMs,
+      );
+    });
+    const { done, value } = await (
+      opts.inactivityMs ? Promise.race([read, inactivity]) : read
+    ).finally(() => {
+      if (inactivityTimer) clearTimeout(inactivityTimer);
+    });
     if (value) {
+      bufferedBytes += value.byteLength;
+      if (bufferedBytes > maxEventBytes) {
+        throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
+      }
       buffer += decoder.decode(value, { stream: true });
     }
 
@@ -65,7 +94,15 @@ export async function* parseSSEStream(
       const boundary = /\r?\n\r?\n/.exec(buffer);
       if (!boundary) break;
       const block = buffer.slice(0, boundary.index);
+      frameCounter.count++;
+      if (frameCounter.count > maxFrames) {
+        throw new Error(`SSE stream exceeded ${maxFrames} frame limit`);
+      }
+      if (Buffer.byteLength(block) > maxEventBytes) {
+        throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
+      }
       buffer = buffer.slice(boundary.index + boundary[0].length);
+      bufferedBytes = Buffer.byteLength(buffer);
 
       // Skip empty blocks
       if (block.trim() === "") continue;

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -38,10 +38,22 @@ export interface ResponsesAccState {
   model: string;
   stopReason: string;
   usage: GatewayUsage;
+  terminalEvent?:
+    | "response.completed"
+    | "response.incomplete"
+    | "response.failed";
+  /** Original upstream output items, retained for terminal rebuilds. */
+  rawItems: Map<number, Record<string, unknown>>;
   /** Accumulating output items indexed by output_index. */
   items: Map<
     number,
-    | { type: "text"; text: string }
+    | {
+        type: "text";
+        id: string;
+        text: string;
+        refusal?: string;
+        content?: Array<Record<string, unknown>>;
+      }
     | {
         type: "tool_use";
         id: string;
@@ -59,6 +71,7 @@ export function makeResponsesAccState(): ResponsesAccState {
     stopReason: "end_turn",
     usage: { inputTokens: 0, outputTokens: 0 },
     items: new Map(),
+    rawItems: new Map(),
   };
 }
 
@@ -86,9 +99,14 @@ export function applyResponsesEvent(
       const outputIndex = parsed.output_index as number;
       const item = parsed.item as Record<string, unknown> | undefined;
       if (typeof outputIndex !== "number" || !item) break;
+      state.rawItems.set(outputIndex, { ...item });
 
       if (item.type === "message") {
-        state.items.set(outputIndex, { type: "text", text: "" });
+        state.items.set(outputIndex, {
+          type: "text",
+          id: asString(item.id),
+          text: "",
+        });
       } else if (item.type === "function_call") {
         state.items.set(outputIndex, {
           type: "tool_use",
@@ -97,6 +115,21 @@ export function applyResponsesEvent(
           name: asString(item.name),
           args: "",
         });
+      }
+      break;
+    }
+
+    case "response.output_item.done": {
+      const outputIndex = parsed.output_index as number;
+      const item = parsed.item as Record<string, unknown> | undefined;
+      if (typeof outputIndex === "number" && item) {
+        state.rawItems.set(outputIndex, { ...item });
+        if (item.type === "message" && Array.isArray(item.content)) {
+          const normalized = state.items.get(outputIndex);
+          if (normalized?.type === "text") {
+            normalized.content = item.content as Array<Record<string, unknown>>;
+          }
+        }
       }
       break;
     }
@@ -122,6 +155,26 @@ export function applyResponsesEvent(
       if (item?.type === "text" && typeof text === "string") {
         // Replace accumulated text with the final version (more reliable)
         item.text = text;
+      }
+      break;
+    }
+
+    case "response.refusal.delta": {
+      const outputIndex = parsed.output_index as number;
+      const delta = parsed.delta as string | undefined;
+      const item = state.items.get(outputIndex);
+      if (item?.type === "text" && typeof delta === "string") {
+        item.refusal = (item.refusal ?? "") + delta;
+      }
+      break;
+    }
+
+    case "response.refusal.done": {
+      const outputIndex = parsed.output_index as number;
+      const refusal = parsed.refusal as string | undefined;
+      const item = state.items.get(outputIndex);
+      if (item?.type === "text" && typeof refusal === "string") {
+        item.refusal = refusal;
       }
       break;
     }
@@ -155,10 +208,20 @@ export function applyResponsesEvent(
     // gateway sees the RAW upstream stream, so finalize on them here too.
     // `resp.status` ("incomplete"/"completed"/…) drives the stop reason via
     // `mapStatusToStopReason`.
+    case "response.failed":
     case "response.done":
     case "response.incomplete":
     case "response.completed": {
       const resp = parsed.response as Record<string, unknown> | undefined;
+      const status = typeof resp?.status === "string" ? resp.status : "";
+      state.terminalEvent =
+        event === "response.failed" ||
+        status === "failed" ||
+        status === "cancelled"
+          ? "response.failed"
+          : event === "response.incomplete" || status === "incomplete"
+            ? "response.incomplete"
+            : "response.completed";
       if (resp) {
         if (typeof resp.id === "string") state.id = resp.id;
         if (typeof resp.model === "string") state.model = resp.model;
@@ -199,7 +262,7 @@ export function applyResponsesEvent(
       break;
     }
 
-    // Other events (response.output_item.done, response.content_part.*,
+    // Other events (response.content_part.*,
     // response.reasoning_summary_*, etc.) — ignored for accumulation
   }
 }
@@ -215,6 +278,41 @@ export function finalizeResponsesAcc(
     const item = state.items.get(index);
     if (!item) continue;
     if (item.type === "text") {
+      if (item.content) {
+        for (const part of item.content) {
+          if (part.type === "output_text" && typeof part.text === "string") {
+            content.push({ type: "text", text: part.text });
+          } else {
+            content.push({
+              type: "opaque",
+              responsesItem: true,
+              raw: {
+                ...(state.rawItems.get(index) ?? {
+                  type: "message",
+                  id: item.id,
+                  role: "assistant",
+                  status: "completed",
+                }),
+                content: [part],
+              },
+            });
+          }
+        }
+        continue;
+      }
+      if (item.refusal !== undefined) {
+        content.push({
+          type: "opaque",
+          responsesItem: true,
+          raw: {
+            type: "message",
+            id: item.id,
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "refusal", refusal: item.refusal }],
+          },
+        });
+      }
       if (item.text) {
         content.push({ type: "text", text: item.text });
       }
@@ -246,6 +344,10 @@ export function finalizeResponsesAcc(
     id: state.id,
     model: state.model,
     content,
+    rawOutputItems: Array.from(state.rawItems.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([, item]) => item)
+      .filter((item) => item.type !== "item_reference"),
     stopReason,
     usage: state.usage,
   };

--- a/packages/gateway/src/temporal-adapter.ts
+++ b/packages/gateway/src/temporal-adapter.ts
@@ -10,7 +10,7 @@
  * messages into "completed" state.
  */
 import { createHash, randomUUID } from "node:crypto";
-import { isToolPart } from "@loreai/core";
+import { estimateTokens as coreEstimateTokens, isToolPart } from "@loreai/core";
 import type {
   LoreAssistantMessage,
   LoreContentBlock,
@@ -76,10 +76,6 @@ function hashBlocks(
         hashBlocks(h, block.content);
         break;
       case "opaque": {
-        // Hash includes the text projection (type + media_type + length) plus
-        // a prefix of the payload data for collision resistance — two images
-        // with identical type, media_type, and size but different content will
-        // produce distinct hashes.
         const source = block.raw.source as Record<string, unknown> | undefined;
         const data =
           (source?.data as string | undefined) ??
@@ -225,6 +221,13 @@ export function gatewayMessagesToLore(
     const parts: LorePart[] = m.content.map((block, pi) =>
       contentBlockToPart(block, sessionID, id, pi),
     );
+    const hiddenInputTokens = m.provenanceContent
+      ? Math.max(
+          0,
+          coreEstimateTokens(JSON.stringify(m.provenanceContent)) -
+            coreEstimateTokens(JSON.stringify(m.content)),
+        )
+      : 0;
 
     if (m.role === "user") {
       const info: LoreUserMessage = {
@@ -235,7 +238,11 @@ export function gatewayMessagesToLore(
         agent: "gateway",
         model: { providerID: "anthropic", modelID: "unknown" },
       };
-      out.push({ info, parts });
+      out.push({
+        info,
+        parts,
+        ...(hiddenInputTokens ? { hiddenInputTokens } : {}),
+      });
     } else {
       const info: LoreAssistantMessage = {
         id,
@@ -255,7 +262,11 @@ export function gatewayMessagesToLore(
           cache: { read: 0, write: 0 },
         },
       };
-      out.push({ info, parts });
+      out.push({
+        info,
+        parts,
+        ...(hiddenInputTokens ? { hiddenInputTokens } : {}),
+      });
     }
   }
 

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -158,6 +158,30 @@ function parseInputItems(input: unknown): GatewayMessage[] {
   if (!Array.isArray(input)) return [];
 
   const messages: GatewayMessage[] = [];
+  let pendingReasoning: GatewayContentBlock[] = [];
+
+  const appendAssistant = (
+    content: GatewayContentBlock[],
+    provenanceContent?: GatewayContentBlock[],
+    provenancePositions?: number[],
+  ): GatewayMessage => {
+    const message: GatewayMessage = { role: "assistant", content };
+    if (provenanceContent) {
+      message.provenanceContent = [...pendingReasoning, ...provenanceContent];
+      message.provenancePositions = (provenancePositions ?? []).map(
+        (position) => pendingReasoning.length + position,
+      );
+      pendingReasoning = [];
+    } else if (pendingReasoning.length > 0) {
+      message.provenanceContent = [...pendingReasoning, ...content];
+      message.provenancePositions = content.map(
+        (_block, index) => pendingReasoning.length + index,
+      );
+      pendingReasoning = [];
+    }
+    messages.push(message);
+    return message;
+  };
 
   for (const item of input as Array<Record<string, unknown>>) {
     const itemType = item.type as string | undefined;
@@ -179,7 +203,12 @@ function parseInputItems(input: unknown): GatewayMessage[] {
           messages.push({ role: "user", content });
         }
       } else if (msgRole === "assistant") {
-        messages.push({ role: "assistant", content });
+        const parsed = parseAssistantMessageContent(item);
+        appendAssistant(
+          parsed.content,
+          parsed.provenanceContent,
+          parsed.provenancePositions,
+        );
       } else {
         if (content.length > 0) {
           messages.push({ role: "user", content });
@@ -213,9 +242,21 @@ function parseInputItems(input: unknown): GatewayMessage[] {
         last.content.length > 0 &&
         last.content.every((b) => b.type === "tool_use");
       if (lastIsToolUseMessage) {
+        const provenance = last.provenanceContent ?? [...last.content];
+        const positions =
+          last.provenancePositions ??
+          last.content.map((_block, index) => index);
+        const position = provenance.length + pendingReasoning.length;
+        provenance.push(...pendingReasoning, toolUseBlock);
+        positions.push(position);
         last.content.push(toolUseBlock);
+        if (last.provenanceContent || pendingReasoning.length > 0) {
+          last.provenanceContent = provenance;
+          last.provenancePositions = positions;
+        }
+        pendingReasoning = [];
       } else {
-        messages.push({ role: "assistant", content: [toolUseBlock] });
+        appendAssistant([toolUseBlock]);
       }
       continue;
     }
@@ -249,6 +290,11 @@ function parseInputItems(input: unknown): GatewayMessage[] {
       continue;
     }
 
+    if (itemType === "reasoning") {
+      pendingReasoning.push({ type: "opaque", raw: item, responsesItem: true });
+      continue;
+    }
+
     // Other item types — skip, but warn about ones that can carry conversation
     // content the gateway cannot reconstruct.
     //
@@ -265,7 +311,22 @@ function parseInputItems(input: unknown): GatewayMessage[] {
         `dropping unresolvable Responses API item_reference (id=${asString(item.id, "?")}); ` +
           `gateway is stateless full-history and cannot resolve server-side item references`,
       );
+      continue;
     }
+
+    // Preserve every self-contained item in request-only provenance. The
+    // gateway may not render an unknown item, but canonical replay must hash
+    // the same full transcript on both the producing and consuming turns.
+    pendingReasoning.push({ type: "opaque", raw: item, responsesItem: true });
+  }
+
+  if (pendingReasoning.length > 0) {
+    messages.push({
+      role: "assistant",
+      content: [],
+      provenanceContent: pendingReasoning,
+      provenancePositions: [],
+    });
   }
 
   return messages;
@@ -294,6 +355,48 @@ function parseMessageContent(content: unknown): GatewayContentBlock[] {
     }
   }
   return blocks;
+}
+
+function parseAssistantMessageContent(item: Record<string, unknown>): {
+  content: GatewayContentBlock[];
+  provenanceContent: GatewayContentBlock[];
+  provenancePositions: number[];
+} {
+  if (typeof item.content === "string") {
+    const content = item.content
+      ? [{ type: "text" as const, text: item.content }]
+      : [];
+    return {
+      content,
+      provenanceContent: [...content],
+      provenancePositions: content.map((_block, index) => index),
+    };
+  }
+
+  const content: GatewayContentBlock[] = [];
+  const provenanceContent: GatewayContentBlock[] = [];
+  const provenancePositions: number[] = [];
+  if (!Array.isArray(item.content)) {
+    return { content, provenanceContent, provenancePositions };
+  }
+  for (const part of item.content as Array<Record<string, unknown>>) {
+    const isText = part.type === "output_text" || part.type === "text";
+    const text = isText ? asString(part.text) : "";
+    const visible: GatewayContentBlock | undefined = text
+      ? { type: "text", text }
+      : !isText
+        ? { type: "opaque", raw: part }
+        : undefined;
+    if (!visible) continue;
+    provenancePositions.push(provenanceContent.length);
+    content.push(visible);
+    provenanceContent.push({
+      type: "opaque",
+      raw: { ...item, content: [part] },
+      responsesItem: true,
+    });
+  }
+  return { content, provenanceContent, provenancePositions };
 }
 
 function parseArguments(args: unknown): unknown {
@@ -346,12 +449,39 @@ export function buildOpenAIResponsesUpstreamRequest(
 
   // Add tools in Responses API format
   if (req.tools.length > 0) {
-    body.tools = req.tools.map((t) => ({
-      type: "function",
-      name: t.name,
-      description: t.description,
-      parameters: t.inputSchema,
-    }));
+    body.tools = req.tools.map((t) => {
+      if (t.name !== "recall" || t.inputSchema.additionalProperties !== false) {
+        return {
+          type: "function",
+          name: t.name,
+          description: t.description,
+          parameters: t.inputSchema,
+        };
+      }
+      const properties = t.inputSchema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      return {
+        type: "function",
+        name: t.name,
+        description: t.description,
+        strict: true,
+        parameters: {
+          ...t.inputSchema,
+          properties: {
+            ...properties,
+            scope: {
+              ...properties.scope,
+              type: ["string", "null"],
+              enum: [...((properties.scope.enum as unknown[]) ?? []), null],
+            },
+            id: { ...properties.id, type: ["string", "null"] },
+          },
+          required: Object.keys(properties),
+        },
+      };
+    });
   }
 
   // Forward extras
@@ -396,6 +526,9 @@ export function buildOpenAIResponsesUpstreamRequest(
     }
     if (req.extras.truncation !== undefined) {
       body.truncation = req.extras.truncation;
+    }
+    if (req.extras.parallel_tool_calls !== undefined) {
+      body.parallel_tool_calls = req.extras.parallel_tool_calls;
     }
   }
 
@@ -457,11 +590,27 @@ function buildResponsesInput(
   messages: GatewayMessage[],
 ): Array<Record<string, unknown>> {
   const items: Array<Record<string, unknown>> = [];
+  const appendItem = (item: Record<string, unknown>): void => {
+    const previous = items[items.length - 1];
+    if (item.type === "message" && previous?.type === "message") {
+      const { content: itemContent, ...itemEnvelope } = item;
+      const { content: previousContent, ...previousEnvelope } = previous;
+      if (
+        JSON.stringify(itemEnvelope) === JSON.stringify(previousEnvelope) &&
+        Array.isArray(itemContent) &&
+        Array.isArray(previousContent)
+      ) {
+        previous.content = [...previousContent, ...itemContent];
+        return;
+      }
+    }
+    items.push(item);
+  };
 
   for (const msg of messages) {
-    for (const block of msg.content) {
+    for (const block of msg.provenanceContent ?? msg.content) {
       if (block.type === "text") {
-        items.push({
+        appendItem({
           type: "message",
           role: msg.role === "assistant" ? "assistant" : "user",
           content: [
@@ -472,7 +621,7 @@ function buildResponsesInput(
           ],
         });
       } else if (block.type === "tool_use") {
-        items.push({
+        appendItem({
           type: "function_call",
           call_id: block.id,
           name: block.name,
@@ -483,18 +632,25 @@ function buildResponsesInput(
         // text projection. (Non-text tool-result sub-blocks can't be
         // represented on this wire format; Anthropic-native clients are
         // unaffected.)
-        items.push({
+        appendItem({
           type: "function_call_output",
           call_id: block.toolUseId,
           output: blocksToText(block.content),
         });
       } else if (block.type === "opaque") {
-        // Re-emit opaque blocks as message content parts (e.g. input_image).
-        items.push({
-          type: "message",
-          role: msg.role === "assistant" ? "assistant" : "user",
-          content: [block.raw],
-        });
+        if (block.responsesItem) {
+          if (block.raw.type === "item_reference") continue;
+          // Stateless follow-ups must replay complete top-level output items
+          // verbatim, including encrypted reasoning, refusals, and future types.
+          appendItem(block.raw);
+        } else {
+          // Re-emit opaque blocks as message content parts (e.g. input_image).
+          appendItem({
+            type: "message",
+            role: msg.role === "assistant" ? "assistant" : "user",
+            content: [block.raw],
+          });
+        }
       }
     }
   }

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -67,6 +67,8 @@ export type GatewayToolResultBlock = {
 export type GatewayOpaqueBlock = {
   type: "opaque";
   raw: Record<string, unknown>;
+  /** Raw is a complete top-level Responses item, not a message content part. */
+  responsesItem?: boolean;
 };
 
 export type GatewayContentBlock =
@@ -168,6 +170,14 @@ export function opaquePlaceholder(raw: Record<string, unknown>): string {
 export type GatewayMessage = {
   role: "user" | "assistant";
   content: GatewayContentBlock[];
+  /**
+   * Request-only content used to fingerprint recall-anchor provenance. It may
+   * include Responses wire items (notably encrypted reasoning) that must bind a
+   * replay anchor but must never enter normal content or temporal storage.
+   */
+  provenanceContent?: GatewayContentBlock[];
+  /** Index of each visible `content` block inside `provenanceContent`. */
+  provenancePositions?: number[];
 };
 
 // ---------------------------------------------------------------------------
@@ -320,6 +330,8 @@ export type GatewayResponse = {
   id: string;
   model: string;
   content: GatewayContentBlock[];
+  /** Original Responses output items needed for stateless follow-up requests. */
+  rawOutputItems?: Array<Record<string, unknown>>;
   /** Provider stop reason (e.g. `end_turn`, `stop`, `tool_use`, `length`). */
   stopReason: string;
   /**
@@ -342,13 +354,27 @@ export type StoredRecall = {
   input: { query: string; scope?: string };
   /** Position (content block index) in the original assistant message. */
   position: number;
-  /** Original content index of the hidden recall within the assistant turn. */
-  anchorPosition?: number;
   /** Executed recall result (formatted markdown). */
   result: string;
+  /** Unique replay anchor. Unlike query/scope or provider call IDs, this stays
+   * unique when the model repeats an identical recall. */
+  anchorId?: string;
+  /** Fingerprint of the transcript prefix that produced the anchor. */
+  /** Missing only on query-keyed entries persisted by pre-anchor releases. */
+  anchorContextId?: string;
+  /** Non-recall tool calls emitted beside this hidden recall in the original
+   *  response. Used to restore only genuine mixed-tool turns; a tool called by
+   *  the later recall continuation must remain in its own assistant message. */
+  companionToolUseIds?: string[];
+  companionToolUses?: Array<{
+    id: string;
+    name: string;
+    input: unknown;
+    side: "before" | "after";
+  }>;
 };
 
-/** Map from marker key (`${scope}:${query}`) → stored recall data. */
+/** Map from unique anchor or legacy marker keys to stored recall data. */
 export type RecallStore = Map<string, StoredRecall>;
 
 // ---------------------------------------------------------------------------
@@ -534,6 +560,8 @@ export type SessionState = {
   headerSessionId?: string;
   /** Name of the header that provided `headerSessionId`. */
   headerName?: string;
+  /** Privacy-safe credential scope for header/marker session identity. */
+  credentialFingerprint?: string;
   /** Candidate headers being tracked during the Tier 2 learning phase.
    *  Key: header name. Value: last seen value + consecutive stable turn count. */
   candidateHeaders?: Map<string, { value: string; seenCount: number }>;

--- a/packages/gateway/test/compact-endpoint-integration.test.ts
+++ b/packages/gateway/test/compact-endpoint-integration.test.ts
@@ -23,17 +23,16 @@ async function postCompact(
   baseURL: string,
   body: string,
   sessionID: string,
+  apiKey: string | null = "test-key",
 ): Promise<Response> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-lore-session-id": sessionID,
+  };
+  if (apiKey) headers["x-api-key"] = apiKey;
   return fetch(`${baseURL}/v1/compact`, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      // Tier-1 session header: ensures both the chat and the compact POST
-      // resolve to the SAME session (otherwise the compact POST, with
-      // empty messages, has a different fingerprint and would mint a new
-      // session with no lastUpstream).
-      "x-lore-session-id": sessionID,
-    },
+    headers,
     body,
   });
 }
@@ -147,6 +146,168 @@ describe("POST /v1/compact — integration (real session populated via chat turn
     expect(body.cancel).toBe(true);
     expect(body.summary).toBeUndefined();
   });
+
+  it.each([
+    ["cancel", 50_000],
+    ["summary", 873_000],
+  ])(
+    "rejects a mismatched project before the %s branch",
+    async (_branch, tokensBefore) => {
+      harness = await createHarness({
+        fixtures: [
+          makeFixtureEntry({
+            seq: 0,
+            requestMessages: [{ role: "user", content: "hello" }],
+            responseText: "hi",
+            model: "claude-sonnet-4-6",
+          }),
+        ],
+        projectPath: PROJECT_PATH,
+      });
+
+      const sessionID = `test-session-project-mismatch-${_branch}`;
+      const chatResp = await chatWithSession(
+        harness,
+        realConversationBody("claude-sonnet-4-6"),
+        sessionID,
+      );
+      expect(chatResp.status).toBe(200);
+
+      const mismatchedProject = `${PROJECT_PATH}-other-tenant`;
+      const compactResp = await postCompact(
+        harness.baseURL,
+        JSON.stringify({
+          project_path: mismatchedProject,
+          tokens_before: tokensBefore,
+        }),
+        sessionID,
+      );
+      expect(compactResp.status).toBe(403);
+      expect(await compactResp.json()).toEqual({
+        error: "project_mismatch",
+        message: "project_path does not match the authenticated session",
+      });
+      expect(harness.upstreamBodies()).toHaveLength(1);
+      expect(
+        harness.queryDB<{ path: string }>(
+          "SELECT path FROM projects WHERE path = ?",
+          [mismatchedProject],
+        ),
+      ).toEqual([]);
+    },
+  );
+
+  it("rejects a compact request without a provider credential", async () => {
+    harness = await createHarness({
+      fixtures: [
+        makeFixtureEntry({ seq: 0, requestMessages: [], responseText: "hi" }),
+      ],
+      projectPath: PROJECT_PATH,
+    });
+    const sessionID = "test-session-compact-no-auth";
+    expect(
+      (
+        await chatWithSession(
+          harness,
+          realConversationBody("claude-sonnet-4-6"),
+          sessionID,
+        )
+      ).status,
+    ).toBe(200);
+
+    const response = await postCompact(
+      harness.baseURL,
+      JSON.stringify({ project_path: PROJECT_PATH, tokens_before: 50_000 }),
+      sessionID,
+      null,
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: "unauthorized",
+      message: "A provider credential is required",
+    });
+  });
+
+  it.each([
+    ["cancel", 50_000],
+    ["summary", 873_000],
+  ])(
+    "does not adopt a session under the wrong credential before the %s branch",
+    async (_branch, tokensBefore) => {
+      harness = await createHarness({
+        fixtures: [
+          makeFixtureEntry({ seq: 0, requestMessages: [], responseText: "hi" }),
+        ],
+        projectPath: PROJECT_PATH,
+      });
+      const sessionID = `test-session-compact-wrong-auth-${_branch}`;
+      expect(
+        (
+          await chatWithSession(
+            harness,
+            realConversationBody("claude-sonnet-4-6"),
+            sessionID,
+          )
+        ).status,
+      ).toBe(200);
+
+      const response = await postCompact(
+        harness.baseURL,
+        JSON.stringify({
+          project_path: PROJECT_PATH,
+          tokens_before: tokensBefore,
+        }),
+        sessionID,
+        "other-tenant-key",
+      );
+      expect(response.status).toBe(404);
+      expect(await response.json()).toMatchObject({
+        error: "session_not_found",
+      });
+      expect(harness.upstreamBodies()).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    ["cancel", 1, true],
+    ["summary", Number.MAX_SAFE_INTEGER, false],
+  ])(
+    "restores the authenticated session and model after restart for the %s branch",
+    async (_branch, tokensBefore, shouldCancel) => {
+      harness = await createHarness({
+        fixtures: [
+          makeFixtureEntry({ seq: 0, requestMessages: [], responseText: "hi" }),
+        ],
+        projectPath: PROJECT_PATH,
+      });
+      const sessionID = `test-session-compact-restart-${_branch}`;
+      expect(
+        (
+          await chatWithSession(
+            harness,
+            realConversationBody("claude-sonnet-4-6"),
+            sessionID,
+          )
+        ).status,
+      ).toBe(200);
+      await harness.restartPipeline();
+
+      const response = await postCompact(
+        harness.baseURL,
+        JSON.stringify({
+          project_path: PROJECT_PATH,
+          tokens_before: tokensBefore,
+        }),
+        sessionID,
+      );
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as {
+        cancel?: boolean;
+        summary?: string;
+      };
+      expect(result.cancel === true).toBe(shouldCancel);
+    },
+  );
 
   it("cancels at the exact budget boundary (872K for Sonnet 1M / 128K output)", async () => {
     // models.dev: claude-sonnet-4-6 (anthropic) has limit { context: 1_000_000,

--- a/packages/gateway/test/compact-endpoint.test.ts
+++ b/packages/gateway/test/compact-endpoint.test.ts
@@ -12,7 +12,10 @@ import { shouldCancelCompactionFromBudget } from "../src/pipeline";
 async function postCompact(baseURL: string, body: string): Promise<Response> {
   return fetch(`${baseURL}/v1/compact`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": "test-key",
+    },
     body,
   });
 }

--- a/packages/gateway/test/fetch.test.ts
+++ b/packages/gateway/test/fetch.test.ts
@@ -113,6 +113,43 @@ describe("upstreamFetch runtime split", () => {
     }
   });
 
+  test("Bun: abort destroys a request waiting for response headers", async () => {
+    let requestStartedResolve: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      requestStartedResolve = resolve;
+    });
+    let requestClosedResolve: (() => void) | undefined;
+    const requestClosed = new Promise<void>((resolve) => {
+      requestClosedResolve = resolve;
+    });
+    const server: Server = await new Promise((resolve) => {
+      const s = createServer((req) => {
+        requestStartedResolve?.();
+        req.on("close", () => requestClosedResolve?.());
+      });
+      s.listen(0, () => resolve(s));
+    });
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      (globalThis as { Bun?: unknown }).Bun = { version: "1.3.14" };
+      vi.resetModules();
+      vi.doMock("undici", () => ({ fetch: vi.fn(), Agent: class {} }));
+      const { upstreamFetch } = await import("../src/fetch");
+      const controller = new AbortController();
+      const pending = upstreamFetch(`http://localhost:${port}/wait`, {
+        signal: controller.signal,
+      });
+      await requestStarted;
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      await requestClosed;
+    } finally {
+      server.close();
+    }
+  });
+
   test("Node: uses undici fetch with a timeout-disabled dispatcher", async () => {
     delete (globalThis as { Bun?: unknown }).Bun;
     vi.resetModules();

--- a/packages/gateway/test/harness.test.ts
+++ b/packages/gateway/test/harness.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+
+describe("gateway test harness", () => {
+  let harness: Harness | undefined;
+  const originalPort = process.env.LORE_LISTEN_PORT;
+
+  afterEach(async () => {
+    await harness?.teardown();
+    if (originalPort === undefined) delete process.env.LORE_LISTEN_PORT;
+    else process.env.LORE_LISTEN_PORT = originalPort;
+  });
+
+  test("pins the requested port instead of re-reading shared process state", async () => {
+    harness = await createHarness({
+      fixtures: [],
+      beforeConfigLoad: () => {
+        process.env.LORE_LISTEN_PORT = "1";
+      },
+    });
+    const port = Number(new URL(harness.baseURL).port);
+    expect(port).toBeGreaterThan(0);
+    expect(port).not.toBe(1);
+  });
+});

--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -44,6 +44,8 @@ export interface HarnessOptions {
   budget?: { maxLayer0Tokens?: number };
   /** Project path to bind requests to (and where `budget` .lore.json is written). */
   projectPath?: string;
+  /** Test-only race hook: runs after selecting the port, before loadConfig(). */
+  beforeConfigLoad?: () => void;
 }
 
 export interface Harness {
@@ -162,8 +164,18 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   }
 
   // --- 5. Start gateway ---
+  opts.beforeConfigLoad?.();
   const config = loadConfig();
+  // Vitest files share process.env within a worker. Another file can clobber
+  // LORE_LISTEN_PORT between the assignment above and this loadConfig() call,
+  // so pin the requested harness port on the config object itself.
+  config.port = port;
+  config.portExplicit = port !== 0;
   const server = await startServer(config);
+  if (server.port <= 0) {
+    server.stop();
+    throw new Error(`test gateway resolved invalid port ${server.port}`);
+  }
 
   const baseURL = `http://127.0.0.1:${server.port}`;
 

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -20,6 +20,8 @@ vi.mock("../src/worker-health", async (importOriginal) => {
 
 import {
   backoffMs,
+  abortableSleep,
+  readWorkerResponseText,
   createGatewayLLMClient,
   getLastWorkerError,
   maxRetriesFor,
@@ -98,6 +100,45 @@ describe("backoffMs — with Retry-After", () => {
   test("caps Retry-After at 32s regardless of attempt", () => {
     expect(backoffMs(0, 60_000)).toBe(32_000);
     expect(backoffMs(2, 300_000)).toBe(32_000);
+  });
+});
+
+describe("abortableSleep", () => {
+  test("rejects immediately when retry backoff is aborted", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    try {
+      const pending = abortableSleep(32_000, controller.signal);
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("readWorkerResponseText", () => {
+  test("cancels a stalled worker error body on abort", async () => {
+    const controller = new AbortController();
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { status: 500 },
+    );
+    const pending = readWorkerResponseText(response, controller.signal);
+    await Promise.resolve();
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(cancelled).toBe(true);
   });
 });
 

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -12,9 +12,14 @@
  */
 import { describe, test, expect } from "vitest";
 import { streamResponsesRecallAware } from "../src/pipeline";
+import type { GatewayResponse } from "../src/translate/types";
 
 function sseEvent(event: string, data: unknown): string {
-  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  const payload =
+    data && typeof data === "object" && !Array.isArray(data)
+      ? { type: event, ...(data as Record<string, unknown>) }
+      : data;
+  return `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
 }
 
 /** Build an upstream Responses SSE stream from ordered events. */
@@ -41,26 +46,32 @@ async function drain(resp: Response): Promise<string> {
 const created = (id: string, model: string) =>
   sseEvent("response.created", { response: { id, model } });
 
-const recallCall = (outputIndex: number, args: Record<string, unknown>) =>
+const recallCall = (
+  outputIndex: number,
+  args: Record<string, unknown>,
+  itemId = `fc_${outputIndex}`,
+  callId = `call_${outputIndex}`,
+) =>
   sseEvent("response.output_item.added", {
     output_index: outputIndex,
     item: {
       type: "function_call",
-      id: `fc_${outputIndex}`,
-      call_id: `call_${outputIndex}`,
+      id: itemId,
+      call_id: callId,
       name: "recall",
     },
   }) +
   sseEvent("response.function_call_arguments.done", {
     output_index: outputIndex,
+    item_id: itemId,
     arguments: JSON.stringify(args),
   }) +
   sseEvent("response.output_item.done", {
     output_index: outputIndex,
     item: {
       type: "function_call",
-      id: `fc_${outputIndex}`,
-      call_id: `call_${outputIndex}`,
+      id: itemId,
+      call_id: callId,
       name: "recall",
       arguments: JSON.stringify(args),
       status: "completed",
@@ -77,25 +88,61 @@ const completed = (id: string, usage?: unknown) =>
     },
   });
 
-const textItem = (outputIndex: number, text: string) =>
+const incomplete = (id: string) =>
+  sseEvent("response.incomplete", {
+    response: {
+      id,
+      model: "gpt-5.6-terra",
+      status: "incomplete",
+    },
+  });
+
+const doneIncomplete = (id: string) =>
+  sseEvent("response.done", {
+    response: {
+      id,
+      model: "gpt-5.6-terra",
+      status: "incomplete",
+    },
+  });
+
+const doneWithStatus = (id: string, status: string) =>
+  sseEvent("response.done", {
+    response: {
+      id,
+      model: "gpt-5.6-terra",
+      status,
+    },
+  });
+
+const PUBLIC_RECALL_ERROR = "Lore could not continue the response after recall";
+
+const textItem = (
+  outputIndex: number,
+  text: string,
+  itemId = `msg_${outputIndex}`,
+) =>
   sseEvent("response.output_item.added", {
     output_index: outputIndex,
-    item: { type: "message", id: `msg_${outputIndex}`, role: "assistant" },
+    item: { type: "message", id: itemId, role: "assistant" },
   }) +
   sseEvent("response.output_text.delta", {
     output_index: outputIndex,
+    item_id: itemId,
     content_index: 0,
     delta: text,
   }) +
   sseEvent("response.output_text.done", {
     output_index: outputIndex,
+    item_id: itemId,
+    content_index: 0,
     text,
   }) +
   sseEvent("response.output_item.done", {
     output_index: outputIndex,
     item: {
       type: "message",
-      id: `msg_${outputIndex}`,
+      id: itemId,
       role: "assistant",
       status: "completed",
       content: [{ type: "output_text", text }],
@@ -112,7 +159,7 @@ describe("streamResponsesRecallAware", () => {
       ]),
       {
         onComplete: () => {},
-        onRecall: async () => null,
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
         runFollowUp: async () => {
           throw new Error("should not be called");
         },
@@ -126,6 +173,66 @@ describe("streamResponsesRecallAware", () => {
     expect(out).not.toContain("lore_marker");
     expect(out).not.toContain("response.failed");
   });
+
+  test("forwards a principal response.failed exactly once when no recall occurs", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_failed", "gpt-5.6-terra"),
+        sseEvent("response.failed", {
+          response: {
+            id: "resp_failed",
+            model: "gpt-5.6-terra",
+            status: "failed",
+            error: { message: "provider failed" },
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not be called");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out.match(/^event: response\.failed$/gm)).toHaveLength(1);
+    expect(out).toContain("provider failed");
+    expect(out).not.toContain("ended without a terminal event");
+  });
+
+  test.each(["failed", "cancelled"])(
+    "hides recall when the principal response.done status is %s",
+    async (status) => {
+      let completedResponse: unknown;
+      const client = streamResponsesRecallAware(
+        streamFrom([
+          created("resp_principal_failure", "gpt-5.6-terra"),
+          recallCall(0, { query: "architecture" }),
+          doneWithStatus("resp_principal_failure", status),
+        ]),
+        {
+          onComplete: (response) => {
+            completedResponse = response;
+          },
+          onRecall: async () => {
+            throw new Error("should not execute");
+          },
+          runFollowUp: async () => {
+            throw new Error("should not run");
+          },
+        },
+      );
+
+      const out = await drain(client);
+      expect(out.match(/^event: response\.failed$/gm)).toHaveLength(1);
+      expect(out).not.toContain('"name":"recall"');
+      expect(out).not.toContain("call_0");
+      expect(JSON.stringify(completedResponse)).not.toContain("recall");
+      expect(JSON.stringify(completedResponse)).not.toContain("call_0");
+    },
+  );
 
   test("suppresses a recall function_call and emits a marker (mixed tools)", async () => {
     const client = streamResponsesRecallAware(
@@ -145,14 +252,26 @@ describe("streamResponsesRecallAware", () => {
         }),
         sseEvent("response.function_call_arguments.done", {
           output_index: 1,
+          item_id: "fc_1",
           arguments: JSON.stringify({ file: "x" }),
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "read",
+            arguments: JSON.stringify({ file: "x" }),
+            status: "completed",
+          },
         }),
         completed("resp_mixed"),
       ]),
       {
         onComplete: () => {},
         onRecall: async ({ query }) => ({
-          markerText: buildMarker(query),
+          anchorText: buildAnchor(query),
           resultText: "some results",
         }),
         runFollowUp: async () => {
@@ -166,10 +285,701 @@ describe("streamResponsesRecallAware", () => {
     expect(out).not.toMatch(/name":\s*"recall/);
     // The non-recall tool (read) must still be present.
     expect(out).toMatch(/name":\s*"read/);
-    // A synthetic marker text item must be emitted.
-    expect(out).toContain("🧠 marker: what is lore");
+    expect(out).toContain(buildAnchor("what is lore"));
+    expect(out).not.toContain("Searching");
     // A rebuilt response.completed is emitted.
     expect(out).toContain("response.completed");
+    expect(out.indexOf(buildAnchor("what is lore"))).toBeLessThan(
+      out.indexOf('name":"read"'),
+    );
+    const terminal = JSON.parse(
+      /event: response\.completed\ndata: (.+)/.exec(out)?.[1] ?? "{}",
+    ) as { response?: { output?: Array<{ id?: string }> } };
+    expect(terminal.response?.output?.map((item) => item.id)).toEqual([
+      "msg_resp_mixed_0",
+      "fc_1",
+    ]);
+  });
+
+  test("binds parallel recalls to their own call IDs and fails before an invalid follow-up", async () => {
+    const seen: string[] = [];
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_parallel", "gpt-5.6-terra"),
+        recallCall(0, { query: "same" }),
+        recallCall(1, { query: "same" }),
+        completed("resp_parallel"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ outputIndex, toolUseId }) => {
+          seen.push(`${outputIndex}:${toolUseId}`);
+          return {
+            anchorText: buildAnchor(`${outputIndex}-${toolUseId}`),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run for multiple recalls");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(seen).toEqual([]);
+    expect(out).toContain("response.failed");
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("rejects repeated call IDs before recall execution", async () => {
+    const seen: Array<{ outputIndex: number; contentPosition: number }> = [];
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_duplicate", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_read",
+            call_id: "call_reused",
+            name: "read",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_read",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.added", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_recall",
+            call_id: "call_reused",
+            name: "recall",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 1,
+          item_id: "fc_recall",
+          arguments: JSON.stringify({ query: "same" }),
+        }),
+        completed("resp_duplicate"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ outputIndex, contentPosition }) => {
+          seen.push({ outputIndex, contentPosition });
+          return { anchorText: buildAnchor("same"), resultText: "results" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run for mixed tools");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(seen).toEqual([]);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain('name":"recall"');
+  });
+
+  test("rejects parallel recalls even when a non-recall tool is present", async () => {
+    let executed = false;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_parallel_mixed", "gpt-5.6-terra"),
+        recallCall(0, { query: "one" }),
+        recallCall(1, { query: "two" }),
+        sseEvent("response.output_item.added", {
+          output_index: 2,
+          item: {
+            type: "function_call",
+            id: "fc_read",
+            call_id: "call_read",
+            name: "read",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 2,
+          item_id: "fc_read",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 2,
+          item: {
+            type: "function_call",
+            id: "fc_read",
+            call_id: "call_read",
+            name: "read",
+            arguments: "{}",
+          },
+        }),
+        completed("resp_parallel_mixed"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          executed = true;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(executed).toBe(false);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("bounds deferred principal output after recall detection", async () => {
+    const recall = recallCall(0, { query: "architecture" });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_deferred", "gpt-5.6-terra"),
+        recall,
+        textItem(1, "too large"),
+        completed("resp_deferred"),
+      ]),
+      {
+        maxDeferredBytes: new TextEncoder().encode(recall).byteLength + 1,
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should fail before follow-up");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("bounds suppressed recall argument events", async () => {
+    const added = sseEvent("response.output_item.added", {
+      output_index: 0,
+      item: {
+        type: "function_call",
+        id: "fc_args",
+        call_id: "call_args",
+        name: "recall",
+      },
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_args", "gpt-5.6-terra"),
+        added,
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_args",
+          arguments: JSON.stringify({ query: "architecture" }),
+        }),
+        completed("resp_args"),
+      ]),
+      {
+        maxDeferredBytes: new TextEncoder().encode(added).byteLength + 1,
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should fail before follow-up");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("bounds retained output before recall detection", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_retained", "gpt-5.6-terra"),
+        textItem(0, "large retained output"),
+        completed("resp_retained"),
+      ]),
+      {
+        maxRetainedStateBytes: 1,
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects an SSE event name that disagrees with the payload type", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_type_mismatch", "gpt-5.6-terra"),
+        sseEvent("response.created", {
+          type: "response.in_progress",
+          response: { id: "resp_type_mismatch", model: "gpt-5.6-terra" },
+        }),
+        completed("resp_type_mismatch"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects response.in_progress changing the created response identity", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_identity_a", "gpt-5.6-terra"),
+        sseEvent("response.in_progress", {
+          response: { id: "resp_identity_b", model: "gpt-5.6-terra" },
+        }),
+        completed("resp_identity_b"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects malformed named Responses events in a continuation", async () => {
+    const followUp = streamFrom([
+      created("resp_bad_continuation", "gpt-5.6-terra"),
+      "event: response.completed\ndata: {not-json}\n\n",
+      completed("resp_bad_continuation"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_bad_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_bad_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("{not-json}");
+  });
+
+  test("rejects one content index changing type", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_content_type", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_content_type", role: "assistant" },
+        }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_content_type",
+          content_index: 0,
+          text: "text",
+        }),
+        sseEvent("response.refusal.done", {
+          output_index: 0,
+          item_id: "msg_content_type",
+          content_index: 0,
+          refusal: "no",
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects output_item.done changing finalized content", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_content_done", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_content_done", role: "assistant" },
+        }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_content_done",
+          content_index: 0,
+          text: "original",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_content_done",
+            role: "assistant",
+            content: [{ type: "output_text", text: "changed" }],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects terminal output changing streamed identity", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_identity", "gpt-5.6-terra"),
+        textItem(0, "answer", "msg_streamed"),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_identity",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "msg_changed",
+                role: "assistant",
+                content: [{ type: "output_text", text: "answer" }],
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("never forwards response-side item_reference lifecycle events", async () => {
+    let completedResponse: GatewayResponse | undefined;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reference", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "item_reference",
+            id: "msg_server_only",
+          },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "item_reference",
+            id: "msg_server_only",
+          },
+        }),
+        completed("resp_reference"),
+      ]),
+      {
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    const out = await drain(client);
+    expect(out).not.toContain("item_reference");
+    expect(JSON.stringify(completedResponse)).not.toContain("item_reference");
+  });
+
+  test("accepts reasoning summaries with summary_index", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_summary", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_summary" },
+        }),
+        sseEvent("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          item_id: "rs_summary",
+          summary_index: 0,
+          delta: "summary",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_summary", summary: [] },
+        }),
+        completed("resp_summary"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    const out = await drain(client);
+    expect(out).toContain("response.reasoning_summary_text.delta");
+    expect(out).not.toContain("response.failed");
+  });
+
+  test.each([
+    {
+      name: "duplicate argument completion",
+      extra: sseEvent("response.function_call_arguments.done", {
+        output_index: 0,
+        item_id: "fc_0",
+        arguments: JSON.stringify({ query: "changed" }),
+      }),
+    },
+    {
+      name: "argument delta after completion",
+      extra: sseEvent("response.function_call_arguments.delta", {
+        output_index: 0,
+        item_id: "fc_0",
+        delta: "changed",
+      }),
+    },
+  ])("rejects $name", async ({ extra }) => {
+    let recalled = 0;
+    const callWithoutItemDone =
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_0",
+          call_id: "call_0",
+          name: "recall",
+        },
+      }) +
+      sseEvent("response.function_call_arguments.done", {
+        output_index: 0,
+        item_id: "fc_0",
+        arguments: JSON.stringify({ query: "original" }),
+      });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_lifecycle", "gpt-5.6-terra"),
+        callWithoutItemDone,
+        extra,
+        completed("resp_lifecycle"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects output_item.done arguments that differ from completed arguments", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_argument_toctou", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_toctou",
+            call_id: "call_toctou",
+            name: "recall",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_toctou",
+          arguments: JSON.stringify({ query: "original" }),
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_toctou",
+            call_id: "call_toctou",
+            name: "recall",
+            arguments: JSON.stringify({ query: "changed" }),
+          },
+        }),
+        completed("resp_argument_toctou"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test.each([
+    {
+      name: "refusal on a function call",
+      item: {
+        type: "function_call",
+        id: "fc_wrong_refusal",
+        call_id: "call_wrong_refusal",
+        name: "read",
+      },
+      event: sseEvent("response.refusal.delta", {
+        output_index: 0,
+        item_id: "fc_wrong_refusal",
+        content_index: 0,
+        delta: "cannot",
+      }),
+    },
+    {
+      name: "reasoning summary on a message",
+      item: { type: "message", id: "msg_wrong_reasoning", role: "assistant" },
+      event: sseEvent("response.reasoning_summary_text.delta", {
+        output_index: 0,
+        item_id: "msg_wrong_reasoning",
+        summary_index: 0,
+        delta: "summary",
+      }),
+    },
+  ])("rejects $name", async ({ item, event }) => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_wrong_item_type", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", { output_index: 0, item }),
+        event,
+        completed("resp_wrong_item_type"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects a recall item missing output_item.done", async () => {
+    const incompleteCall =
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_incomplete",
+          call_id: "call_incomplete",
+          name: "recall",
+        },
+      }) +
+      sseEvent("response.function_call_arguments.done", {
+        output_index: 0,
+        item_id: "fc_incomplete",
+        arguments: JSON.stringify({ query: "architecture" }),
+      });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_incomplete_call", "gpt-5.6-terra"),
+        incompleteCall,
+        completed("resp_incomplete_call"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("caps chained recall depth", async () => {
+    const chained = streamFrom([
+      created("resp_chained", "gpt-5.6-terra"),
+      recallCall(0, { query: "detail" }),
+      completed("resp_chained"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        maxRecallDepth: 0,
+        onComplete: () => {},
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: chained.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("allows the final answer after one recall at depth one", async () => {
+    const final = streamFrom([
+      created("resp_final", "gpt-5.6-terra"),
+      textItem(0, "final answer"),
+      completed("resp_final"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        maxRecallDepth: 1,
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: final.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("final answer");
+    expect(out).not.toContain("depth exhausted");
+    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
   });
 
   test("recall-only: emits marker, pipes the continuation inline, rebuilds completed", async () => {
@@ -194,17 +1004,17 @@ describe("streamResponsesRecallAware", () => {
       {
         onComplete: (r) => {
           // The completed response has no recall tool_use and includes the
-          // continuation text (merged) + marker.
+          // continuation text (merged) + hidden replay anchor.
           expect(r.content.some((b) => b.type === "tool_use")).toBe(false);
           const text = r.content
             .filter((b) => b.type === "text")
             .map((b) => b.text)
             .join("");
           expect(text).toContain("Here is the answer from the continuation.");
-          expect(text).toContain("🧠 marker: architecture");
+          expect(text).toContain(buildAnchor("architecture"));
         },
         onRecall: async ({ query }) => ({
-          markerText: buildMarker(query),
+          anchorText: buildAnchor(query),
           resultText: "architecture results",
         }),
         runFollowUp: async ({ acc, resultText }) => {
@@ -216,8 +1026,8 @@ describe("streamResponsesRecallAware", () => {
     );
     const out = await drain(client);
 
-    // Marker emitted.
-    expect(out).toContain("🧠 marker: architecture");
+    expect(out).toContain(buildAnchor("architecture"));
+    expect(out).not.toContain("Searching");
     // Continuation text streamed inline.
     expect(out).toContain("Here is the answer from the continuation.");
     // Rebuilt terminal event.
@@ -231,6 +1041,1733 @@ describe("streamResponsesRecallAware", () => {
     expect(out.match(/^event: response\.created$/gm)).toHaveLength(1);
     expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
     expect(out.match(/^event: response\.in_progress$/gm) ?? []).toHaveLength(0);
+    const sequenceNumbers = [...out.matchAll(/"sequence_number":(\d+)/g)].map(
+      (match) => Number(match[1]),
+    );
+    expect(sequenceNumbers).toEqual(sequenceNumbers.map((_, index) => index));
+  });
+
+  test("places continuation after deferred principal output without index collisions", async () => {
+    const followUp = streamFrom([
+      created("resp_followup", "gpt-5.6-terra"),
+      textItem(0, "continuation"),
+      completed("resp_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_collision", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        textItem(1, "principal"),
+        completed("resp_collision"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    const terminal = JSON.parse(
+      /event: response\.completed\ndata: (.+)/.exec(out)?.[1] ?? "{}",
+    ) as { response?: { output?: Array<{ content?: unknown }> } };
+    expect(out).toContain('"output_index":1');
+    expect(out).toContain('"output_index":2');
+    expect(JSON.stringify(terminal.response?.output)).toContain("principal");
+    expect(JSON.stringify(terminal.response?.output)).toContain("continuation");
+  });
+
+  test("rejects continuation identities that collide with principal output", async () => {
+    const followUp = streamFrom([
+      created("resp_followup", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: { type: "message", id: "fc_0", role: "assistant" },
+      }),
+      sseEvent("response.output_item.done", {
+        output_index: 0,
+        item: {
+          type: "message",
+          id: "fc_0",
+          role: "assistant",
+          status: "completed",
+          content: [],
+        },
+      }),
+      completed("resp_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("lore-recall");
+  });
+
+  test("caps frames across the principal and chained continuations", async () => {
+    const second = streamFrom([
+      created("resp_frame_second", "gpt-5.6-terra"),
+      recallCall(0, { query: "detail" }),
+      completed("resp_frame_second"),
+    ]);
+    let recalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_frame_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_frame_first"),
+      ]),
+      {
+        maxSSEFrames: 8,
+        onComplete: () => {},
+        onRecall: async ({ query }) => {
+          recalls++;
+          return {
+            anchorText: buildAnchor(query),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({ reader: second.body!.getReader() }),
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalls).toBe(1);
+  });
+
+  test("caps hidden recall bytes across chained continuations", async () => {
+    const firstRecall = recallCall(0, { query: "architecture" });
+    const secondRecall = recallCall(0, { query: "detail" });
+    const second = streamFrom([
+      created("resp_bytes_second", "gpt-5.6-terra"),
+      secondRecall,
+      completed("resp_bytes_second"),
+    ]);
+    const oneRecallBytes = new TextEncoder().encode(firstRecall).byteLength;
+    let recalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_bytes_first", "gpt-5.6-terra"),
+        firstRecall,
+        completed("resp_bytes_first"),
+      ]),
+      {
+        maxDeferredBytes: 1024 * 1024,
+        maxHiddenRecallBytes: oneRecallBytes + 32,
+        onComplete: () => {},
+        onRecall: async ({ query }) => {
+          recalls++;
+          return {
+            anchorText: buildAnchor(query),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({ reader: second.body!.getReader() }),
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalls).toBe(1);
+  });
+
+  test("stops reading upstream while the client applies backpressure", async () => {
+    const encoder = new TextEncoder();
+    const events = [
+      created("resp_backpressure", "gpt-5.6-terra"),
+      sseEvent("response.in_progress", { type: "response.in_progress" }),
+      completed("resp_backpressure"),
+    ];
+    let pulls = 0;
+    const thirdPull = Promise.withResolvers<void>();
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls++;
+          if (pulls === 3) thirdPull.resolve();
+          const event = events.shift();
+          if (event) controller.enqueue(encoder.encode(event));
+          else controller.close();
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const client = streamResponsesRecallAware(upstream, {
+      onComplete: () => {},
+      onRecall: async () => ({ anchorText: "", resultText: "" }),
+      runFollowUp: async () => {
+        throw new Error("should not run");
+      },
+    });
+    await thirdPull.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(pulls).toBe(3);
+    const reader = client.body!.getReader();
+    await reader.cancel();
+  });
+
+  test("bounds request-wide no-index stream bytes", async () => {
+    const lifecycle = created("resp_stream_bytes", "gpt-5.6-terra");
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        lifecycle,
+        sseEvent("response.in_progress", { padding: "x".repeat(128) }),
+        completed("resp_stream_bytes"),
+      ]),
+      {
+        maxStreamBytes: new TextEncoder().encode(lifecycle).byteLength + 1,
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("caps raw stream bytes across a continuation", async () => {
+    const principal = [
+      created("resp_stream_chain", "gpt-5.6-terra"),
+      recallCall(0, { query: "architecture" }),
+      completed("resp_stream_chain"),
+    ];
+    const continuationCreated = created(
+      "resp_stream_chain_followup",
+      "gpt-5.6-terra",
+    );
+    const followUp = streamFrom([
+      continuationCreated,
+      textItem(0, "answer"),
+      completed("resp_stream_chain_followup"),
+    ]);
+    const client = streamResponsesRecallAware(streamFrom(principal), {
+      maxStreamBytes:
+        new TextEncoder().encode(principal.join("") + continuationCreated)
+          .byteLength + 1,
+      onComplete: () => {},
+      onRecall: async () => ({
+        anchorText: buildAnchor("architecture"),
+        resultText: "results",
+      }),
+      runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+    });
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("caps retained indexed state across a continuation", async () => {
+    const principal = [
+      created("resp_retained_chain", "gpt-5.6-terra"),
+      recallCall(0, { query: "architecture" }),
+      completed("resp_retained_chain"),
+    ];
+    const retainedPrincipalBytes = principal
+      .join("")
+      .matchAll(/data: (.+)\n\n/g)
+      .reduce((sum, match) => {
+        const parsed = JSON.parse(match[1]) as Record<string, unknown>;
+        return Object.hasOwn(parsed, "output_index")
+          ? sum + new TextEncoder().encode(match[1]).byteLength
+          : sum;
+      }, 0);
+    const followUp = streamFrom([
+      created("resp_retained_followup", "gpt-5.6-terra"),
+      textItem(0, "answer"),
+      completed("resp_retained_followup"),
+    ]);
+    const client = streamResponsesRecallAware(streamFrom(principal), {
+      maxRetainedStateBytes: retainedPrincipalBytes + 1,
+      onComplete: () => {},
+      onRecall: async () => ({
+        anchorText: buildAnchor("architecture"),
+        resultText: "results",
+      }),
+      runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+    });
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("shifts refusal event coordinates in a continuation", async () => {
+    const followUp = streamFrom([
+      created("resp_followup", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: { type: "message", id: "msg_refusal", role: "assistant" },
+      }),
+      sseEvent("response.refusal.delta", {
+        output_index: 0,
+        item_id: "msg_refusal",
+        content_index: 0,
+        delta: "no",
+      }),
+      sseEvent("response.refusal.done", {
+        output_index: 0,
+        item_id: "msg_refusal",
+        content_index: 0,
+        refusal: "no",
+      }),
+      sseEvent("response.output_item.done", {
+        output_index: 0,
+        item: {
+          type: "message",
+          id: "msg_refusal",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "refusal", refusal: "no" }],
+        },
+      }),
+      completed("resp_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("event: response.refusal.delta");
+    expect(out).toContain('"output_index":1');
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    const terminal = JSON.parse(
+      /event: response\.completed\ndata: (.+)/.exec(out)?.[1] ?? "{}",
+    ) as { response?: { output?: Array<Record<string, unknown>> } };
+    expect(terminal.response?.output).toContainEqual(
+      expect.objectContaining({
+        id: "msg_refusal",
+        content: [{ type: "refusal", refusal: "no" }],
+      }),
+    );
+  });
+
+  test("preserves refusal supplied only by output_item.done", async () => {
+    let completedResponse: GatewayResponse | undefined;
+    const followUp = streamFrom([
+      created("resp_refusal_done", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: { type: "message", id: "msg_refusal_done", role: "assistant" },
+      }),
+      sseEvent("response.output_item.done", {
+        output_index: 0,
+        item: {
+          type: "message",
+          id: "msg_refusal_done",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "refusal", refusal: "cannot comply" }],
+        },
+      }),
+      completed("resp_refusal_done"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain('"type":"refusal"');
+    expect(out).toContain("cannot comply");
+    expect(JSON.stringify(completedResponse)).toContain("cannot comply");
+  });
+
+  test("rejects an upstream item that collides with the synthetic anchor ID", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_collision", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        sseEvent("response.output_item.added", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "msg_resp_collision_0",
+            call_id: "call_read",
+            name: "read",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 1,
+          item_id: "msg_resp_collision_0",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "msg_resp_collision_0",
+            call_id: "call_read",
+            name: "read",
+            arguments: "{}",
+          },
+        }),
+        completed("resp_collision"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return {
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("lore-recall");
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects continuation output using the reserved principal anchor ID", async () => {
+    const continuation = streamFrom([
+      created("resp_continuation_collision", "gpt-5.6-terra"),
+      textItem(0, "collision", "msg_resp_principal_collision_0"),
+      completed("resp_continuation_collision"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_principal_collision", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_principal_collision"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: continuation.body!.getReader() }),
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("counts refusal content before a recall position", async () => {
+    let seenPosition = -1;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_refusal_position", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_refusal", role: "assistant" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_refusal",
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "refusal", refusal: "cannot" }],
+          },
+        }),
+        recallCall(1, { query: "architecture" }),
+        completed("resp_refusal_position"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ contentPosition }) => {
+          seenPosition = contentPosition;
+          return {
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({
+          reader: streamFrom([
+            created("resp_answer", "gpt-5.6-terra"),
+            textItem(0, "answer"),
+            completed("resp_answer"),
+          ]).body!.getReader(),
+        }),
+      },
+    );
+    const out = await drain(client);
+    expect(seenPosition).toBe(1);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("counts every part in a multi-part message before recall", async () => {
+    let seenPosition = -1;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_multipart_position", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_multipart", role: "assistant" },
+        }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_multipart",
+          content_index: 0,
+          text: "preamble",
+        }),
+        sseEvent("response.refusal.done", {
+          output_index: 0,
+          item_id: "msg_multipart",
+          content_index: 1,
+          refusal: "cannot",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_multipart",
+            role: "assistant",
+            status: "completed",
+            content: [
+              { type: "output_text", text: "preamble" },
+              { type: "refusal", refusal: "cannot" },
+            ],
+          },
+        }),
+        recallCall(1, { query: "architecture" }),
+        completed("resp_multipart_position"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ contentPosition }) => {
+          seenPosition = contentPosition;
+          return {
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({
+          reader: streamFrom([
+            created("resp_multipart_answer", "gpt-5.6-terra"),
+            textItem(0, "answer"),
+            completed("resp_multipart_answer"),
+          ]).body!.getReader(),
+        }),
+      },
+    );
+    const out = await drain(client);
+    expect(seenPosition).toBe(2);
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    const terminal = JSON.parse(
+      /event: response\.completed\ndata: (.+)/.exec(out)?.[1] ?? "{}",
+    ) as { response?: { output?: Array<Record<string, unknown>> } };
+    expect(terminal.response?.output?.[0]).toMatchObject({
+      id: "msg_multipart",
+      content: [
+        { type: "output_text", text: "preamble" },
+        { type: "refusal", refusal: "cannot" },
+      ],
+    });
+  });
+
+  test("rejects a call_id that collides with the synthetic anchor ID", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_cross_collision", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        sseEvent("response.output_item.added", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_read",
+            call_id: "msg_resp_cross_collision_0",
+            name: "read",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 1,
+          item_id: "fc_read",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_read",
+            call_id: "msg_resp_cross_collision_0",
+            name: "read",
+            arguments: "{}",
+          },
+        }),
+        completed("resp_cross_collision"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return {
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects a chained recall call_id matching its future marker ID", async () => {
+    const second = streamFrom([
+      created("resp_second_collision", "gpt-5.6-terra"),
+      recallCall(
+        0,
+        { query: "detail" },
+        "fc_second_collision",
+        "msg_resp_first_collision_1",
+      ),
+      completed("resp_second_collision"),
+    ]);
+    let recalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first_collision", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first_collision"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => {
+          recalls++;
+          return {
+            anchorText: buildAnchor(query),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({ reader: second.body!.getReader() }),
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalls).toBe(1);
+  });
+
+  test("rejects cross-field identity reuse between upstream items", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_cross_fields", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_first",
+            call_id: "call_shared",
+            name: "read",
+          },
+        }),
+        sseEvent("response.output_item.added", {
+          output_index: 1,
+          item: { type: "message", id: "call_shared", role: "assistant" },
+        }),
+        completed("resp_cross_fields"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("intercepts a chained recall before streaming its final continuation", async () => {
+    const second = streamFrom([
+      created("resp_second", "gpt-5.6-terra"),
+      recallCall(0, { query: "detail" }, "fc_second", "call_second"),
+      completed("resp_second"),
+    ]);
+    const final = streamFrom([
+      created("resp_final", "gpt-5.6-terra"),
+      textItem(0, "final answer", "msg_final"),
+      completed("resp_final"),
+    ]);
+    const seen: string[] = [];
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => {
+          seen.push(query);
+          return {
+            anchorText: buildAnchor(query),
+            resultText: `${query} results`,
+          };
+        },
+        runFollowUp: async () => ({
+          reader: (seen.length === 1 ? second : final).body!.getReader(),
+        }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(seen).toEqual(["architecture", "detail"]);
+    expect(out).toContain("final answer");
+    expect(out).not.toMatch(/name":\s*"recall/);
+    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
+  });
+
+  test("rolls back intermediate continuation state when a later chain fails", async () => {
+    const second = streamFrom([
+      created("resp_second", "gpt-5.6-terra"),
+      textItem(0, "intermediate", "msg_second"),
+      recallCall(1, { query: "detail" }, "fc_second", "call_second"),
+      completed("resp_second"),
+    ]);
+    let completedResponse: GatewayResponse | undefined;
+    let followUps = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: `${query} results`,
+        }),
+        runFollowUp: async () => {
+          followUps++;
+          if (followUps === 1) return { reader: second.body!.getReader() };
+          throw new Error("later continuation failed");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("intermediate");
+    expect(JSON.stringify(completedResponse)).not.toContain("intermediate");
+    expect(JSON.stringify(completedResponse)).not.toContain("lore-recall");
+  });
+
+  test("rolls back deferred persistence when a recall-only continuation fails", async () => {
+    let committed = 0;
+    let rolledBack = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_persist", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_persist"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+          commit: () => committed++,
+          rollback: () => rolledBack++,
+        }),
+        runFollowUp: async () => {
+          throw new Error("follow-up failed");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(committed).toBe(0);
+    expect(rolledBack).toBe(1);
+  });
+
+  test("rolls back persistence without contradicting an already delivered terminal", async () => {
+    let completedCalls = 0;
+    let committed = 0;
+    let rolledBack = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_complete_failure", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_complete_failure"),
+      ]),
+      {
+        onComplete: () => {
+          completedCalls++;
+          throw new Error("postResponse failed");
+        },
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+          commit: () => committed++,
+          rollback: () => rolledBack++,
+        }),
+        runFollowUp: async () => ({
+          reader: streamFrom([
+            created("resp_followup", "gpt-5.6-terra"),
+            textItem(0, "answer", "msg_answer"),
+            completed("resp_followup"),
+          ]).body!.getReader(),
+        }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("lore-recall");
+    expect(out).toContain("answer");
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
+    expect(out).not.toContain("event: response.failed");
+    expect(committed).toBe(0);
+    expect(rolledBack).toBe(1);
+    expect(completedCalls).toBe(1);
+  });
+
+  test("never commits when an abort-ignoring recall callback resolves late", async () => {
+    let markRecallStarted: (() => void) | undefined;
+    const recallStarted = new Promise<void>((resolve) => {
+      markRecallStarted = resolve;
+    });
+    let resolveRecall: (() => void) | undefined;
+    const recallReady = new Promise<void>((resolve) => {
+      resolveRecall = resolve;
+    });
+    let committed = 0;
+    let rolledBack = 0;
+    const rollbackObserved = Promise.withResolvers<void>();
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_abort_commit", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_abort_commit"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          markRecallStarted?.();
+          await recallReady;
+          return {
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+            commit: () => committed++,
+            rollback: () => {
+              rolledBack++;
+              rollbackObserved.resolve();
+            },
+          };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    const reader = client.body!.getReader();
+    await recallStarted;
+    const cancelled = reader.cancel();
+    resolveRecall?.();
+    await cancelled;
+    await rollbackObserved.promise;
+    expect(committed).toBe(0);
+    expect(rolledBack).toBe(1);
+  });
+
+  test("rolls back when the client disconnects after continuation delivery starts", async () => {
+    let committed = 0;
+    let completedCalls = 0;
+    const rollbackObserved = Promise.withResolvers<void>();
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_mid_delivery_abort", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_mid_delivery_abort"),
+      ]),
+      {
+        onComplete: () => completedCalls++,
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+          commit: () => committed++,
+          rollback: () => rollbackObserved.resolve(),
+        }),
+        runFollowUp: async () => ({
+          reader: streamFrom([
+            created("resp_mid_delivery_followup", "gpt-5.6-terra"),
+            textItem(0, "answer", "msg_mid_delivery_answer"),
+            completed("resp_mid_delivery_followup"),
+          ]).body!.getReader(),
+        }),
+      },
+    );
+
+    const reader = client.body!.getReader();
+    const decoder = new TextDecoder();
+    for (;;) {
+      const { done, value } = await reader.read();
+      expect(done).toBe(false);
+      if (value && decoder.decode(value).includes("lore-recall")) break;
+    }
+    await reader.cancel();
+    await rollbackObserved.promise;
+    expect(committed).toBe(0);
+    expect(completedCalls).toBe(0);
+  });
+
+  test("cancellation never waits for a non-settling recall callback", async () => {
+    const recallStarted = Promise.withResolvers<void>();
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_pending_recall", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_pending_recall"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recallStarted.resolve();
+          return new Promise<never>(() => {});
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    const reader = client.body!.getReader();
+    await recallStarted.promise;
+    await expect(
+      Promise.race([
+        reader.cancel().then(() => "cancelled"),
+        new Promise<string>((resolve) =>
+          setImmediate(() => resolve("still pending")),
+        ),
+      ]),
+    ).resolves.toBe("cancelled");
+  });
+
+  test("cancels a reader returned late by an abort-ignoring follow-up setup", async () => {
+    const followUpStarted = Promise.withResolvers<void>();
+    const releaseFollowUp = Promise.withResolvers<void>();
+    const followUpCancelled = Promise.withResolvers<void>();
+    let cancelCalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_abort_late_followup", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_abort_late_followup"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => {
+          followUpStarted.resolve();
+          await releaseFollowUp.promise;
+          const stream = new ReadableStream<Uint8Array>({
+            cancel() {
+              cancelCalls++;
+              followUpCancelled.resolve();
+            },
+          });
+          return { reader: stream.getReader() };
+        },
+      },
+    );
+    const reader = client.body!.getReader();
+    await followUpStarted.promise;
+    const cancelled = reader.cancel();
+    releaseFollowUp.resolve();
+    await cancelled;
+    await followUpCancelled.promise;
+    expect(cancelCalls).toBe(1);
+  });
+
+  test("cancellation never waits for non-settling follow-up setup", async () => {
+    const followUpStarted = Promise.withResolvers<void>();
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_pending_followup", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_pending_followup"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => {
+          followUpStarted.resolve();
+          return new Promise<never>(() => {});
+        },
+      },
+    );
+    const reader = client.body!.getReader();
+    await followUpStarted.promise;
+    await expect(
+      Promise.race([
+        reader.cancel().then(() => "cancelled"),
+        new Promise<string>((resolve) =>
+          setImmediate(() => resolve("still pending")),
+        ),
+      ]),
+    ).resolves.toBe("cancelled");
+  });
+
+  test("rejects a chained recall whose arguments never complete", async () => {
+    const malformed = streamFrom([
+      created("resp_malformed", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_malformed",
+          call_id: "call_malformed",
+          name: "recall",
+        },
+      }),
+      completed("resp_malformed"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: malformed.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("call_malformed");
+    expect(out).not.toContain("response.completed");
+  });
+
+  test("rejects malformed completed recall arguments before execution", async () => {
+    let executed = false;
+    let completedResponse: unknown;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_malformed_args", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_malformed",
+            call_id: "call_malformed",
+            name: "recall",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_malformed",
+          arguments: "{not json",
+        }),
+        completed("resp_malformed_args"),
+      ]),
+      {
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async () => {
+          executed = true;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(executed).toBe(false);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).toContain("response.failed");
+    expect(out).not.toContain('"name":"recall"');
+    expect(out).not.toContain("call_malformed");
+    expect(JSON.stringify(completedResponse)).not.toContain("recall");
+    expect(JSON.stringify(completedResponse)).not.toContain("call_malformed");
+  });
+
+  test.each([
+    [
+      "arguments before item declaration",
+      sseEvent("response.function_call_arguments.done", {
+        output_index: 0,
+        arguments: '{"query":"secret"}',
+      }),
+    ],
+    [
+      "recall only revealed by item.done",
+      sseEvent("response.output_item.done", {
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_late",
+          call_id: "call_late",
+          name: "recall",
+          arguments: '{"query":"secret"}',
+          status: "completed",
+        },
+      }),
+    ],
+    [
+      "recall item without output index",
+      sseEvent("response.output_item.added", {
+        item: {
+          type: "function_call",
+          id: "fc_no_index",
+          call_id: "call_no_index",
+          name: "recall",
+        },
+      }),
+    ],
+    [
+      "item identity changes at done",
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: { type: "message", id: "msg_changed", role: "assistant" },
+      }) +
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_changed",
+            call_id: "call_changed",
+            name: "recall",
+            arguments: '{"query":"secret"}',
+          },
+        }),
+    ],
+    [
+      "function call omits its name at declaration",
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_hidden",
+          call_id: "call_hidden",
+        },
+      }) +
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_hidden",
+            call_id: "call_hidden",
+            name: "recall",
+          },
+        }),
+    ],
+  ])("fails closed for malformed event ordering: %s", async (_name, event) => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_order", "gpt-5.6-terra"),
+        event,
+        completed("resp_order"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          throw new Error("should not execute");
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("response.failed");
+    expect(out).not.toContain('"name":"recall"');
+    expect(out).not.toContain("secret");
+  });
+
+  test("aborts an in-flight recall callback when the client disconnects", async () => {
+    let callbackSignal: AbortSignal | undefined;
+    let startedResolve: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      startedResolve = resolve;
+    });
+    let settledResolve: (() => void) | undefined;
+    const settled = new Promise<void>((resolve) => {
+      settledResolve = resolve;
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_abort_recall", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_abort_recall"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: ({ signal }) => {
+          callbackSignal = signal;
+          startedResolve?.();
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                settledResolve?.();
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          });
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const reader = client.body!.getReader();
+    await started;
+    await reader.cancel();
+    await settled;
+    expect(callbackSignal?.aborted).toBe(true);
+  });
+
+  test("aborts in-flight follow-up setup when the client disconnects", async () => {
+    let callbackSignal: AbortSignal | undefined;
+    let startedResolve: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      startedResolve = resolve;
+    });
+    let settledResolve: (() => void) | undefined;
+    const settled = new Promise<void>((resolve) => {
+      settledResolve = resolve;
+    });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_abort_followup", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_abort_followup"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: ({ signal }) => {
+          callbackSignal = signal;
+          startedResolve?.();
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                settledResolve?.();
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          });
+        },
+      },
+    );
+
+    const reader = client.body!.getReader();
+    await started;
+    await reader.cancel();
+    await settled;
+    expect(callbackSignal?.aborted).toBe(true);
+  });
+
+  test.each([
+    ['{"query":"x","scope":42}', "scope must be a string"],
+    ['{"query":"x","extra":true}', "unknown property"],
+    ['{"query":42}', "query must be a string"],
+    ['{"query":"x","id":42}', "id must be a string"],
+  ])("rejects strict recall arguments %s", async (argumentsJSON, message) => {
+    let executed = false;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_strict_args", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_strict",
+            call_id: "call_strict",
+            name: "recall",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_strict",
+          arguments: argumentsJSON,
+        }),
+        completed("resp_strict_args"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          executed = true;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(executed).toBe(false);
+    expect(out).not.toContain(message);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain('"name":"recall"');
+  });
+
+  test("accepts nullable strict optional recall arguments", async () => {
+    let seen: { scope?: string; id?: string } | undefined;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_nullable_args", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture", scope: null, id: null }),
+        completed("resp_nullable_args"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ scope, id }) => {
+          seen = { scope, id };
+          return {
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({
+          reader: streamFrom([
+            created("resp_nullable_followup", "gpt-5.6-terra"),
+            textItem(0, "answer"),
+            completed("resp_nullable_followup"),
+          ]).body!.getReader(),
+        }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(seen).toEqual({ scope: undefined, id: undefined });
+    expect(out).toContain("answer");
+  });
+
+  test("holds no-index continuation events after chained recall detection", async () => {
+    const malformed = streamFrom([
+      created("resp_malformed", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_malformed",
+          call_id: "call_malformed",
+          name: "recall",
+        },
+      }),
+      sseEvent("response.custom", { secret: "must-not-leak" }),
+      completed("resp_malformed"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: malformed.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).not.toContain("must-not-leak");
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("recall-only: fails the response when the continuation fails", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_failure", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_failure"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: "architecture results",
+        }),
+        runFollowUp: async () => {
+          throw new Error("follow-up unavailable");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("response.failed");
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("follow-up unavailable");
+    expect(out).not.toContain("lore-recall");
+    expect(out).not.toContain("Searching");
+    expect(out).not.toContain("response.completed");
+  });
+
+  test("recall-only: never converts a failed continuation into completed", async () => {
+    const failedFollowUp = streamFrom([
+      created("resp_followup_failure", "gpt-5.6-terra"),
+      textItem(0, "partial answer"),
+      sseEvent("response.failed", {
+        response: {
+          id: "resp_followup_failure",
+          status: "failed",
+          error: { message: "provider failed" },
+        },
+      }),
+    ]);
+    let completedResponse: unknown;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_failure", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_failure"),
+      ]),
+      {
+        onComplete: (response) => {
+          completedResponse = response;
+        },
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: "architecture results",
+        }),
+        runFollowUp: async () => ({
+          reader: failedFollowUp.body!.getReader(),
+        }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("response.failed");
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("recall follow-up returned response.failed");
+    expect(out).not.toContain("lore-recall");
+    expect(out).not.toContain("partial answer");
+    expect(JSON.stringify(completedResponse)).not.toContain("partial answer");
+    expect(out).not.toContain("response.completed");
+  });
+
+  test.each(["failed", "cancelled"])(
+    "treats response.done with %s status as a failed continuation",
+    async (status) => {
+      const followUp = streamFrom([
+        created("resp_followup", "gpt-5.6-terra"),
+        textItem(0, "partial"),
+        doneWithStatus("resp_followup", status),
+      ]);
+      const client = streamResponsesRecallAware(
+        streamFrom([
+          created("resp_first", "gpt-5.6-terra"),
+          recallCall(0, { query: "architecture" }),
+          completed("resp_first"),
+        ]),
+        {
+          onComplete: () => {},
+          onRecall: async () => ({
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          }),
+          runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+        },
+      );
+
+      const out = await drain(client);
+      expect(out.match(/^event: response\.failed$/gm)).toHaveLength(1);
+      expect(out).not.toContain('"type":"response.completed"');
+    },
+  );
+
+  test("merges continuation cache usage into onComplete", async () => {
+    let usage: unknown;
+    const followUp = streamFrom([
+      created("resp_followup", "gpt-5.6-terra"),
+      textItem(0, "answer"),
+      completed("resp_followup", {
+        input_tokens: 20,
+        output_tokens: 5,
+        input_tokens_details: {
+          cached_tokens: 7,
+          cache_write_tokens: 3,
+        },
+      }),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: (response) => {
+          usage = response.usage;
+        },
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(usage).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 5,
+      cacheReadInputTokens: 7,
+      cacheCreationInputTokens: 3,
+    });
+    const terminal = JSON.parse(
+      /event: response\.completed\ndata: (.+)/.exec(out)?.[1] ?? "{}",
+    ) as { response?: { usage?: Record<string, unknown> } };
+    expect(terminal.response?.usage).toEqual({
+      input_tokens: 20,
+      output_tokens: 5,
+      total_tokens: 25,
+      input_tokens_details: {
+        cached_tokens: 7,
+        cache_write_tokens: 3,
+      },
+    });
+  });
+
+  test("preserves response.incomplete from the continuation", async () => {
+    const followUp = streamFrom([
+      created("resp_followup", "gpt-5.6-terra"),
+      textItem(0, "partial"),
+      incomplete("resp_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out.match(/^event: response\.incomplete$/gm)).toHaveLength(1);
+    expect(out.match(/^event: response\.completed$/gm) ?? []).toHaveLength(0);
+  });
+
+  test("never executes recall from an incomplete principal", async () => {
+    let recalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_incomplete_principal_recall", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        incomplete("resp_incomplete_principal_recall"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalls++;
+          return {
+            anchorText: buildAnchor("architecture"),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalls).toBe(0);
+  });
+
+  test("never executes a chained recall from an incomplete continuation", async () => {
+    const followUp = streamFrom([
+      created("resp_incomplete_recall", "gpt-5.6-terra"),
+      recallCall(0, { query: "detail" }),
+      incomplete("resp_incomplete_recall"),
+    ]);
+    let recalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_incomplete_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_incomplete_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => {
+          recalls++;
+          return {
+            anchorText: buildAnchor(query),
+            resultText: "results",
+          };
+        },
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalls).toBe(1);
+  });
+
+  test("maps response.done with incomplete status to response.incomplete", async () => {
+    const followUp = streamFrom([
+      created("resp_followup", "gpt-5.6-terra"),
+      textItem(0, "partial"),
+      doneIncomplete("resp_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_first", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_first"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(out.match(/^event: response\.incomplete$/gm)).toHaveLength(1);
+    expect(out).not.toContain('"type":"response.completed"');
+  });
+
+  test("retains reasoning items in the rebuilt terminal", async () => {
+    const followUp = streamFrom([
+      created("resp_followup", "gpt-5.6-terra"),
+      textItem(0, "answer"),
+      completed("resp_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reasoning", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_0", summary: [] },
+        }),
+        recallCall(1, { query: "architecture" }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_0",
+            summary: [{ type: "summary_text", text: "reasoned" }],
+          },
+        }),
+        completed("resp_reasoning"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async ({ acc }) => {
+          expect(acc.rawOutputItems).toContainEqual(
+            expect.objectContaining({
+              id: "rs_0",
+              type: "reasoning",
+            }),
+          );
+          return { reader: followUp.body!.getReader() };
+        },
+      },
+    );
+
+    const out = await drain(client);
+    const terminal = JSON.parse(
+      /event: response\.completed\ndata: (.+)/.exec(out)?.[1] ?? "{}",
+    ) as { response?: { output?: Array<{ id?: string; type?: string }> } };
+    expect(terminal.response?.output).toContainEqual(
+      expect.objectContaining({ id: "rs_0", type: "reasoning" }),
+    );
+  });
+
+  test("emits response.failed when upstream closes without a terminal event", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_eof", "gpt-5.6-terra"),
+        textItem(0, "partial"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not be called");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("response.failed");
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("ended without a terminal event");
   });
 
   test("does NOT emit a second response.completed when the follow-up has none and no recall", async () => {
@@ -243,46 +2780,20 @@ describe("streamResponsesRecallAware", () => {
       ]),
       {
         onComplete: () => {},
-        onRecall: async () => null,
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
         runFollowUp: async () => {
           throw new Error("should not be called");
         },
       },
     );
     const out = await drain(client);
-    expect(out.match(/response\.completed/g)).toHaveLength(1);
+    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
+    expect(out).not.toContain("response.failed");
     expect(out).not.toContain("lore_marker");
-  });
-
-  test("tracks repeated recalls by their own tool IDs", async () => {
-    const seen: string[] = [];
-    const client = streamResponsesRecallAware(
-      streamFrom([
-        created("resp_repeated", "gpt-5.6-terra"),
-        recallCall(0, { query: "same" }),
-        recallCall(1, { query: "same" }),
-        completed("resp_repeated"),
-      ]),
-      {
-        onComplete: () => {},
-        onRecall: async ({ toolUseId }) => {
-          seen.push(toolUseId);
-          return { markerText: `marker:${toolUseId}`, resultText: "results" };
-        },
-        runFollowUp: async () => {
-          throw new Error("should not run for multiple recalls");
-        },
-      },
-    );
-
-    const out = await drain(client);
-    expect(seen).toEqual(["call_0", "call_1"]);
-    expect(out).toContain("marker:call_0");
-    expect(out).toContain("marker:call_1");
   });
 });
 
 /** Minimal marker builder (mirrors buildRecallMarker's shape). */
-function buildMarker(query: string): string {
-  return `🧠 marker: ${query}`;
+function buildAnchor(query: string): string {
+  return `<!-- lore-recall:${query.replaceAll(" ", "-")} -->`;
 }

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -177,6 +177,154 @@ describe("parseOpenAIResponsesRequest", () => {
     ]);
   });
 
+  test("binds incoming reasoning to provenance without normalizing it as content", () => {
+    const reasoning = {
+      type: "reasoning",
+      id: "rs_1",
+      encrypted_content: "encrypted",
+      summary: [],
+    };
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.6",
+        input: [
+          { type: "message", role: "user", content: "continue" },
+          reasoning,
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "answer" }],
+          },
+        ],
+      },
+      headers,
+    );
+
+    expect(req.messages[1].content).toEqual([{ type: "text", text: "answer" }]);
+    const assistantProvenance = req.messages
+      .filter((message) => message.role === "assistant")
+      .flatMap((message) => message.provenanceContent ?? message.content);
+    expect(assistantProvenance).toEqual([
+      { type: "opaque", raw: reasoning, responsesItem: true },
+      {
+        type: "opaque",
+        raw: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "answer" }],
+        },
+        responsesItem: true,
+      },
+    ]);
+    expect(req.messages[1].provenancePositions).toEqual([1]);
+  });
+
+  test("binds unknown self-contained output items to provenance", () => {
+    const unknown = {
+      type: "computer_screenshot",
+      id: "screen_1",
+      image_url: "data:image/png;base64,AAA",
+    };
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.6",
+        input: [
+          { type: "message", role: "user", content: "continue" },
+          unknown,
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "answer" }],
+          },
+        ],
+      },
+      headers,
+    );
+
+    expect(req.messages[1].content).toEqual([{ type: "text", text: "answer" }]);
+    const assistantProvenance = req.messages
+      .filter((message) => message.role === "assistant")
+      .flatMap((message) => message.provenanceContent ?? message.content);
+    expect(assistantProvenance).toEqual([
+      { type: "opaque", raw: unknown, responsesItem: true },
+      {
+        type: "opaque",
+        raw: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "answer" }],
+        },
+        responsesItem: true,
+      },
+    ]);
+  });
+
+  test("round-trips refusal and unknown output as top-level Responses items", () => {
+    const refusal = {
+      type: "message",
+      id: "msg_refusal",
+      role: "assistant",
+      content: [{ type: "refusal", refusal: "cannot comply" }],
+    };
+    const unknown = {
+      type: "computer_screenshot",
+      id: "screen_1",
+      image_url: "data:image/png;base64,AAA",
+    };
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5.6",
+        input: [
+          { type: "message", role: "user", content: "continue" },
+          refusal,
+          unknown,
+        ],
+      },
+      headers,
+    );
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+
+    expect(
+      req.messages
+        .filter((message) => message.role === "assistant")
+        .flatMap((message) => message.provenanceContent ?? message.content),
+    ).toEqual([
+      { type: "opaque", raw: refusal, responsesItem: true },
+      { type: "opaque", raw: unknown, responsesItem: true },
+    ]);
+    expect(body.input).toContainEqual(refusal);
+    expect(body.input).toContainEqual(unknown);
+    expect(body.input).not.toContainEqual(
+      expect.objectContaining({ content: [refusal] }),
+    );
+  });
+
+  test("coalesces canonical fragments from one assistant message", () => {
+    const message = {
+      type: "message",
+      id: "msg_mixed",
+      role: "assistant",
+      status: "completed",
+      content: [
+        { type: "output_text", text: "preamble" },
+        { type: "refusal", refusal: "cannot continue" },
+      ],
+    };
+    const req = parseOpenAIResponsesRequest(
+      { model: "gpt-5.6", input: [message] },
+      headers,
+    );
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+
+    expect(body.input).toEqual([message]);
+  });
+
   test("coalesces parallel function_call items into one assistant message", () => {
     const req = parseOpenAIResponsesRequest(
       {
@@ -447,6 +595,7 @@ describe("parseOpenAIResponsesRequest", () => {
   });
 
   test("drops item_reference items without breaking surrounding messages", () => {
+    const reference = { type: "item_reference", id: "msg_server_123" };
     const req = parseOpenAIResponsesRequest(
       {
         model: "gpt-5.5",
@@ -454,7 +603,7 @@ describe("parseOpenAIResponsesRequest", () => {
           { type: "message", role: "user", content: "hello" },
           // Server-side reference the gateway cannot resolve — must be dropped,
           // not crash, and not corrupt the surrounding messages.
-          { type: "item_reference", id: "msg_server_123" },
+          reference,
           {
             type: "message",
             role: "assistant",
@@ -468,6 +617,16 @@ describe("parseOpenAIResponsesRequest", () => {
     expect(req.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
     expect(req.messages[0].content).toEqual([{ type: "text", text: "hello" }]);
     expect(req.messages[1].content).toEqual([{ type: "text", text: "hi" }]);
+    expect(
+      req.messages.flatMap(
+        (message) => message.provenanceContent ?? message.content,
+      ),
+    ).not.toContainEqual(reference);
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+    expect(body.input).not.toContainEqual(reference);
   });
 
   test("extracts instructions as system prompt", () => {
@@ -655,6 +814,54 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
     expect(tools[0].parameters).toEqual({ type: "object", properties: {} });
   });
 
+  test("marks the closed recall schema strict without changing client tools", () => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-4o",
+        input: "Hello",
+        tools: [
+          {
+            type: "function",
+            name: "read",
+            description: "Read a file",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      },
+      {},
+    );
+    req.tools.push({
+      name: "recall",
+      description: "Recall memory",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          scope: { type: "string" },
+          id: { type: "string" },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    });
+
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://api.openai.com",
+    ).body as { tools: Array<Record<string, unknown>> };
+
+    expect(body.tools[0]).not.toHaveProperty("strict");
+    expect(body.tools[1]).toMatchObject({ name: "recall", strict: true });
+    expect(body.tools[1].parameters).toMatchObject({
+      required: ["query", "scope", "id"],
+      additionalProperties: false,
+      properties: {
+        scope: { type: ["string", "null"], enum: [null] },
+        id: { type: ["string", "null"] },
+      },
+    });
+  });
+
   test("does NOT forward previous_response_id (gateway is stateless full-history)", () => {
     // The gateway always sends the complete conversation as `input`. Forwarding
     // previous_response_id would make the upstream ALSO prepend its server-stored
@@ -716,6 +923,44 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
     expect(input[2].type).toBe("function_call_output");
     expect(input[2].call_id).toBe("call_1");
     expect(input[2].output).toBe("cats found");
+  });
+
+  test("emits preserved reasoning as a top-level Responses input item", () => {
+    const req = parseOpenAIResponsesRequest(
+      { model: "gpt-5.6", input: "continue", stream: true },
+      {},
+    );
+    req.messages.push({
+      role: "assistant",
+      content: [
+        {
+          type: "opaque",
+          responsesItem: true,
+          raw: {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "encrypted",
+          },
+        },
+      ],
+    });
+
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+
+    expect(body.input).toContainEqual({
+      type: "reasoning",
+      id: "rs_1",
+      encrypted_content: "encrypted",
+    });
+    expect(body.input).not.toContainEqual(
+      expect.objectContaining({
+        type: "message",
+        content: [expect.objectContaining({ type: "reasoning" })],
+      }),
+    );
   });
 });
 

--- a/packages/gateway/test/recall-codex-stream.test.ts
+++ b/packages/gateway/test/recall-codex-stream.test.ts
@@ -32,7 +32,11 @@ import { join } from "node:path";
 
 /** One Responses-API SSE event (`event:` + `data:` framing). */
 function sseEvent(event: string, data: unknown): string {
-  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  const payload =
+    data && typeof data === "object" && !Array.isArray(data)
+      ? { type: event, ...(data as Record<string, unknown>) }
+      : data;
+  return `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
 }
 
 /** Responses SSE stream emitting a single `recall` function_call. */
@@ -52,7 +56,19 @@ function codexRecallStream(): Response {
     }) +
     sseEvent("response.function_call_arguments.done", {
       output_index: 0,
+      item_id: "fc_recall",
       arguments: JSON.stringify({ query: "decide" }),
+    }) +
+    sseEvent("response.output_item.done", {
+      output_index: 0,
+      item: {
+        type: "function_call",
+        id: "fc_recall",
+        call_id: "call_recall1",
+        name: "recall",
+        arguments: JSON.stringify({ query: "decide" }),
+        status: "completed",
+      },
     }) +
     sseEvent("response.completed", {
       response: {
@@ -77,11 +93,23 @@ function codexFinalStream(): Response {
     }) +
     sseEvent("response.output_item.added", {
       output_index: 0,
-      item: { type: "message" },
+      item: { type: "message", id: "msg_final", role: "assistant" },
     }) +
     sseEvent("response.output_text.done", {
       output_index: 0,
+      item_id: "msg_final",
+      content_index: 0,
       text: "Here is the answer.",
+    }) +
+    sseEvent("response.output_item.done", {
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "msg_final",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "Here is the answer." }],
+      },
     }) +
     sseEvent("response.completed", {
       response: {
@@ -149,8 +177,14 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     // like the real backend.
     let upstreamCalls = 0;
     let followUpStreamFlag: boolean | undefined;
+    const parallelToolCallFlags: unknown[] = [];
     setUpstreamInterceptor(async (upstreamBody) => {
-      const streaming = (upstreamBody as { stream?: unknown }).stream === true;
+      const body = upstreamBody as {
+        stream?: unknown;
+        parallel_tool_calls?: unknown;
+      };
+      const streaming = body.stream === true;
+      parallelToolCallFlags.push(body.parallel_tool_calls);
       upstreamCalls++;
       if (upstreamCalls === 1) {
         // Initial request — Pi's codex provider always streams.
@@ -197,6 +231,7 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
       body: JSON.stringify({
         model: "gpt-5.5",
         stream: true,
+        parallel_tool_calls: true,
         input: "what did we decide?",
         // Non-empty tools so the gateway injects the recall tool.
         tools: [
@@ -217,6 +252,7 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     // was sent with stream:false and ChatGPT 400'd.
     expect(upstreamCalls).toBe(2);
     expect(followUpStreamFlag).toBe(true);
+    expect(parallelToolCallFlags).toEqual([false, false]);
 
     // The continuation must reach the client — proving the follow-up succeeded
     // instead of falling back to the bare recall marker.
@@ -226,13 +262,7 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     expect(bodyText).not.toContain('"name": "recall"');
   });
 
-  // Guard the gate direction: the forced-streaming follow-up is keyed on the
-  // `codex` flag, NOT the `openai-responses` protocol. The standard OpenAI
-  // Responses API (`/v1/responses`) accepts `stream: false`, so its recall
-  // follow-up MUST stay on the non-streaming JSON path. This kills any mutation
-  // that widens the gate (e.g. "always force streaming" or "force when protocol
-  // === openai-responses"), which would needlessly change non-codex behavior.
-  test("non-codex openai-responses keeps the non-streaming JSON follow-up", async () => {
+  test("non-codex openai-responses also streams the follow-up", async () => {
     const dbPath = `/tmp/lore-recall-resp-${Date.now()}-${Math.random().toString(36).slice(2)}.db`;
     process.env.LORE_DB_PATH = dbPath;
     process.env.LORE_LISTEN_PORT = "0";
@@ -263,8 +293,14 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     // client's perspective.
     let upstreamCalls = 0;
     let followUpStreamFlag: boolean | undefined;
+    const parallelToolCallFlags: unknown[] = [];
     setUpstreamInterceptor(async (upstreamBody) => {
-      const streaming = (upstreamBody as { stream?: unknown }).stream === true;
+      const body = upstreamBody as {
+        stream?: unknown;
+        parallel_tool_calls?: unknown;
+      };
+      const streaming = body.stream === true;
+      parallelToolCallFlags.push(body.parallel_tool_calls);
       upstreamCalls++;
       if (upstreamCalls === 1) return codexRecallStream();
       followUpStreamFlag = streaming;
@@ -305,6 +341,7 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
       body: JSON.stringify({
         model: "gpt-5.5",
         stream: true,
+        parallel_tool_calls: true,
         input: "what did we decide?",
         tools: [
           {
@@ -325,6 +362,7 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     // identical continuation either way).
     expect(upstreamCalls).toBe(2);
     expect(followUpStreamFlag).toBe(true);
+    expect(parallelToolCallFlags).toEqual([false, false]);
 
     // The continuation still reaches the client.
     expect(bodyText).toContain("Here is the answer.");

--- a/packages/gateway/test/recall-stream.test.ts
+++ b/packages/gateway/test/recall-stream.test.ts
@@ -20,6 +20,7 @@ import {
   expandRecallMarkers,
   recallStoreKey,
   buildRecallMarker,
+  recallAnchorContext,
 } from "../src/recall";
 import type {
   GatewayRequest,
@@ -936,6 +937,7 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
       position: accum.recallBlockIndex(),
       result:
         "Found: gateway uses Anthropic protocol, recall interception is transparent",
+      anchorContextId: "0".repeat(64),
     });
 
     // --- Step 6: Expand markers in next request ---
@@ -987,6 +989,13 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
       metadata: {},
       rawHeaders: {},
     };
+    const storedRecall = store.get(storeKey);
+    if (!storedRecall) throw new Error("missing stored recall fixture");
+    storedRecall.anchorContextId = recallAnchorContext(
+      nextReq.messages,
+      1,
+      nextReq.messages[1].content.slice(0, 1),
+    );
 
     const expanded = expandRecallMarkers(nextReq, store);
     expect(expanded).toBe(true);
@@ -1065,6 +1074,7 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
       input: { query: "patterns" },
       position: accum.recallBlockIndex(),
       result: "Found patterns info",
+      anchorContextId: "0".repeat(64),
     });
 
     // Next request: client provides tool_results for Read and Bash,
@@ -1115,6 +1125,13 @@ describe("Case 2 integration — mixed tools end-to-end", () => {
       metadata: {},
       rawHeaders: {},
     };
+    const storedRecall = store.get(storeKey);
+    if (!storedRecall) throw new Error("missing stored recall fixture");
+    storedRecall.anchorContextId = recallAnchorContext(
+      nextReq.messages,
+      1,
+      nextReq.messages[1].content.slice(0, 1),
+    );
 
     const expanded = expandRecallMarkers(nextReq, store);
     expect(expanded).toBe(true);
@@ -1567,9 +1584,13 @@ describe("Recall streaming marker emission — Anthropic split vs non-Anthropic 
           input: { query: "patterns", scope: "all" },
           position: 0,
           result: '[{"title":"pattern X","content":"..."}]',
+          anchorContextId: "0".repeat(64),
         },
       ],
     ]);
+    const storedRecall = store.get(recallStoreKey("patterns", "all"));
+    if (!storedRecall) throw new Error("missing stored recall fixture");
+    storedRecall.anchorContextId = recallAnchorContext(req.messages, 2);
 
     const expanded = expandRecallMarkers(req, store);
     expect(expanded).toBe(true);

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -8,8 +8,14 @@
  *  - Pending recall injection
  *  - Response stripping
  */
-import { describe, test, expect } from "vitest";
-import { LORE_COMMIT_REMINDER } from "../src/pipeline";
+import { describe, test, expect, vi } from "vitest";
+import {
+  LORE_COMMIT_REMINDER,
+  loreMessagesToGateway,
+  responsesProvenanceContent,
+  responsesProvenanceByMessageId,
+  responsesAnchorContext,
+} from "../src/pipeline";
 import {
   RECALL_GATEWAY_TOOL,
   RECALL_TOOL_NAME,
@@ -24,6 +30,9 @@ import {
   runRecallFollowUpStreamAccumulated,
   type RecallFollowUpCtx,
   buildRecallMarker,
+  buildRecallAnchor,
+  parseRecallAnchor,
+  recallAnchorContext,
   parseRecallMarker,
   isRecallMarker,
   scopeToLabel,
@@ -34,7 +43,18 @@ import {
   replaceRecallWithMarker,
   serializeRecallStore,
   deserializeRecallStore,
+  addRecallStoreEntry,
+  MAX_RECALL_STORE_ENTRIES,
+  MAX_RECALL_STORE_BYTES,
 } from "../src/recall";
+import {
+  buildOpenAIResponsesUpstreamRequest,
+  parseOpenAIResponsesRequest,
+} from "../src/translate/openai-responses";
+import {
+  gatewayMessagesToLore,
+  resolveToolResults,
+} from "../src/temporal-adapter";
 import type {
   GatewayResponse,
   GatewayRequest,
@@ -96,8 +116,56 @@ function makeStoredRecall(overrides: Partial<StoredRecall> = {}): StoredRecall {
     input: { query: "test query", scope: "all" },
     position: 1,
     result: "## Recall Results\n* some result",
+    anchorContextId: "0".repeat(64),
     ...overrides,
   };
+}
+
+function bindCanonicalAnchors(req: GatewayRequest, store: RecallStore): void {
+  for (let i = 0; i < req.messages.length; i++) {
+    const message = req.messages[i];
+    if (message.role !== "assistant") continue;
+    for (let j = 0; j < message.content.length; j++) {
+      const block = message.content[j];
+      if (block.type !== "text") continue;
+      const anchorId = parseRecallAnchor(block.text);
+      if (!anchorId) continue;
+      const stored = store.get(`anchor:${anchorId}`);
+      if (stored) {
+        stored.anchorContextId = recallAnchorContext(
+          req.messages,
+          i,
+          message.content.slice(0, j),
+        );
+      }
+    }
+  }
+}
+
+function bindReplayEntries(req: GatewayRequest, store: RecallStore): void {
+  for (let i = 0; i < req.messages.length; i++) {
+    const message = req.messages[i];
+    if (message.role !== "assistant") continue;
+    for (let j = 0; j < message.content.length; j++) {
+      const block = message.content[j];
+      if (block.type !== "text") continue;
+      const anchorId = parseRecallAnchor(block.text);
+      const marker = parseRecallMarker(block.text);
+      const key = anchorId
+        ? `anchor:${anchorId}`
+        : marker
+          ? recallStoreKey(marker.query, marker.scope, marker.id)
+          : undefined;
+      const stored = key ? store.get(key) : undefined;
+      if (stored) {
+        stored.anchorContextId = recallAnchorContext(
+          req.messages,
+          i,
+          message.content.slice(0, j),
+        );
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +182,7 @@ describe("RECALL_GATEWAY_TOOL", () => {
     expect(props).toHaveProperty("query");
     expect(props).toHaveProperty("scope");
     expect(schema.required).toEqual(["query"]);
+    expect(schema.additionalProperties).toBe(false);
   });
 
   test("instructs resolving named references via recall before exploring", () => {
@@ -283,6 +352,36 @@ describe("buildRecallMarker", () => {
   });
 });
 
+describe("recall replay anchors", () => {
+  test("round-trips a canonical UUID without exposing the recall query", () => {
+    const id = "123e4567-e89b-42d3-a456-426614174000";
+    const anchor = buildRecallAnchor(id);
+    expect(anchor).toBe(`<!-- lore-recall:${id} -->`);
+    expect(anchor).not.toContain("Searching");
+    expect(parseRecallAnchor(anchor)).toBe(id);
+    expect(parseRecallAnchor(`<!-- lore-recall:${id} -->\n`)).toBeNull();
+    expect(parseRecallAnchor("<!-- lore-recall:%31 -->")).toBeNull();
+    expect(parseRecallAnchor("ordinary assistant text")).toBeNull();
+  });
+
+  test("finds an anchored status marker when the query contains newlines", () => {
+    const id = "123e4567-e89b-42d3-a456-426614174010";
+    const marker = `${buildRecallMarker("line one\nline two")}\n${buildRecallAnchor(id)}`;
+    expect(isRecallMarker(marker)).toBe(true);
+  });
+
+  test("legacy markers match only an entire text block", () => {
+    expect(
+      parseRecallMarker(
+        `prefix ${buildRecallMarker("auth", "session")} suffix`,
+      ),
+    ).toBeNull();
+    expect(
+      parseRecallMarker(`prefix ${buildRecallMarker("", "all", "k:abc")}`),
+    ).toBeNull();
+  });
+});
+
 describe("parseRecallMarker", () => {
   test("parses a valid marker", () => {
     const result = parseRecallMarker(
@@ -343,9 +442,12 @@ describe("serializeRecallStore / deserializeRecallStore", () => {
         'all:sync tiers "pro" max',
         {
           toolUseId: "toolu_1",
+          anchorId: "resp_1:0:toolu_1",
           input: { query: 'sync tiers "pro" max', scope: "all" },
           position: 2,
           result: "## Results\n\n* entry one\n* entry two",
+          anchorContextId: "1".repeat(64),
+          companionToolUseIds: ["call_read"],
         },
       ],
       [
@@ -355,6 +457,7 @@ describe("serializeRecallStore / deserializeRecallStore", () => {
           input: { query: "", scope: "all", id: "k:abc123" },
           position: 0,
           result: "detail body",
+          anchorContextId: "2".repeat(64),
         },
       ],
     ]);
@@ -366,18 +469,214 @@ describe("serializeRecallStore / deserializeRecallStore", () => {
     expect(deserializeRecallStore("not json").size).toBe(0);
     expect(deserializeRecallStore("{}").size).toBe(0);
     expect(deserializeRecallStore("[]").size).toBe(0);
+    expect(
+      deserializeRecallStore(
+        JSON.stringify([
+          [
+            "bad-optional",
+            {
+              toolUseId: "t",
+              input: { query: "q" },
+              position: 0,
+              result: "r",
+              companionToolUses: {},
+            },
+          ],
+        ]),
+      ).size,
+    ).toBe(0);
     // Entries missing required fields are dropped, valid ones kept.
     const mixed = JSON.stringify([
       ["bad", { toolUseId: 123 }],
       [
         "good",
-        { toolUseId: "t", input: { query: "q" }, position: 0, result: "r" },
+        {
+          toolUseId: "t",
+          input: { query: "q" },
+          position: 0,
+          result: "r",
+          anchorContextId: "3".repeat(64),
+        },
       ],
     ]);
     const restored = deserializeRecallStore(mixed);
     expect(restored.size).toBe(1);
     expect(restored.get("good")?.result).toBe("r");
   });
+
+  test("restores pre-anchor query-keyed entries without weakening anchor validation", () => {
+    const legacy = {
+      toolUseId: "legacy-tool",
+      input: { query: "old query", scope: "all" },
+      position: 0,
+      result: "old result",
+    };
+    const restored = deserializeRecallStore(
+      JSON.stringify([
+        ["all:old query", legacy],
+        [
+          "anchor:123e4567-e89b-42d3-a456-426614174099",
+          {
+            ...legacy,
+            anchorId: "123e4567-e89b-42d3-a456-426614174099",
+          },
+        ],
+      ]),
+    );
+    expect(restored.get("all:old query")).toEqual(legacy);
+    expect(restored.size).toBe(1);
+
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: buildRecallMarker("old query", "all") },
+        ],
+      },
+    ]);
+    expect(expandRecallMarkers(req, restored)).toBe(true);
+    expect(req.messages[0].content[0]).toMatchObject({
+      type: "tool_use",
+      id: "legacy-tool",
+      name: RECALL_TOOL_NAME,
+    });
+    expect(req.messages[1].content[0]).toMatchObject({
+      type: "tool_result",
+      toolUseId: "legacy-tool",
+    });
+  });
+
+  test.each(["xyz", "A".repeat(64), "g".repeat(64)])(
+    "rejects query-keyed entry with malformed context hash %s",
+    (anchorContextId) => {
+      const restored = deserializeRecallStore(
+        JSON.stringify([
+          [
+            "all:old query",
+            {
+              toolUseId: "legacy-tool",
+              input: { query: "old query", scope: "all" },
+              position: 0,
+              result: "old result",
+              anchorContextId,
+            },
+          ],
+        ]),
+      );
+      expect(restored.size).toBe(0);
+    },
+  );
+
+  test("rejects a new entry without evicting live anchors at the entry cap", () => {
+    const store: RecallStore = new Map();
+    for (let i = 0; i < MAX_RECALL_STORE_ENTRIES; i++) {
+      addRecallStoreEntry(store, `legacy-${i}`, {
+        toolUseId: `tool-${i}`,
+        input: { query: `query-${i}` },
+        position: 0,
+        result: "result",
+        anchorContextId: "5".repeat(64),
+      });
+    }
+    expect(() =>
+      addRecallStoreEntry(store, "overflow", {
+        toolUseId: "overflow",
+        input: { query: "overflow" },
+        position: 0,
+        result: "result",
+        anchorContextId: "6".repeat(64),
+      }),
+    ).toThrow("recall store capacity exceeded");
+    expect(store.size).toBe(MAX_RECALL_STORE_ENTRIES);
+    expect(store.has("legacy-0")).toBe(true);
+  });
+
+  test("bounds restored stores", () => {
+    const entries = Array.from(
+      { length: MAX_RECALL_STORE_ENTRIES + 1 },
+      (_, i) => [
+        `legacy-${i}`,
+        {
+          toolUseId: `tool-${i}`,
+          input: { query: `query-${i}` },
+          position: 0,
+          result: "result",
+          anchorContextId: "4".repeat(64),
+        },
+      ],
+    );
+    expect(deserializeRecallStore(JSON.stringify(entries)).size).toBe(
+      MAX_RECALL_STORE_ENTRIES,
+    );
+  });
+
+  test("rejects oversized persisted blobs before JSON parsing", () => {
+    const parse = vi.spyOn(JSON, "parse");
+    expect(
+      deserializeRecallStore("[" + " ".repeat(MAX_RECALL_STORE_BYTES)).size,
+    ).toBe(0);
+    expect(parse).not.toHaveBeenCalled();
+    parse.mockRestore();
+  });
+
+  test("rejects an oversized entry without mutating the store", () => {
+    const store: RecallStore = new Map();
+    expect(() =>
+      addRecallStoreEntry(store, "oversized", {
+        toolUseId: "tool",
+        input: { query: "oversized" },
+        position: 0,
+        result: "x".repeat(MAX_RECALL_STORE_BYTES),
+        anchorContextId: "7".repeat(64),
+      }),
+    ).toThrow("recall store capacity exceeded");
+    expect(store.size).toBe(0);
+  });
+
+  test.each([
+    [
+      "anchor key does not match value",
+      "123e4567-e89b-42d3-a456-426614174001",
+      "123e4567-e89b-42d3-a456-426614174002",
+      0,
+      undefined,
+    ],
+    ["non-canonical anchor", "not-a-uuid", "not-a-uuid", 0, undefined],
+    [
+      "invalid context hash",
+      "123e4567-e89b-42d3-a456-426614174001",
+      "123e4567-e89b-42d3-a456-426614174001",
+      0,
+      "xyz",
+    ],
+    [
+      "unsafe position",
+      "123e4567-e89b-42d3-a456-426614174001",
+      "123e4567-e89b-42d3-a456-426614174001",
+      Number.MAX_SAFE_INTEGER + 1,
+      undefined,
+    ],
+  ])(
+    "rejects canonical anchor record with %s",
+    (_name, keyId, anchorId, position, anchorContextId) => {
+      const restored = deserializeRecallStore(
+        JSON.stringify([
+          [
+            `anchor:${keyId}`,
+            {
+              toolUseId: "call_recall",
+              anchorId,
+              anchorContextId,
+              input: { query: "architecture", scope: "all" },
+              position,
+              result: "results",
+            },
+          ],
+        ]),
+      );
+      expect(restored.size).toBe(0);
+    },
+  );
 });
 
 describe("isRecallMarker", () => {
@@ -574,6 +873,73 @@ describe("buildRecallFollowUpRequest", () => {
     );
   });
 
+  test("preserves raw Responses reasoning for a stateless follow-up", () => {
+    const req = makeRequest();
+    req.protocol = "openai-responses";
+    const recallBlock = makeRecallToolUse();
+    const resp = makeResponse([recallBlock], "tool_use");
+    resp.rawOutputItems = [
+      {
+        type: "reasoning",
+        id: "rs_1",
+        encrypted_content: "encrypted",
+      },
+      {
+        type: "item_reference",
+        id: "msg_server_only",
+      },
+      {
+        type: "function_call",
+        id: "fc_1",
+        call_id: recallBlock.id,
+        name: "recall",
+        arguments: JSON.stringify(recallBlock.input),
+      },
+    ];
+
+    const followUp = buildRecallFollowUpRequest(
+      req,
+      resp,
+      "result",
+      recallBlock,
+      true,
+    );
+
+    expect(followUp.messages[0].content).toContainEqual({
+      type: "opaque",
+      responsesItem: true,
+      raw: {
+        type: "reasoning",
+        id: "rs_1",
+        encrypted_content: "encrypted",
+      },
+    });
+    expect(followUp.messages[0].content).not.toContainEqual(
+      expect.objectContaining({
+        type: "opaque",
+        raw: expect.objectContaining({ type: "function_call" }),
+      }),
+    );
+    expect(followUp.messages[0].content).not.toContainEqual(
+      expect.objectContaining({
+        type: "opaque",
+        raw: expect.objectContaining({ type: "item_reference" }),
+      }),
+    );
+    const wire = buildOpenAIResponsesUpstreamRequest(
+      followUp,
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+    expect(wire.input).toContainEqual({
+      type: "reasoning",
+      id: "rs_1",
+      encrypted_content: "encrypted",
+    });
+    expect(wire.input).not.toContainEqual(
+      expect.objectContaining({ type: "item_reference" }),
+    );
+  });
+
   test("excludes text blocks but keeps thinking blocks", () => {
     const req = makeRequest([
       { role: "user", content: [{ type: "text", text: "hello" }] },
@@ -741,6 +1107,168 @@ describe("runRecallFollowUpStreaming", () => {
       expect(result.followUp).toBeDefined();
       void result.reader.cancel(); // cleanup
     }
+  });
+
+  test("passes one abort signal through follow-up forwarding", async () => {
+    const controller = new AbortController();
+    let forwardedSignal: AbortSignal | undefined;
+    const ctx: RecallFollowUpCtx = {
+      forward: async (_request, signal) => {
+        forwardedSignal = signal;
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        });
+      },
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    const pending = runRecallFollowUpStreaming(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+      controller.signal,
+    );
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(forwardedSignal).toBe(controller.signal);
+  });
+
+  test("cancellation interrupts a stalled non-OK response body", async () => {
+    const controller = new AbortController();
+    let bodyCancelled = false;
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            pull() {
+              return new Promise(() => {});
+            },
+            cancel() {
+              bodyCancelled = true;
+            },
+          }),
+          { status: 500 },
+        ),
+        effectiveProtocol: "openai-responses",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+    const pending = runRecallFollowUpStreaming(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+      controller.signal,
+    );
+    await Promise.resolve();
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(bodyCancelled).toBe(true);
+  });
+
+  test("accepts headerless SSE and preserves the stream body", async () => {
+    const body =
+      'event: response.created\ndata: {"type":"response.created"}\n\n';
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response(body, { status: 200 }),
+        effectiveProtocol: "openai-responses",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    const result = await runRecallFollowUpStreaming(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const response = new Response(
+        new ReadableStream({
+          async start(controller) {
+            for (;;) {
+              const { done, value } = await result.reader.read();
+              if (done) break;
+              controller.enqueue(value);
+            }
+            controller.close();
+          },
+        }),
+      );
+      expect(await response.text()).toBe(body);
+    }
+  });
+
+  test("accepts headerless SSE after a leading comment frame", async () => {
+    const body =
+      ': keepalive\n\nevent: response.created\ndata: {"type":"response.created"}\n\n';
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response(body, { status: 200 }),
+        effectiveProtocol: "openai-responses",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    const result = await runRecallFollowUpStreaming(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const chunks: Uint8Array[] = [];
+      for (;;) {
+        const { done, value } = await result.reader.read();
+        if (done) break;
+        if (value) chunks.push(value);
+      }
+      expect(new TextDecoder().decode(Buffer.concat(chunks))).toBe(body);
+    }
+  });
+
+  test("rejects headerless JSON after body sniffing", async () => {
+    const ctx: RecallFollowUpCtx = {
+      forward: async () => ({
+        response: new Response('{"type":"message"}', { status: 200 }),
+        effectiveProtocol: "openai-responses",
+      }),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+
+    await expect(
+      runRecallFollowUpStreaming(
+        ctx,
+        makeRequest(),
+        resp,
+        "recall results",
+        recallBlock,
+      ),
+    ).rejects.toThrow("a non-SSE body");
   });
 
   test("returns error when upstream responds with non-OK status", async () => {
@@ -1042,6 +1570,873 @@ describe("runRecallFollowUpStreamAccumulated", () => {
 // ---------------------------------------------------------------------------
 
 describe("expandRecallMarkers", () => {
+  test("expands a hidden Responses anchor without a visible status message", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174001";
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          toolUseId: "call_recall",
+          anchorId,
+          input: { query: "original request", scope: "session" },
+          result: "The original request was to compare hosting options.",
+          companionToolUseIds: ["call_read"],
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "continue" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: buildRecallAnchor(anchorId),
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "call_read", name: "read", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "call_read",
+            content: [{ type: "text", text: "file" }],
+          },
+        ],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    expect(req.messages[1].content[0]).toMatchObject({
+      type: "tool_use",
+      id: "call_recall",
+      name: "recall",
+    });
+    expect(req.messages[2].content[0]).toMatchObject({
+      type: "tool_result",
+      toolUseId: "call_recall",
+    });
+    expect(JSON.stringify(req.messages)).not.toContain("Searching");
+  });
+
+  test("rejoins a companion tool that precedes the hidden recall", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174002";
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          toolUseId: "call_recall",
+          anchorId,
+          companionToolUses: [
+            {
+              id: "call_read",
+              name: "read",
+              input: {},
+              side: "before",
+            },
+          ],
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "call_read", name: "read", input: {} },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "call_read",
+            content: [{ type: "text", text: "file" }],
+          },
+        ],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    expect(req.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "user",
+    ]);
+    expect(req.messages[0].content.map((block) => block.type)).toEqual([
+      "tool_use",
+      "tool_use",
+    ]);
+    expect(
+      req.messages[1].content.map((block) =>
+        block.type === "tool_result" ? block.toolUseId : "",
+      ),
+    ).toEqual(["call_read", "call_recall"]);
+  });
+
+  test("moves a companion in visible and Responses provenance exactly once", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174098";
+    const reasoning = {
+      type: "opaque" as const,
+      responsesItem: true,
+      raw: {
+        type: "reasoning",
+        id: "rs_companion",
+        encrypted_content: "encrypted",
+      },
+    };
+    const read = {
+      type: "tool_use" as const,
+      id: "call_read",
+      name: "read",
+      input: {},
+    };
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          toolUseId: "call_recall",
+          anchorId,
+          companionToolUses: [
+            { id: "call_read", name: "read", input: {}, side: "before" },
+          ],
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [read],
+        provenanceContent: [reasoning, read],
+        provenancePositions: [1],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "call_read",
+            content: [{ type: "text", text: "file" }],
+          },
+        ],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    const body = buildOpenAIResponsesUpstreamRequest(
+      { ...req, protocol: "openai-responses", model: "gpt-5.6" },
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+    expect(body.input.filter((item) => item.type === "reasoning")).toEqual([
+      reasoning.raw,
+    ]);
+    expect(
+      body.input.filter(
+        (item) => item.type === "function_call" && item.call_id === "call_read",
+      ),
+    ).toHaveLength(1);
+    expect(
+      body.input
+        .filter((item) => item.type === "function_call")
+        .map((item) => item.call_id),
+    ).toEqual(["call_read", "call_recall"]);
+  });
+
+  test("preserves hidden provenance between multiple moved companions", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174097";
+    const read = {
+      type: "tool_use" as const,
+      id: "call_read",
+      name: "read",
+      input: {},
+    };
+    const write = {
+      type: "tool_use" as const,
+      id: "call_write",
+      name: "write",
+      input: {},
+    };
+    const reasoning = {
+      type: "opaque" as const,
+      responsesItem: true,
+      raw: {
+        type: "reasoning",
+        id: "rs_between_companions",
+        encrypted_content: "encrypted",
+      },
+    };
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          toolUseId: "call_recall",
+          anchorId,
+          companionToolUses: [
+            { id: "call_read", name: "read", input: {}, side: "before" },
+            { id: "call_write", name: "write", input: {}, side: "before" },
+          ],
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [read, write],
+        provenanceContent: [read, reasoning, write],
+        provenancePositions: [0, 2],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    const body = buildOpenAIResponsesUpstreamRequest(
+      { ...req, protocol: "openai-responses", model: "gpt-5.6" },
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+    expect(body.input.filter((item) => item.type === "reasoning")).toEqual([
+      reasoning.raw,
+    ]);
+    expect(
+      body.input.map((item) =>
+        item.type === "function_call" ? item.call_id : item.type,
+      ),
+    ).toEqual([
+      "call_read",
+      "reasoning",
+      "call_write",
+      "call_recall",
+      "function_call_output",
+    ]);
+  });
+
+  test("preserves complete provenance order for following companions", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174096";
+    const read = {
+      type: "tool_use" as const,
+      id: "call_read",
+      name: "read",
+      input: {},
+    };
+    const write = {
+      type: "tool_use" as const,
+      id: "call_write",
+      name: "write",
+      input: {},
+    };
+    const reasoning = {
+      type: "opaque" as const,
+      responsesItem: true,
+      raw: {
+        type: "reasoning",
+        id: "rs_after_companions",
+        encrypted_content: "encrypted",
+      },
+    };
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          toolUseId: "call_recall",
+          anchorId,
+          companionToolUses: [
+            { id: "call_read", name: "read", input: {}, side: "after" },
+            { id: "call_write", name: "write", input: {}, side: "after" },
+          ],
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+      {
+        role: "assistant",
+        content: [read, write],
+        provenanceContent: [read, reasoning, write],
+        provenancePositions: [0, 2],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    const body = buildOpenAIResponsesUpstreamRequest(
+      { ...req, protocol: "openai-responses", model: "gpt-5.6" },
+      "https://api.openai.com",
+    ).body as { input: Array<Record<string, unknown>> };
+    expect(
+      body.input.map((item) =>
+        item.type === "function_call" ? item.call_id : item.type,
+      ),
+    ).toEqual([
+      "call_recall",
+      "call_read",
+      "reasoning",
+      "call_write",
+      "function_call_output",
+    ]);
+  });
+
+  test("rejoins an Anthropic companion suffix while preserving its preamble", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174011";
+    const user = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "inspect memory" }],
+    };
+    const originalAssistant = {
+      role: "assistant" as const,
+      content: [
+        { type: "text" as const, text: "I will search and read." },
+        {
+          type: "tool_use" as const,
+          id: "call_read",
+          name: "read",
+          input: { file: "notes.md" },
+        },
+        { type: "text" as const, text: "Waiting for both results." },
+      ],
+    };
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          toolUseId: "call_recall",
+          anchorId,
+          anchorContextId: recallAnchorContext([user, originalAssistant]),
+          companionToolUses: [
+            {
+              id: "call_read",
+              name: "read",
+              input: { file: "notes.md" },
+              side: "before",
+            },
+          ],
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      user,
+      originalAssistant,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "call_read",
+            content: [{ type: "text", text: "notes" }],
+          },
+        ],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    expect(req.messages[1].content).toEqual([
+      { type: "text", text: "I will search and read." },
+      { type: "text", text: "Waiting for both results." },
+    ]);
+    expect(req.messages[2].content.map((block) => block.type)).toEqual([
+      "tool_use",
+      "tool_use",
+    ]);
+    expect(
+      req.messages[3].content.map((block) =>
+        block.type === "tool_result" ? block.toolUseId : "",
+      ),
+    ).toEqual(["call_read", "call_recall"]);
+  });
+
+  test("replays repeated identical recalls through distinct anchor keys", () => {
+    const firstAnchor = "123e4567-e89b-42d3-a456-426614174003";
+    const secondAnchor = "123e4567-e89b-42d3-a456-426614174004";
+    const store: RecallStore = new Map([
+      [
+        `anchor:${firstAnchor}`,
+        makeStoredRecall({ toolUseId: "call_1", result: "first" }),
+      ],
+      [
+        `anchor:${secondAnchor}`,
+        makeStoredRecall({ toolUseId: "call_2", result: "second" }),
+      ],
+    ]);
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "start" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(firstAnchor) }],
+      },
+      { role: "user", content: [{ type: "text", text: "next" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(secondAnchor) }],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    expect(JSON.stringify(req.messages)).toContain("first");
+    expect(JSON.stringify(req.messages)).toContain("second");
+  });
+
+  test("validates every anchor against the immutable incoming transcript", () => {
+    const firstAnchor = "123e4567-e89b-42d3-a456-426614174012";
+    const secondAnchor = "123e4567-e89b-42d3-a456-426614174013";
+    const user = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "start" }],
+    };
+    const firstAssistant = {
+      role: "assistant" as const,
+      content: [
+        { type: "text" as const, text: buildRecallAnchor(firstAnchor) },
+      ],
+    };
+    const nextUser = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "continue" }],
+    };
+    const store: RecallStore = new Map([
+      [
+        `anchor:${firstAnchor}`,
+        makeStoredRecall({
+          toolUseId: "call_1",
+          result: "first",
+          anchorId: firstAnchor,
+          anchorContextId: recallAnchorContext([user]),
+        }),
+      ],
+      [
+        `anchor:${secondAnchor}`,
+        makeStoredRecall({
+          toolUseId: "call_2",
+          result: "second",
+          anchorId: secondAnchor,
+          anchorContextId: recallAnchorContext([
+            user,
+            firstAssistant,
+            nextUser,
+          ]),
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      user,
+      firstAssistant,
+      nextUser,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(secondAnchor) }],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    expect(JSON.stringify(req.messages)).toContain("first");
+    expect(JSON.stringify(req.messages)).toContain("second");
+    expect(JSON.stringify(req.messages)).not.toContain("lore-recall");
+  });
+
+  test("keeps a recall continuation tool in a later assistant turn", () => {
+    const toolUseId = "call_recall";
+    const anchorId = "123e4567-e89b-42d3-a456-426614174005";
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          toolUseId,
+          anchorId,
+          input: { query: "architecture", scope: "all" },
+          result: "architecture results",
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "investigate" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "call_read", name: "read", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "call_read",
+            content: [{ type: "text", text: "file" }],
+          },
+        ],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    expect(req.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(req.messages[2].content[0]).toMatchObject({
+      type: "tool_result",
+      toolUseId,
+    });
+    expect(req.messages[3].content[0]).toMatchObject({
+      type: "tool_use",
+      id: "call_read",
+    });
+  });
+
+  test("does not expand a copied anchor under a different user turn", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174006";
+    const originalUser = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "original request" }],
+    };
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          anchorId,
+          anchorContextId: recallAnchorContext([originalUser]),
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "attacker turn" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+    ]);
+
+    expect(expandRecallMarkers(req, store)).toBe(false);
+    expect(req.messages[1].content[0]).toMatchObject({ type: "text" });
+  });
+
+  test("binds an anchor to request-only Responses reasoning provenance", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174012";
+    const reasoning = (encrypted: string) => ({
+      role: "assistant" as const,
+      content: [] as GatewayRequest["messages"][number]["content"],
+      provenanceContent: [
+        {
+          type: "opaque" as const,
+          raw: {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: encrypted,
+          },
+        },
+      ],
+      provenancePositions: [],
+    });
+    const user = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "continue" }],
+    };
+    const storedContext = recallAnchorContext([user, reasoning("original")]);
+    const makeReplay = (encrypted: string) =>
+      makeRequest([
+        user,
+        reasoning(encrypted),
+        {
+          role: "assistant",
+          content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+        },
+      ]);
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({ anchorId, anchorContextId: storedContext }),
+      ],
+    ]);
+
+    const valid = makeReplay("original");
+    expect(expandRecallMarkers(valid, store)).toBe(true);
+
+    const changed = makeReplay("changed");
+    expect(expandRecallMarkers(changed, store)).toBe(false);
+  });
+
+  test("binds an anchor to request-only Responses refusal provenance", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174015";
+    const refusal = (text: string) => ({
+      role: "assistant" as const,
+      content: [] as GatewayRequest["messages"][number]["content"],
+      provenanceContent: [
+        {
+          type: "opaque" as const,
+          raw: {
+            type: "message",
+            id: "msg_refusal",
+            content: [{ type: "refusal", refusal: text }],
+          },
+        },
+      ],
+      provenancePositions: [],
+    });
+    const user = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "continue" }],
+    };
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          anchorId,
+          anchorContextId: recallAnchorContext([user, refusal("original")]),
+        }),
+      ],
+    ]);
+    const replay = (text: string) =>
+      makeRequest([
+        user,
+        refusal(text),
+        {
+          role: "assistant",
+          content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+        },
+      ]);
+
+    expect(expandRecallMarkers(replay("original"), store)).toBe(true);
+    expect(expandRecallMarkers(replay("changed"), store)).toBe(false);
+  });
+
+  test("round-trips producer provenance through Lore and parser replay", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174016";
+    const refusal = {
+      type: "message",
+      id: "msg_refusal",
+      role: "assistant",
+      content: [{ type: "refusal", refusal: "cannot comply" }],
+    };
+    const unknown = {
+      type: "computer_screenshot",
+      id: "screen_1",
+      image_url: "data:image/png;base64,AAA",
+    };
+    const anchor = buildRecallAnchor(anchorId);
+    const producerResponse: GatewayResponse = {
+      id: "resp_producer",
+      model: "gpt-5.6",
+      content: [
+        { type: "opaque", raw: refusal, responsesItem: true },
+        { type: "opaque", raw: unknown, responsesItem: true },
+        { type: "text", text: anchor },
+      ],
+      rawOutputItems: [refusal, unknown],
+      stopReason: "end_turn",
+      usage: { inputTokens: 0, outputTokens: 0 },
+    };
+    const user = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "continue" }],
+    };
+    const producerProvenance = [
+      ...responsesProvenanceContent(producerResponse),
+      { type: "text" as const, text: anchor },
+    ];
+    const producerMessages = [
+      user,
+      {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: anchor }],
+        provenanceContent: producerProvenance,
+        provenancePositions: [producerProvenance.length - 1],
+      },
+    ];
+    const anchorContextId = responsesAnchorContext(
+      [user],
+      [],
+      producerResponse,
+      "missing-recall-tool",
+    );
+    const store: RecallStore = new Map([
+      [`anchor:${anchorId}`, makeStoredRecall({ anchorId, anchorContextId })],
+    ]);
+
+    const lore = gatewayMessagesToLore(producerMessages, "replay-session");
+    const provenanceByMessageId = responsesProvenanceByMessageId(
+      producerMessages,
+      lore,
+    );
+    resolveToolResults(lore);
+    const transformed = loreMessagesToGateway(lore, provenanceByMessageId);
+    const wire = buildOpenAIResponsesUpstreamRequest(
+      {
+        ...makeRequest(transformed),
+        protocol: "openai-responses",
+        model: "gpt-5.6",
+      },
+      "https://api.openai.com",
+    ).body;
+    const replay = parseOpenAIResponsesRequest(wire, {});
+
+    expect(expandRecallMarkers(replay, store)).toBe(true);
+    expect(
+      loreMessagesToGateway(lore.slice(1), provenanceByMessageId, false)[0]
+        .provenanceContent,
+    ).toBeUndefined();
+    const changedLore = structuredClone(lore);
+    const textPart = changedLore[1].parts.find((part) => part.type === "text");
+    if (!textPart || !("text" in textPart)) throw new Error("missing anchor");
+    textPart.text = "changed";
+    expect(
+      loreMessagesToGateway(changedLore, provenanceByMessageId)[1]
+        .provenanceContent,
+    ).toBeUndefined();
+  });
+
+  test("does not expand a copied anchor after an identical later user message", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174009";
+    const original = [
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "same" }],
+      },
+    ];
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          anchorId,
+          anchorContextId: recallAnchorContext(original),
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      ...original,
+      { role: "assistant", content: [{ type: "text", text: "prior answer" }] },
+      { role: "user", content: [{ type: "text", text: "same" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+    ]);
+
+    expect(expandRecallMarkers(req, store)).toBe(false);
+  });
+
+  test("does not expand an anchor moved within the same assistant turn", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174008";
+    const prefix = [
+      { type: "text" as const, text: "the original preceding text" },
+    ];
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          anchorId,
+          anchorContextId: recallAnchorContext([], 0, prefix),
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: buildRecallAnchor(anchorId) },
+          ...prefix,
+        ],
+      },
+    ]);
+
+    expect(expandRecallMarkers(req, store)).toBe(false);
+  });
+
+  test("does not coalesce a reused companion ID with different tool content", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174007";
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({
+          anchorId,
+          companionToolUses: [
+            {
+              id: "call_reused",
+              name: "read",
+              input: { file: "original" },
+              side: "before",
+            },
+          ],
+        }),
+      ],
+    ]);
+    const req = makeRequest([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_reused",
+            name: "write",
+            input: { file: "different" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+    ]);
+    bindCanonicalAnchors(req, store);
+
+    expect(expandRecallMarkers(req, store)).toBe(true);
+    expect(req.messages[0].content[0]).toMatchObject({ name: "write" });
+    expect(req.messages[1].content[0]).toMatchObject({ name: "recall" });
+  });
+
+  test("never expands a canonical anchor without provenance", () => {
+    const anchorId = "123e4567-e89b-42d3-a456-426614174014";
+    const store: RecallStore = new Map([
+      [
+        `anchor:${anchorId}`,
+        makeStoredRecall({ anchorId, anchorContextId: undefined }),
+      ],
+    ]);
+    const req = makeRequest([
+      { role: "user", content: [{ type: "text", text: "start" }] },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: buildRecallAnchor(anchorId) }],
+      },
+    ]);
+
+    expect(expandRecallMarkers(req, store)).toBe(false);
+  });
+
   test("expands marker in assistant message back to tool_use + tool_result", () => {
     const store: RecallStore = new Map();
     store.set(recallStoreKey("test query", "all"), makeStoredRecall());
@@ -1072,6 +2467,7 @@ describe("expandRecallMarkers", () => {
         ],
       },
     ]);
+    bindReplayEntries(req, store);
 
     const result = expandRecallMarkers(req, store);
 
@@ -1159,6 +2555,7 @@ describe("expandRecallMarkers", () => {
         content: [{ type: "text", text: "thanks, tell me more" }],
       },
     ]);
+    bindReplayEntries(req, store);
 
     const result = expandRecallMarkers(req, store);
     expect(result).toBe(true);
@@ -1239,6 +2636,7 @@ describe("expandRecallMarkers", () => {
         ],
       },
     ]);
+    bindReplayEntries(req, store);
 
     const result = expandRecallMarkers(req, store);
     expect(result).toBe(true);
@@ -1296,6 +2694,7 @@ describe("expandRecallMarkers", () => {
       },
       { role: "user", content: [{ type: "text", text: "third" }] },
     ]);
+    bindReplayEntries(req, store);
 
     const result = expandRecallMarkers(req, store);
     expect(result).toBe(true);
@@ -1339,8 +2738,9 @@ describe("cleanupRecallStore", () => {
       },
       { role: "user", content: [{ type: "text", text: "next" }] },
     ]);
+    bindReplayEntries(req, store);
 
-    cleanupRecallStore(req, store);
+    expect(cleanupRecallStore(req, store)).toBe(true);
 
     expect(store.size).toBe(1);
     expect(store.has(recallStoreKey("active", "all"))).toBe(true);
@@ -1353,7 +2753,7 @@ describe("cleanupRecallStore", () => {
       { role: "user", content: [{ type: "text", text: "hello" }] },
     ]);
 
-    cleanupRecallStore(req, store);
+    expect(cleanupRecallStore(req, store)).toBe(false);
     expect(store.size).toBe(0);
   });
 });

--- a/packages/gateway/test/session-adoption.e2e.test.ts
+++ b/packages/gateway/test/session-adoption.e2e.test.ts
@@ -18,8 +18,11 @@
  * (clears in-memory maps, keeps the DB), and assert on session_state rows.
  */
 import { describe, it, expect, afterEach } from "vitest";
+import { DatabaseSync } from "node:sqlite";
 import type { Harness } from "./helpers/harness";
 import { createHarness } from "./helpers/harness";
+import { fingerprintMessages } from "../src/session";
+import { deterministicID } from "../src/temporal-adapter";
 import {
   makeFixtureEntry,
   STANDARD_TOOLS,
@@ -58,6 +61,26 @@ function loreSessionRows(h: Harness): Row[] {
   return h.queryDB<Row>(
     "SELECT session_id, header_session_id FROM session_state WHERE header_name = 'x-lore-session-id'",
   );
+}
+
+async function makeSessionLegacy(
+  h: Harness,
+  sessionId: string,
+  firstUserContent = U0,
+): Promise<void> {
+  const fingerprint = await fingerprintMessages([
+    { role: "user", content: firstUserContent },
+  ]);
+  const db = new DatabaseSync(h.dbPath);
+  try {
+    db.prepare(
+      `UPDATE session_state
+          SET fingerprint = ?, credential_fingerprint = ''
+        WHERE session_id = ?`,
+    ).run(fingerprint, sessionId);
+  } finally {
+    db.close();
+  }
 }
 
 describe("issue #796: restart-proof session adoption (Tier 3b)", () => {
@@ -202,5 +225,291 @@ describe("issue #796: restart-proof session adoption (Tier 3b)", () => {
 
     const rows = loreSessionRows(harness);
     expect(rows.length).toBe(2);
+  });
+
+  it("adopts a pre-credential session only after same-project transcript overlap", async () => {
+    harness = await createHarness({ fixtures: fixtures() });
+    const legacyHeader = "legacy-exact-header";
+
+    let r = await harness.chat(body([{ role: "user", content: U0 }]), "key-A", {
+      "x-lore-session-id": legacyHeader,
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": legacyHeader },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const before = loreSessionRows(harness);
+    expect(before).toHaveLength(1);
+    await makeSessionLegacy(harness, before[0].session_id);
+    await harness.restartPipeline();
+
+    const migratedHeader = "legacy-after-credential-scope";
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+        { role: "assistant", content: "A1 done." },
+        { role: "user", content: U2 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": migratedHeader },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const after = harness.queryDB<Row & { credential_fingerprint: string }>(
+      `SELECT session_id, header_session_id, credential_fingerprint
+         FROM session_state
+        WHERE header_name = 'x-lore-session-id'`,
+    );
+    expect(after).toHaveLength(1);
+    expect(after[0].session_id).toBe(before[0].session_id);
+    expect(after[0].header_session_id).toBe(migratedHeader);
+    expect(after[0].credential_fingerprint).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("does NOT let another transcript claim an exact legacy header", async () => {
+    harness = await createHarness({ fixtures: fixtures() });
+    const legacyHeader = "legacy-copied-header";
+
+    let r = await harness.chat(body([{ role: "user", content: U0 }]), "key-A", {
+      "x-lore-session-id": legacyHeader,
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": legacyHeader },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+    const before = loreSessionRows(harness);
+    await makeSessionLegacy(harness, before[0].session_id);
+    await harness.restartPipeline();
+
+    r = await harness.chat(
+      body([
+        { role: "user", content: "attacker opening" },
+        { role: "assistant", content: "unrelated" },
+        { role: "user", content: "attacker follow-up" },
+      ]),
+      "key-B",
+      { "x-lore-session-id": legacyHeader },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const after = loreSessionRows(harness);
+    expect(after).toHaveLength(2);
+    expect(new Set(after.map((row) => row.session_id)).size).toBe(2);
+  });
+
+  it("does NOT adopt a pre-credential session when only its fingerprint-implied first message overlaps", async () => {
+    harness = await createHarness({ fixtures: fixtures() });
+    const legacyHeader = "legacy-one-message";
+
+    let r = await harness.chat(body([{ role: "user", content: U0 }]), "key-A", {
+      "x-lore-session-id": legacyHeader,
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": legacyHeader },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+    const before = loreSessionRows(harness);
+    await makeSessionLegacy(harness, before[0].session_id);
+    await harness.restartPipeline();
+
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "unrelated response" },
+        { role: "user", content: "different second user message" },
+      ]),
+      "key-B",
+      { "x-lore-session-id": legacyHeader },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const after = loreSessionRows(harness);
+    expect(after).toHaveLength(2);
+    expect(new Set(after.map((row) => row.session_id)).size).toBe(2);
+  });
+
+  it("does NOT adopt either of two equally supported legacy candidates", async () => {
+    const users = [U0, U1, U2, "fourth instruction for ambiguity proof"];
+    harness = await createHarness({
+      fixtures: Array.from({ length: 5 }, (_, seq) =>
+        makeFixtureEntry({
+          seq,
+          requestMessages: [],
+          responseText: `A${seq} done.`,
+        }),
+      ),
+    });
+
+    const messages: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < users.length; i++) {
+      messages.push({ role: "user", content: users[i] });
+      if (i < users.length - 1) {
+        messages.push({ role: "assistant", content: `A${i} done.` });
+      }
+      const r = await harness.chat(body(messages), "key-A", {
+        "x-lore-session-id": "legacy-ambiguous-a",
+      });
+      expect(r.status).toBe(200);
+      await r.text();
+    }
+
+    const [first] = loreSessionRows(harness);
+    expect(first).toBeDefined();
+    await makeSessionLegacy(harness, first.session_id);
+    const secondSession = `legacy-ambiguous-${crypto.randomUUID()}`;
+    const fingerprint = await fingerprintMessages([
+      { role: "user", content: U0 },
+    ]);
+    const db = new DatabaseSync(harness.dbPath);
+    try {
+      const state = db
+        .prepare(
+          `SELECT message_count, project_path, project_path_provisional, is_subagent
+             FROM session_state
+            WHERE session_id = ?`,
+        )
+        .get(first.session_id) as {
+        message_count: number;
+        project_path: string;
+        project_path_provisional: number;
+        is_subagent: number;
+      };
+      db.prepare(
+        `INSERT INTO session_state
+           (session_id, force_min_layer, updated_at, message_count, fingerprint,
+            credential_fingerprint, project_path, project_path_provisional, is_subagent)
+         VALUES (?, 0, ?, ?, ?, '', ?, ?, ?)`,
+      ).run(
+        secondSession,
+        Date.now(),
+        state.message_count,
+        fingerprint,
+        state.project_path,
+        state.project_path_provisional,
+        state.is_subagent,
+      );
+      for (const index of [2, 6]) {
+        const id = deterministicID("user", index, [
+          { type: "text", text: users[index / 2] },
+        ]);
+        db.prepare(
+          "UPDATE temporal_messages SET session_id = ? WHERE id = ?",
+        ).run(secondSession, id);
+      }
+    } finally {
+      db.close();
+    }
+    await harness.restartPipeline();
+
+    const resumed: Array<{ role: string; content: string }> = [];
+    for (let i = 0; i < users.length; i++) {
+      resumed.push({ role: "user", content: users[i] });
+      if (i < users.length - 1) {
+        resumed.push({ role: "assistant", content: `A${i} done.` });
+      }
+    }
+    const r = await harness.chat(body(resumed), "key-B", {
+      "x-lore-session-id": "legacy-ambiguous-new",
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const rows = harness.queryDB<{
+      session_id: string;
+      header_session_id: string | null;
+    }>(
+      `SELECT session_id, header_session_id
+         FROM session_state
+        WHERE session_id IN (?, ?)
+           OR header_session_id = 'legacy-ambiguous-new'`,
+      [first.session_id, secondSession],
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => row.session_id)).toContain(first.session_id);
+    expect(rows.map((row) => row.session_id)).toContain(secondSession);
+    expect(rows.map((row) => row.header_session_id)).toContain(
+      "legacy-ambiguous-new",
+    );
+  });
+
+  it("does NOT adopt a pre-credential session across projects", async () => {
+    harness = await createHarness({
+      fixtures: fixtures(),
+      projectPath: "/tmp/lore-legacy-project-a",
+    });
+
+    let r = await harness.chat(body([{ role: "user", content: U0 }]), "key-A", {
+      "x-lore-session-id": "legacy-project-a",
+    });
+    expect(r.status).toBe(200);
+    await r.text();
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+      ]),
+      "key-A",
+      { "x-lore-session-id": "legacy-project-a" },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+    const before = loreSessionRows(harness);
+    await makeSessionLegacy(harness, before[0].session_id);
+    await harness.restartPipeline();
+
+    r = await harness.chat(
+      body([
+        { role: "user", content: U0 },
+        { role: "assistant", content: "A0 done." },
+        { role: "user", content: U1 },
+        { role: "assistant", content: "A1 done." },
+        { role: "user", content: U2 },
+      ]),
+      "key-B",
+      {
+        "x-lore-session-id": "legacy-project-a",
+        "x-lore-project": "/tmp/lore-legacy-project-b",
+      },
+    );
+    expect(r.status).toBe(200);
+    await r.text();
+
+    const after = loreSessionRows(harness);
+    expect(after).toHaveLength(2);
+    expect(new Set(after.map((row) => row.session_id)).size).toBe(2);
   });
 });

--- a/packages/gateway/test/session-rotation-merge.test.ts
+++ b/packages/gateway/test/session-rotation-merge.test.ts
@@ -59,6 +59,7 @@ interface SessionRow {
   header_name: string | null;
   project_path: string | null;
   project_path_provisional: number;
+  credential_fingerprint: string;
 }
 
 describe("Tier 1b session-merge regression (x-claude-code-session-id)", () => {
@@ -399,5 +400,46 @@ describe("Tier 1b: x-lore-session-id isolation (Lore plugin stable ID)", () => {
     expect(new Set(sessions.map((s) => s.project_path))).toEqual(
       new Set(["/proj/ls-alpha", "/proj/ls-beta"]),
     );
+  });
+
+  it("does not share one session header across credentials", async () => {
+    harness = await createHarness({
+      fixtures: [
+        ...makeConversationFixtures([
+          { userMessage: "credential alpha", assistantText: "A." },
+        ]),
+        ...makeConversationFixtures([
+          { userMessage: "credential beta", assistantText: "B." },
+        ]),
+      ],
+    });
+    const sessionHeader = "shared-by-two-clients";
+
+    const first = await harness.chat(body("credential alpha"), "key-A", {
+      "x-lore-session-id": sessionHeader,
+      "x-lore-project": "/proj/shared",
+    });
+    expect(first.status).toBe(200);
+    await first.text();
+
+    const second = await harness.chat(body("credential beta"), "key-B", {
+      "x-lore-session-id": sessionHeader,
+      "x-lore-project": "/proj/shared",
+    });
+    expect(second.status).toBe(200);
+    await second.text();
+
+    const rows = harness.queryDB<SessionRow>(
+      `SELECT session_id, credential_fingerprint
+         FROM session_state
+        WHERE header_name = 'x-lore-session-id'
+          AND header_session_id = 'shared-by-two-clients'`,
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((row) => row.session_id)).size).toBe(2);
+    expect(new Set(rows.map((row) => row.credential_fingerprint)).size).toBe(2);
+    expect(
+      rows.every((row) => /^[0-9a-f]{16}$/.test(row.credential_fingerprint)),
+    ).toBe(true);
   });
 });

--- a/packages/gateway/test/session.test.ts
+++ b/packages/gateway/test/session.test.ts
@@ -698,10 +698,14 @@ describe("findRotationPredecessor", () => {
   /** Helper to build a simple header index map. */
   function buildIndex(
     entries: Array<[string, string, string]>,
+    credentialFingerprint = "cred-a",
   ): Map<string, string> {
     const index = new Map<string, string>();
     for (const [headerName, headerValue, sid] of entries) {
-      index.set(`${headerName}:${headerValue}`, sid);
+      index.set(
+        `${credentialFingerprint}\x1f${headerName}\x1f${headerValue}`,
+        sid,
+      );
     }
     return index;
   }
@@ -729,6 +733,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -747,6 +752,7 @@ describe("findRotationPredecessor", () => {
     const candidates = new Map<string, RotationCandidate>();
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "first-nanoid-abc",
       index,
@@ -782,6 +788,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -808,6 +815,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -835,6 +843,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -871,6 +880,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -905,6 +915,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -944,6 +955,7 @@ describe("findRotationPredecessor", () => {
 
     // Rotating x-session-affinity should only find the opencode session, not claude
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -965,6 +977,7 @@ describe("findRotationPredecessor", () => {
     const candidates = new Map<string, RotationCandidate>();
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -993,6 +1006,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -1024,6 +1038,7 @@ describe("findRotationPredecessor", () => {
     ]);
 
     const result = findRotationPredecessor(
+      "cred-a",
       "x-session-affinity",
       "new-nanoid-xyz",
       index,
@@ -1032,6 +1047,34 @@ describe("findRotationPredecessor", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  test("ignores predecessors owned by another credential", () => {
+    const index = buildIndex(
+      [["x-session-affinity", "old-nanoid", "other-session"]],
+      "cred-b",
+    );
+    const candidates = new Map<string, RotationCandidate>([
+      [
+        "other-session",
+        {
+          sid: "other-session",
+          isSubagent: false,
+          lastActiveAt: now - 60_000,
+        },
+      ],
+    ]);
+
+    expect(
+      findRotationPredecessor(
+        "cred-a",
+        "x-session-affinity",
+        "new-nanoid",
+        index,
+        buildLookup(candidates),
+        now,
+      ),
+    ).toBeNull();
   });
 });
 

--- a/packages/gateway/test/stream-anthropic.test.ts
+++ b/packages/gateway/test/stream-anthropic.test.ts
@@ -6,7 +6,7 @@
  * (buildKeepaliveCompactionStream and createRecallAwareAccumulator are
  * covered by keepalive-compaction.test.ts / recall-stream.test.ts.)
  */
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import {
   formatSSEEvent,
   parseSSEStream,
@@ -125,6 +125,65 @@ describe("parseSSEStream", () => {
       readerFromChunks(["event: message_stop\ndata: {}"]),
     );
     expect(events).toEqual([{ event: "message_stop", data: "{}" }]);
+  });
+
+  test("rejects an oversized event before a blank-line delimiter arrives", async () => {
+    const reader = readerFromChunks([
+      "event: response.output_item.added\ndata: ",
+      "x".repeat(64),
+    ]);
+    const collectBounded = async (): Promise<void> => {
+      for await (const _event of parseSSEStream(reader, {
+        maxEventBytes: 32,
+      })) {
+        // No complete event should be yielded.
+      }
+    };
+
+    await expect(collectBounded()).rejects.toThrow(
+      "SSE event exceeded 32 byte limit",
+    );
+  });
+
+  test("rejects an unlimited sequence of small frames", async () => {
+    const reader = readerFromChunks([
+      "data: one\n\ndata: two\n\ndata: three\n\n",
+    ]);
+    const collectBounded = async (): Promise<void> => {
+      for await (const _event of parseSSEStream(reader, { maxFrames: 2 })) {
+        // Consume until the frame cap rejects.
+      }
+    };
+    await expect(collectBounded()).rejects.toThrow(
+      "SSE stream exceeded 2 frame limit",
+    );
+  });
+
+  test("rejects a stalled stream after its inactivity deadline", async () => {
+    vi.useFakeTimers();
+    const reader = new ReadableStream<Uint8Array>({
+      pull() {
+        return new Promise(() => {});
+      },
+    }).getReader();
+    const collectBounded = async (): Promise<void> => {
+      for await (const _event of parseSSEStream(reader, {
+        inactivityMs: 100,
+      })) {
+        // No frames arrive.
+      }
+    };
+    try {
+      const pending = collectBounded();
+      const assertion = expect(pending).rejects.toThrow(
+        "SSE stream inactivity deadline exceeded",
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+      void reader.cancel();
+    }
   });
 });
 

--- a/packages/gateway/test/temporal-adapter.test.ts
+++ b/packages/gateway/test/temporal-adapter.test.ts
@@ -6,6 +6,7 @@ import {
 import type { GatewayMessage } from "../src/translate/types";
 import type { LorePart } from "@loreai/core";
 import { isToolPart } from "@loreai/core";
+import { estimateMessages } from "../../core/src/gradient";
 
 // Test-local view of a tool part's state covering all status variants.
 type TestToolState = {
@@ -313,5 +314,33 @@ describe("resolveToolResults", () => {
     const toolState = toolStateOf(toolPart);
     expect(toolState.status).toBe("error");
     expect(toolState.error).toBe("command failed with exit code 1");
+  });
+
+  test("counts hidden Responses provenance without persisting it as parts", () => {
+    const messages = gatewayMessagesToLore(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "anchor" }],
+          provenanceContent: [
+            {
+              type: "opaque",
+              responsesItem: true,
+              raw: {
+                type: "reasoning",
+                id: "rs_large",
+                encrypted_content: "x".repeat(16_000),
+              },
+            },
+            { type: "text", text: "anchor" },
+          ],
+        },
+      ],
+      "sess-hidden",
+    );
+
+    expect(messages[0].parts).toHaveLength(1);
+    expect(messages[0].hiddenInputTokens).toBeGreaterThan(1_000);
+    expect(estimateMessages(messages)).toBeGreaterThan(1_000);
   });
 });

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -114,10 +114,9 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
 
   let projectPath = process.cwd();
   let currentSessionID = sessionIDFor(undefined);
+  let compactAuthHeaders: Record<string, string> = {};
 
-  // Cache git remote once at init — avoid spawning `git remote -v` on every
-  // intercepted fetch call.
-  const cachedGitRemote = getGitRemote(projectPath) ?? "";
+  let cachedGitRemote = getGitRemote(projectPath) ?? "";
 
   // Install fetch-level interceptor — transparently reroutes LLM API calls
   // through the gateway while preserving original auth headers and URLs.
@@ -137,6 +136,21 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
         };
         if (cachedGitRemote) headers["x-lore-git-remote"] = cachedGitRemote;
         return headers;
+      },
+      onRequestHeaders: (headers) => {
+        if (
+          headers.get("x-lore-session-id") !== currentSessionID ||
+          headers.get("x-lore-project") !== projectPath
+        ) {
+          return;
+        }
+        const apiKey = headers.get("x-api-key");
+        const authorization = headers.get("authorization");
+        compactAuthHeaders = apiKey
+          ? { "x-api-key": apiKey }
+          : authorization
+            ? { authorization }
+            : {};
       },
     });
     fetchInterceptorInstalled = true;
@@ -165,10 +179,13 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
   registerProviders();
 
   pi.on("session_start", async (_event: SessionStartEvent, ctx) => {
-    projectPath = ctx.cwd;
+    const nextProjectPath = ctx.cwd;
     const newID = sessionIDFor(ctx.sessionManager.getSessionFile());
-    if (newID !== currentSessionID) {
+    if (newID !== currentSessionID || nextProjectPath !== projectPath) {
       currentSessionID = newID;
+      projectPath = nextProjectPath;
+      cachedGitRemote = getGitRemote(projectPath) ?? "";
+      compactAuthHeaders = {};
       // Re-register with the real session ID so all subsequent provider
       // requests carry the correct x-lore-session-id header.
       registerProviders();
@@ -198,6 +215,7 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
         previousSummary: event.preparation.previousSummary,
         firstKeptEntryId: event.preparation.firstKeptEntryId,
         tokensBefore: event.preparation.tokensBefore,
+        authHeaders: compactAuthHeaders,
       }),
   );
 }

--- a/packages/pi/src/internal.ts
+++ b/packages/pi/src/internal.ts
@@ -300,6 +300,7 @@ export async function runCompaction(opts: {
   previousSummary: string | undefined;
   firstKeptEntryId: string;
   tokensBefore: number;
+  authHeaders?: Readonly<Record<string, string>>;
   fetchImpl?: typeof fetch;
 }): Promise<SessionBeforeCompactResult | undefined> {
   const {
@@ -309,6 +310,7 @@ export async function runCompaction(opts: {
     previousSummary,
     firstKeptEntryId,
     tokensBefore,
+    authHeaders,
     fetchImpl = fetch,
   } = opts;
 
@@ -318,6 +320,7 @@ export async function runCompaction(opts: {
       headers: {
         "content-type": "application/json",
         "x-lore-session-id": sessionID,
+        ...authHeaders,
       },
       body: JSON.stringify({
         project_path: projectPath,

--- a/packages/pi/test/extension.e2e.test.ts
+++ b/packages/pi/test/extension.e2e.test.ts
@@ -177,6 +177,25 @@ describe("pi extension — e2e against a real gateway", () => {
     expect(sid).toMatch(/^pi-[0-9a-f]{24}$/);
   });
 
+  test("re-registers when cwd changes without changing the session id", async () => {
+    const before = mock.registrations.length;
+    const onStart = mock.handlers.get("session_start");
+    await onStart?.(
+      {},
+      {
+        cwd: "/tmp/lore-pi-other-project",
+        sessionManager: {
+          getSessionFile: () => "/tmp/lore-pi-e2e-session.json",
+        },
+      },
+    );
+    const after = mock.registrations.slice(before);
+    expect(after.length).toBeGreaterThan(0);
+    expect(after[0].config.headers["x-lore-project"]).toBe(
+      "/tmp/lore-pi-other-project",
+    );
+  });
+
   test("compaction for an unrouted session falls back gracefully (real /v1/compact)", async () => {
     const onCompact = mock.handlers.get("session_before_compact");
     const result = await onCompact?.(

--- a/packages/pi/test/internal.test.ts
+++ b/packages/pi/test/internal.test.ts
@@ -109,6 +109,7 @@ describe("runCompaction", () => {
     previousSummary: "prev",
     firstKeptEntryId: "entry-7",
     tokensBefore: 4242,
+    authHeaders: { authorization: "Bearer pi-auth" },
   };
 
   test("POSTs to /v1/compact with session header + body, returns shaped result", async () => {
@@ -126,6 +127,9 @@ describe("runCompaction", () => {
     expect(url).toBe(`${GW}/v1/compact`);
     expect((init!.headers as Record<string, string>)["x-lore-session-id"]).toBe(
       "sess-c",
+    );
+    expect((init!.headers as Record<string, string>).authorization).toBe(
+      "Bearer pi-auth",
     );
     expect(JSON.parse(init?.body as string)).toEqual({
       project_path: "/proj",

--- a/packages/pi/test/no-tui-output.test.ts
+++ b/packages/pi/test/no-tui-output.test.ts
@@ -30,10 +30,16 @@ import lorePiExtension from "../src/index";
 type AnyHandler = (...args: unknown[]) => unknown;
 
 function createMockPi() {
-  const providers: Array<{ name: string; config: unknown }> = [];
+  const providers: Array<{
+    name: string;
+    config: { baseUrl: string; headers: Record<string, string> };
+  }> = [];
   const handlers = new Map<string, AnyHandler>();
   const pi = {
-    registerProvider(name: string, config: unknown): void {
+    registerProvider(
+      name: string,
+      config: { baseUrl: string; headers: Record<string, string> },
+    ): void {
       providers.push({ name, config });
     },
     on(event: string, handler: AnyHandler): void {
@@ -48,6 +54,9 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
   let baseUrl: string;
   const originalFetch = globalThis.fetch;
   const originalEnv = { ...process.env };
+  const compactCapture: {
+    headers: Record<string, string | undefined> | undefined;
+  } = { headers: undefined };
 
   beforeAll(async () => {
     // Minimal fake gateway: healthy, but rejects compaction as a session that
@@ -60,6 +69,10 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
         return;
       }
       if (url.pathname === "/v1/compact") {
+        compactCapture.headers = {
+          "x-api-key": req.headers["x-api-key"] as string | undefined,
+          authorization: req.headers.authorization,
+        };
         res.writeHead(404, { "content-type": "application/json" });
         res.end(
           JSON.stringify({
@@ -104,7 +117,8 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
     );
 
     try {
-      const { pi, handlers } = createMockPi();
+      compactCapture.headers = undefined;
+      const { pi, providers, handlers } = createMockPi();
 
       await lorePiExtension(
         pi as unknown as Parameters<typeof lorePiExtension>[0],
@@ -116,6 +130,11 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
       expect(onStart).toBeTypeOf("function");
       expect(onCompact).toBeTypeOf("function");
 
+      const staleRegistration = providers.find(
+        ({ name }) => name === "anthropic",
+      );
+      expect(staleRegistration).toBeDefined();
+
       // session_start: updates the session id and re-registers providers.
       await onStart?.(
         {},
@@ -124,6 +143,18 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
           sessionManager: { getSessionFile: () => "/tmp/lore-pi-session" },
         },
       );
+
+      // A delayed request from a provider registration created before the
+      // session switch must not repopulate compaction auth for the new session.
+      await fetch(`${baseUrl}/v1/messages`, {
+        method: "POST",
+        headers: {
+          ...staleRegistration?.config.headers,
+          "content-type": "application/json",
+          "x-api-key": "stale-session-key",
+        },
+        body: JSON.stringify({ model: "claude", messages: [] }),
+      });
 
       // Compaction → gateway returns 404 session_not_found → graceful fallback.
       const result = await onCompact?.(
@@ -137,6 +168,10 @@ describe("pi extension — no TUI (stdout/stderr) output", () => {
         {},
       );
       expect(result).toBeUndefined();
+      expect(compactCapture.headers).toEqual({
+        "x-api-key": undefined,
+        authorization: undefined,
+      });
 
       // The whole point: zero raw terminal writes on success + fallback paths.
       expect(stdoutSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- continue OpenAI Responses streams after intercepted recall calls without exposing recall tool events
- bind replay anchors to exact transcript provenance and preserve output ordering, identities, terminal semantics, and resource limits
- persist restart-safe upstream routing for authenticated Pi compaction without storing credentials
- isolate Pi compaction auth across session/project switches and fix the shared test-harness port race
- preserve pre-credential session continuity through unowned legacy fingerprint lookup plus same-project transcript proof

## Root cause

Headerless but valid ChatGPT/Codex SSE follow-ups were rejected by a header-only check. The gateway then converted the failed continuation into a successful marker-only completion, so the agent stopped after every recall call.

Credential-scoped session keys also made pre-v78 rows invisible after upgrade. Directly claiming an empty-fingerprint row by caller-supplied header would create a first-claim-wins IDOR, so legacy adoption now requires an unsuffixed fingerprint match, an unowned persisted row, at least two deterministic user-message overlaps, and the same project. Equal candidates fail closed.

## Validation

- final changed-path matrix: 767/767 passed across 23 files
- focused session/core battery: 227/227 passed
- critical lifecycle/security stability: 1,190/1,190 passed across ten runs
- mutation probes kill legacy lookup removal, owned-row inclusion, one-message adoption, cross-project adoption, ambiguous-candidate selection, direct exact-header claiming, and recall lifecycle/provenance regressions
- all package typechecks passed
- format check passed across 720 files
- lint passed with existing warnings only
- full suite: 7,393 passed, 227 skipped; two unchanged environment/test failures remain in `agents.test.ts` (jj workspace has no discoverable Git remote) and `team-cmd.test.ts` (`expect.anything()` rejects the documented allowed `undefined` argument)
