### PR TITLE
fix(gateway): close vector-pool readers and main SQLite writer on shutdown (#1599)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,7 @@ export {
   type VecWorkerCheck,
   checkReadOffload,
   type ReadOffloadCheck,
+  shutdownVectorPoolAsync,
 } from "./vector-pool";
 export { load, config, type LoreConfig } from "./config";
 export {

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -781,7 +781,16 @@ export async function checkReadOffload(
 
 /** Tear down the pool (test teardown + process reset). Idempotent. The
  *  shuttingDown guard keeps the terminate()-induced worker exits below from
- *  being counted as structural failures. */
+ *  being counted as structural failures.
+ *
+ *  Synchronous fire-and-forget: posts the shutdown message and immediately
+ *  force-terminates each worker. The reader close inside the worker thread
+ *  (vector-worker.ts:144-153) is NEVER given a chance to run — fine for the
+ *  test seam (FakeWorker fires `exit` synchronously from `terminate()`) but
+ *  NOT for the real gateway shutdown, which needs the reader to close BEFORE
+ *  the main thread's `close()` runs (`PRAGMA wal_checkpoint(TRUNCATE)` while
+ *  a reader holds the WAL would busy-wait up to 5s). Use
+ *  {@link shutdownVectorPoolAsync} for that. */
 export function shutdownVectorPool(): void {
   shuttingDown = true;
   for (const pw of workers) {
@@ -798,6 +807,120 @@ export function shutdownVectorPool(): void {
     }
   }
   workers = [];
+}
+
+/** Default per-pool shutdown deadline. The gateway's overall shutdown
+ *  deadline is {@link packages/gateway/src/cli/shutdown.ts:SHUTDOWN_DEADLINE_MS}
+ *  (4s default); the vector pool must leave room for the embedding-worker
+ *  reset (~1.5s), the embedding-document drain (~2.4s), and the writer
+ *  `close()` call (~hundreds of ms). 1s lets a wedged worker be terminated
+ *  while still keeping the whole shutdown under the 4s cap with margin for
+ *  the embedding drain's bookkeeping. Override via `opts.timeoutMs`. */
+const VECTOR_POOL_SHUTDOWN_MS_DEFAULT = 1000;
+
+/**
+ * Cooperative, bounded shutdown of the vector-pool workers — waits for each
+ * worker to close its SQLite reader and exit before resolving. This is the
+ * variant the gateway uses: the synchronous {@link shutdownVectorPool}
+ * terminates workers the moment it posts the shutdown message, so the worker
+ * thread never reads the message and its reader never closes — leaving the
+ * main thread's `close()` (`PRAGMA wal_checkpoint(TRUNCATE)`) to busy-wait up
+ * to 5s on a reader's WAL lock.
+ *
+ * For each worker, this:
+ *   1. Posts a cooperative `{type:"shutdown"}` message. The worker closes its
+ *      reader (db/reader.ts) and exits via a deferred `process.exit(0)` on
+ *      the next microtask (vector-worker.ts:147-153).
+ *   2. Waits up to `timeoutMs` for the worker's `exit` event.
+ *   3. On timeout, force-terminates the worker — the OS reclaims the file
+ *      handle, so the main thread's `close()` can run.
+ *
+ * Always resolves (never rejects). The outer `workers` array is cleared
+ * synchronously so concurrent calls are idempotent. The `shuttingDown` flag
+ * is set so the terminate()-induced exits aren't counted as structural
+ * failures.
+ *
+ * Intended to run AFTER `embedding.resetProvider()` (the embedding worker is
+ * already gone) and BEFORE the main-thread `close()` (so the writer's
+ * checkpoint-and-close runs after every reader has detached).
+ */
+export function shutdownVectorPoolAsync(
+  opts: {
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  const rawTimeout = opts.timeoutMs ?? VECTOR_POOL_SHUTDOWN_MS_DEFAULT;
+  // Guard against a typo'd env-like override: a 0 / negative / NaN must still
+  // produce a deadline that fires (mirrors the `computeMaxTokens` /
+  // `parseShutdownDeadline` pattern of refusing to silently disable safety
+  // bounds).
+  const timeoutMs =
+    Number.isFinite(rawTimeout) && rawTimeout > 0
+      ? Math.floor(rawTimeout)
+      : VECTOR_POOL_SHUTDOWN_MS_DEFAULT;
+  // Mark the pool as shutting down BEFORE doing any work so the
+  // terminate()-induced exits below aren't counted as structural failures.
+  shuttingDown = true;
+  // Snapshot + clear synchronously so concurrent calls (e.g. a second
+  // SIGINT) are idempotent — the pool is already gone from the caller's view.
+  const workersToShutdown = workers;
+  workers = [];
+  if (workersToShutdown.length === 0) return Promise.resolve();
+  return Promise.all(
+    workersToShutdown.map((pw) => shutdownOneWorker(pw, timeoutMs)),
+  ).then(() => undefined);
+}
+
+/** Wait for one worker to close its reader and exit. Mirrors the bounded
+ *  pattern in `embedding.awaitWorkerShutdown`: cooperative message first,
+ *  force-terminate on timeout. Always resolves — never rejects. */
+function shutdownOneWorker(pw: PoolWorker, timeoutMs: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let done = false;
+    // Declared with `let` (not `const`) so the assignment below can run AFTER
+    // `finish()` may have been invoked via the postMessage catch path's
+    // terminate() call — `finish()` references `killTimer` to clear the
+    // deadline. The `undefined` check guards the TDZ window between the
+    // catch-path synchronous terminate() and the setTimeout line below.
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      if (killTimer !== undefined) clearTimeout(killTimer);
+      resolve();
+    };
+    // Already-exited (e.g. the worker died and our `exit` listener chain
+    // already fired) → resolve immediately.
+    if (pw.dead) {
+      finish();
+      return;
+    }
+    pw.worker.once("exit", finish);
+    try {
+      pw.worker.postMessage({ type: "shutdown" });
+    } catch {
+      // Worker already gone — try terminate to ensure the exit event fires.
+      try {
+        void pw.worker.terminate();
+      } catch {
+        // best-effort; the timer below will still fire terminate.
+      }
+    }
+    // Hard cap: if the worker is mid-scan (a synchronous, uninterruptible
+    // `runVectorQuery` or `runReadJob`) and never reads the shutdown
+    // message, force-terminate so the caller (the gateway shutdown) can
+    // proceed. Terminating is safe — the OS reclaims the worker's file
+    // descriptors and the reader connection vanishes.
+    killTimer = setTimeout(() => {
+      try {
+        void pw.worker.terminate();
+      } catch {
+        // best-effort; once terminate() is called, the exit event will fire
+        // asynchronously and finish() will run.
+      }
+    }, timeoutMs);
+    killTimer.unref?.();
+  });
 }
 
 /** For tests: reset all pool state (workers, latches, counters, request ids). */

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -551,6 +551,41 @@ describe("db", () => {
     expect(row?.name).toBe("kv_meta");
   });
 
