### PR TITLE
fix(gateway): accept empty Codex terminal output

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -6234,6 +6234,9 @@ export function streamResponsesRecallAware(
     if (!Array.isArray(response.output)) {
       throw new Error("Responses terminal output must be an array");
     }
+    // ChatGPT/Codex can emit `output: []` in the terminal response even though
+    // the preceding output_item events carried the complete response.
+    if (response.output.length === 0) return;
     const actualOutput = response.output.filter(
       (item): item is Record<string, unknown> =>
         !!item &&

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -202,6 +202,35 @@ describe("streamResponsesRecallAware", () => {
     expect(out).not.toContain("ended without a terminal event");
   });
 
+  test("accepts an empty Codex terminal output after streamed items", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_codex_empty_output", "gpt-5.6-terra"),
+        textItem(0, "answer"),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_codex_empty_output",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not be called");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("answer");
+    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
+    expect(out).not.toContain("response.failed");
+  });
+
   test.each(["failed", "cancelled"])(
     "hides recall when the principal response.done status is %s",
     async (status) => {

--- a/packages/gateway/test/recall-codex-stream.test.ts
+++ b/packages/gateway/test/recall-codex-stream.test.ts
@@ -75,6 +75,9 @@ function codexRecallStream(): Response {
         id: "resp_recall",
         model: "gpt-5.5",
         status: "completed",
+        // ChatGPT may omit streamed items from the terminal snapshot. The
+        // output_item lifecycle above is the authoritative response content.
+        output: [],
         usage: { input_tokens: 100, output_tokens: 10 },
       },
     }) +
@@ -116,6 +119,7 @@ function codexFinalStream(): Response {
         id: "resp_final",
         model: "gpt-5.5",
         status: "completed",
+        output: [],
         usage: { input_tokens: 120, output_tokens: 5 },
       },
     }) +


### PR DESCRIPTION
## Summary

- accept ChatGPT/Codex terminal `response.output: []` when streamed output-item lifecycles completed successfully
- preserve strict terminal validation for non-empty snapshots
- cover ordinary Responses turns and recall principal/follow-up streams

## Root cause

The recall-aware Responses streamer treated Codex's empty terminal output snapshot as contradictory to the already completed streamed items. Since Lore injects recall into every request, this failed ordinary tool turns too and surfaced the misleading `Lore could not continue the response after recall` error.

## Validation

- `pnpm exec vitest run packages/gateway/test/openai-responses-recall-aware-stream.test.ts packages/gateway/test/recall-codex-stream.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm --filter @loreai/gateway run build`
- independent adversarial correctness and protocol-security reviews: no findings