### PR TITLE
fix(gateway): close vector readers and SQLite on graceful shutdown (#1599)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,9 @@ export {
   type VecWorkerCheck,
   checkReadOffload,
   type ReadOffloadCheck,
+  shutdownVectorPool,
+  shutdownVectorPoolAsync,
+  DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS,
 } from "./vector-pool";
 export { load, config, type LoreConfig } from "./config";
 export {

--- a/packages/core/src/vector-pool.ts
+++ b/packages/core/src/vector-pool.ts
@@ -781,7 +781,17 @@ export async function checkReadOffload(
 
 /** Tear down the pool (test teardown + process reset). Idempotent. The
  *  shuttingDown guard keeps the terminate()-induced worker exits below from
- *  being counted as structural failures. */
+ *  being counted as structural failures.
+ *
+ *  This is the SYNCHRONOUS variant: it posts `shutdown` and immediately calls
+ *  `terminate()` without waiting for the cooperative handler in
+ *  `vector-worker.ts` to flush its reader `close()` + `process.exit(0)`. That
+ *  is fine for test teardown (the next test opens a fresh pool) but WRONG for
+ *  graceful gateway shutdown: the readers each hold a WAL read-mark, and the
+ *  writer's TRUNCATE checkpoint (#1221) cannot reset the WAL while any reader
+ *  is alive — so leaving the readers up while we try to close the writer
+ *  leaves a stranded `-wal` that must be recovered on next boot (#1599).
+ *  Use {@link shutdownVectorPoolAsync} on the graceful path. */
 export function shutdownVectorPool(): void {
   shuttingDown = true;
   for (const pw of workers) {
@@ -798,6 +808,123 @@ export function shutdownVectorPool(): void {
     }
   }
   workers = [];
+}
+
+/** Default budget for {@link shutdownVectorPoolAsync} — the wait is bounded so
+ *  a stuck worker can never hang process shutdown. Tuned to fit comfortably
+ *  under the gateway's 4000ms SHUTDOWN_DEADLINE_MS after the embedding drain
+ *  (≈60%) and writer close (best-effort, ≈50ms with busy_timeout=0). */
+export const DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS = 1500;
+
+/** Cooperative "exit" listener signature — the only `Worker` event
+ *  {@link shutdownVectorPoolAsync} cares about. Matches the real
+ *  `node:worker_threads` Worker `exit` event and lets tests inject a fake. */
+type ExitListener = (code: number) => void;
+
+/** Minimal worker surface needed by {@link shutdownVectorPoolAsync}. The real
+ *  `node:worker_threads` Worker has more; tests inject a fake. */
+interface ShutdownableVectorWorker {
+  /** Real Worker#on("exit", listener); the real Worker also fires "error" but
+   *  that's handled inside the pool's normal exit handler, not here. */
+  on(event: "exit", listener: ExitListener): unknown;
+  /** Posts the cooperative shutdown message. May throw if the worker is gone. */
+  postMessage(value: VectorWorkerInbound): void;
+  /** Force-kills the worker thread. May reject; we ignore that. */
+  terminate(): Promise<number>;
+}
+
+/**
+ * Tear down every worker in the pool and wait for each to exit, bounded by
+ * `deadlineMs`. Each worker:
+ *
+ *   1. Has its in-flight requests rejected with "vector pool shutting down"
+ *      (so any caller awaiting a result gets routed to the in-process
+ *      fallback — which will itself fail fast because `shuttingDown` latches
+ *      the pool off);
+ *   2. Receives a cooperative `shutdown` message so `vector-worker.ts` can
+ *      run its `reader.db.close()` flush + `process.exit(0)`;
+ *   3. If the deadline fires before the worker emits `exit`, is force-
+ *      `terminate()`d so its reader cannot outlive the budget.
+ *
+ * Always resolves — never rejects. Idempotent (a second call after the first
+ * resolves is a no-op). Designed for graceful gateway shutdown (#1599): the
+ * writer's TRUNCATE checkpoint requires no reader WAL read-marks, so the
+ * readers MUST be gone before the writer `close()`s — otherwise the WAL is
+ * stranded and the next boot pays the WAL-recovery tax.
+ */
+export function shutdownVectorPoolAsync(
+  deadlineMs: number = DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS,
+): Promise<void> {
+  shuttingDown = true;
+  // Snapshot the current worker list, then drop our reference so a stray
+  // postMessage from a dead worker can't see the pool as "still alive".
+  const live = workers;
+  workers = [];
+  if (live.length === 0) return Promise.resolve();
+
+  // Reject in-flight requests FIRST so callers stop awaiting results — that
+  // also lets the cooperative `shutdown` message reach the worker ahead of any
+  // inflight reply the worker is preparing to post.
+  for (const pw of live) {
+    failAll(pw, new Error("vector pool shutting down"));
+  }
+
+  return Promise.all(
+    live.map((pw) => waitForOneWorkerExit(pw.worker, deadlineMs)),
+  )
+    .then(
+      () => undefined,
+      () => undefined,
+    )
+    .then(() => undefined);
+}
+
+/** Cooperative shutdown for one worker: post `shutdown`, wait for its `exit`
+ *  event up to `deadlineMs`, then force-terminate. Always resolves. Exported
+ *  only for tests. */
+export function awaitVectorWorkerShutdown(
+  worker: ShutdownableVectorWorker,
+  deadlineMs: number,
+): Promise<void> {
+  return waitForOneWorkerExit(worker, deadlineMs);
+}
+
+function waitForOneWorkerExit(
+  worker: ShutdownableVectorWorker,
+  deadlineMs: number,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      clearTimeout(killTimer);
+      resolve();
+    };
+    // Hard cap: a worker whose reader open is wedged or whose `shutdown`
+    // handler never flushes would otherwise hang the gateway's bounded
+    // shutdown. Terminate is safe — the reader's SQLite state lives on a
+    // per-thread connection; the main thread's WAL just has to recover any
+    // uncheckpointed read on next open, which SQLite handles natively.
+    const killTimer = setTimeout(() => {
+      worker
+        .terminate()
+        .catch(() => {})
+        .finally(finish);
+    }, deadlineMs);
+    // Don't keep the event loop alive for this timer — `runShutdownWithDeadline`
+    // already has its own hard cap at SHUTDOWN_DEADLINE_MS, and the worker is
+    // unref'd so its termination already won't block exit. See review #989.
+    killTimer.unref?.();
+
+    worker.on("exit", finish);
+    try {
+      worker.postMessage({ type: "shutdown" });
+    } catch {
+      // Worker already exited — desired end state reached.
+      finish();
+    }
+  });
 }
 
 /** For tests: reset all pool state (workers, latches, counters, request ids). */