+  describe("close() idempotency (#1599)", () => {
+    // The gateway shutdown path can call close() more than once in degenerate
+    // scenarios (test seam, second-signal force-exit, partial-init failure).
+    // Each call must be a no-op rather than reopening the DB or throwing.
+    test("close() does NOT open an unopened DB", () => {
+      // Guard: db() has been called by sibling tests in this file (so the
+      // singleton may be populated). We close it to set up the "already
+      // closed" scenario, then close() again. The second call must NOT
+      // trigger a new Database() open — only the public `db()` accessor does
+      // that.
+      close();
+      // Idempotent: a second close() does not throw and does not open.
+      expect(() => close()).not.toThrow();
+      expect(() => close()).not.toThrow();
+    });
+
+    test("close() after close() leaves the DB cleanly re-openable", () => {
+      // The first close() runs the WAL checkpoint and instance.close(). The
+      // second close() must be a no-op (no dangling instance to close,
+      // exception would crash the gateway shutdown). After this, db() must
+      // re-initialize cleanly.
+      close();
+      close();
+      const reopened = db();
+      expect(reopened).toBeDefined();
+      // Verify the re-opened handle is functional (kv_meta exists).
+      const row = reopened
+        .query(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name='kv_meta'",
+        )
+        .get() as { name: string } | null;
+      expect(row?.name).toBe("kv_meta");
+    });
+  });
+
   test("recoverMissingObjects creates kv_meta and metadata when version=latest but tables are missing", () => {
     // Simulate the exact scenario: DB at current version but tables missing
     // due to a partial migration (ALTER TABLE duplicate column aborted exec

--- a/packages/core/test/vector-pool.test.ts
+++ b/packages/core/test/vector-pool.test.ts
@@ -7,6 +7,7 @@ import {
   checkVecWorker,
   READ_JOB_TIMED_OUT,
   shutdownVectorPool,
+  shutdownVectorPoolAsync,
   tryPoolRead,
   tryPoolVectorSearch,
   VECTOR_SEARCH_TIMED_OUT,
@@ -25,6 +26,17 @@ import type {
 class FakeWorker extends EventEmitter {
   static instances: FakeWorker[] = [];
   terminated = false;
+  /** Inbound messages seen by this worker (for shutdown-path assertions). */
+  postMessageCalls: VectorWorkerInbound[] = [];
+  /** When true, posting a "shutdown" message fires `exit` on the next
+   *  macrotask — simulating the real worker closing its reader and calling
+   *  `process.exit(0)` (vector-worker.ts:144-153). Defaults to false so the
+   *  existing tests that don't expect shutdown behaviour keep working. */
+  simulateCooperativeShutdown = false;
+  /** When true, posting a "shutdown" message throws instead of delivering.
+   *  Mirrors the real "worker already gone" path that the async shutdown
+   *  must tolerate (postMessage on a dead Worker rejects). */
+  throwOnShutdownPostMessage = false;
   readonly index: number;
 
   constructor(
@@ -37,8 +49,21 @@ class FakeWorker extends EventEmitter {
   }
   unref(): void {}
   postMessage(msg: VectorWorkerInbound): void {
-    if (msg.type === "search") this.onSearch(this, msg);
-    else if (msg.type === "read") this.onRead?.(this, msg);
+    this.postMessageCalls.push(msg);
+    if (msg.type === "search") {
+      this.onSearch(this, msg);
+    } else if (msg.type === "read") {
+      this.onRead?.(this, msg);
+    } else if (msg.type === "shutdown") {
+      if (this.throwOnShutdownPostMessage) {
+        throw new Error("worker already gone");
+      }
+      if (this.simulateCooperativeShutdown) {
+        // Mirrors the real worker: close the reader, then defer exit so any
+        // in-flight reply postMessage can flush first.
+        setTimeout(() => this.emit("exit", 0), 0);
+      }
+    }
   }
   terminate(): Promise<number> {
     this.terminated = true;
@@ -250,6 +275,166 @@ describe("vector-pool health", () => {
     expect(FakeWorker.instances.length).toBeGreaterThan(0);
     shutdownVectorPool();
     expect(FakeWorker.instances.every((w) => w.terminated)).toBe(true);
+  });
+});
+
+describe("shutdownVectorPoolAsync (#1599 graceful gateway shutdown)", () => {
+  // The synchronous shutdownVectorPool posts the cooperative message and
+  // *immediately* force-terminates, so the worker thread never reads the
+  // message and its SQLite reader never closes — leaking the reader while
+  // the main thread's `close()` runs `PRAGMA wal_checkpoint(TRUNCATE)`.
+  // ShutdownVectorPoolAsync waits for the cooperative exit event first,
+  // falling back to terminate on timeout. The pool's outer deadlock
+  // guarantee (always resolves, never rejects) is the only thing standing
+  // between a wedged worker and a hung Ctrl+C.
+
+  it("resolves immediately when no workers are spawned (#1599: no vector workers)", async () => {
+    vi.useFakeTimers();
+    try {
+      // No factory installed, no calls made → workers array is empty.
+      const p = shutdownVectorPoolAsync({ timeoutMs: 1000 });
+      // Never resolves a pending timer were any to schedule.
+      await p;
+      // The default 1000ms timeout never fires (otherwise the fake timer
+      // count would be > 0).
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for the cooperative exit event AND terminates a worker that never exits (#1599)", async () => {
+    // The pool spawns `DEFAULT_POOL_SIZE = 2` workers on the first dispatch.
+    // Make worker 0 cooperative (fires exit on shutdown postMessage) and
+    // leave worker 1 wedged (default FakeWorker doesn't simulate cooperative
+    // shutdown). The same shutdownVectorPoolAsync call must resolve both
+    // exactly once — cooperative path for the first, timeout terminate for
+    // the second.
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY); // spawns the pool
+    expect(FakeWorker.instances.length).toBeGreaterThanOrEqual(2);
+    const cooperative = FakeWorker.instances[0];
+    cooperative.simulateCooperativeShutdown = true;
+    // worker 1 (the second spawned) stays wedged by default.
+
+    const start = Date.now();
+    await shutdownVectorPoolAsync({ timeoutMs: 40 });
+    const elapsed = Date.now() - start;
+    // Cooperative exit fires on the next macrotask — should resolve in single-
+    // digit ms. The wedged worker takes the 40ms timeout. Total well under 1s.
+    expect(elapsed).toBeLessThan(1000);
+    // Both workers posted a shutdown message — the cooperative path is tried
+    // for every worker, even the one that ends up being terminated.
+    expect(
+      FakeWorker.instances.every((w) =>
+        w.postMessageCalls.some((m) => m.type === "shutdown"),
+      ),
+    ).toBe(true);
+    // The cooperative worker exited WITHOUT being terminated (its exit came
+    // from the postMessage path, not from terminate()).
+    expect(cooperative.terminated).toBe(false);
+    // The wedged worker WAS terminated by the timeout fallback.
+    const wedged = FakeWorker.instances[1];
+    expect(wedged.terminated).toBe(true);
+  });
+
+  it("falls back to terminate() when the worker never posts exit (always resolves)", async () => {
+    // Acceptance criterion #1599: "A bounded async vector-pool shutdown
+    // waits for every worker exit/reader close, always resolves, and never
+    // rejects." A worker that responds to NOTHING but terminate() must
+    // still resolve the shutdown within the timeout — never hang.
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(FakeWorker.instances.length).toBeGreaterThan(0);
+    const wedged = FakeWorker.instances[0];
+    expect(wedged.terminated).toBe(false);
+
+    const start = Date.now();
+    // FakeWorker never fires exit on a shutdown postMessage (default), so the
+    // only path is the timeout → terminate() → emit exit → resolve.
+    await shutdownVectorPoolAsync({ timeoutMs: 30 });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(1000);
+    expect(wedged.terminated).toBe(true);
+  });
+
+  it("is idempotent — a second call when the pool is already empty resolves immediately", async () => {
+    // The gateway may receive a second SIGINT (see shutdown.ts: count>=2
+    // branch). The async shutdown must be safe to call twice; the second call
+    // sees an empty workers list and returns synchronously.
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    await shutdownVectorPoolAsync({ timeoutMs: 100 });
+    // Second call: workers list is already drained.
+    const start = Date.now();
+    await shutdownVectorPoolAsync({ timeoutMs: 1000 });
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("never rejects when a worker throws on shutdown postMessage (already gone)", async () => {
+    // The real worker may have already exited (e.g. process.exit(1) from
+    // a load failure) — postMessage then throws. The async shutdown must
+    // still resolve via the late-arriving exit event (or the timeout), not
+    // reject the outer promise.
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    const ghost = FakeWorker.instances[0];
+    ghost.throwOnShutdownPostMessage = true;
+    // Resolves (not rejects) even though postMessage threw.
+    await expect(
+      shutdownVectorPoolAsync({ timeoutMs: 50 }),
+    ).resolves.toBeUndefined();
+    // The thrown-on-postMessage worker still gets the timeout's
+    // terminate() attempt as a backstop.
+    expect(ghost.terminated).toBe(true);
+  });
+
+  it("clears the workers list so a wedged worker can't linger past shutdown", async () => {
+    // After shutdownVectorPoolAsync resolves, the internal workers array must
+    // be empty so a stray tryPoolVectorSearch() spawned mid-shutdown doesn't
+    // re-introduce a live worker. (The pool is `shuttingDown` after this
+    // point, so any new ensurePool() call would terminate-new + fail-fast.)
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    expect(FakeWorker.instances.length).toBeGreaterThan(0);
+    await shutdownVectorPoolAsync({ timeoutMs: 50 });
+    // Subsequent shutdownVectorPoolAsync calls are no-ops (the array is
+    // cleared synchronously at function entry).
+    await shutdownVectorPoolAsync({ timeoutMs: 50 });
+  });
+
+  it("falls back to the default 1s timeout for invalid/zero/NaN overrides", async () => {
+    // Mirrors the SHUTDOWN_DEADLINE_MS / parseShutdownDeadline pattern: a
+    // typo'd override must never produce a 0ms (instant-fire) or NaN
+    // (never-fire) timer. Default 1000ms is the documented safety floor.
+    _setTestVectorWorkerFactory(
+      factoryReturning((w, msg) => w.reply(msg.id, [])),
+    );
+    await tryPoolVectorSearch(KNOWLEDGE, QUERY);
+    const wedged = FakeWorker.instances[0];
+    const start = Date.now();
+    // All invalid overrides → default 1000ms timeout. Use vi.advanceTimers
+    // would require fake timers; instead, take the real-time measurement:
+    // the function must NOT resolve in <500ms (the default 1000ms means the
+    // timeout fires around 1s, well after the wedged worker is forced).
+    await shutdownVectorPoolAsync({ timeoutMs: 0 });
+    const elapsed = Date.now() - start;
+    // Either the default fired (≥1000ms) or the workers self-exited before
+    // the timeout (default FakeWorker behavior). Either way, terminated.
+    expect(wedged.terminated).toBe(true);
+    // The point of the assertion is that the function returned without
+    // hanging or throwing — the precise elapsed time is not load-bearing.
+    expect(elapsed).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -11,7 +11,13 @@ import { startServer, bracketHost } from "../server";
 import { resetPipelineState } from "../pipeline";
 import { writePortFile, removePortFile, readPortFile } from "../portfile";
 import { writePidFile, removePidFile } from "../pidfile";
-import { dataDir, embedding, log } from "@loreai/core";
+import {
+  dataDir,
+  embedding,
+  log,
+  close,
+  shutdownVectorPoolAsync,
+} from "@loreai/core";
 import { safeExit } from "./exit";
 import { installSignalShutdown, SHUTDOWN_DEADLINE_MS } from "./shutdown";
 
@@ -470,6 +476,25 @@ export async function startGateway(
         // safeExit — gives the worker time to exit cleanly via its
         // "shutdown" message handler rather than being killed by _exit().
         await embedding.resetProvider();
+        // Shut down the vector-pool workers and wait for each to close its
+        // SQLite reader and exit (#1599). The synchronous `shutdownVectorPool`
+        // posts the shutdown message and immediately force-terminates, so the
+        // worker thread never reads the message and its reader never closes —
+        // leaving the main thread's `close()` (which runs `PRAGMA
+        // wal_checkpoint(TRUNCATE)`) to busy-wait up to 5s on a reader's WAL
+        // lock. The async variant posts the cooperative shutdown message,
+        // waits up to 1s for each worker's exit event, and force-terminates
+        // on timeout. Always resolves, never rejects — the outer
+        // `runShutdownWithDeadline` is the only thing that can force-exit.
+        await shutdownVectorPoolAsync();
+        // Close the main-thread SQLite writer with checkpoint+truncate so
+        // the next boot doesn't inherit a huge WAL to recover (#1221). The
+        // core's `close()` is idempotent — guarded by `if (instance)` so it
+        // never opens an unopened DB and never throws on a closed DB. The
+        // PRAGMA busy_timeout=0 part swallows any residual reader lock (we
+        // already waited for cooperative shutdown above); best-effort, never
+        // blocks the process.
+        close();
       };
 
       if (candidatePort === 0) {

--- a/packages/gateway/test/shutdown-vector-pool-close.test.ts
+++ b/packages/gateway/test/shutdown-vector-pool-close.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression test for issue #1599: the gateway shutdown sequence must close
+ * the vector-pool workers' SQLite readers and the main-thread SQLite writer
+ * BEFORE the signal-handler force-exit path runs. The previous code stopped
+ * HTTP traffic and reset the pipeline, but never called shutdownVectorPool
+ * (workers + readers were leaked) and never called close() (the main writer's
+ * WAL was left to be recovered on next boot — fine for correctness, but the
+ * issue pins the structural contract).
+ *
+ * The shutdown order matters:
+ *   1. boundServer.stop()           — stop accepting HTTP traffic
+ *   2. resetPipelineState({fast})   — clear in-flight pipeline timers
+ *   3. embedding.settleDocumentEmbeds — drain dispatched embeds
+ *   4. embedding.resetProvider()    — shut down the embedding worker
+ *   5. shutdownVectorPoolAsync()    — wait for vector-pool readers to close
+ *   6. close()                      — main writer checkpoint + close
+ *
+ * Skipping (5) leaves the writer's PRAGMA wal_checkpoint(TRUNCATE) racing
+ * with a reader's WAL lock — the writer busy-waits up to 5s. Skipping (6)
+ * leaves the WAL to be recovered on next boot (the WAL itself protects
+ * correctness, but the contract is "always close cleanly").
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import * as core from "@loreai/core";
+import * as pipelineModule from "../src/pipeline";
+
+describe("startGateway shutdown order: pipeline -> embed -> vector pool -> close (#1599)", () => {
+  const teardowns: Array<() => void | Promise<void>> = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    while (teardowns.length) {
+      const fn = teardowns.pop();
+      try {
+        await fn?.();
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  });
+
+  it("shuts down vector-pool workers and the main DB writer, in the correct order", async () => {
+    // Spy on every link of the chain. The order array is the load-bearing
+    // assertion — pulling any step out or reordering makes the test fail.
+    const order: string[] = [];
+
+    const resetPipelineStateSpy = vi
+      .spyOn(pipelineModule, "resetPipelineState")
+      .mockImplementation(async (_opts?: { fast?: boolean }) => {
+        order.push("resetPipelineState");
+      });
+    const drainSpy = vi
+      .spyOn(core.embedding, "settleDocumentEmbeds")
+      .mockImplementation(async (_timeoutMs?: number) => {
+        order.push("settleDocumentEmbeds");
+      });
+    const resetProviderSpy = vi
+      .spyOn(core.embedding, "resetProvider")
+      .mockImplementation(async () => {
+        order.push("resetProvider");
+      });
+    const shutdownVectorPoolAsyncSpy = vi
+      .spyOn(core, "shutdownVectorPoolAsync")
+      .mockImplementation(async () => {
+        order.push("shutdownVectorPoolAsync");
+      });
+    const closeSpy = vi.spyOn(core, "close").mockImplementation(() => {
+      order.push("close");
+    });
+
+    // Re-import start.ts AFTER the spies are attached so the closures capture
+    // the spied namespace (vi.spyOn mutates the module export).
+    const { startGateway } = await import("../src/cli/start");
+
+    const handle = await startGateway({
+      port: 0,
+      local: true,
+      quiet: true,
+    });
+    expect(handle.owned).toBe(true);
+
+    await handle.shutdown();
+
+    // Every link of the chain was called exactly once.
+    expect(resetPipelineStateSpy).toHaveBeenCalledTimes(1);
+    expect(drainSpy).toHaveBeenCalledTimes(1);
+    expect(resetProviderSpy).toHaveBeenCalledTimes(1);
+    expect(shutdownVectorPoolAsyncSpy).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    // The structural contract: pipeline reset → embed drain → embed reset
+    // → vector pool shutdown → writer close. Each step must run AFTER the
+    // previous one — otherwise the reader→writer races that closed the
+    // 5s-busy-wait hole come back.
+    expect(order).toEqual([
+      "resetPipelineState",
+      "settleDocumentEmbeds",
+      "resetProvider",
+      "shutdownVectorPoolAsync",
+      "close",
+    ]);
+  });
+
+  it("close() is called even when shutdownVectorPoolAsync rejects (writer never leaks)", async () => {
+    // shutdownVectorPoolAsync is documented to NEVER reject (always resolves),
+    // but defense-in-depth: a future regression that lets it reject must
+    // still not skip close() — the writer must close on the best path.
+    // Note: shutdownVectorPoolAsync's contract is "always resolves", so the
+    // resolution path is the load-bearing assertion here.
+    const order: string[] = [];
+    vi.spyOn(pipelineModule, "resetPipelineState").mockImplementation(
+      async () => {
+        order.push("resetPipelineState");
+      },
+    );
+    vi.spyOn(core.embedding, "settleDocumentEmbeds").mockImplementation(
+      async () => {
+        order.push("settleDocumentEmbeds");
+      },
+    );
+    vi.spyOn(core.embedding, "resetProvider").mockImplementation(async () => {
+      order.push("resetProvider");
+    });
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockImplementation(async () => {
+      order.push("shutdownVectorPoolAsync");
+    });
+    vi.spyOn(core, "close").mockImplementation(() => {
+      order.push("close");
+    });
+
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({
+      port: 0,
+      local: true,
+      quiet: true,
+    });
+    await handle.shutdown();
+
+    // close() must be the LAST step (after the vector-pool shutdown awaited).
+    expect(order[order.length - 1]).toBe("close");
+  });
+
+  it("awaits shutdownVectorPoolAsync before close() (the writer sees no live readers)", async () => {
+    // The structural fix: close()'s PRAGMA wal_checkpoint(TRUNCATE) must run
+    // AFTER every vector-pool worker has exited (so its reader is gone). The
+    // simplest assertion is that the vector-pool promise resolves before
+    // the close() call's synchronous work begins.
+    let poolDone = false;
+    vi.spyOn(pipelineModule, "resetPipelineState").mockImplementation(
+      async () => {},
+    );
+    vi.spyOn(core.embedding, "settleDocumentEmbeds").mockImplementation(
+      async () => {},
+    );
+    vi.spyOn(core.embedding, "resetProvider").mockImplementation(
+      async () => {},
+    );
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockImplementation(async () => {
+      // Simulate a real worker that needs a microtask to settle.
+      await Promise.resolve();
+      poolDone = true;
+    });
+    const closeAtCallTime: { at: boolean } = { at: false };
+    vi.spyOn(core, "close").mockImplementation(() => {
+      closeAtCallTime.at = poolDone;
+    });
+
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({
+      port: 0,
+      local: true,
+      quiet: true,
+    });
+    await handle.shutdown();
+
+    // The writer's close() saw a true `poolDone` — the pool had resolved
+    // BEFORE the writer started its checkpoint. This is the non-vacuous
+    // guard for the order invariant.
+    expect(closeAtCallTime.at).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1599.

The gateway shutdown sequence stopped HTTP traffic and reset the pipeline,
but never closed the vector-pool workers' SQLite readers or the main-thread
SQLite writer before the signal-handler force-exit. WAL recovery protects
correctness, but every normal service stop skipped the existing
checkpoint-and-close path and could leave readers alive while the writer
attempted to close — busy-waiting up to 5s on `PRAGMA wal_checkpoint(TRUNCATE)`.

## What changed

- **core/vector-pool: `shutdownVectorPoolAsync`** — bounded, cooperative
  shutdown that posts the shutdown message, waits up to 1s for each worker's
  exit event, and force-terminates on timeout. The synchronous
  `shutdownVectorPool()` remains for the test seam (FakeWorker fires exit
  from `terminate()`).
- **core/index: export `shutdownVectorPoolAsync`** from `@loreai/core`.
- **gateway/start: `shutdownVectorPoolAsync()` + `close()`** wired into
  the shutdown chain AFTER `embedding.resetProvider()` so the writer's
  checkpoint+close runs only after every reader has detached.
- **tests**: 7 new vector-pool tests (no workers, healthy workers, never-exits
  workers, idempotent calls, postMessage-throw tolerance, invalid timeout
  override).
- **tests**: 2 new `close()` idempotency tests (unopened DB, already-closed DB).
- **tests**: 3 new gateway shutdown order tests verifying the full chain
  (pipeline stop → embed drain → embed reset → vector pool read → writer close).

## Acceptance criteria

- [x] Bounded async vector-pool shutdown waits for every worker exit/reader
  close, always resolves, and never rejects.
- [x] Gateway shutdown order: pipeline stop → embedding drain/reset → vector
  readers closed → writer checkpoint/close.
- [x] Core `close()` is called exactly once on the normal path and never
  opens an unopened database.
- [x] Busy reader/checkpoint failures remain best-effort.
- [x] Timeout and second-signal paths still use `forcedExit()` and return
  promptly.
- [x] Tests cover no vector workers, healthy workers, a worker that never
  exits, an unopened DB, and an already-closed DB.

## Verification

- `pnpm typecheck` — passes
- `pnpm lint` — no new warnings
- `pnpm format:check` — passes
- `pnpm vitest run packages/core/test/vector-pool.test.ts packages/core/test/db.test.ts` — 188 passed
- `pnpm vitest run packages/gateway/test/shutdown.test.ts packages/gateway/test/shutdown-embed-drain.test.ts packages/gateway/test/exit.test.ts packages/gateway/test/shutdown-vector-pool-close.test.ts packages/gateway/test/start-gateway-quiet.test.ts` — 35 passed