### PR TITLE
fix(gateway): harden Codex recall stream lifecycle

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -5705,6 +5705,8 @@ export function streamResponsesRecallAware(
 ): Response {
   const state = makeResponsesAccState();
   const syntheticIdentities = new Set<string>();
+  const referenceIdentities = new Set<string>();
+  const outputIdentities = new Set<string>();
   const responseLifecycles = new WeakMap<
     ResponsesAccState,
     { created: boolean; terminal: boolean }
@@ -5719,21 +5721,24 @@ export function streamResponsesRecallAware(
     }
     return lifecycle;
   };
+  type TextPartLifecycle = {
+    kind: string;
+    authoritativeValue: string;
+    authoritativeValueSeen: boolean;
+    deltaSeen: boolean;
+    valueDone: boolean;
+    finalValue?: string;
+    partAdded: boolean;
+    partDone: boolean;
+    partFinalValue?: string;
+  };
   type OutputLifecycle = {
+    argumentDeltaSeen: boolean;
+    argumentDeltas: string;
     argumentsDone: boolean;
     outputDone: boolean;
-    content: Map<
-      number,
-      {
-        kind?: string;
-        valueSeen: boolean;
-        valueDone: boolean;
-        finalValue?: string;
-        partFinalValue?: string;
-        partAdded: boolean;
-        partDone: boolean;
-      }
-    >;
+    reasoning: Map<number, TextPartLifecycle>;
+    content: Map<number, TextPartLifecycle>;
   };
   const outputLifecycles = new WeakMap<
     ResponsesAccState,
@@ -5749,6 +5754,54 @@ export function streamResponsesRecallAware(
     }
     return lifecycles;
   };