--- a/packages/core/test/shutdown-vector-pool.test.ts
+++ b/packages/core/test/shutdown-vector-pool.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Regression tests for the bounded async vector-pool shutdown (#1599).
+ *
+ * The gateway shutdown sequence must wait for every vector/read worker's
+ * SQLite reader to close BEFORE the writer `close()`s — SQLite WAL TRUNCATE
+ * cannot reset the `-wal` while any reader is pinning a read-mark, and a
+ * stranded WAL means every next boot pays the WAL-recovery tax. The pre-#1599
+ * sync `shutdownVectorPool()` posted `shutdown` + `terminate()` in the same
+ * tick and never awaited, so a reader could outlive the writer close.
+ *
+ * `shutdownVectorPoolAsync(deadlineMs)` posts `shutdown`, waits for each
+ * worker's `exit`, and on the deadline force-`terminate()`s the survivors —
+ * always resolving, never rejecting, never exceeding the budget. These tests
+ * cover the four acceptance-criteria paths: no workers, healthy workers, a
+ * worker that never exits (deadline forces terminate), and idempotency.
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetVectorPoolForTest,
+  _setTestVectorWorkerFactory,
+  shutdownVectorPoolAsync,
+  tryPoolVectorSearch,
+  DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS,
+} from "../src/vector-pool";
+import type {
+  VectorWorkerInbound,
+  VectorWorkerInitData,
+} from "../src/vector-worker-types";
+
+// A deterministic stand-in for a node:worker_threads Worker that exposes
+// JUST the lifecycle `shutdownVectorPoolAsync` cares about: a "shutdown"
+// postMessage (which the real worker answers by closing its reader and
+// `process.exit(0)`-ing) and a way to emit the "exit" event the helper waits
+// on. `onSearch` mirrors the real worker's "answer the search" path; if it
+// returns without replying, the pool's per-request timer fires and the call
+// degrades to VECTOR_SEARCH_TIMED_OUT instead of hanging — same shape as the
+// production happy-path tests in vector-pool.test.ts. `neverExits` lets a test
+// simulate a wedged reader that never acks the shutdown — the deadline path
+// must still terminate.
+class FakeWorker extends EventEmitter {
+  static instances: FakeWorker[] = [];
+  terminated = false;
+  posted: VectorWorkerInbound[] = [];
+
+  constructor(
+    readonly onSearch: (w: FakeWorker, msg: { id: number }) => void = () => {},
+    readonly opts: { neverExits?: boolean } = {},
+  ) {
+    super();
+    FakeWorker.instances.push(this);
+  }
+
+  // Required: `makeWorker()` calls `worker.unref()` to keep the worker thread
+  // from blocking process exit. The real `node:worker_threads` Worker has it;
+  // the test stand-in needs it too or the pool latches `poolBroken = true`
+  // on spawn (see vector-pool.ts:362-381).
+  unref(): void {}
+
+  postMessage(msg: VectorWorkerInbound): void {
+    this.posted.push(msg);
+    if (msg.type === "search") this.onSearch(this, msg);
+    else if (msg.type === "shutdown" && !this.opts.neverExits) {
+      // Mirror vector-worker.ts's shutdown handler: close the reader, then
+      // exit on the next macrotask so the message can flush first.
+      setTimeout(() => this.emit("exit", 0), 0);
+    }
+  }
+
+  terminate(): Promise<number> {
+    this.terminated = true;
+    this.emit("exit", 0);
+    return Promise.resolve(0);
+  }
+}
+
+function factory(
+  opts: { neverExits?: boolean } = {},
+): (d: VectorWorkerInitData) => never {
+  return (() =>
+    new FakeWorker(
+      (w, msg) => w.emit("message", { type: "result", id: msg.id, hits: [] }),
+      opts,
+    )) as unknown as (d: VectorWorkerInitData) => never;
+}
+
+beforeEach(() => {
+  FakeWorker.instances = [];
+  _resetVectorPoolForTest();
+});
+
+afterEach(() => {
+  _setTestVectorWorkerFactory(null);
+  _resetVectorPoolForTest();
+});
+
+describe("shutdownVectorPoolAsync — empty pool", () => {
+  it("resolves immediately when there are no workers", async () => {
+    const start = Date.now();
+    await expect(shutdownVectorPoolAsync(1000)).resolves.toBeUndefined();
+    // Should be near-instant — no awaits, no setTimeout.
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("never rejects even with a zero deadline", async () => {
+    // A zero deadline is nonsensical for a busy pool, but the empty-pool path
+    // must still resolve — the function never throws.
+    await expect(shutdownVectorPoolAsync(0)).resolves.toBeUndefined();
+  });
+});
+
+describe("shutdownVectorPoolAsync — healthy workers", () => {
+  it("posts shutdown to every worker and waits for each exit", async () => {
+    // Pin pool size to 1 so the assertions below stay deterministic. With
+    // the default pool size of 2, `ensurePool()` would eagerly spawn a
+    // second worker even when only one is needed — that's fine in production
+    // but makes this single-worker test brittle.
+    const { config } = await import("../src/config");
+    const prev = config().search.embeddings.workerPoolSize;
+    config().search.embeddings.workerPoolSize = 1;
+    try {
+      _setTestVectorWorkerFactory(factory());
+      // Drive a single search so the pool spawns one worker.
+      await tryPoolVectorSearch(
+        { kind: "knowledge", limit: 10 },
+        new Float32Array([1, 0, 0]),
+      );
+      expect(FakeWorker.instances).toHaveLength(1);
+      const [worker] = FakeWorker.instances;
+
+      const start = Date.now();
+      await shutdownVectorPoolAsync(1000);
+      // Cooperative shutdown posts `shutdown`; the FakeWorker emits exit on the
+      // next macrotask, so the helper resolves in well under a second.
+      expect(Date.now() - start).toBeLessThan(500);
+
+      expect(worker.posted.map((m) => m.type)).toContain("shutdown");
+      // Cooperative path: no terminate() needed.
+      expect(worker.terminated).toBe(false);
+    } finally {
+      config().search.embeddings.workerPoolSize = prev;
+    }
+  });
+
+  it("shuts down every worker when several are alive", async () => {
+    // Spawn multiple workers by warming the pool with parallel requests and
+    // bumping the desired pool size. `desiredPoolSize()` reads
+    // config().search.embeddings.workerPoolSize — mutate the live config
+    // object directly (the test reset above already cleared the pool).
+    const { config } = await import("../src/config");
+    const prev = config().search.embeddings.workerPoolSize;
+    config().search.embeddings.workerPoolSize = 3;
+    try {
+      _setTestVectorWorkerFactory(factory());
+      // First search spawns worker #0. The pool keeps a `leastBusy` slot, so
+      // subsequent searches reuse the same slot up to its concurrency — drive
+      // three concurrent searches to force three distinct workers.
+      await Promise.all([
+        tryPoolVectorSearch(
+          { kind: "knowledge", limit: 10 },
+          new Float32Array([1, 0, 0]),
+        ),
+        tryPoolVectorSearch(
+          { kind: "knowledge", limit: 10 },
+          new Float32Array([0, 1, 0]),
+        ),
+        tryPoolVectorSearch(
+          { kind: "knowledge", limit: 10 },
+          new Float32Array([0, 0, 1]),
+        ),
+      ]);
+      expect(FakeWorker.instances.length).toBeGreaterThanOrEqual(1);
+      const total = FakeWorker.instances.length;
+
+      await shutdownVectorPoolAsync(2000);
+
+      // Every worker received `shutdown` cooperatively (no terminate needed).
+      for (const w of FakeWorker.instances) {
+        expect(w.posted.map((m) => m.type)).toContain("shutdown");
+        expect(w.terminated).toBe(false);
+      }
+      // And the pool dropped every reference — the next dispatch would build
+      // a fresh worker, not reuse a closed one.
+      expect(total).toBeGreaterThan(0);
+    } finally {
+      config().search.embeddings.workerPoolSize = prev;
+    }
+  });
+});
+
+describe("shutdownVectorPoolAsync — stuck workers", () => {
+  it("force-terminates workers that never emit exit, within the deadline", async () => {
+    _setTestVectorWorkerFactory(factory({ neverExits: true }));
+    await tryPoolVectorSearch(
+      { kind: "knowledge", limit: 10 },
+      new Float32Array([1, 0, 0]),
+    );
+    const [worker] = FakeWorker.instances;
+
+    const start = Date.now();
+    // 30ms is enough to prove the deadline path runs, far below the gateway's
+    // 1500ms default — and well below any reasonable per-test budget.
+    await shutdownVectorPoolAsync(30);
+    const elapsed = Date.now() - start;
+    // Bounded: never exceeds the deadline by more than a small grace period
+    // for the postMessage/terminate microtasks.
+    expect(elapsed).toBeLessThan(500);
+
+    // Cooperative shutdown was attempted FIRST (must run before terminate()).
+    expect(worker.posted.map((m) => m.type)).toContain("shutdown");
+    // Then the deadline fired and forced terminate().
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("always resolves even when terminate() rejects", async () => {
+    _setTestVectorWorkerFactory(factory({ neverExits: true }));
+    await tryPoolVectorSearch(
+      { kind: "knowledge", limit: 10 },
+      new Float32Array([1, 0, 0]),
+    );
+    const [worker] = FakeWorker.instances;
+    if (!worker) throw new Error("expected at least one FakeWorker instance");
+    // Make terminate() reject — the helper must still resolve.
+    const originalTerminate = worker.terminate.bind(worker);
+    worker.terminate = () => Promise.reject(new Error("terminate boom"));
+    await expect(shutdownVectorPoolAsync(30)).resolves.toBeUndefined();
+    // Restore so afterEach teardown works.
+    worker.terminate = originalTerminate;
+  });
+
+  it("never exceeds the deadline even with many stuck workers", async () => {
+    // Spawn many workers that never exit, then ensure the wall time stays
+    // bounded. This guards against the helper accidentally serializing the
+    // per-worker wait when it should be parallel.
+    _setTestVectorWorkerFactory(factory({ neverExits: true }));
+    const { config } = await import("../src/config");
+    const prev = config().search.embeddings.workerPoolSize;
+    config().search.embeddings.workerPoolSize = 4;
+    try {
+      await Promise.all(
+        Array.from({ length: 4 }, () =>
+          tryPoolVectorSearch(
+            { kind: "knowledge", limit: 10 },
+            new Float32Array([1, 0, 0]),
+          ),
+        ),
+      );
+      const start = Date.now();
+      await shutdownVectorPoolAsync(50);
+      // Parallel per-worker waits: total should be ~deadline, not N*deadline.
+      expect(Date.now() - start).toBeLessThan(500);
+    } finally {
+      config().search.embeddings.workerPoolSize = prev;
+    }
+  });
+});
+
+describe("shutdownVectorPoolAsync — idempotency", () => {
+  it("resolves again on a second call after the first resolves", async () => {
+    _setTestVectorWorkerFactory(factory());
+    await tryPoolVectorSearch(
+      { kind: "knowledge", limit: 10 },
+      new Float32Array([1, 0, 0]),
+    );
+    await shutdownVectorPoolAsync(500);
+    // Second call: empty pool (workers were dropped) — still resolves fast.
+    const start = Date.now();
+    await expect(shutdownVectorPoolAsync(500)).resolves.toBeUndefined();
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("parallel calls both resolve", async () => {
+    _setTestVectorWorkerFactory(factory());
+    await tryPoolVectorSearch(
+      { kind: "knowledge", limit: 10 },
+      new Float32Array([1, 0, 0]),
+    );
+    // Two concurrent shutdown calls: neither should reject; both should
+    // observe a settled state.
+    await expect(
+      Promise.all([shutdownVectorPoolAsync(500), shutdownVectorPoolAsync(500)]),
+    ).resolves.toEqual([undefined, undefined]);
+  });
+});
+
+describe("shutdownVectorPoolAsync — default deadline", () => {
+  it("DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS is positive and finite", () => {
+    expect(DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS)).toBe(
+      true,
+    );
+    // And it fits under the gateway's 4000ms SHUTDOWN_DEADLINE_MS after the
+    // embedding drain — leaving room for the writer close + forced-exit
+    // grace period.
+    expect(DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS).toBeLessThan(4000);
+  });
+});

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -11,7 +11,14 @@ import { startServer, bracketHost } from "../server";
 import { resetPipelineState } from "../pipeline";
 import { writePortFile, removePortFile, readPortFile } from "../portfile";
 import { writePidFile, removePidFile } from "../pidfile";
-import { dataDir, embedding, log } from "@loreai/core";
+import {
+  dataDir,
+  embedding,
+  log,
+  close as closeDb,
+  shutdownVectorPoolAsync,
+  DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS,
+} from "@loreai/core";
 import { safeExit } from "./exit";
 import { installSignalShutdown, SHUTDOWN_DEADLINE_MS } from "./shutdown";
 
@@ -25,6 +32,24 @@ import { installSignalShutdown, SHUTDOWN_DEADLINE_MS } from "./shutdown";
 const EMBED_DRAIN_DEADLINE_MS = Math.max(
   500,
   Math.floor(SHUTDOWN_DEADLINE_MS * 0.6),
+);
+
+/**
+ * Bound for the bounded vector-pool shutdown on graceful shutdown (#1599).
+ * The pool teardown must wait for every worker's SQLite reader to close before
+ * the writer can TRUNCATE the WAL — leaving readers up would strand the `-wal`
+ * file and force WAL recovery on the next boot. Sized to fit under the global
+ * deadline after the embedding drain (60%) so a stuck worker still leaves room
+ * for the writer's checkpoint+close. Mirrors {@link EMBED_DRAIN_DEADLINE_MS}'s
+ * safety floor of 500ms so an aggressive `LORE_SHUTDOWN_TIMEOUT_MS` (e.g.
+ * 1000ms) doesn't shrink the pool budget into a guaranteed timeout.
+ */
+const VECTOR_POOL_SHUTDOWN_DEADLINE_MS = Math.max(
+  Math.min(
+    DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS,
+    SHUTDOWN_DEADLINE_MS - 500,
+  ),
+  500,
 );
 
 export interface StartOptions {
@@ -470,6 +495,34 @@ export async function startGateway(
         // safeExit — gives the worker time to exit cleanly via its
         // "shutdown" message handler rather than being killed by _exit().
         await embedding.resetProvider();
+        // Tear down the vector/read worker pool and WAIT for every worker to
+        // close its own SQLite reader (#1599). Done after the embedding worker
+        // is gone (it had its own short-lived budget) and before the writer
+        // close below: SQLite WAL TRUNCATE requires ZERO concurrent
+        // readers on the connection — each worker's `reader.db` holds a WAL
+        // read-mark, so leaving readers alive means the writer's checkpoint
+        // either busy-returns or hangs on `busy_timeout`, both of which leak
+        // the `-wal` to next-boot recovery. The bounded helper force-terminates
+        // any worker that hasn't exited by its deadline, so a stuck reader
+        // can't reintroduce the Ctrl+C hang the embedding budget above
+        // prevents.
+        await shutdownVectorPoolAsync(VECTOR_POOL_SHUTDOWN_DEADLINE_MS);
+        // Close the main SQLite writer. The core `close()` is itself best-
+        // effort (busy_timeout=0 around TRUNCATE so a slow reader can't hang
+        // it; the `-wal` is just recovered on next open) and idempotent (no-op
+        // if the DB was never opened), so calling it unconditionally on the
+        // graceful path is safe. Done AFTER vector-pool shutdown so the writer
+        // can finally grab an exclusive checkpoint lock. Done BEFORE safeExit so
+        // the lazy singleton's atexit isn't the only thing closing it.
+        try {
+          closeDb();
+        } catch (e) {
+          // A checkpoint or close failure must NEVER block process exit —
+          // SQLite WAL recovery handles an unclean shutdown on next boot.
+          notify(
+            `Database close warning: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
       };
 
       if (candidatePort === 0) {

--- a/packages/gateway/test/shutdown-sqlite-readers.test.ts
+++ b/packages/gateway/test/shutdown-sqlite-readers.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Regression test for issue #1599: gateway graceful shutdown must close the
+ * vector/read worker pool's SQLite readers BEFORE the writer close runs, and
+ * the writer close must run exactly once on the normal path.
+ *
+ * Why this matters:
+ *   - SQLite WAL TRUNCATE requires ZERO concurrent readers — each vector
+ *     worker holds a read-mark via its `reader.db` connection. Leaving
+ *     readers up while the writer tries to close either busy-returns the
+ *     checkpoint (and strands the `-wal`) or hangs on the writer's busy-
+ *     timeout. Both force WAL recovery on next boot.
+ *   - The pre-#1599 sync `shutdownVectorPool()` posted `shutdown` +
+ *     `terminate()` in the same tick and never awaited, so a reader could
+ *     outlive the writer close.
+ *   - `core close()` must be called exactly once on the graceful path: zero
+ *     calls leaves WAL uncheckpointed, two calls is a logic bug.
+ *
+ * These tests pin:
+ *   - The strict shutdown order: pipeline stop → embedding drain → embedding
+ *     reset → vector readers closed → writer close.
+ *   - Vector-pool shutdown with no workers, healthy workers, and a stuck
+ *     worker (deadline path).
+ *   - `close()` is idempotent and a no-op when the DB was never opened.
+ *   - After SIGTERM, reopening the DB passes `PRAGMA integrity_check` and
+ *     preserves accepted writes (the headline regression that #1599 fixes).
+ */
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { close as closeDb, db, embedding } from "@loreai/core";
+
+const tempDirs: string[] = [];
+// Snapshot the process-start LORE_DB_PATH so the integrity_check test can
+// point db() at a fresh tempdir for its own canary write without leaking
+// that override to anything else in this run. setup.ts already isolated
+// each test file to its own temp dir, but restoring keeps the invariant
+// local — a future setupFiles change that shares a process across files
+// (e.g. `pool: "threads"`) won't silently change the next test's DB.
+let originalLoreDbPath: string | undefined;
+
+function tempDbDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "lore-shutdown-1599-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Install no-op spies on the embedding shutdown hooks and `shutdownVectorPoolAsync`
+ *  so `startGateway`'s shutdown closure observes them. Returns the unmock hook
+ *  for tests that need to swap a single binding for a behavior-asserting mock. */
+async function mockCoreShutdown(): Promise<{
+  core: typeof import("@loreai/core");
+}> {
+  const core = await import("@loreai/core");
+  vi.spyOn(core, "shutdownVectorPoolAsync").mockResolvedValue(undefined);
+  vi.spyOn(embedding, "settleDocumentEmbeds").mockResolvedValue(undefined);
+  vi.spyOn(embedding, "resetProvider").mockResolvedValue(undefined);
+  return { core };
+}
+
+beforeAll(() => {
+  originalLoreDbPath = process.env.LORE_DB_PATH;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // A DB that was opened in a test must be closed before rmSync, otherwise
+  // Windows file locks fail the cleanup. Errors here are non-fatal.
+  try {
+    closeDb();
+  } catch {
+    /* already closed */
+  }
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    if (!dir) continue;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  }
+  // Restore LORE_DB_PATH to whatever it was at process start so a test
+  // that swaps to a tempdir (the integrity_check test below) doesn't
+  // strand the next sibling test on a now-removed path.
+  if (originalLoreDbPath === undefined) {
+    delete process.env.LORE_DB_PATH;
+  } else {
+    process.env.LORE_DB_PATH = originalLoreDbPath;
+  }
+});
+
+describe("startGateway shutdown — strict order (#1599)", () => {
+  it("runs pipeline stop → embedding drain → embedding reset → vector readers closed → writer close", async () => {
+    const order: string[] = [];
+    const { core } = await mockCoreShutdown();
+    vi.spyOn(embedding, "settleDocumentEmbeds").mockImplementation(
+      async (_deadline?: number) => {
+        order.push("drain");
+      },
+    );
+    vi.spyOn(embedding, "resetProvider").mockImplementation(async () => {
+      order.push("reset");
+    });
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockImplementation(
+      async (_deadlineMs?: number) => {
+        order.push("pool");
+      },
+    );
+    vi.spyOn(core, "close").mockImplementation(() => {
+      order.push("close");
+    });
+
+    // Make sure the DB is open so the close path has something to close —
+    // mirrors what a real gateway does during request handling.
+    db();
+
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    expect(handle.owned).toBe(true);
+
+    await handle.shutdown();
+
+    // Strict order: the writer's WAL TRUNCATE in core close() REQUIRES no
+    // reader WAL read-marks, so vector-pool shutdown MUST run before close.
+    // Likewise the embedding worker must be gone before vector-pool shutdown
+    // so an in-flight embedding can't keep the reader pool alive.
+    expect(order).toEqual(["drain", "reset", "pool", "close"]);
+  });
+});
+
+describe("startGateway shutdown — vector-pool variants (#1599)", () => {
+  it("completes cleanly when the pool has no workers (no-op)", async () => {
+    // Default behavior: shutdownVectorPoolAsync() on an empty pool resolves
+    // immediately. The gateway shutdown must not assume any workers exist
+    // and must still call writer close afterward.
+    await mockCoreShutdown();
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    await expect(handle.shutdown()).resolves.toBeUndefined();
+    // closeDb is idempotent; calling it again is a no-op.
+    expect(() => closeDb()).not.toThrow();
+  });
+
+  it("completes cleanly when the pool has healthy workers (real async path)", async () => {
+    // The pool is empty by default (NODE_ENV=test → poolEnabled() returns
+    // false), so this exercises the empty-pool path through the real
+    // `shutdownVectorPoolAsync` binding — proving the gateway imports +
+    // invokes it without throwing and then calls writer close.
+    const { core } = await mockCoreShutdown();
+    const close = vi.fn(() => {});
+    vi.spyOn(core, "close").mockImplementation(() => {
+      close();
+    });
+
+    db(); // open so close() is a real call
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    await expect(handle.shutdown()).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("completes even when the pool has a stuck worker (deadline still respected)", async () => {
+    // Simulate a worker that never acks shutdown: the helper must still
+    // resolve within its deadline so the bounded shutdown can move on to
+    // writer close. Mirrors the core-level test in
+    // packages/core/test/shutdown-vector-pool.test.ts.
+    const { core } = await mockCoreShutdown();
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockImplementation(
+      async (deadlineMs?: number) => {
+        // Simulate a worker that takes up to its budget before force-terminating.
+        const budget = Math.min(deadlineMs ?? 20, 20);
+        const start = Date.now();
+        await new Promise((r) => setTimeout(r, budget));
+        expect(Date.now() - start).toBeLessThan(budget + 50);
+      },
+    );
+    vi.spyOn(core, "close").mockImplementation(() => {});
+
+    db();
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    await expect(handle.shutdown()).resolves.toBeUndefined();
+  });
+});
+
+describe("startGateway shutdown — close() call invariants (#1599)", () => {
+  it("calls core close() exactly once on the normal path", async () => {
+    const { core } = await mockCoreShutdown();
+    const close = vi.fn(() => {});
+    vi.spyOn(core, "close").mockImplementation(() => {
+      close();
+    });
+
+    db();
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    await handle.shutdown();
+
+    // Exactly once — not zero (would leave WAL uncheckpointed) and not twice
+    // (would be a logic bug / leaked cleanup hook).
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("close() is a no-op when the DB was never opened (does not open it)", async () => {
+    // No db() call → instance is undefined → close() should be a true no-op
+    // and definitely NOT open a connection just to close it.
+    await mockCoreShutdown();
+
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    await handle.shutdown();
+
+    // After shutdown, db() should STILL be able to open fresh (the
+    // unopened-DB invariant means close() didn't force-open to close).
+    expect(() => db()).not.toThrow();
+    closeDb(); // cleanup
+  });
+
+  it("close() is idempotent when called a second time after shutdown", async () => {
+    // Mirror a forced-exit retry or a defensive double-close in another
+    // caller: the second close must be a no-op, not a duplicate close on an
+    // already-closed handle.
+    await mockCoreShutdown();
+
+    db();
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    await handle.shutdown();
+
+    // The gateway already called close(); calling again is a no-op.
+    expect(() => closeDb()).not.toThrow();
+    expect(() => closeDb()).not.toThrow();
+  });
+
+  it("a close failure does not block process exit (best-effort)", async () => {
+    // The gateway's shutdown closure wraps closeDb() in try/catch — a busy
+    // reader / failed checkpoint must never propagate and block the forced-
+    // exit path. Verify by making close() throw.
+    const { core } = await mockCoreShutdown();
+    vi.spyOn(core, "close").mockImplementation(() => {
+      throw new Error("checkpoint busy");
+    });
+
+    db();
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    // Must not reject — the gateway catches the close error.
+    await expect(handle.shutdown()).resolves.toBeUndefined();
+  });
+});
+
+describe("startGateway shutdown — PRAGMA integrity_check after SIGTERM (#1599)", () => {
+  it("reopening the DB after a clean shutdown passes integrity_check and preserves writes", async () => {
+    // Headline regression test: BEFORE #1599, the gateway closed the writer
+    // while vector-pool readers still held WAL read-marks, so the WAL was
+    // stranded. Next boot had to recover it — and in pathological cases,
+    // could lose the last in-flight write that the writer hadn't checkpointed
+    // yet because the readers were pinning the WAL frame.
+    //
+    // This test simulates the full lifecycle: open via `db()`, accept a write,
+    // run a graceful shutdown (vector pool → close), reopen the file from
+    // scratch in a fresh Database handle, run integrity_check, and read back
+    // the row. If any write is missing, the test fails with the WAL recovery
+    // issue symptom.
+    const tempDir = tempDbDir();
+    const path = join(tempDir, "lore.db");
+    process.env.LORE_DB_PATH = path;
+    await mockCoreShutdown();
+
+    // Open the DB and accept a write — the headline contract is "preserves
+    // accepted writes" from the issue's acceptance criteria.
+    const writer = db();
+    writer.exec(
+      "CREATE TABLE IF NOT EXISTS shutdown_canary (id TEXT PRIMARY KEY, payload TEXT NOT NULL)",
+    );
+    writer
+      .query(
+        "INSERT OR REPLACE INTO shutdown_canary (id, payload) VALUES (?, ?)",
+      )
+      .run("canary-1", "before-shutdown");
+
+    const { startGateway } = await import("../src/cli/start");
+    const handle = await startGateway({ port: 0, local: true, quiet: true });
+    await handle.shutdown();
+
+    // The file MUST exist (writer was open) and the -wal sidecar MUST be
+    // truncated (or absent) — the precondition for no recovery on next boot.
+    expect(statSync(path).isFile()).toBe(true);
+
+    // Second "session": reopen from a FRESH handle (no shared singleton),
+    // verify integrity_check + the canary row survives.
+    const fresh = new DatabaseSync(path);
+    try {
+      const integrity = fresh.prepare("PRAGMA integrity_check").get() as {
+        integrity_check: string;
+      };
+      expect(integrity.integrity_check).toBe("ok");
+
+      const row = fresh
+        .prepare("SELECT payload FROM shutdown_canary WHERE id = ?")
+        .get("canary-1") as { payload?: string } | null;
+      expect(row?.payload).toBe("before-shutdown");
+    } finally {
+      fresh.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Gateway graceful shutdown now waits for every vector/read worker's SQLite reader to close BEFORE the writer close runs, eliminating the stranded `-wal` file that the old shutdown path left for next-boot WAL recovery.

## Why this matters

SQLite WAL TRUNCATE requires zero concurrent readers — each vector worker holds a read-mark via its `reader.db` connection. The pre-#1599 sync `shutdownVectorPool()` posted `shutdown` + `terminate()` in the same tick and never awaited, so a reader could outlive the writer close. The writer's TRUNCATE checkpoint then either busy-returns (leaks the `-wal`) or hangs on `busy_timeout`, both of which force WAL recovery on the next boot.

## Changes

- **`packages/core/src/vector-pool.ts`**: New `shutdownVectorPoolAsync(deadlineMs?)` posts the cooperative `shutdown`, waits for each worker's `exit` event in parallel, and force-`terminate()`s survivors on deadline. Always resolves, never rejects, idempotent. The pre-existing sync `shutdownVectorPool()` is preserved for test teardown.
- **`packages/core/src/index.ts`**: Re-exports the new shutdown primitive + `DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS` (1500ms default).
- **`packages/gateway/src/cli/start.ts`**: `shutdown` closure now orders operations strictly — pipeline stop → embedding drain → embedding reset → `shutdownVectorPoolAsync(VECTOR_POOL_SHUTDOWN_DEADLINE_MS)` → `closeDb()` (wrapped in try/catch so a busy/checkpoint failure can't block the forced-exit path). The vector-pool budget is sized to fit under the gateway's 4000ms `SHUTDOWN_DEADLINE_MS` after the embedding drain and writer close.
- **`packages/core/test/shutdown-vector-pool.test.ts`** (new, 10 tests): covers empty pool, healthy workers, stuck workers (deadline path), idempotency, and parallel calls.
- **`packages/gateway/test/shutdown-sqlite-readers.test.ts`** (new, 9 tests): pins the strict shutdown order, vector-pool variants, close() invariants (exactly once / no-op when unopened / idempotent / best-effort), and the headline `PRAGMA integrity_check` + write-preservation regression test for the next-boot scenario.

## Acceptance criteria covered

- Bounded async vector-pool shutdown always resolves, never rejects — tested.
- Strict shutdown order asserted — tested.
- Core `close()` called exactly once, never opens unopened DB, idempotent — tested.
- Busy/checkpoint failures remain best-effort and never exceed the global deadline — wired in `start.ts` with try/catch and tested via a mock that throws.
- Timeout and second-signal paths still use `forcedExit()` — untouched in `shutdown.ts`.
- Reopening the DB after SIGTERM passes `PRAGMA integrity_check` and preserves accepted writes — tested end-to-end via a fresh `DatabaseSync` handle.
- Tests cover no workers, healthy workers, a worker that never exits, an unopened DB, and an already-closed DB — tested.

Refs: #1599