+  const emptyTextPartLifecycle = (kind: string): TextPartLifecycle => ({
+    kind,
+    authoritativeValue: "",
+    authoritativeValueSeen: false,
+    deltaSeen: false,
+    valueDone: false,
+    partAdded: false,
+    partDone: false,
+  });
+  const partValue = (
+    kind: string,
+    part: Record<string, unknown>,
+    description: string,
+  ): string => {
+    const value = kind === "refusal" ? part.refusal : part.text;
+    if (typeof value !== "string") {
+      throw new Error(`invalid Responses ${description} value`);
+    }
+    return value;
+  };
+  const seedTextParts = (
+    parts: unknown,
+    target: Map<number, TextPartLifecycle>,
+    allowedKinds: ReadonlySet<string>,
+    description: string,
+  ): void => {
+    if (parts === undefined) return;
+    if (!Array.isArray(parts)) {
+      throw new Error(`Responses ${description} must be an array`);
+    }
+    for (const [index, rawPart] of parts.entries()) {
+      if (!rawPart || typeof rawPart !== "object" || Array.isArray(rawPart)) {
+        throw new Error(`invalid Responses ${description} item`);
+      }
+      const part = rawPart as Record<string, unknown>;
+      if (typeof part.type !== "string" || !allowedKinds.has(part.type)) {
+        throw new Error(`invalid Responses ${description} item`);
+      }
+      const lifecycle = emptyTextPartLifecycle(part.type);
+      lifecycle.authoritativeValue = partValue(
+        part.type,
+        part,
+        `${description} initial`,
+      );
+      lifecycle.authoritativeValueSeen = true;
+      target.set(index, lifecycle);
+    }
+  };
   let transactionBaseline: ResponsesAccState | undefined;
   const transactionRollbacks: Array<() => void> = [];
   const restoreTransactionBaseline = (): void => {
@@ -5757,6 +5810,7 @@ export function streamResponsesRecallAware(
     state.model = transactionBaseline.model;
     state.stopReason = transactionBaseline.stopReason;
     state.terminalEvent = transactionBaseline.terminalEvent;
+    state.terminalResponse = transactionBaseline.terminalResponse;
     state.usage = { ...transactionBaseline.usage };
     state.items = new Map(transactionBaseline.items);
     state.rawItems = new Map(transactionBaseline.rawItems);
@@ -5852,18 +5906,62 @@ export function streamResponsesRecallAware(
     return { query, ...(scope ? { scope } : {}), ...(id ? { id } : {}) };
   };
 
+  const addUsageTokens = (left: number, right: number): number => {
+    const result = left + right;
+    if (
+      !Number.isSafeInteger(left) ||
+      left < 0 ||
+      !Number.isSafeInteger(right) ||
+      right < 0 ||
+      !Number.isSafeInteger(result)
+    ) {
+      throw new Error("Responses usage token overflow");
+    }
+    return result;
+  };
   const mergeUsage = (target: GatewayUsage, source: GatewayUsage): void => {
-    target.inputTokens += source.inputTokens;
-    target.outputTokens += source.outputTokens;
+    target.inputTokens = addUsageTokens(target.inputTokens, source.inputTokens);
+    target.outputTokens = addUsageTokens(
+      target.outputTokens,
+      source.outputTokens,
+    );
     if (source.cacheReadInputTokens != null) {
-      target.cacheReadInputTokens =
-        (target.cacheReadInputTokens ?? 0) + source.cacheReadInputTokens;
+      target.cacheReadInputTokens = addUsageTokens(
+        target.cacheReadInputTokens ?? 0,
+        source.cacheReadInputTokens,
+      );
     }
     if (source.cacheCreationInputTokens != null) {
-      target.cacheCreationInputTokens =
-        (target.cacheCreationInputTokens ?? 0) +
-        source.cacheCreationInputTokens;
+      target.cacheCreationInputTokens = addUsageTokens(
+        target.cacheCreationInputTokens ?? 0,
+        source.cacheCreationInputTokens,
+      );
     }
+  };
+  const assertUsageMergeable = (
+    target: GatewayUsage,
+    source: GatewayUsage,
+  ): void => {
+    const inputTokens = addUsageTokens(target.inputTokens, source.inputTokens);
+    const outputTokens = addUsageTokens(
+      target.outputTokens,
+      source.outputTokens,
+    );
+    const cacheReadInputTokens = addUsageTokens(
+      target.cacheReadInputTokens ?? 0,
+      source.cacheReadInputTokens ?? 0,
+    );
+    const cacheCreationInputTokens = addUsageTokens(
+      target.cacheCreationInputTokens ?? 0,
+      source.cacheCreationInputTokens ?? 0,
+    );
+    addUsageTokens(
+      addUsageTokens(
+        addUsageTokens(inputTokens, cacheReadInputTokens),
+        cacheCreationInputTokens,
+      ),
+      outputTokens,
+    );
   };
 
   let cancelled = false;
@@ -5878,7 +5976,7 @@ export function streamResponsesRecallAware(
     state: ResponsesAccState,
   ): number | undefined => {
     const requiresOutputIndex =
-      /^response\.(?:output_item|output_text|function_call_arguments|content_part|reasoning_summary|refusal)/.test(
+      /^response\.(?:output_item|output_text|function_call_arguments|content_part|reasoning_(?:summary|text)|refusal)/.test(
         event,
       );
     const hasOutputIndex = Object.hasOwn(parsed, "output_index");
@@ -5918,12 +6016,46 @@ export function streamResponsesRecallAware(
       if (item.type === "function_call" && item.id === item.call_id) {
         throw new Error("duplicate Responses identity within output item");
       }
+      if (
+        item.type === "function_call" &&
+        item.arguments !== undefined &&
+        typeof item.arguments !== "string"
+      ) {
+        throw new Error("invalid initial Responses function arguments");
+      }
+      if (
+        item.type === "function_call" &&
+        item.status !== undefined &&
+        typeof item.status !== "string"
+      ) {
+        throw new Error("invalid initial Responses function status");
+      }
+      if (
+        item.type === "function_call" &&
+        item.name === RECALL_TOOL_NAME &&
+        item.status !== undefined &&
+        item.status !== "in_progress" &&
+        item.status !== "completed"
+      ) {
+        throw new Error("recall function call cannot start failed");
+      }
+      if (item.type === "message" && item.role !== "assistant") {
+        throw new Error("Responses output message must have assistant role");
+      }
       const identities = [item.id, item.call_id].filter(
         (value): value is string => typeof value === "string",
       );
-      if (identities.some((identity) => syntheticIdentities.has(identity))) {
-        throw new Error("duplicate synthetic Responses item identity");
+      if (
+        identities.some(
+          (identity) =>
+            outputIdentities.has(identity) ||
+            referenceIdentities.has(identity) ||
+            syntheticIdentities.has(identity),
+        )
+      ) {
+        throw new Error("duplicate Responses item identity");
       }
+      for (const identity of identities) outputIdentities.add(identity);
       for (const [existingIndex, existing] of state.rawItems) {
         const newIdentities = [item.id, item.call_id].filter(
           (value): value is string => typeof value === "string",
@@ -5940,11 +6072,40 @@ export function streamResponsesRecallAware(
           throw new Error("duplicate Responses item identity");
         }
       }
-      lifecycles.set(outputIndex, {
+      const initialArguments =
+        item.type === "function_call" && typeof item.arguments === "string"
+          ? item.arguments
+          : "";
+      const newLifecycle: OutputLifecycle = {
+        argumentDeltaSeen: initialArguments.length > 0,
+        argumentDeltas: initialArguments,
         argumentsDone: item.type !== "function_call",
         outputDone: false,
+        reasoning: new Map(),
         content: new Map(),
-      });
+      };
+      if (item.type === "message") {
+        seedTextParts(
+          item.content,
+          newLifecycle.content,
+          new Set(["output_text", "refusal"]),
+          "message content",
+        );
+      } else if (item.type === "reasoning") {
+        seedTextParts(
+          item.summary,
+          newLifecycle.reasoning,
+          new Set(["summary_text"]),
+          "reasoning summary",
+        );
+        seedTextParts(
+          item.content,
+          newLifecycle.content,
+          new Set(["reasoning_text"]),
+          "reasoning content",
+        );
+      }
+      lifecycles.set(outputIndex, newLifecycle);
     } else if (!state.rawItems.has(outputIndex)) {
       throw new Error(
         `Responses ${event} arrived before output_item.added for index ${outputIndex}`,
@@ -5961,7 +6122,8 @@ export function streamResponsesRecallAware(
           item.type !== declared?.type ||
           item.id !== declared?.id ||
           item.call_id !== declared?.call_id ||
-          item.name !== declared?.name)
+          item.name !== declared?.name ||
+          (declared?.type === "message" && item.role !== declared.role))
       ) {
         throw new Error(
           `Responses output_item.done changed item identity for index ${outputIndex}`,
@@ -5980,6 +6142,7 @@ export function streamResponsesRecallAware(
       if (
         (event.startsWith("response.output_text") ||
           event.startsWith("response.content_part") ||
+          event.startsWith("response.reasoning_text") ||
           event.startsWith("response.refusal")) &&
         (!Number.isSafeInteger(parsed.content_index) ||
           (parsed.content_index as number) < 0)
@@ -5989,20 +6152,17 @@ export function streamResponsesRecallAware(
       if (
         event.startsWith("response.output_text") ||
         event.startsWith("response.content_part") ||
+        event.startsWith("response.reasoning_text") ||
         event.startsWith("response.refusal")
       ) {
         const contentIndex = parsed.content_index as number;
-        const contentState = lifecycle.content.get(contentIndex) ?? {
-          valueSeen: false,
-          valueDone: false,
-          partAdded: false,
-          partDone: false,
-        };
         const expectedKind = event.startsWith("response.output_text")
           ? "output_text"
           : event.startsWith("response.refusal")
             ? "refusal"
-            : undefined;
+            : event.startsWith("response.reasoning_text")
+              ? "reasoning_text"
+              : undefined;
         const part = parsed.part as Record<string, unknown> | undefined;
         const partKind =
           event.startsWith("response.content_part") &&
@@ -6010,54 +6170,106 @@ export function streamResponsesRecallAware(
             ? part.type
             : undefined;
         const kind = expectedKind ?? partKind;
-        if (!kind || (contentState.kind && contentState.kind !== kind)) {
+        if (
+          !kind ||
+          !["output_text", "refusal", "reasoning_text"].includes(kind)
+        ) {
+          throw new Error(`invalid Responses content type for ${event}`);
+        }
+        const expectedItemType =
+          kind === "reasoning_text" ? "reasoning" : "message";
+        if (declaredType !== expectedItemType) {
+          throw new Error(
+            `Responses ${event} does not match item type ${String(declaredType)}`,
+          );
+        }
+        const contentState =
+          lifecycle.content.get(contentIndex) ?? emptyTextPartLifecycle(kind);
+        if (contentState.kind !== kind) {
           throw new Error(
             `Responses ${event} changed content type for index ${outputIndex}:${contentIndex}`,
           );
         }
-        contentState.kind = kind;
         if (event === "response.content_part.added") {
-          if (contentState.partAdded) {
+          if (
+            contentState.partAdded ||
+            contentState.deltaSeen ||
+            contentState.valueDone
+          ) {
             throw new Error(
-              `duplicate Responses content_part.added for index ${outputIndex}:${contentIndex}`,
+              `invalid Responses content_part.added for index ${outputIndex}:${contentIndex}`,
+            );
+          }
+          if (!part) {
+            throw new Error(`invalid Responses ${event} part`);
+          }
+          const initialValue = partValue(kind, part, event);
+          if (
+            contentState.authoritativeValueSeen &&
+            contentState.authoritativeValue !== initialValue
+          ) {
+            throw new Error(
+              `Responses content_part.added changed initial content for index ${outputIndex}:${contentIndex}`,
             );
           }
           contentState.partAdded = true;
+          contentState.authoritativeValue = initialValue;
+          contentState.authoritativeValueSeen = true;
         } else if (event === "response.content_part.done") {
           if (!contentState.partAdded || contentState.partDone) {
             throw new Error(
               `invalid Responses content_part.done for index ${outputIndex}:${contentIndex}`,
             );
           }
-          contentState.partDone = true;
-          const partValue = kind === "output_text" ? part?.text : part?.refusal;
-          if (typeof partValue !== "string") {
-            throw new Error(`invalid Responses ${event} final value`);
+          if (!part) {
+            throw new Error(`invalid Responses ${event} part`);
           }
-          contentState.partFinalValue = partValue;
+          const finalPartValue = partValue(kind, part, event);
           if (
-            contentState.finalValue !== undefined &&
-            contentState.finalValue !== partValue
+            (contentState.authoritativeValueSeen &&
+              contentState.authoritativeValue !== finalPartValue) ||
+            (contentState.finalValue !== undefined &&
+              contentState.finalValue !== finalPartValue)
           ) {
             throw new Error(
               `Responses content_part.done changed content for index ${outputIndex}:${contentIndex}`,
             );
           }
+          contentState.partDone = true;
+          contentState.partFinalValue = finalPartValue;
+          contentState.authoritativeValue = finalPartValue;
+          contentState.authoritativeValueSeen = true;
         } else {
-          if (contentState.valueDone) {
+          if (contentState.valueDone || contentState.partDone) {
             throw new Error(
               `Responses content changed after completion for index ${outputIndex}:${contentIndex}`,
             );
           }
-          contentState.valueSeen = true;
-          if (event.endsWith(".done")) {
+          if (event.endsWith(".delta")) {
+            if (typeof parsed.delta !== "string") {
+              throw new Error(`invalid Responses ${event} delta`);
+            }
+            contentState.deltaSeen = true;
+            contentState.authoritativeValue += parsed.delta;
+            contentState.authoritativeValueSeen = true;
+          } else if (event.endsWith(".done")) {
             const finalValue =
-              kind === "output_text" ? parsed.text : parsed.refusal;
+              kind === "refusal" ? parsed.refusal : parsed.text;
             if (typeof finalValue !== "string") {
               throw new Error(`invalid Responses ${event} final value`);
             }
             contentState.valueDone = true;
             contentState.finalValue = finalValue;
+            if (
+              contentState.authoritativeValueSeen &&
+              contentState.authoritativeValue !== finalValue
+            ) {
+              throw new Error(
+                `Responses ${event} changed streamed content for index ${outputIndex}:${contentIndex}`,
+              );
+            }
+            contentState.authoritativeValue = finalValue;
+            contentState.authoritativeValueSeen = true;
             if (
               contentState.partFinalValue !== undefined &&
               contentState.partFinalValue !== finalValue
@@ -6079,7 +6291,6 @@ export function streamResponsesRecallAware(
       }
       if (
         ((event.startsWith("response.output_text") ||
-          event.startsWith("response.content_part") ||
           event.startsWith("response.refusal")) &&
           declaredType !== "message") ||
         (event.startsWith("response.reasoning_summary") &&
@@ -6091,10 +6302,125 @@ export function streamResponsesRecallAware(
           `Responses ${event} does not match item type ${String(declaredType)}`,
         );
       }
+      if (event.startsWith("response.reasoning_summary")) {
+        const summaryIndex = parsed.summary_index as number;
+        const summaryState =
+          lifecycle.reasoning.get(summaryIndex) ??
+          emptyTextPartLifecycle("summary_text");
+        if (event === "response.reasoning_summary_part.added") {
+          if (
+            summaryState.partAdded ||
+            summaryState.deltaSeen ||
+            summaryState.valueDone
+          ) {
+            throw new Error(
+              `invalid Responses reasoning summary part for index ${outputIndex}:${summaryIndex}`,
+            );
+          }
+          const part = parsed.part as Record<string, unknown> | undefined;
+          if (part !== undefined) {
+            if (part.type !== "summary_text") {
+              throw new Error("invalid Responses reasoning summary part");
+            }
+            const initialValue = partValue(
+              "summary_text",
+              part,
+              "reasoning summary initial",
+            );
+            if (
+              summaryState.authoritativeValueSeen &&
+              summaryState.authoritativeValue !== initialValue
+            ) {
+              throw new Error(
+                `Responses reasoning summary part changed initial content for index ${outputIndex}:${summaryIndex}`,
+              );
+            }
+            summaryState.authoritativeValue = initialValue;
+            summaryState.authoritativeValueSeen = true;
+          }
+          summaryState.partAdded = true;
+        } else if (event === "response.reasoning_summary_part.done") {
+          if (!summaryState.partAdded || summaryState.partDone) {
+            throw new Error(
+              `invalid Responses reasoning summary completion for index ${outputIndex}:${summaryIndex}`,
+            );
+          }
+          const part = parsed.part as Record<string, unknown> | undefined;
+          if (part !== undefined) {
+            if (part.type !== "summary_text") {
+              throw new Error("invalid Responses reasoning summary part");
+            }
+            const finalPartValue = partValue(
+              "summary_text",
+              part,
+              "reasoning summary final",
+            );
+            if (
+              (summaryState.authoritativeValueSeen &&
+                summaryState.authoritativeValue !== finalPartValue) ||
+              (summaryState.finalValue !== undefined &&
+                summaryState.finalValue !== finalPartValue)
+            ) {
+              throw new Error(
+                `Responses reasoning summary part changed content for index ${outputIndex}:${summaryIndex}`,
+              );
+            }
+            summaryState.partFinalValue = finalPartValue;
+            summaryState.authoritativeValue = finalPartValue;
+            summaryState.authoritativeValueSeen = true;
+          }
+          summaryState.partDone = true;
+        } else if (event.endsWith(".delta")) {
+          if (summaryState.valueDone || summaryState.partDone) {
+            throw new Error(
+              `Responses reasoning summary changed after completion for index ${outputIndex}:${summaryIndex}`,
+            );
+          }
+          if (typeof parsed.delta !== "string") {
+            throw new Error("invalid Responses reasoning summary delta");
+          }
+          summaryState.deltaSeen = true;
+          summaryState.authoritativeValue += parsed.delta;
+          summaryState.authoritativeValueSeen = true;
+        } else if (event.endsWith(".done")) {
+          if (summaryState.valueDone || summaryState.partDone) {
+            throw new Error(
+              `duplicate Responses reasoning summary completion for index ${outputIndex}:${summaryIndex}`,
+            );
+          }
+          if (typeof parsed.text !== "string") {
+            throw new Error("invalid Responses reasoning summary final value");
+          }
+          if (
+            summaryState.authoritativeValueSeen &&
+            summaryState.authoritativeValue !== parsed.text
+          ) {
+            throw new Error(
+              `Responses reasoning summary changed streamed content for index ${outputIndex}:${summaryIndex}`,
+            );
+          }
+          summaryState.valueDone = true;
+          summaryState.finalValue = parsed.text;
+          summaryState.authoritativeValue = parsed.text;
+          summaryState.authoritativeValueSeen = true;
+        }
+        lifecycle.reasoning.set(summaryIndex, summaryState);
+      }
       if (event === "response.function_call_arguments.done") {
         if (lifecycle.argumentsDone) {
           throw new Error(
             `duplicate Responses function arguments completion for index ${outputIndex}`,
+          );
+        }
+        if (typeof parsed.arguments !== "string") {
+          throw new Error("invalid Responses function arguments completion");
+        }
+        if (
+          lifecycle.argumentDeltaSeen &&
+          lifecycle.argumentDeltas !== parsed.arguments
+        ) {
+          throw new Error(
+            `Responses function arguments completion changed streamed arguments for index ${outputIndex}`,
           );
         }
         lifecycle.argumentsDone = true;
@@ -6105,6 +6431,12 @@ export function streamResponsesRecallAware(
         throw new Error(
           `Responses function arguments changed after completion for index ${outputIndex}`,
         );
+      } else if (event === "response.function_call_arguments.delta") {
+        if (typeof parsed.delta !== "string") {
+          throw new Error("invalid Responses function arguments delta");
+        }
+        lifecycle.argumentDeltaSeen = true;
+        lifecycle.argumentDeltas += parsed.delta;
       }
       if (event === "response.output_item.done") {
         if (declaredType === "function_call" && !lifecycle.argumentsDone) {
@@ -6123,6 +6455,16 @@ export function streamResponsesRecallAware(
               `Responses output_item.done changed arguments for index ${outputIndex}`,
             );
           }
+          if (item?.status !== undefined && typeof item.status !== "string") {
+            throw new Error("invalid Responses function call status");
+          }
+          if (
+            declared?.name === RECALL_TOOL_NAME &&
+            item?.status !== undefined &&
+            item.status !== "completed"
+          ) {
+            throw new Error("recall function call did not complete");
+          }
         }
         if (declaredType === "message") {
           const finalContent = item?.content;
@@ -6140,7 +6482,7 @@ export function streamResponsesRecallAware(
                 `Responses output_item.done changed content type for index ${outputIndex}:${contentIndex}`,
               );
             }
-            if (contentState.valueSeen && !contentState.valueDone) {
+            if (contentState.deltaSeen && !contentState.valueDone) {
               throw new Error(
                 `Responses content ended before completion for index ${outputIndex}:${contentIndex}`,
               );
@@ -6150,17 +6492,126 @@ export function streamResponsesRecallAware(
                 `Responses content part ended before completion for index ${outputIndex}:${contentIndex}`,
               );
             }
-            const finalValue =
-              contentState.kind === "output_text"
-                ? finalPart.text
-                : finalPart.refusal;
+            const finalValue = partValue(
+              contentState.kind,
+              finalPart,
+              "output item content",
+            );
             if (
-              contentState.finalValue !== undefined &&
-              finalValue !== contentState.finalValue
+              (contentState.authoritativeValueSeen &&
+                finalValue !== contentState.authoritativeValue) ||
+              (contentState.finalValue !== undefined &&
+                finalValue !== contentState.finalValue) ||
+              (contentState.partFinalValue !== undefined &&
+                finalValue !== contentState.partFinalValue)
             ) {
               throw new Error(
                 `Responses output_item.done changed content for index ${outputIndex}:${contentIndex}`,
               );
+            }
+          }
+        }
+        if (declaredType === "reasoning") {
+          const summary = item?.summary;
+          if (summary !== undefined && !Array.isArray(summary)) {
+            throw new Error("Responses reasoning summary must be an array");
+          }
+          if (summary === undefined) {
+            for (const [summaryIndex, summaryState] of lifecycle.reasoning) {
+              if (
+                (summaryState.deltaSeen && !summaryState.valueDone) ||
+                (summaryState.partAdded && !summaryState.partDone)
+              ) {
+                throw new Error(
+                  `Responses reasoning summary ended before completion for index ${outputIndex}:${summaryIndex}`,
+                );
+              }
+            }
+          }
+          if (Array.isArray(summary)) {
+            for (const [summaryIndex, summaryState] of lifecycle.reasoning) {
+              const finalPart = summary[summaryIndex] as
+                | Record<string, unknown>
+                | undefined;
+              if (!finalPart) {
+                if (
+                  (summaryState.deltaSeen && !summaryState.valueDone) ||
+                  (summaryState.partAdded && !summaryState.partDone)
+                ) {
+                  throw new Error(
+                    `Responses reasoning summary ended before completion for index ${outputIndex}:${summaryIndex}`,
+                  );
+                }
+                continue;
+              }
+              if (
+                finalPart.type !== "summary_text" ||
+                typeof finalPart.text !== "string"
+              ) {
+                throw new Error("invalid Responses reasoning summary item");
+              }
+              if (
+                (summaryState.deltaSeen && !summaryState.valueDone) ||
+                (summaryState.partAdded && !summaryState.partDone)
+              ) {
+                throw new Error(
+                  `Responses reasoning summary ended before completion for index ${outputIndex}:${summaryIndex}`,
+                );
+              }
+              if (
+                summaryState.authoritativeValueSeen &&
+                summaryState.authoritativeValue !== finalPart.text
+              ) {
+                throw new Error(
+                  `Responses output_item.done changed reasoning summary for index ${outputIndex}:${summaryIndex}`,
+                );
+              }
+            }
+          }
+          const finalContent = item?.content;
+          if (finalContent !== undefined && !Array.isArray(finalContent)) {
+            throw new Error("Responses reasoning content must be an array");
+          }
+          if (lifecycle.content.size > 0) {
+            if (!Array.isArray(finalContent)) {
+              throw new Error(
+                `Responses reasoning completed without content for index ${outputIndex}`,
+              );
+            }
+            for (const [contentIndex, contentState] of lifecycle.content) {
+              const finalPart = finalContent[contentIndex] as
+                | Record<string, unknown>
+                | undefined;
+              if (!finalPart || finalPart.type !== contentState.kind) {
+                throw new Error(
+                  `Responses output_item.done changed reasoning content type for index ${outputIndex}:${contentIndex}`,
+                );
+              }
+              if (
+                (contentState.deltaSeen && !contentState.valueDone) ||
+                (contentState.partAdded && !contentState.partDone)
+              ) {
+                throw new Error(
+                  `Responses reasoning content ended before completion for index ${outputIndex}:${contentIndex}`,
+                );
+              }
+              const finalValue = partValue(
+                contentState.kind,
+                finalPart,
+                "reasoning output item content",
+              );
+              if (
+                (contentState.authoritativeValueSeen &&
+                  contentState.authoritativeValue !== finalValue) ||
+                (contentState.finalValue !== undefined &&
+                  contentState.finalValue !== finalValue) ||
+                (contentState.partFinalValue !== undefined &&
+                  contentState.partFinalValue !== finalValue)
+              ) {
+                throw new Error(
+                  `Responses output_item.done changed reasoning content for index ${outputIndex}:${contentIndex}`,
+                );
+              }
             }
           }
         }
@@ -6184,6 +6635,15 @@ export function streamResponsesRecallAware(
       if (!response || typeof response.id !== "string" || !response.id) {
         throw new Error("response.created missing response identity");
       }
+      if (response.status !== undefined && response.status !== "in_progress") {
+        throw new Error("response.created has invalid status");
+      }
+      if (
+        response.output !== undefined &&
+        (!Array.isArray(response.output) || response.output.length > 0)
+      ) {
+        throw new Error("response.created must start with empty output");
+      }
       lifecycle.created = true;
       return;
     }
@@ -6197,6 +6657,15 @@ export function streamResponsesRecallAware(
           "Responses in-progress event changed response identity",
         );
       }
+      if (response?.status !== undefined && response.status !== "in_progress") {
+        throw new Error("response.in_progress has invalid status");
+      }
+      if (
+        response?.output !== undefined &&
+        (!Array.isArray(response.output) || response.output.length > 0)
+      ) {
+        throw new Error("response.in_progress must have empty output");
+      }
     }
     if (
       event === "response.completed" ||
@@ -6208,6 +6677,25 @@ export function streamResponsesRecallAware(
       if (acc.id && response?.id !== acc.id) {
         throw new Error("Responses terminal event changed response identity");
       }
+      const status = response?.status;
+      const terminalStatuses = new Set([
+        "completed",
+        "incomplete",
+        "failed",
+        "cancelled",
+      ]);
+      if (typeof status !== "string" || !terminalStatuses.has(status)) {
+        throw new Error("Responses terminal event has nonterminal status");
+      }
+      if (
+        (event === "response.completed" && status !== "completed") ||
+        (event === "response.incomplete" && status !== "incomplete") ||
+        (event === "response.failed" &&
+          status !== "failed" &&
+          status !== "cancelled")
+      ) {
+        throw new Error("Responses terminal event contradicts response status");
+      }
       lifecycle.terminal = true;
     }
   };
@@ -6218,6 +6706,148 @@ export function streamResponsesRecallAware(
         throw new Error(
           `Responses stream ended before output_item.done for index ${index}`,
         );
+      }
+    }
+  };
+  const preserveStreamedReasoning = (
+    acc: ResponsesAccState,
+    outputIndex: number,
+  ): void => {
+    const raw = acc.rawItems.get(outputIndex);
+    const lifecycle = lifecyclesFor(acc).get(outputIndex);
+    if (raw?.type !== "reasoning" || !lifecycle?.reasoning.size) return;
+    const summary = Array.isArray(raw.summary) ? [...raw.summary] : [];
+    let changed = false;
+    for (const [summaryIndex, summaryState] of lifecycle.reasoning) {
+      if (
+        summary[summaryIndex] === undefined &&
+        summaryState.authoritativeValueSeen
+      ) {
+        summary[summaryIndex] = {
+          type: "summary_text",
+          text: summaryState.authoritativeValue,
+        };
+        changed = true;
+      }
+    }
+    if (changed) acc.rawItems.set(outputIndex, { ...raw, summary });
+  };
+  const terminalTextPartsMatch = (
+    actual: unknown,
+    streamed: unknown,
+  ): boolean => {
+    if (!Array.isArray(actual) || !Array.isArray(streamed)) return false;
+    if (actual.length !== streamed.length) return false;
+    return streamed.every((streamedPart, index) => {
+      const actualPart = actual[index];
+      if (
+        !streamedPart ||
+        typeof streamedPart !== "object" ||
+        Array.isArray(streamedPart) ||
+        !actualPart ||
+        typeof actualPart !== "object" ||
+        Array.isArray(actualPart)
+      ) {
+        return false;
+      }
+      const streamedRecord = streamedPart as Record<string, unknown>;
+      const actualRecord = actualPart as Record<string, unknown>;
+      if (actualRecord.type !== streamedRecord.type) return false;
+      if (
+        typeof streamedRecord.type === "string" &&
+        ["output_text", "reasoning_text", "summary_text", "refusal"].includes(
+          streamedRecord.type,
+        )
+      ) {
+        return (
+          partValue(streamedRecord.type, actualRecord, "terminal content") ===
+          partValue(streamedRecord.type, streamedRecord, "streamed content")
+        );
+      }
+      return isDeepStrictEqual(actualRecord, streamedRecord);
+    });
+  };
+  const terminalItemMatches = (
+    actual: Record<string, unknown>,
+    streamed: Record<string, unknown>,
+  ): boolean => {
+    if (actual.type !== streamed.type || actual.id !== streamed.id)
+      return false;
+    if (actual.status !== undefined && typeof actual.status !== "string") {
+      return false;
+    }
+    if (
+      streamed.status !== undefined &&
+      actual.status !== undefined &&
+      actual.status !== streamed.status
+    ) {
+      return false;
+    }
+    if (actual.type === "function_call") {
+      return (
+        actual.call_id === streamed.call_id &&
+        actual.name === streamed.name &&
+        actual.arguments === streamed.arguments
+      );
+    }
+    if (actual.type === "message") {
+      return (
+        actual.role === streamed.role &&
+        terminalTextPartsMatch(actual.content, streamed.content)
+      );
+    }
+    if (actual.type === "reasoning") {
+      for (const field of ["summary", "content"]) {
+        if (streamed[field] !== undefined) {
+          if (!terminalTextPartsMatch(actual[field], streamed[field])) {
+            return false;
+          }
+        }
+      }
+      if (
+        streamed.encrypted_content !== undefined &&
+        !isDeepStrictEqual(actual.encrypted_content, streamed.encrypted_content)
+      ) {
+        return false;
+      }
+      return true;
+    }
+    const { status: _actualStatus, ...actualSemantic } = actual;
+    const { status: _streamedStatus, ...streamedSemantic } = streamed;
+    return isDeepStrictEqual(actualSemantic, streamedSemantic);
+  };
+  const assertTerminalReasoningMatchesLifecycle = (
+    lifecycle: OutputLifecycle,
+    actual: Record<string, unknown>,
+    outputIndex: number,
+  ): void => {
+    const collections: Array<
+      [unknown, ReadonlyMap<number, TextPartLifecycle>, string]
+    > = [
+      [actual.summary, lifecycle.reasoning, "reasoning summary"],
+      [actual.content, lifecycle.content, "reasoning content"],
+    ];
+    for (const [rawParts, states, description] of collections) {
+      if (rawParts === undefined) continue;
+      if (!Array.isArray(rawParts)) {
+        throw new Error(`Responses terminal ${description} must be an array`);
+      }
+      for (const [partIndex, state] of states) {
+        const part = rawParts[partIndex];
+        if (!part || typeof part !== "object" || Array.isArray(part)) {
+          throw new Error(`Responses terminal changed ${description}`);
+        }
+        const record = part as Record<string, unknown>;
+        if (
+          record.type !== state.kind ||
+          (state.authoritativeValueSeen &&
+            partValue(state.kind, record, `terminal ${description}`) !==
+              state.authoritativeValue)
+        ) {
+          throw new Error(
+            `Responses terminal changed ${description} for index ${outputIndex}:${partIndex}`,
+          );
+        }
       }
     }
   };
@@ -6234,38 +6864,160 @@ export function streamResponsesRecallAware(
     if (!Array.isArray(response.output)) {
       throw new Error("Responses terminal output must be an array");
     }
-    // ChatGPT/Codex can emit `output: []` in the terminal response even though
-    // the preceding output_item events carried the complete response.
-    if (response.output.length === 0) return;
-    const actualOutput = response.output.filter(
-      (item): item is Record<string, unknown> =>
-        !!item &&
-        typeof item === "object" &&
-        (item as Record<string, unknown>).type !== "item_reference",
-    );
-    const expected = [...acc.rawItems.entries()]
-      .sort(([a], [b]) => a - b)
-      .map(([, item]) => item)
-      .filter((item) => item.type !== "item_reference");
-    if (actualOutput.length !== expected.length) {
-      throw new Error("Responses terminal output changed item count");
-    }
-    for (let i = 0; i < expected.length; i++) {
-      const actual = actualOutput[i];
-      const streamed = expected[i];
+    // ChatGPT/Codex can omit some or all streamed items from the terminal
+    // snapshot. Treat the output_item lifecycle as authoritative while still
+    // requiring every repeated terminal item to match in stream order.
+    const actualOutput = response.output.map((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        throw new Error("Responses terminal output contains malformed item");
+      }
+      return item as Record<string, unknown>;
+    });
+    const expected = [...acc.rawItems.entries()].sort(([a], [b]) => a - b);
+    let expectedIndex = 0;
+    for (const actual of actualOutput) {
+      const isReference = actual.type === "item_reference";
       if (
-        !actual ||
-        actual.type !== streamed.type ||
-        actual.id !== streamed.id ||
-        actual.call_id !== streamed.call_id ||
-        (streamed.type === "message" &&
-          !isDeepStrictEqual(actual.content, streamed.content)) ||
-        (streamed.type === "function_call" &&
-          actual.arguments !== streamed.arguments)
+        isReference &&
+        (typeof actual.id !== "string" ||
+          !actual.id ||
+          Object.keys(actual).some((key) => key !== "type" && key !== "id"))
       ) {
+        throw new Error("Responses terminal output contains invalid reference");
+      }
+      const matchIndex = expected.findIndex(
+        ([, streamed], index) =>
+          index >= expectedIndex &&
+          actual.id === streamed.id &&
+          (isReference ||
+            (actual.type === streamed.type &&
+              actual.call_id === streamed.call_id)),
+      );
+      if (matchIndex < 0) {
         throw new Error("Responses terminal output changed streamed item");
       }
+      const [outputIndex, streamed] = expected[matchIndex];
+      if (!isReference && !terminalItemMatches(actual, streamed)) {
+        throw new Error("Responses terminal output changed streamed item");
+      }
+      if (!isReference && actual.type === "reasoning") {
+        const lifecycle = lifecyclesFor(acc).get(outputIndex);
+        if (!lifecycle) {
+          throw new Error(
+            `missing Responses lifecycle for index ${outputIndex}`,
+          );
+        }
+        assertTerminalReasoningMatchesLifecycle(lifecycle, actual, outputIndex);
+      }
+      if (!isReference) {
+        acc.rawItems.set(outputIndex, { ...streamed, ...actual });
+      }
+      expectedIndex = matchIndex + 1;
     }
+  };
+  type ReferenceLifecycle = { id: string; done: boolean };
+  const consumeReferenceEvent = (
+    acc: ResponsesAccState,
+    references: Map<number, ReferenceLifecycle>,
+    event: string,
+    parsed: Record<string, unknown>,
+  ): boolean => {
+    const rawIndex = parsed.output_index;
+    const item = parsed.item as Record<string, unknown> | undefined;
+    if (
+      event === "response.output_item.added" &&
+      item?.type === "item_reference"
+    ) {
+      if (!Number.isSafeInteger(rawIndex) || (rawIndex as number) < 0) {
+        throw new Error("invalid Responses output_index for item_reference");
+      }
+      const outputIndex = rawIndex as number;
+      if (
+        typeof item.id !== "string" ||
+        !item.id ||
+        Object.keys(item).some((key) => key !== "type" && key !== "id")
+      ) {
+        throw new Error("invalid Responses output item reference");
+      }
+      if (
+        references.has(outputIndex) ||
+        acc.rawItems.has(outputIndex) ||
+        syntheticIdentities.has(item.id) ||
+        outputIdentities.has(item.id) ||
+        [...acc.rawItems.values()].some(
+          (existing) => existing.id === item.id || existing.call_id === item.id,
+        ) ||
+        referenceIdentities.has(item.id)
+      ) {
+        throw new Error("duplicate Responses item reference");
+      }
+      references.set(outputIndex, { id: item.id, done: false });
+      referenceIdentities.add(item.id);
+      return true;
+    }
+    if (!Number.isSafeInteger(rawIndex)) return false;
+    const outputIndex = rawIndex as number;
+    const reference = references.get(outputIndex);
+    if (!reference) return false;
+    if (
+      event !== "response.output_item.done" ||
+      reference.done ||
+      !item ||
+      item.type !== "item_reference" ||
+      item.id !== reference.id ||
+      Object.keys(item).some((key) => key !== "type" && key !== "id")
+    ) {
+      throw new Error(
+        `invalid Responses item_reference lifecycle for index ${outputIndex}`,
+      );
+    }
+    reference.done = true;
+    return true;
+  };
+  const assertReferenceLifecyclesComplete = (
+    references: ReadonlyMap<number, ReferenceLifecycle>,
+  ): void => {
+    for (const [outputIndex, reference] of references) {
+      if (!reference.done) {
+        throw new Error(
+          `Responses stream ended before item_reference completion for index ${outputIndex}`,
+        );
+      }
+    }
+  };
+  const assertRecallItemsCompleted = (
+    acc: ResponsesAccState,
+    recallIndices: readonly number[],
+  ): void => {
+    for (const outputIndex of recallIndices) {
+      const status = acc.rawItems.get(outputIndex)?.status;
+      if (status !== undefined && status !== "completed") {
+        throw new Error(
+          `recall function call did not complete for index ${outputIndex}`,
+        );
+      }
+    }
+  };
+  const stripHiddenReferenceOutput = (
+    parsed: Record<string, unknown>,
+  ): Record<string, unknown> => {
+    const response = parsed.response as Record<string, unknown> | undefined;
+    if (!Array.isArray(response?.output)) return parsed;
+    const output = response.output.filter(
+      (item) =>
+        !(
+          item &&
+          typeof item === "object" &&
+          !Array.isArray(item) &&
+          (item as Record<string, unknown>).type === "item_reference" &&
+          typeof (item as Record<string, unknown>).id === "string" &&
+          referenceIdentities.has(
+            (item as Record<string, unknown>).id as string,
+          )
+        ),
+    );
+    if (output.length === response.output.length) return parsed;
+    return { ...parsed, response: { ...response, output } };
   };
   const reserveSyntheticIdentity = (
     syntheticId: string,
@@ -6273,6 +7025,8 @@ export function streamResponsesRecallAware(
   ): void => {
     if (
       syntheticIdentities.has(syntheticId) ||
+      referenceIdentities.has(syntheticId) ||
+      outputIdentities.has(syntheticId) ||
       states.some(
         (acc) =>
           [...acc.items.values()].some(
@@ -6418,6 +7172,13 @@ export function streamResponsesRecallAware(
     }
     return result;
   };
+  const shiftedOutputIndex = (index: number, offset: number): number => {
+    const shifted = index + offset;
+    if (!Number.isSafeInteger(shifted) || shifted < 0) {
+      throw new Error("Responses output_index overflow");
+    }
+    return shifted;
+  };
 
   /**
    * Serialize a synthetic Responses output_text item as its SSE flow events
@@ -6509,14 +7270,14 @@ export function streamResponsesRecallAware(
     const finalOutput = buildOutputItems();
     const finalStatus = mapStatusFromStopReason(res.stopReason);
     const ru = res.usage ?? ZERO_USAGE;
-    const inclusiveInputTokens =
-      ru.inputTokens +
-      (ru.cacheReadInputTokens ?? 0) +
-      (ru.cacheCreationInputTokens ?? 0);
+    const inclusiveInputTokens = addUsageTokens(
+      addUsageTokens(ru.inputTokens, ru.cacheReadInputTokens ?? 0),
+      ru.cacheCreationInputTokens ?? 0,
+    );
     const usageData: Record<string, unknown> = {
       input_tokens: inclusiveInputTokens,
       output_tokens: ru.outputTokens,
-      total_tokens: inclusiveInputTokens + ru.outputTokens,
+      total_tokens: addUsageTokens(inclusiveInputTokens, ru.outputTokens),
     };
     if (
       ru.cacheReadInputTokens != null ||
@@ -6528,14 +7289,17 @@ export function streamResponsesRecallAware(
       };
     }
     const terminalEvent = state.terminalEvent ?? "response.completed";
+    const terminalResponse = state.terminalResponse;
     return formatResponsesEvent(
       terminalEvent,
       JSON.stringify({
         type: terminalEvent,
         response: {
+          ...terminalResponse,
           id: state.id,
           object: "response",
-          created_at: Math.floor(Date.now() / 1000),
+          created_at:
+            terminalResponse?.created_at ?? Math.floor(Date.now() / 1000),
           model: res.model || state.model,
           status: finalStatus,
           output: finalOutput,
@@ -6572,7 +7336,7 @@ export function streamResponsesRecallAware(
               role: "assistant",
               status: "completed",
             }),
-            content: item.content,
+            content: Array.isArray(raw?.content) ? raw.content : item.content,
           });
           continue;
         }
@@ -6594,13 +7358,15 @@ export function streamResponsesRecallAware(
           content: [{ type: "output_text", text: item.text, annotations: [] }],
         });
       } else {
+        const raw = state.rawItems.get(index);
         finalOutput.push({
+          ...raw,
           type: "function_call",
           id: item.id,
           call_id: item.callId,
           name: item.name,
           arguments: item.args,
-          status: "completed",
+          status: typeof raw?.status === "string" ? raw.status : "completed",
         });
       }
     }
@@ -6658,7 +7424,7 @@ export function streamResponsesRecallAware(
         // Recall items are gateway-internal and must stay hidden on every exit,
         // including failures raised before marker replacement.
         const recallIndices = new Set<number>();
-        const referenceIndices = new Set<number>();
+        const referenceIndices = new Map<number, ReferenceLifecycle>();
 
         try {
           if (!upstreamResponse.body) {
@@ -6725,29 +7491,7 @@ export function streamResponsesRecallAware(
             }
             validateResponseLifecycle(state, event, parsed);
 
-            const rawOutputIndex = parsed.output_index;
-            const addedItem = parsed.item as
-              | Record<string, unknown>
-              | undefined;
-            if (
-              event === "response.output_item.added" &&
-              addedItem?.type === "item_reference"
-            ) {
-              if (
-                !Number.isSafeInteger(rawOutputIndex) ||
-                (rawOutputIndex as number) < 0
-              ) {
-                throw new Error(
-                  "invalid Responses output_index for item_reference",
-                );
-              }
-              referenceIndices.add(rawOutputIndex as number);
-              continue;
-            }
-            if (
-              Number.isSafeInteger(rawOutputIndex) &&
-              referenceIndices.has(rawOutputIndex as number)
-            ) {
+            if (consumeReferenceEvent(state, referenceIndices, event, parsed)) {
               continue;
             }
 
@@ -6779,6 +7523,12 @@ export function streamResponsesRecallAware(
 
             // Always accumulate into the internal state for postResponse.
             applyResponsesEvent(state, event, parsed);
+            if (
+              event === "response.output_item.done" &&
+              outputIndex !== undefined
+            ) {
+              preserveStreamedReasoning(state, outputIndex);
+            }
 
             // Suppress all events belonging to a recall item, but still count
             // them so malformed argument streams cannot grow without bound.
@@ -6838,8 +7588,14 @@ export function streamResponsesRecallAware(
               event === "response.incomplete" ||
               event === "response.failed"
             ) {
+              const terminalParsed = stripHiddenReferenceOutput(parsed);
               assertOutputLifecyclesComplete(state);
-              assertTerminalOutputMatches(state, parsed);
+              assertReferenceLifecyclesComplete(referenceIndices);
+              assertTerminalOutputMatches(state, terminalParsed);
+              assertRecallItemsCompleted(
+                state,
+                pendingRecalls.map((recall) => recall.outputIndex),
+              );
               if (pendingRecalls.length === 0) {
                 if (recallIndices.size > 0) {
                   throw new Error(
@@ -6849,7 +7605,14 @@ export function streamResponsesRecallAware(
                 // No recall — forward the terminal event verbatim.
                 if (
                   !(await safeEnqueue(
-                    encoder.encode(formatResponsesEvent(event, data)),
+                    encoder.encode(
+                      formatResponsesEvent(
+                        event,
+                        terminalParsed === parsed
+                          ? data
+                          : JSON.stringify(terminalParsed),
+                      ),
+                    ),
                   ))
                 )
                   break;
@@ -6903,13 +7666,22 @@ export function streamResponsesRecallAware(
                 const syntheticId = `msg_${state.id || "lore"}_${recall.outputIndex}`;
                 reserveSyntheticIdentity(syntheticId, [state]);
                 const recallAcc = finalizeResponsesAcc(state);
+                const contentPosition = recallAcc.content.findIndex(
+                  (block) =>
+                    block.type === "tool_use" && block.id === recall.toolUseId,
+                );
+                if (contentPosition < 0) {
+                  throw new Error(
+                    "recall block not found in finalized response",
+                  );
+                }
                 const executed = await settleRecall({
                   query: recall.query,
                   scope: recall.scope,
                   id: recall.id,
                   outputIndex: recall.outputIndex,
                   toolUseId: recall.toolUseId,
-                  contentPosition: recall.contentPosition,
+                  contentPosition,
                   acc: recallAcc,
                   signal,
                 });
@@ -6953,7 +7725,7 @@ export function streamResponsesRecallAware(
                       resultText: executed.resultText,
                       acc: recallAcc,
                       toolUseId: recall.toolUseId,
-                      contentPosition: recall.contentPosition,
+                      contentPosition,
                       signal,
                     });
                     let recallDepth = pendingRecalls.length;
@@ -6961,7 +7733,10 @@ export function streamResponsesRecallAware(
                       activeReader = follow.reader;
                       const contState = makeResponsesAccState();
                       const contRecallIndices = new Set<number>();
-                      const contReferenceIndices = new Set<number>();
+                      const contReferenceIndices = new Map<
+                        number,
+                        ReferenceLifecycle
+                      >();
                       const contRecallInputs = new Map<
                         number,
                         { query: string; scope?: string; id?: string }
@@ -6973,12 +7748,14 @@ export function streamResponsesRecallAware(
                       let contOtherTool = false;
                       let continuationCompleted = false;
                       let continuationFailed = false;
-                      const contIndex =
+                      const contIndex = shiftedOutputIndex(
                         Math.max(
                           -1,
                           ...state.rawItems.keys(),
                           ...state.items.keys(),
-                        ) + 1;
+                        ),
+                        1,
+                      );
                       try {
                         for await (const {
                           event: ce,
@@ -7024,31 +7801,12 @@ export function streamResponsesRecallAware(
                             );
                           }
                           validateResponseLifecycle(contState, ce, cparsed);
-                          const rawContinuationIndex = cparsed.output_index;
-                          const addedContinuationItem = cparsed.item as
-                            | Record<string, unknown>
-                            | undefined;
                           if (
-                            ce === "response.output_item.added" &&
-                            addedContinuationItem?.type === "item_reference"
-                          ) {
-                            if (
-                              !Number.isSafeInteger(rawContinuationIndex) ||
-                              (rawContinuationIndex as number) < 0
-                            ) {
-                              throw new Error(
-                                "invalid Responses output_index for item_reference",
-                              );
-                            }
-                            contReferenceIndices.add(
-                              rawContinuationIndex as number,
-                            );
-                            continue;
-                          }
-                          if (
-                            Number.isSafeInteger(rawContinuationIndex) &&
-                            contReferenceIndices.has(
-                              rawContinuationIndex as number,
+                            consumeReferenceEvent(
+                              contState,
+                              contReferenceIndices,
+                              ce,
+                              cparsed,
                             )
                           ) {
                             continue;
@@ -7083,6 +7841,12 @@ export function streamResponsesRecallAware(
                             }
                           }
                           applyResponsesEvent(contState, ce, cparsed);
+                          if (
+                            ce === "response.output_item.done" &&
+                            ci !== undefined
+                          ) {
+                            preserveStreamedReasoning(contState, ci);
+                          }
                           const isContRecall =
                             ci !== undefined && contRecallIndices.has(ci);
                           if (isContRecall) {
@@ -7142,8 +7906,20 @@ export function streamResponsesRecallAware(
                             ce === "response.incomplete" ||
                             ce === "response.failed"
                           ) {
+                            const terminalParsed =
+                              stripHiddenReferenceOutput(cparsed);
                             assertOutputLifecyclesComplete(contState);
-                            assertTerminalOutputMatches(contState, cparsed);
+                            assertReferenceLifecyclesComplete(
+                              contReferenceIndices,
+                            );
+                            assertTerminalOutputMatches(
+                              contState,
+                              terminalParsed,
+                            );
+                            assertRecallItemsCompleted(
+                              contState,
+                              contPending.map((recall) => recall.outputIndex),
+                            );
                             continuationCompleted =
                               contState.terminalEvent !== undefined;
                             continuationFailed =
@@ -7162,7 +7938,10 @@ export function streamResponsesRecallAware(
                                 ce,
                                 JSON.stringify({
                                   ...cparsed,
-                                  output_index: ci + contIndex,
+                                  output_index: shiftedOutputIndex(
+                                    ci,
+                                    contIndex,
+                                  ),
                                 }),
                               ),
                             );
@@ -7240,10 +8019,16 @@ export function streamResponsesRecallAware(
                           }
                         }
                         for (const [idx, item] of contState.items) {
-                          state.items.set(idx + contIndex, item);
+                          state.items.set(
+                            shiftedOutputIndex(idx, contIndex),
+                            item,
+                          );
                         }
                         for (const [idx, item] of contState.rawItems) {
-                          state.rawItems.set(idx + contIndex, item);
+                          state.rawItems.set(
+                            shiftedOutputIndex(idx, contIndex),
+                            item,
+                          );
                         }
                         mergeUsage(state.usage, contState.usage);
                       };
@@ -7254,7 +8039,7 @@ export function streamResponsesRecallAware(
                       }
                       if (
                         !continuationCompleted ||
-                        contState.items.size === 0
+                        contState.rawItems.size === 0
                       ) {
                         throw new Error(
                           "recall follow-up ended without a completed response containing output",
@@ -7278,6 +8063,7 @@ export function streamResponsesRecallAware(
                           "incomplete recall continuation cannot execute another recall",
                         );
                       }
+                      assertUsageMergeable(state.usage, contState.usage);
                       let nextRecall: (typeof contPending)[number] | undefined;
                       let nextExecuted:
                         | {
@@ -7295,9 +8081,27 @@ export function streamResponsesRecallAware(
                           );
                         }
                         recallDepth++;
-                        nextRecall = contPending[0];
                         nextAcc = finalizeResponsesAcc(contState);
-                        const nextSyntheticId = `msg_${state.id || "lore"}_${nextRecall.outputIndex + contIndex}`;
+                        const pendingNextRecall = contPending[0];
+                        const contentPosition = nextAcc.content.findIndex(
+                          (block) =>
+                            block.type === "tool_use" &&
+                            block.id === pendingNextRecall.toolUseId,
+                        );
+                        if (contentPosition < 0) {
+                          throw new Error(
+                            "recall block not found in finalized continuation",
+                          );
+                        }
+                        nextRecall = {
+                          ...pendingNextRecall,
+                          contentPosition,
+                        };
+                        const shiftedRecallIndex = shiftedOutputIndex(
+                          nextRecall.outputIndex,
+                          contIndex,
+                        );
+                        const nextSyntheticId = `msg_${state.id || "lore"}_${shiftedRecallIndex}`;
                         reserveSyntheticIdentity(nextSyntheticId, [
                           state,
                           contState,
@@ -7322,7 +8126,7 @@ export function streamResponsesRecallAware(
                         queueTransactional(
                           encoder.encode(
                             emitTextItem(
-                              nextRecall.outputIndex + contIndex,
+                              shiftedRecallIndex,
                               nextExecuted.anchorText,
                             ),
                           ),
@@ -7335,6 +8139,7 @@ export function streamResponsesRecallAware(
                       if (!nextRecall || !nextExecuted || contOtherTool) {
                         state.stopReason = contState.stopReason;
                         state.terminalEvent = contState.terminalEvent;
+                        state.terminalResponse = contState.terminalResponse;
                         break;
                       }
                       follow = await settleFollowUp({

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -42,6 +42,8 @@ export interface ResponsesAccState {
     | "response.completed"
     | "response.incomplete"
     | "response.failed";
+  /** Final upstream response snapshot, used when rebuilding transformed SSE. */
+  terminalResponse?: Record<string, unknown>;
   /** Original upstream output items, retained for terminal rebuilds. */
   rawItems: Map<number, Record<string, unknown>>;
   /** Accumulating output items indexed by output_index. */
@@ -113,7 +115,7 @@ export function applyResponsesEvent(
           id: asString(item.id),
           callId: asString(item.call_id),
           name: asString(item.name),
-          args: "",
+          args: asString(item.arguments),
         });
       }
       break;
@@ -223,6 +225,7 @@ export function applyResponsesEvent(
             ? "response.incomplete"
             : "response.completed";
       if (resp) {
+        state.terminalResponse = { ...resp };
         if (typeof resp.id === "string") state.id = resp.id;
         if (typeof resp.model === "string") state.model = resp.model;
         if (typeof resp.status === "string") {
@@ -231,6 +234,26 @@ export function applyResponsesEvent(
 
         const respUsage = resp.usage as Record<string, unknown> | undefined;
         if (respUsage) {
+          const assertTokenCount = (value: unknown, field: string): void => {
+            if (
+              value !== undefined &&
+              (!Number.isSafeInteger(value) || (value as number) < 0)
+            ) {
+              throw new Error(`invalid Responses usage ${field}`);
+            }
+          };
+          assertTokenCount(respUsage.output_tokens, "output_tokens");
+          assertTokenCount(respUsage.input_tokens, "input_tokens");
+          assertTokenCount(respUsage.total_tokens, "total_tokens");
+          if (
+            typeof respUsage.input_tokens === "number" &&
+            typeof respUsage.output_tokens === "number" &&
+            !Number.isSafeInteger(
+              respUsage.input_tokens + respUsage.output_tokens,
+            )
+          ) {
+            throw new Error("Responses usage total token overflow");
+          }
           if (typeof respUsage.output_tokens === "number") {
             state.usage.outputTokens = respUsage.output_tokens;
           }
@@ -240,6 +263,28 @@ export function applyResponsesEvent(
             respUsage.prompt_tokens_details) as
             | Record<string, number>
             | undefined;
+          assertTokenCount(promptDetails?.cached_tokens, "cached_tokens");
+          assertTokenCount(
+            promptDetails?.cache_write_tokens,
+            "cache_write_tokens",
+          );
+          const cachedTokens = promptDetails?.cached_tokens ?? 0;
+          const cacheWriteTokens = promptDetails?.cache_write_tokens ?? 0;
+          const cacheTokens = cachedTokens + cacheWriteTokens;
+          if (!Number.isSafeInteger(cacheTokens)) {
+            throw new Error("Responses usage cache token overflow");
+          }
+          if (
+            typeof respUsage.input_tokens === "number" &&
+            cacheTokens > respUsage.input_tokens
+          ) {
+            throw new Error("Responses usage cache tokens exceed input tokens");
+          }
+          if (cacheTokens > 0 && typeof respUsage.input_tokens !== "number") {
+            throw new Error(
+              "Responses usage cache tokens require input_tokens",
+            );
+          }
           if (promptDetails?.cached_tokens !== undefined) {
             state.usage.cacheReadInputTokens = promptDetails.cached_tokens;
           }
@@ -252,9 +297,7 @@ export function applyResponsesEvent(
             // to match the gateway's disjoint token convention.
             state.usage.inputTokens = Math.max(
               0,
-              respUsage.input_tokens -
-                (promptDetails?.cached_tokens ?? 0) -
-                (promptDetails?.cache_write_tokens ?? 0),
+              respUsage.input_tokens - cacheTokens,
             );
           }
         }

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -231,6 +231,44 @@ describe("streamResponsesRecallAware", () => {
     expect(out).not.toContain("response.failed");
   });
 
+  test("accepts a partial Codex terminal output after streamed items", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_codex_partial_output", "gpt-5.6-terra"),
+        textItem(0, "omitted from terminal", "msg_omitted"),
+        textItem(1, "answer", "msg_answer"),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_codex_partial_output",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "message",
+                id: "msg_answer",
+                role: "assistant",
+                status: "completed",
+                content: [{ type: "output_text", text: "answer" }],
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not be called");
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("answer");
+    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
+    expect(out).not.toContain("response.failed");
+  });
+
   test.each(["failed", "cancelled"])(
     "hides recall when the principal response.done status is %s",
     async (status) => {
@@ -706,6 +744,241 @@ describe("streamResponsesRecallAware", () => {
     expect(await drain(client)).toContain("response.failed");
   });
 
+  test("rejects terminal function calls changing the streamed tool name", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_name", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_terminal_name",
+            call_id: "call_terminal_name",
+            name: "read",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_terminal_name",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_terminal_name",
+            call_id: "call_terminal_name",
+            name: "read",
+            arguments: "{}",
+            status: "completed",
+          },
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_name",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "function_call",
+                id: "fc_terminal_name",
+                call_id: "call_terminal_name",
+                name: "recall",
+                arguments: "{}",
+                status: "completed",
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects malformed terminal output items", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_malformed", "gpt-5.6-terra"),
+        textItem(0, "answer", "msg_terminal_malformed"),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_malformed",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [null],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects terminal output reordering streamed items", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_order", "gpt-5.6-terra"),
+        textItem(0, "first", "msg_first"),
+        textItem(1, "second", "msg_second"),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_order",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "item_reference",
+                id: "msg_second",
+              },
+              {
+                type: "message",
+                id: "msg_first",
+                role: "assistant",
+                content: [{ type: "output_text", text: "first" }],
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("accepts terminal items that add optional status metadata", async () => {
+    const doneItem = {
+      type: "function_call",
+      id: "fc_terminal_status",
+      call_id: "call_terminal_status",
+      name: "read",
+      arguments: "{}",
+    };
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_status", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: doneItem,
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_terminal_status",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: doneItem,
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_status",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [{ ...doneItem, status: "completed" }],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).not.toContain("response.failed");
+  });
+
+  test.each([
+    {
+      name: "message annotations",
+      doneItem: {
+        type: "message",
+        id: "msg_terminal_metadata",
+        role: "assistant",
+        content: [{ type: "output_text", text: "answer" }],
+      },
+      terminalItem: {
+        type: "message",
+        id: "msg_terminal_metadata",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "answer", annotations: [] }],
+      },
+    },
+    {
+      name: "hosted-tool status",
+      doneItem: {
+        type: "web_search_call",
+        id: "ws_terminal_metadata",
+        action: { type: "search", query: "lore" },
+      },
+      terminalItem: {
+        type: "web_search_call",
+        id: "ws_terminal_metadata",
+        status: "completed",
+        action: { type: "search", query: "lore" },
+      },
+    },
+  ])(
+    "accepts terminal enrichment with optional $name",
+    async ({ doneItem, terminalItem }) => {
+      const client = streamResponsesRecallAware(
+        streamFrom([
+          created("resp_terminal_metadata", "gpt-5.6-terra"),
+          sseEvent("response.output_item.added", {
+            output_index: 0,
+            item: doneItem,
+          }),
+          sseEvent("response.output_item.done", {
+            output_index: 0,
+            item: doneItem,
+          }),
+          sseEvent("response.completed", {
+            response: {
+              id: "resp_terminal_metadata",
+              model: "gpt-5.6-terra",
+              status: "completed",
+              output: [terminalItem],
+            },
+          }),
+        ]),
+        {
+          onComplete: () => {},
+          onRecall: async () => ({ anchorText: "", resultText: "" }),
+          runFollowUp: async () => {
+            throw new Error("should not run");
+          },
+        },
+      );
+
+      expect(await drain(client)).not.toContain("response.failed");
+    },
+  );
+
   test("never forwards response-side item_reference lifecycle events", async () => {
     let completedResponse: GatewayResponse | undefined;
     const client = streamResponsesRecallAware(
@@ -725,7 +998,14 @@ describe("streamResponsesRecallAware", () => {
             id: "msg_server_only",
           },
         }),
-        completed("resp_reference"),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_reference",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [{ type: "item_reference", id: "msg_server_only" }],
+          },
+        }),
       ]),
       {
         onComplete: (response) => {
@@ -739,10 +1019,34 @@ describe("streamResponsesRecallAware", () => {
     );
     const out = await drain(client);
     expect(out).not.toContain("item_reference");
+    expect(out).not.toContain("response.failed");
     expect(JSON.stringify(completedResponse)).not.toContain("item_reference");
   });
 
+  test("rejects an item_reference missing output_item.done", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reference_incomplete", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "item_reference", id: "msg_reference_incomplete" },
+        }),
+        completed("resp_reference_incomplete"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
   test("accepts reasoning summaries with summary_index", async () => {
+    let completedResponse: GatewayResponse | undefined;
     const client = streamResponsesRecallAware(
       streamFrom([
         created("resp_summary", "gpt-5.6-terra"),
@@ -756,6 +1060,12 @@ describe("streamResponsesRecallAware", () => {
           summary_index: 0,
           delta: "summary",
         }),
+        sseEvent("response.reasoning_summary_text.done", {
+          output_index: 0,
+          item_id: "rs_summary",
+          summary_index: 0,
+          text: "summary",
+        }),
         sseEvent("response.output_item.done", {
           output_index: 0,
           item: { type: "reasoning", id: "rs_summary", summary: [] },
@@ -763,7 +1073,9 @@ describe("streamResponsesRecallAware", () => {
         completed("resp_summary"),
       ]),
       {
-        onComplete: () => {},
+        onComplete: (response) => {
+          completedResponse = response;
+        },
         onRecall: async () => ({ anchorText: "", resultText: "" }),
         runFollowUp: async () => {
           throw new Error("should not run");
@@ -773,6 +1085,1652 @@ describe("streamResponsesRecallAware", () => {
     const out = await drain(client);
     expect(out).toContain("response.reasoning_summary_text.delta");
     expect(out).not.toContain("response.failed");
+    expect(completedResponse?.rawOutputItems).toContainEqual(
+      expect.objectContaining({
+        summary: [{ type: "summary_text", text: "summary" }],
+      }),
+    );
+  });
+
+  test("rejects unfinished reasoning omitted from output_item.done", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_summary_unfinished", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_summary_unfinished", summary: [] },
+        }),
+        sseEvent("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          item_id: "rs_summary_unfinished",
+          summary_index: 0,
+          delta: "partial",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_summary_unfinished", summary: [] },
+        }),
+        completed("resp_summary_unfinished"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects unfinished reasoning when output_item.done omits summary", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_summary_field_omitted", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_summary_field_omitted",
+            summary: [],
+          },
+        }),
+        sseEvent("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          item_id: "rs_summary_field_omitted",
+          summary_index: 0,
+          delta: "partial",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_summary_field_omitted" },
+        }),
+        completed("resp_summary_field_omitted"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects output text deltas that differ from the final text", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_text_delta_mismatch", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_text_delta_mismatch",
+            role: "assistant",
+          },
+        }),
+        sseEvent("response.output_text.delta", {
+          output_index: 0,
+          item_id: "msg_text_delta_mismatch",
+          content_index: 0,
+          delta: "different",
+        }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_text_delta_mismatch",
+          content_index: 0,
+          text: "final",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_text_delta_mismatch",
+            role: "assistant",
+            content: [{ type: "output_text", text: "final" }],
+          },
+        }),
+        completed("resp_text_delta_mismatch"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects function argument deltas that differ from the final arguments", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_argument_delta_mismatch", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_argument_delta_mismatch",
+            call_id: "call_argument_delta_mismatch",
+            name: "read",
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_argument_delta_mismatch",
+          delta: '{"path":"different"}',
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_argument_delta_mismatch",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_argument_delta_mismatch",
+            call_id: "call_argument_delta_mismatch",
+            name: "read",
+            arguments: "{}",
+          },
+        }),
+        completed("resp_argument_delta_mismatch"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("accepts function argument deltas extending an initial snapshot", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_argument_initial", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_argument_initial",
+            call_id: "call_argument_initial",
+            name: "read",
+            arguments: '{"path":"',
+          },
+        }),
+        sseEvent("response.function_call_arguments.delta", {
+          output_index: 0,
+          item_id: "fc_argument_initial",
+          delta: 'file"}',
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_argument_initial",
+          arguments: '{"path":"file"}',
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_argument_initial",
+            call_id: "call_argument_initial",
+            name: "read",
+            arguments: '{"path":"file"}',
+          },
+        }),
+        completed("resp_argument_initial"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).not.toContain("response.failed");
+  });
+
+  test("rejects output_item.done changing initial function arguments", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_argument_initial_changed", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_argument_initial_changed",
+            call_id: "call_argument_initial_changed",
+            name: "read",
+            arguments: '{"path":"secret"}',
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_argument_initial_changed",
+          arguments: "{}",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_argument_initial_changed",
+            call_id: "call_argument_initial_changed",
+            name: "read",
+            arguments: "{}",
+          },
+        }),
+        completed("resp_argument_initial_changed"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects output_item.done changing initial message content", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_message_initial_changed", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_initial_changed",
+            role: "assistant",
+            content: [{ type: "output_text", text: "secret" }],
+          },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_initial_changed",
+            role: "assistant",
+            content: [{ type: "output_text", text: "safe" }],
+          },
+        }),
+        completed("resp_message_initial_changed"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects content_part.done changing initial part content", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_part_initial_changed", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_part_initial_changed",
+            role: "assistant",
+          },
+        }),
+        sseEvent("response.content_part.added", {
+          output_index: 0,
+          item_id: "msg_part_initial_changed",
+          content_index: 0,
+          part: { type: "output_text", text: "secret" },
+        }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_part_initial_changed",
+          content_index: 0,
+          text: "safe",
+        }),
+        sseEvent("response.content_part.done", {
+          output_index: 0,
+          item_id: "msg_part_initial_changed",
+          content_index: 0,
+          part: { type: "output_text", text: "safe" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_part_initial_changed",
+            role: "assistant",
+            content: [{ type: "output_text", text: "safe" }],
+          },
+        }),
+        completed("resp_part_initial_changed"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects finalized reasoning that contradicts summary deltas", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reasoning_changed", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_changed", summary: [] },
+        }),
+        sseEvent("response.reasoning_summary_part.added", {
+          output_index: 0,
+          item_id: "rs_changed",
+          summary_index: 0,
+        }),
+        sseEvent("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          item_id: "rs_changed",
+          summary_index: 0,
+          delta: "secret",
+        }),
+        sseEvent("response.reasoning_summary_text.done", {
+          output_index: 0,
+          item_id: "rs_changed",
+          summary_index: 0,
+          text: "secret",
+        }),
+        sseEvent("response.reasoning_summary_part.done", {
+          output_index: 0,
+          item_id: "rs_changed",
+          summary_index: 0,
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_changed",
+            summary: [{ type: "summary_text", text: "safe" }],
+          },
+        }),
+        completed("resp_reasoning_changed"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects reuse of an item_reference output index", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reference_reuse", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "item_reference", id: "msg_server_only" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: { type: "item_reference", id: "msg_server_only" },
+        }),
+        recallCall(0, { query: "hidden" }),
+        completed("resp_reference_reuse"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+    expect(recalled).toBe(0);
+  });
+
+  test("accepts unchanged non-empty initial message content", async () => {
+    const item = {
+      type: "message",
+      id: "msg_initial_unchanged",
+      role: "assistant",
+      content: [{ type: "output_text", text: "already complete" }],
+    };
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_message_initial_unchanged", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", { output_index: 0, item }),
+        sseEvent("response.output_item.done", { output_index: 0, item }),
+        completed("resp_message_initial_unchanged"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).not.toContain("response.failed");
+  });
+
+  test("rejects output_item.done changing a message role", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_message_role_changed", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_role_changed",
+            role: "assistant",
+            content: [],
+          },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_role_changed",
+            role: "user",
+            content: [],
+          },
+        }),
+        completed("resp_message_role_changed"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("accepts content-part prefixes extended by deltas", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_part_prefix", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_part_prefix", role: "assistant" },
+        }),
+        sseEvent("response.content_part.added", {
+          output_index: 0,
+          item_id: "msg_part_prefix",
+          content_index: 0,
+          part: { type: "output_text", text: "pre" },
+        }),
+        sseEvent("response.output_text.delta", {
+          output_index: 0,
+          item_id: "msg_part_prefix",
+          content_index: 0,
+          delta: "fix",
+        }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_part_prefix",
+          content_index: 0,
+          text: "prefix",
+        }),
+        sseEvent("response.content_part.done", {
+          output_index: 0,
+          item_id: "msg_part_prefix",
+          content_index: 0,
+          part: { type: "output_text", text: "prefix" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_part_prefix",
+            role: "assistant",
+            content: [{ type: "output_text", text: "prefix" }],
+          },
+        }),
+        completed("resp_part_prefix"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).not.toContain("response.failed");
+  });
+
+  test.each([
+    {
+      name: "part completion changing initial content",
+      events:
+        sseEvent("response.content_part.added", {
+          output_index: 0,
+          item_id: "msg_part_order",
+          content_index: 0,
+          part: { type: "output_text", text: "secret" },
+        }) +
+        sseEvent("response.content_part.done", {
+          output_index: 0,
+          item_id: "msg_part_order",
+          content_index: 0,
+          part: { type: "output_text", text: "safe" },
+        }),
+    },
+    {
+      name: "part added after text completion",
+      events:
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_part_order",
+          content_index: 0,
+          text: "safe",
+        }) +
+        sseEvent("response.content_part.added", {
+          output_index: 0,
+          item_id: "msg_part_order",
+          content_index: 0,
+          part: { type: "output_text", text: "evil" },
+        }) +
+        sseEvent("response.content_part.done", {
+          output_index: 0,
+          item_id: "msg_part_order",
+          content_index: 0,
+          part: { type: "output_text", text: "safe" },
+        }),
+    },
+  ])("rejects $name", async ({ events }) => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_part_order", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_part_order", role: "assistant" },
+        }),
+        events,
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_part_order",
+            role: "assistant",
+            content: [{ type: "output_text", text: "safe" }],
+          },
+        }),
+        completed("resp_part_order"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("accepts reasoning summary prefixes extended by deltas", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_summary_prefix", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_summary_prefix",
+            summary: [{ type: "summary_text", text: "pre" }],
+          },
+        }),
+        sseEvent("response.reasoning_summary_part.added", {
+          output_index: 0,
+          item_id: "rs_summary_prefix",
+          summary_index: 0,
+          part: { type: "summary_text", text: "pre" },
+        }),
+        sseEvent("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          item_id: "rs_summary_prefix",
+          summary_index: 0,
+          delta: "fix",
+        }),
+        sseEvent("response.reasoning_summary_text.done", {
+          output_index: 0,
+          item_id: "rs_summary_prefix",
+          summary_index: 0,
+          text: "prefix",
+        }),
+        sseEvent("response.reasoning_summary_part.done", {
+          output_index: 0,
+          item_id: "rs_summary_prefix",
+          summary_index: 0,
+          part: { type: "summary_text", text: "prefix" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_summary_prefix",
+            summary: [{ type: "summary_text", text: "prefix" }],
+          },
+        }),
+        completed("resp_summary_prefix"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).not.toContain("response.failed");
+  });
+
+  test("accepts indexed reasoning-text content lifecycles", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reasoning_text", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_text", content: [] },
+        }),
+        sseEvent("response.content_part.added", {
+          output_index: 0,
+          item_id: "rs_text",
+          content_index: 0,
+          part: { type: "reasoning_text", text: "pre" },
+        }),
+        sseEvent("response.reasoning_text.delta", {
+          output_index: 0,
+          item_id: "rs_text",
+          content_index: 0,
+          delta: "fix",
+        }),
+        sseEvent("response.reasoning_text.done", {
+          output_index: 0,
+          item_id: "rs_text",
+          content_index: 0,
+          text: "prefix",
+        }),
+        sseEvent("response.content_part.done", {
+          output_index: 0,
+          item_id: "rs_text",
+          content_index: 0,
+          part: { type: "reasoning_text", text: "prefix" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_text",
+            content: [{ type: "reasoning_text", text: "prefix" }],
+          },
+        }),
+        completed("resp_reasoning_text"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).not.toContain("response.failed");
+  });
+
+  test("rejects reasoning deltas after text completion", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reasoning_late_delta", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_late_delta", summary: [] },
+        }),
+        sseEvent("response.reasoning_summary_text.done", {
+          output_index: 0,
+          item_id: "rs_late_delta",
+          summary_index: 0,
+          text: "safe",
+        }),
+        sseEvent("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          item_id: "rs_late_delta",
+          summary_index: 0,
+          delta: "evil",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_late_delta",
+            summary: [{ type: "summary_text", text: "safe" }],
+          },
+        }),
+        completed("resp_reasoning_late_delta"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects output_item.done changing reasoning text", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reasoning_text_changed", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_text_changed", content: [] },
+        }),
+        sseEvent("response.reasoning_text.done", {
+          output_index: 0,
+          item_id: "rs_text_changed",
+          content_index: 0,
+          text: "secret",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_text_changed",
+            content: [{ type: "reasoning_text", text: "safe" }],
+          },
+        }),
+        completed("resp_reasoning_text_changed"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects reuse of an item_reference index in a continuation", async () => {
+    const followUp = streamFrom([
+      created("resp_reference_reuse_followup", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: { type: "item_reference", id: "msg_server_followup" },
+      }),
+      sseEvent("response.output_item.done", {
+        output_index: 0,
+        item: { type: "item_reference", id: "msg_server_followup" },
+      }),
+      recallCall(0, { query: "hidden followup" }),
+      completed("resp_reference_reuse_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reference_reuse_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "start" }),
+        completed("resp_reference_reuse_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: "recalled",
+          resultText: "result",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("rejects content-part declarations after value deltas", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_late_part", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_late_part", role: "assistant" },
+        }),
+        sseEvent("response.output_text.delta", {
+          output_index: 0,
+          item_id: "msg_late_part",
+          content_index: 0,
+          delta: "text",
+        }),
+        sseEvent("response.content_part.added", {
+          output_index: 0,
+          item_id: "msg_late_part",
+          content_index: 0,
+          part: { type: "output_text", text: "text" },
+        }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_late_part",
+          content_index: 0,
+          text: "text",
+        }),
+        sseEvent("response.content_part.done", {
+          output_index: 0,
+          item_id: "msg_late_part",
+          content_index: 0,
+          part: { type: "output_text", text: "text" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_late_part",
+            role: "assistant",
+            content: [{ type: "output_text", text: "text" }],
+          },
+        }),
+        completed("resp_late_part"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("uses the finalized content position for interleaved recall items", async () => {
+    let observedPosition = -1;
+    const followUp = streamFrom([
+      created("resp_interleaved_followup", "gpt-5.6-terra"),
+      textItem(0, "answer", "msg_interleaved_answer"),
+      completed("resp_interleaved_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_interleaved", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_interleaved", role: "assistant" },
+        }),
+        recallCall(1, { query: "position" }),
+        sseEvent("response.output_text.done", {
+          output_index: 0,
+          item_id: "msg_interleaved",
+          content_index: 0,
+          text: "earlier",
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "message",
+            id: "msg_interleaved",
+            role: "assistant",
+            content: [{ type: "output_text", text: "earlier" }],
+          },
+        }),
+        completed("resp_interleaved"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ contentPosition }) => {
+          observedPosition = contentPosition;
+          return { anchorText: "recalled", resultText: "result" };
+        },
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(observedPosition).toBe(1);
+  });
+
+  test("rejects non-completed recall output items without executing them", async () => {
+    let recalled = 0;
+    const args = JSON.stringify({ query: "must not execute" });
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_failed_recall_item", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_failed_recall",
+            call_id: "call_failed_recall",
+            name: "recall",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_failed_recall",
+          arguments: args,
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "function_call",
+            id: "fc_failed_recall",
+            call_id: "call_failed_recall",
+            name: "recall",
+            arguments: args,
+            status: "failed",
+          },
+        }),
+        completed("resp_failed_recall_item"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects terminal-only failed recall status without executing it", async () => {
+    let recalled = 0;
+    const args = JSON.stringify({ query: "terminal failure" });
+    const streamedItem = {
+      type: "function_call",
+      id: "fc_terminal_failed_recall",
+      call_id: "call_terminal_failed_recall",
+      name: "recall",
+      arguments: args,
+    };
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_failed_recall", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: streamedItem,
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 0,
+          item_id: "fc_terminal_failed_recall",
+          arguments: args,
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: streamedItem,
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_terminal_failed_recall",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [{ ...streamedItem, status: "failed" }],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects nonterminal response.done status without executing recall", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_nonterminal_done", "gpt-5.6-terra"),
+        recallCall(0, { query: "not terminal" }),
+        doneWithStatus("resp_nonterminal_done", "in_progress"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test.each(["response.created", "response.in_progress"])(
+    "rejects hidden output in %s snapshots",
+    async (event) => {
+      let recalled = 0;
+      const snapshot = sseEvent(event, {
+        response: {
+          id: "resp_snapshot_output",
+          model: "gpt-5.6-terra",
+          status: "in_progress",
+          output: [
+            {
+              type: "function_call",
+              id: "fc_snapshot_recall",
+              call_id: "call_snapshot_recall",
+              name: "recall",
+              arguments: '{"query":"leaked"}',
+            },
+          ],
+        },
+      });
+      const events =
+        event === "response.created"
+          ? [snapshot]
+          : [created("resp_snapshot_output", "gpt-5.6-terra"), snapshot];
+      const client = streamResponsesRecallAware(streamFrom(events), {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      });
+
+      const output = await drain(client);
+      expect(output).toContain("response.failed");
+      expect(output).not.toContain("fc_snapshot_recall");
+      expect(recalled).toBe(0);
+    },
+  );
+
+  test.each(["response.created", "response.in_progress"])(
+    "rejects contradictory status in %s snapshots",
+    async (event) => {
+      const snapshot = sseEvent(event, {
+        response: {
+          id: "resp_snapshot_status",
+          model: "gpt-5.6-terra",
+          status: "failed",
+          output: [],
+        },
+      });
+      const events =
+        event === "response.created"
+          ? [snapshot]
+          : [created("resp_snapshot_status", "gpt-5.6-terra"), snapshot];
+      const client = streamResponsesRecallAware(streamFrom(events), {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      });
+
+      expect(await drain(client)).toContain("response.failed");
+    },
+  );
+
+  test("preserves failed companion-tool status in rebuilt terminals", async () => {
+    const companionArgs = "{}";
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_failed_companion", "gpt-5.6-terra"),
+        recallCall(0, { query: "companion" }),
+        sseEvent("response.output_item.added", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_failed_companion",
+            call_id: "call_failed_companion",
+            name: "read",
+            status: "in_progress",
+          },
+        }),
+        sseEvent("response.function_call_arguments.done", {
+          output_index: 1,
+          item_id: "fc_failed_companion",
+          arguments: companionArgs,
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 1,
+          item: {
+            type: "function_call",
+            id: "fc_failed_companion",
+            call_id: "call_failed_companion",
+            name: "read",
+            arguments: companionArgs,
+          },
+        }),
+        sseEvent("response.completed", {
+          response: {
+            id: "resp_failed_companion",
+            model: "gpt-5.6-terra",
+            status: "completed",
+            output: [
+              {
+                type: "function_call",
+                id: "fc_failed_companion",
+                call_id: "call_failed_companion",
+                name: "read",
+                arguments: companionArgs,
+                status: "failed",
+              },
+            ],
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: "recalled",
+          resultText: "result",
+        }),
+        runFollowUp: async () => {
+          throw new Error("mixed tools should not run a follow-up");
+        },
+      },
+    );
+
+    const output = await drain(client);
+    expect(output).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(output).toContain(
+      '"id":"fc_failed_companion","call_id":"call_failed_companion","name":"read","arguments":"{}","status":"failed"',
+    );
+    expect(output).not.toContain(
+      '"id":"fc_failed_companion","call_id":"call_failed_companion","name":"read","arguments":"{}","status":"completed"',
+    );
+  });
+
+  test("rejects reference identities reused by later output items", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reference_identity", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "item_reference", id: "call_shared_reference" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: { type: "item_reference", id: "call_shared_reference" },
+        }),
+        recallCall(
+          1,
+          { query: "identity" },
+          "fc_reference_identity",
+          "call_shared_reference",
+        ),
+        completed("resp_reference_identity"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects reference identities colliding with synthetic markers", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reference_marker", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: {
+            type: "item_reference",
+            id: "msg_resp_reference_marker_1",
+          },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "item_reference",
+            id: "msg_resp_reference_marker_1",
+          },
+        }),
+        recallCall(1, { query: "marker identity" }),
+        completed("resp_reference_marker"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects reasoning-part declarations after summary deltas", async () => {
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_late_summary_part", "gpt-5.6-terra"),
+        sseEvent("response.output_item.added", {
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_late_part", summary: [] },
+        }),
+        sseEvent("response.reasoning_summary_text.delta", {
+          output_index: 0,
+          item_id: "rs_late_part",
+          summary_index: 0,
+          delta: "summary",
+        }),
+        sseEvent("response.reasoning_summary_part.added", {
+          output_index: 0,
+          item_id: "rs_late_part",
+          summary_index: 0,
+          part: { type: "summary_text", text: "summary" },
+        }),
+        sseEvent("response.reasoning_summary_text.done", {
+          output_index: 0,
+          item_id: "rs_late_part",
+          summary_index: 0,
+          text: "summary",
+        }),
+        sseEvent("response.reasoning_summary_part.done", {
+          output_index: 0,
+          item_id: "rs_late_part",
+          summary_index: 0,
+          part: { type: "summary_text", text: "summary" },
+        }),
+        sseEvent("response.output_item.done", {
+          output_index: 0,
+          item: {
+            type: "reasoning",
+            id: "rs_late_part",
+            summary: [{ type: "summary_text", text: "summary" }],
+          },
+        }),
+        completed("resp_late_summary_part"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({ anchorText: "", resultText: "" }),
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain("response.failed");
+  });
+
+  test("rejects continuation index arithmetic beyond safe integers", async () => {
+    const followUp = streamFrom([
+      created("resp_index_overflow_followup", "gpt-5.6-terra"),
+      textItem(0, "first", "msg_index_overflow_first"),
+      textItem(1, "second", "msg_index_overflow_second"),
+      completed("resp_index_overflow_followup"),
+    ]);
+    const maxIndex = Number.MAX_SAFE_INTEGER;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_index_overflow", "gpt-5.6-terra"),
+        recallCall(maxIndex, { query: "overflow" }),
+        completed("resp_index_overflow"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: "recalled",
+          resultText: "result",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const output = await drain(client);
+    expect(output).toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain('"output_index":9007199254740992');
+  });
+
+  test("rejects usage overflow while merging a continuation", async () => {
+    const followUp = streamFrom([
+      created("resp_usage_overflow_followup", "gpt-5.6-terra"),
+      textItem(0, "answer", "msg_usage_overflow"),
+      completed("resp_usage_overflow_followup", {
+        input_tokens: 1,
+        output_tokens: 0,
+      }),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_usage_overflow", "gpt-5.6-terra"),
+        recallCall(0, { query: "usage" }),
+        completed("resp_usage_overflow", {
+          input_tokens: Number.MAX_SAFE_INTEGER,
+          output_tokens: 0,
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: "recalled",
+          resultText: "result",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const output = await drain(client);
+    expect(output).toContain(PUBLIC_RECALL_ERROR);
+    expect(output).not.toContain('"input_tokens":null');
+  });
+
+  test("rejects per-response usage overflow before recall side effects", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_usage_total_overflow", "gpt-5.6-terra"),
+        recallCall(0, { query: "usage" }),
+        completed("resp_usage_total_overflow", {
+          input_tokens: Number.MAX_SAFE_INTEGER,
+          output_tokens: 1,
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects impossible cache usage before recall side effects", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_cache_usage_overflow", "gpt-5.6-terra"),
+        recallCall(0, { query: "usage" }),
+        completed("resp_cache_usage_overflow", {
+          input_tokens: 0,
+          output_tokens: 1,
+          input_tokens_details: {
+            cached_tokens: Number.MAX_SAFE_INTEGER,
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects cache usage without input_tokens before recall", async () => {
+    let recalled = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_cache_without_input", "gpt-5.6-terra"),
+        recallCall(0, { query: "usage" }),
+        completed("resp_cache_without_input", {
+          output_tokens: 1,
+          input_tokens_details: {
+            cached_tokens: Number.MAX_SAFE_INTEGER,
+          },
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "", resultText: "" };
+        },
+        runFollowUp: async () => {
+          throw new Error("should not run");
+        },
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(0);
+  });
+
+  test("rejects cross-phase usage overflow before chained recall", async () => {
+    let recalled = 0;
+    const followUp = streamFrom([
+      created("resp_chained_usage_overflow", "gpt-5.6-terra"),
+      recallCall(0, { query: "second" }),
+      completed("resp_chained_usage_overflow", {
+        input_tokens: 0,
+        output_tokens: 1,
+      }),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_chained_usage_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "first" }),
+        completed("resp_chained_usage_principal", {
+          input_tokens: Number.MAX_SAFE_INTEGER,
+          output_tokens: 0,
+        }),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => {
+          recalled++;
+          return { anchorText: "recalled", resultText: "result" };
+        },
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+    expect(recalled).toBe(1);
+  });
+
+  test("preserves continuation terminal and item metadata", async () => {
+    const citation = {
+      type: "url_citation",
+      start_index: 0,
+      end_index: 6,
+      url: "https://example.com/lore",
+      title: "Lore",
+    };
+    const followUp = streamFrom([
+      created("resp_terminal_metadata_followup", "gpt-5.6-terra"),
+      textItem(0, "answer", "msg_terminal_metadata_followup"),
+      sseEvent("response.incomplete", {
+        response: {
+          id: "resp_terminal_metadata_followup",
+          model: "gpt-5.6-terra",
+          status: "incomplete",
+          incomplete_details: { reason: "max_output_tokens" },
+          output: [
+            {
+              type: "message",
+              id: "msg_terminal_metadata_followup",
+              role: "assistant",
+              status: "completed",
+              content: [
+                {
+                  type: "output_text",
+                  text: "answer",
+                  annotations: [citation],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_terminal_metadata_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "metadata" }),
+        completed("resp_terminal_metadata_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: "recalled",
+          resultText: "result",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const output = await drain(client);
+    expect(output).toContain('"reason":"max_output_tokens"');
+    expect(output).toContain("https://example.com/lore");
+    expect(output).not.toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("rejects continuation references colliding with principal identities", async () => {
+    const followUp = streamFrom([
+      created("resp_reference_collision_followup", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: { type: "item_reference", id: "call_principal_recall" },
+      }),
+      sseEvent("response.output_item.done", {
+        output_index: 0,
+        item: { type: "item_reference", id: "call_principal_recall" },
+      }),
+      textItem(1, "answer", "msg_reference_collision_answer"),
+      completed("resp_reference_collision_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reference_collision_principal", "gpt-5.6-terra"),
+        recallCall(
+          0,
+          { query: "collision" },
+          "fc_principal_recall",
+          "call_principal_recall",
+        ),
+        completed("resp_reference_collision_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: "recalled",
+          resultText: "result",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    expect(await drain(client)).toContain(PUBLIC_RECALL_ERROR);
+  });
+
+  test("accepts reasoning-only recall continuations", async () => {
+    const followUp = streamFrom([
+      created("resp_reasoning_only_followup", "gpt-5.6-terra"),
+      sseEvent("response.output_item.added", {
+        output_index: 0,
+        item: { type: "reasoning", id: "rs_only", summary: [] },
+      }),
+      sseEvent("response.output_item.done", {
+        output_index: 0,
+        item: { type: "reasoning", id: "rs_only", summary: [] },
+      }),
+      completed("resp_reasoning_only_followup"),
+    ]);
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_reasoning_only_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "reason" }),
+        completed("resp_reasoning_only_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: "recalled",
+          resultText: "result",
+        }),
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const output = await drain(client);
+    expect(output).toContain('"id":"rs_only"');
+    expect(output).not.toContain(PUBLIC_RECALL_ERROR);
   });
 
   test.each([

--- a/packages/gateway/test/recall-codex-stream.test.ts
+++ b/packages/gateway/test/recall-codex-stream.test.ts
@@ -75,9 +75,9 @@ function codexRecallStream(): Response {
         id: "resp_recall",
         model: "gpt-5.5",
         status: "completed",
-        // ChatGPT may omit streamed items from the terminal snapshot. The
+        // ChatGPT may replace streamed items with terminal references. The
         // output_item lifecycle above is the authoritative response content.
-        output: [],
+        output: [{ type: "item_reference", id: "fc_recall" }],
         usage: { input_tokens: 100, output_tokens: 10 },
       },
     }) +
@@ -119,7 +119,7 @@ function codexFinalStream(): Response {
         id: "resp_final",
         model: "gpt-5.5",
         status: "completed",
-        output: [],
+        output: [{ type: "item_reference", id: "msg_final" }],
         usage: { input_tokens: 120, output_tokens: 5 },
       },
     }) +


### PR DESCRIPTION
## Summary

- treat streamed Responses output-item lifecycles as authoritative while accepting ordered terminal subsets and item references
- validate initial/delta/done snapshots, identities, statuses, reasoning, usage, and continuation index arithmetic before recall side effects
- preserve terminal metadata and reasoning content when rebuilding recall continuations
- add adversarial principal and continuation regressions for the recurring Codex recall failure

## Verification

- `pnpm test`
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format:check`
- two independent adversarial/security reviews: MERGE
- standalone Linux binary built and installed locally
- live `lore run opencode run -m openai/gpt-5.6-sol ...` recall probe returned a recall marker and final answer without `Lore could not continue the response after recall`