### PR TITLE
fix(gateway): harden streaming trust boundaries

### DIFF
--- a/packages/core/src/distillation.ts
+++ b/packages/core/src/distillation.ts
@@ -968,6 +968,7 @@ export async function run(input: {
   skipMeta?: boolean;
   urgent?: boolean;
   callType?: "batch" | "direct";
+  signal?: AbortSignal;
   /** Optional hook for the gateway to record worker health events. When the
    *  LLM call returns null (no response), the hook is called with a categorical
    *  reason. The gateway uses this to escalate to Sentry / dashboard after
@@ -1005,6 +1006,7 @@ async function runInner(input: {
   /** Whether the LLM call will use batch or direct pricing. Recorded on the
    *  distillation row for accurate historical cost estimates. */
   callType?: "batch" | "direct";
+  signal?: AbortSignal;
   /** See run() — optional gateway worker-health hook. */
   workerHealth?: {
     recordFailure(reason: string): void;
@@ -1013,6 +1015,7 @@ async function runInner(input: {
   /** See run() — propagated to the `metadata` column on every minted row. */
   metadata?: KnowledgeMetadata;
 }): Promise<{ rounds: number; distilled: number }> {
+  input.signal?.throwIfAborted();
   // Reset orphaned messages (marked distilled by a deleted/migrated distillation)
   const orphans = resetOrphans(input.projectPath, input.sessionID);
   if (orphans > 0) {
@@ -1025,6 +1028,7 @@ async function runInner(input: {
   let distilled = 0;
 
   for (let round = 0; round < maxRounds; round++) {
+    input.signal?.throwIfAborted();
     // Check if there are enough undistilled messages
     const pending = temporal.undistilled(input.projectPath, input.sessionID);
     if (
@@ -1062,12 +1066,14 @@ async function runInner(input: {
           model: input.model,
           urgent: input.urgent,
           callType: input.callType,
+          signal: input.signal,
           workerHealth: input.workerHealth,
           // #627 Phase 1: propagate gitHead down the main distillation path so
           // observer/echo/tag entries minted here get stamped (not just the
           // urgent path).
           metadata: input.metadata,
         });
+        input.signal?.throwIfAborted();
         if (result) {
           distilled += segment.length;
           rounds++;
@@ -1091,11 +1097,13 @@ async function runInner(input: {
         model: input.model,
         urgent: input.urgent,
         callType: input.callType,
+        signal: input.signal,
         workerHealth: input.workerHealth,
         // #627 Phase 1: propagate gitHead so meta-distilled (gen-1+) entries
         // are stamped on the main path too.
         metadata: input.metadata,
       });
+      input.signal?.throwIfAborted();
       rounds++;
     }
 
@@ -1116,6 +1124,7 @@ async function distillSegment(input: {
   model?: { providerID: string; modelID: string };
   urgent?: boolean;
   callType?: "batch" | "direct";
+  signal?: AbortSignal;
   workerHealth?: {
     recordFailure(reason: string): void;
     recordSuccess(): void;
@@ -1202,8 +1211,10 @@ async function distillSegment(input: {
       sessionID: input.sessionID,
       maxTokens,
       temperature: 0,
+      signal: input.signal,
     },
   );
+  input.signal?.throwIfAborted();
   if (!responseText) {
     // Transport failure / empty completion is already recorded by the LLM
     // adapter (single owner of transport-failure attribution) — recording
@@ -1494,6 +1505,7 @@ export async function metaDistill(input: {
   model?: { providerID: string; modelID: string };
   urgent?: boolean;
   callType?: "batch" | "direct";
+  signal?: AbortSignal;
   workerHealth?: {
     recordFailure(reason: string): void;
     recordSuccess(): void;
@@ -1511,6 +1523,7 @@ async function metaDistillInner(input: {
   model?: { providerID: string; modelID: string };
   urgent?: boolean;
   callType?: "batch" | "direct";
+  signal?: AbortSignal;
   workerHealth?: {
     recordFailure(reason: string): void;
     recordSuccess(): void;
@@ -1572,7 +1585,9 @@ async function metaDistillInner(input: {
     sessionID: input.sessionID,
     maxTokens,
     temperature: 0,
+    signal: input.signal,
   });
+  input.signal?.throwIfAborted();
   if (!responseText) {
     // Transport failure / empty completion is already recorded by the LLM
     // adapter (single owner of transport-failure attribution) — recording

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -145,6 +145,8 @@ export type LoreToolPart = {
   messageID: string;
   type: "tool";
   tool: string;
+  /** Provider function name for result parts whose call ID is distinct. */
+  toolName?: string;
   callID: string;
   state: LoreToolState;
 };

--- a/packages/gateway/src/abort-race.ts
+++ b/packages/gateway/src/abort-race.ts
@@ -1,0 +1,74 @@
+/**
+ * Settle a Response-producing operation against an AbortSignal even when the
+ * underlying implementation ignores that signal. Late responses are drained
+ * by cancellation and late rejections stay observed.
+ */
+export function promiseAgainstAbort<T>(
+  start: () => Promise<T>,
+  signal?: AbortSignal,
+  onLateResolve?: (value: T) => void,
+): Promise<T> {
+  if (!signal) return start();
+  signal.throwIfAborted();
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => signal.removeEventListener("abort", onAbort);
+    const onAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(signal.reason);
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    let operation: Promise<T>;
+    try {
+      operation = start();
+    } catch (error) {
+      settled = true;
+      cleanup();
+      reject(error);
+      return;
+    }
+    void operation.then(
+      (value) => {
+        if (settled) {
+          try {
+            onLateResolve?.(value);
+          } catch {
+            // Cleanup callbacks must never turn an observed late settlement
+            // into an unhandled rejection.
+          }
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+export function responseAgainstAbort(
+  start: () => Promise<Response>,
+  signal?: AbortSignal,
+): Promise<Response> {
+  return promiseAgainstAbort(start, signal, (response) => {
+    try {
+      void response.body?.cancel(signal?.reason).catch(() => {});
+    } catch {
+      // Best-effort cleanup for an already-consumed/locked late body.
+    }
+  });
+}

--- a/packages/gateway/src/anthropic-protocol.ts
+++ b/packages/gateway/src/anthropic-protocol.ts
@@ -1,0 +1,36 @@
+/** Anthropic response values accepted at the provider boundary. */
+
+export const ANTHROPIC_STOP_REASONS: ReadonlySet<string> = new Set([
+  "end_turn",
+  "max_tokens",
+  "stop_sequence",
+  "tool_use",
+  "pause_turn",
+  "refusal",
+  "model_context_window_exceeded",
+]);
+
+export const ANTHROPIC_CONTENT_BLOCK_TYPES: ReadonlySet<string> = new Set([
+  "text",
+  "thinking",
+  "redacted_thinking",
+  "tool_use",
+  "server_tool_use",
+  "web_search_tool_result",
+  "web_fetch_tool_result",
+  "code_execution_tool_result",
+  "bash_code_execution_tool_result",
+  "text_editor_code_execution_tool_result",
+  "tool_search_tool_result",
+  "container_upload",
+  // Server-side fallback emits a boundary block with no deltas.
+  "fallback",
+]);
+
+export function normalizeAnthropicStopReason(reason: string): string {
+  return reason === "refusal" ? "content_filter" : reason;
+}
+
+export function toAnthropicStopReason(reason: string): string {
+  return reason === "content_filter" ? "refusal" : reason;
+}

--- a/packages/gateway/src/fetch.ts
+++ b/packages/gateway/src/fetch.ts
@@ -59,6 +59,14 @@ let undiciHandles: UndiciHandles | null = null;
  */
 let dispatcherOverride: Dispatcher | null = null;
 
+/**
+ * Byte-based queue for the Bun Node-HTTP bridge. Once this queue is full the
+ * IncomingMessage is paused, which in turn bounds Node/socket buffering by its
+ * own readable high-water mark. The bridge can transiently hold this amount
+ * plus the single source chunk that crossed the threshold.
+ */
+const NODE_HTTP_BODY_QUEUE_BYTES = 64 * 1024;
+
 /** Inject (or clear, with `null`) the upstream dispatcher. Tests only. */
 export function setUpstreamDispatcherForTest(
   dispatcher: Dispatcher | null,
@@ -77,6 +85,118 @@ async function getUndici(): Promise<UndiciHandles> {
   const dispatcher = new undici.Agent({ bodyTimeout: 0, headersTimeout: 0 });
   undiciHandles = { fetch: undici.fetch, dispatcher };
   return undiciHandles;
+}
+
+/**
+ * Adapt a Node IncomingMessage to a backpressure-aware Web ReadableStream.
+ * Exported so the Bun bridge lifecycle can be regression-tested without a live
+ * socket; production callers should use {@link upstreamFetch}.
+ */
+export function nodeReadableToWebStream(
+  res: http.IncomingMessage,
+): ReadableStream<Uint8Array> {
+  let active = true;
+  let paused = false;
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+
+  const cleanup = (): void => {
+    res.removeListener("data", onData);
+    res.removeListener("end", onEnd);
+    res.removeListener("error", onError);
+    res.removeListener("aborted", onAborted);
+    res.removeListener("close", onClose);
+  };
+
+  const close = (): void => {
+    if (!active) return;
+    active = false;
+    cleanup();
+    try {
+      controller.close();
+    } catch {
+      // The consumer may already have cancelled the Web stream.
+    }
+  };
+
+  const fail = (error: Error, destroy = false): void => {
+    if (!active) return;
+    active = false;
+    cleanup();
+    if (destroy && !res.destroyed) res.destroy();
+    try {
+      controller.error(error);
+    } catch {
+      // The consumer may already have cancelled the Web stream.
+    }
+  };
+
+  function onData(chunk: Buffer): void {
+    if (!active) return;
+    try {
+      controller.enqueue(new Uint8Array(chunk));
+      if ((controller.desiredSize ?? 0) <= 0 && !paused) {
+        paused = true;
+        res.pause();
+      }
+    } catch (error) {
+      fail(
+        error instanceof Error
+          ? error
+          : new Error("failed to enqueue upstream response body"),
+        true,
+      );
+    }
+  }
+
+  function onEnd(): void {
+    close();
+  }
+
+  function onError(error: Error): void {
+    fail(error, true);
+  }
+
+  function onAborted(): void {
+    fail(new Error("upstream response body aborted"), true);
+  }
+
+  function onClose(): void {
+    if (res.complete || res.readableEnded) {
+      close();
+    } else {
+      fail(new Error("upstream response closed before end"));
+    }
+  }
+
+  return new ReadableStream<Uint8Array>(
+    {
+      start(streamController) {
+        controller = streamController;
+        res.on("data", onData);
+        res.once("end", onEnd);
+        res.once("error", onError);
+        res.once("aborted", onAborted);
+        res.once("close", onClose);
+      },
+      pull() {
+        if (active && paused) {
+          paused = false;
+          res.resume();
+        }
+      },
+      cancel() {
+        if (!active) return;
+        active = false;
+        cleanup();
+        if (!res.destroyed) {
+          res.destroy();
+        }
+      },
+    },
+    new ByteLengthQueuingStrategy({
+      highWaterMark: NODE_HTTP_BODY_QUEUE_BYTES,
+    }),
+  );
 }
 
 /**
@@ -142,25 +262,10 @@ function nodeHttpFetch(
           }
         }
 
-        // Wrap the Node readable stream as a Web ReadableStream for the
-        // Response body. This gives callers the same streaming API they'd get
-        // from fetch() (response.body.getReader(), for await...of, etc.).
-        const body = new ReadableStream<Uint8Array>({
-          start(controller) {
-            res.on("data", (chunk: Buffer) => {
-              controller.enqueue(new Uint8Array(chunk));
-            });
-            res.on("end", () => {
-              controller.close();
-            });
-            res.on("error", (err) => {
-              controller.error(err);
-            });
-          },
-          cancel() {
-            res.destroy();
-          },
-        });
+        // Pause the IncomingMessage whenever the Web stream's byte queue is
+        // full; resume only from pull(). This prevents a slow worker parser from
+        // turning the bridge into an unbounded second response buffer.
+        const body = nodeReadableToWebStream(res);
 
         resolve(
           new Response(body, {

--- a/packages/gateway/src/http-body.ts
+++ b/packages/gateway/src/http-body.ts
@@ -21,6 +21,11 @@
 import {
   brotliCompressSync,
   brotliDecompressSync,
+  createBrotliDecompress,
+  createGunzip,
+  createInflate,
+  createInflateRaw,
+  createZstdDecompress,
   deflateSync,
   gunzipSync,
   gzipSync,
@@ -29,6 +34,73 @@ import {
   zstdCompressSync,
   zstdDecompressSync,
 } from "node:zlib";
+import { promiseAgainstAbort } from "./abort-race";
+import { cancelAndReleaseReader } from "./stream/anthropic";
+
+/** Maximum wire bytes accepted from any standard JSON request body. */
+export const MAX_HTTP_REQUEST_COMPRESSED_BYTES = 32 * 1024 * 1024;
+/** Maximum UTF-8/JSON bytes produced after Content-Encoding decoding. */
+export const MAX_HTTP_REQUEST_DECOMPRESSED_BYTES = 32 * 1024 * 1024;
+
+export class HttpRequestBodyTooLargeError extends Error {
+  constructor(phase: "compressed" | "decompressed") {
+    const limit =
+      phase === "compressed"
+        ? MAX_HTTP_REQUEST_COMPRESSED_BYTES
+        : MAX_HTTP_REQUEST_DECOMPRESSED_BYTES;
+    super(`HTTP request ${phase} body exceeded ${limit} byte limit`);
+    this.name = "HttpRequestBodyTooLargeError";
+  }
+}
+
+function outputLimitError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (("code" in error &&
+      (error as Error & { code?: string }).code === "ERR_BUFFER_TOO_LARGE") ||
+      /maxOutputLength|larger than/i.test(error.message))
+  );
+}
+
+async function readRequestBodyBytes(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): Promise<Buffer> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let completed = false;
+  try {
+    while (true) {
+      const { done, value } = await promiseAgainstAbort(
+        () => reader.read(),
+        signal,
+      );
+      signal.throwIfAborted();
+      if (done) {
+        completed = true;
+        break;
+      }
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > MAX_HTTP_REQUEST_COMPRESSED_BYTES) {
+        throw new HttpRequestBodyTooLargeError("compressed");
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks, total);
+  } finally {
+    if (completed) {
+      try {
+        reader.releaseLock();
+      } catch {
+        // Normal EOF has no pending read in conforming runtimes.
+      }
+    } else {
+      cancelAndReleaseReader(reader, signal.reason);
+    }
+  }
+}
 
 /**
  * Content-encodings the gateway can decode AND re-encode. `x-gzip` is the
@@ -69,23 +141,98 @@ export function isSupportedEncoding(enc: string | null | undefined): boolean {
  * encoding or on malformed compressed input.
  */
 export function decompressBody(bytes: Uint8Array, encoding: string): Buffer {
-  switch (encoding) {
-    case "zstd":
-      return zstdDecompressSync(bytes);
-    case "gzip":
-    case "x-gzip":
-      return gunzipSync(bytes);
-    case "br":
-      return brotliDecompressSync(bytes);
-    case "deflate":
-      // Some clients send raw DEFLATE (no zlib header); fall back to it.
-      try {
-        return inflateSync(bytes);
-      } catch {
-        return inflateRawSync(bytes);
+  const opts = { maxOutputLength: MAX_HTTP_REQUEST_DECOMPRESSED_BYTES };
+  try {
+    switch (encoding) {
+      case "zstd":
+        return zstdDecompressSync(bytes, opts);
+      case "gzip":
+      case "x-gzip":
+        return gunzipSync(bytes, opts);
+      case "br":
+        return brotliDecompressSync(bytes, opts);
+      case "deflate":
+        // Some clients send raw DEFLATE (no zlib header); fall back to it.
+        try {
+          return inflateSync(bytes, opts);
+        } catch (error) {
+          if (outputLimitError(error)) throw error;
+          return inflateRawSync(bytes, opts);
+        }
+      default:
+        throw new Error(`Unsupported Content-Encoding: ${encoding}`);
+    }
+  } catch (error) {
+    if (outputLimitError(error)) {
+      throw new HttpRequestBodyTooLargeError("decompressed");
+    }
+    throw error;
+  }
+}
+
+function hasZlibWrapper(bytes: Uint8Array): boolean {
+  if (bytes.byteLength < 2) return false;
+  const cmf = bytes[0];
+  const flg = bytes[1];
+  return (cmf & 0x0f) === 8 && ((cmf << 8) + flg) % 31 === 0;
+}
+
+async function decompressRequestBody(
+  bytes: Uint8Array,
+  encoding: string,
+  signal: AbortSignal,
+): Promise<Buffer> {
+  signal.throwIfAborted();
+  const decoder = (() => {
+    switch (encoding) {
+      case "zstd":
+        return createZstdDecompress();
+      case "gzip":
+      case "x-gzip":
+        return createGunzip();
+      case "br":
+        return createBrotliDecompress();
+      case "deflate":
+        // RFC 1950's two-byte wrapper is self-identifying. Selecting once
+        // avoids decoding hostile input twice through inflate + raw fallback.
+        return hasZlibWrapper(bytes) ? createInflate() : createInflateRaw();
+      default:
+        throw new Error(`Unsupported Content-Encoding: ${encoding}`);
+    }
+  })();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const onAbort = (): void => {
+    const reason =
+      signal.reason instanceof Error
+        ? signal.reason
+        : new DOMException("request aborted", "AbortError");
+    decoder.destroy(reason);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    decoder.end(bytes);
+    for await (const value of decoder) {
+      signal.throwIfAborted();
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      total += chunk.byteLength;
+      if (total > MAX_HTTP_REQUEST_DECOMPRESSED_BYTES) {
+        throw new HttpRequestBodyTooLargeError("decompressed");
       }
-    default:
-      throw new Error(`Unsupported Content-Encoding: ${encoding}`);
+      chunks.push(chunk);
+    }
+    signal.throwIfAborted();
+    return Buffer.concat(chunks, total);
+  } catch (error) {
+    signal.throwIfAborted();
+    if (error instanceof HttpRequestBodyTooLargeError) throw error;
+    if (outputLimitError(error)) {
+      throw new HttpRequestBodyTooLargeError("decompressed");
+    }
+    throw error;
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    decoder.destroy();
   }
 }
 
@@ -121,14 +268,27 @@ export function compressBody(
  * - Unsupported encoding → throws (callers map this to a 400, same as a
  *   JSON parse failure).
  */
-export async function decodeRequestBody(req: Request): Promise<string> {
+export async function decodeRequestBody(
+  req: Request,
+  signal: AbortSignal = req.signal,
+): Promise<string> {
   const enc = normalizeRequestEncoding(req.headers.get("content-encoding"));
-  if (!enc) return req.text();
+  if (!enc) {
+    if (!req.body) return "";
+    const bytes = await readRequestBodyBytes(req.body, signal);
+    if (bytes.byteLength > MAX_HTTP_REQUEST_DECOMPRESSED_BYTES) {
+      throw new HttpRequestBodyTooLargeError("decompressed");
+    }
+    return bytes.toString("utf8");
+  }
   if (!isSupportedEncoding(enc)) {
     throw new Error(`Unsupported Content-Encoding: ${enc}`);
   }
-  const bytes = new Uint8Array(await req.arrayBuffer());
-  return decompressBody(bytes, enc).toString("utf8");
+  if (!req.body) return "";
+  const bytes = await readRequestBodyBytes(req.body, signal);
+  const decompressed = await decompressRequestBody(bytes, enc, signal);
+  signal.throwIfAborted();
+  return decompressed.toString("utf8");
 }
 
 /**

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -42,6 +42,7 @@ import {
 } from "./sentry";
 import { recordWorkerCost } from "./cost-tracker";
 import { upstreamFetch } from "./fetch";
+import { responseAgainstAbort } from "./abort-race";
 import {
   looksLikeSSE,
   type GatewayContentBlock,
@@ -55,8 +56,30 @@ import {
 import { accumulateOpenAISSEStream } from "./stream/openai";
 import { accumulateResponsesSSEStream } from "./stream/openai-responses";
 import { accumulateGeminiSSEStream } from "./stream/gemini";
-import { accumulateSSEResponse } from "./stream/anthropic";
+import {
+  geminiUsageFromMetadata,
+  validateGeminiFunctionCallIdentity,
+} from "./translate/gemini";
+import {
+  accumulateSSEResponse,
+  cancelAndReleaseReader,
+  readStreamChunk,
+  SSEStreamLimitError,
+  SSEStreamTransportError,
+} from "./stream/anthropic";
 import { isBedrockMantleHost, toMantleModelId } from "./translate/bedrock";
+import {
+  ANTHROPIC_CONTENT_BLOCK_TYPES,
+  ANTHROPIC_STOP_REASONS,
+  normalizeAnthropicStopReason,
+} from "./anthropic-protocol";
+import {
+  isRecord,
+  validateAnthropicUsage,
+  validateGeminiUsageMetadata,
+  validateOpenAIUsage,
+  validateResponsesUsage,
+} from "./usage-validation";
 import {
   toVertexBody,
   toVertexModelId,
@@ -474,6 +497,132 @@ const DEFAULT_MAX_RETRIES = 8;
  */
 const DEFAULT_WORKER_MAX_TOKENS = 16384;
 
+const WORKER_ERROR_BODY_MAX_BYTES = 64 * 1024;
+const WORKER_RESPONSE_SNIFF_BYTES = 64 * 1024;
+// Counts all wire bytes exposed to JSON/SSE decoding and accumulator retention,
+// including replay of the sniff prefix. The Bun HTTP bridge also pauses at a
+// 64 KiB byte queue; buffering below that transport boundary (and one already-
+// delivered source chunk) is outside adapter control. Decoded and accumulated
+// content can only derive from bytes admitted under this cap.
+const MAX_WORKER_RESPONSE_BYTES = 4 * 1024 * 1024;
+// Worker prompts are normally bounded to tens of KiB (distillation segments
+// are capped at 16K tokens). This generous wire cap prevents an accidental or
+// adversarial caller from materializing an unbounded serialized request while
+// preserving substantial headroom for JSON escaping and worker system prompts.
+const MAX_WORKER_REQUEST_BYTES = 4 * 1024 * 1024;
+// JSON can expand one input byte (an ASCII control character) to a six-byte
+// `\u00xx` escape. Cap raw prompt bytes at the derived worst-case ratio so the
+// serializer itself cannot transiently allocate far beyond the wire cap.
+const MAX_WORKER_PROMPT_SOURCE_BYTES = Math.floor(MAX_WORKER_REQUEST_BYTES / 6);
+const WORKER_RESPONSE_INACTIVITY_MS = 120_000;
+const WORKER_REQUEST_TIMEOUT_MS = 300_000;
+
+/** Return only URL origin metadata; userinfo, path, query, and fragment vanish. */
+function sanitizedWorkerOrigin(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return "invalid-origin";
+    }
+    return url.origin;
+  } catch {
+    return "invalid-origin";
+  }
+}
+
+/** Prevent control characters in non-body metadata from forging log lines. */
+function diagnosticToken(
+  value: string | undefined,
+  fallback = "unknown",
+): string {
+  if (!value) return fallback;
+  let safe = "";
+  for (const char of value.slice(0, 160)) {
+    const code = char.charCodeAt(0);
+    safe += code < 32 || code === 127 ? "?" : char;
+  }
+  return safe;
+}
+
+function diagnosticContentKind(contentType: string): string {
+  if (!contentType) return "missing";
+  if (looksLikeSSE(contentType, "")) return "sse";
+  return /(?:^|[/+])json(?:$|;)/i.test(contentType) ? "json" : "other";
+}
+
+function diagnosticFinishReason(reason: string | undefined): string {
+  if (!reason) return "n/a";
+  return new Set([
+    "stop",
+    "end_turn",
+    "length",
+    "max_tokens",
+    "max_output_tokens",
+    "content_filter",
+    "tool_calls",
+    "tool_use",
+  ]).has(reason)
+    ? reason
+    : "unknown";
+}
+
+/** Extract a bounded structural transport code without exposing its message. */
+function transportErrorCode(error: unknown): string | undefined {
+  const code = isRecord(error) ? error.code : undefined;
+  return typeof code === "string" && /^[A-Z0-9_]{1,64}$/.test(code)
+    ? code
+    : undefined;
+}
+
+function transportErrorKind(error: unknown): string {
+  if (error instanceof WorkerTransportFailureError) return error.kind;
+  if (error instanceof SSEStreamTransportError) return error.kind;
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return "deadline";
+  }
+  return "transport";
+}
+
+/**
+ * Error detail safe for logs/lastWorkerError. Provider body values and arbitrary
+ * stream error messages are deliberately excluded.
+ */
+function safeWorkerBodyErrorDetail(error: unknown): string {
+  if (error instanceof WorkerResponseTooLargeError) return error.message;
+  if (error instanceof SyntaxError) return "malformed JSON body";
+  const message = error instanceof Error ? error.message : "";
+  const safePatterns = [
+    /^SSE stream exceeded \d+ frame limit$/,
+    /^SSE event exceeded \d+ byte limit$/,
+    /^worker response exceeded \d+ byte limit$/,
+    /^unterminated SSE event at EOF$/,
+    /^missing (?:Anthropic message_stop|OpenAI finish_reason|Gemini finishReason) terminal$/,
+    /^missing terminal response status$/,
+    /^missing Responses compatibility terminal status$/,
+    /^malformed (?:Anthropic|OpenAI|Responses|Gemini) (?:stream event|response body|usage|terminal event)$/,
+    /^worker JSON response root must be an object$/,
+    /^non-success Responses response status$/,
+    /^response\.failed terminal$/,
+    /^Responses terminal reported failure$/,
+    /^Responses terminal event\/status mismatch$/,
+    /^incomplete Responses output lifecycle$/,
+    /^Anthropic stream error event$/,
+    /^(?:Response|Upstream response|Anthropic response) has no body$/,
+  ];
+  return safePatterns.some((pattern) => pattern.test(message))
+    ? message
+    : "invalid response body";
+}
+
+/** Initiate response-body cleanup before a retry without trusting cancel to settle. */
+function cancelWorkerResponseForRetry(
+  response: Response,
+  reason: unknown,
+): void {
+  if (!response.body || response.body.locked) return;
+  void response.body.cancel(reason).catch(() => {});
+}
+
 // Visible-output headroom added on top of an extended-thinking budget so the
 // model has room for the actual answer after reasoning (Anthropic counts thinking
 // against max_tokens). Mirrors pipeline.ts's THINKING_OUTPUT_HEADROOM.
@@ -563,9 +712,21 @@ export function parseRetryAfter(response: Response): number | null {
   const header = response.headers.get("retry-after");
   if (!header) return null;
   const seconds = Number(header);
-  if (!Number.isNaN(seconds)) return seconds * 1000;
+  if (!Number.isNaN(seconds)) {
+    if (!Number.isFinite(seconds) || seconds < 0) return null;
+    const milliseconds = seconds * 1000;
+    if (!Number.isFinite(milliseconds) || !Number.isSafeInteger(milliseconds)) {
+      return null;
+    }
+    return Math.min(milliseconds, MAX_DELAY_MS);
+  }
   const date = Date.parse(header);
-  if (!Number.isNaN(date)) return Math.max(0, date - Date.now());
+  if (!Number.isNaN(date)) {
+    const milliseconds = Math.max(0, date - Date.now());
+    return Number.isSafeInteger(milliseconds)
+      ? Math.min(milliseconds, MAX_DELAY_MS)
+      : null;
+  }
   return null;
 }
 
@@ -579,7 +740,9 @@ export function backoffMs(
   attempt: number,
   retryAfterMs: number | null,
 ): number {
-  if (retryAfterMs != null) return Math.min(retryAfterMs, MAX_DELAY_MS);
+  if (retryAfterMs != null && Number.isFinite(retryAfterMs)) {
+    return Math.min(Math.max(0, retryAfterMs), MAX_DELAY_MS);
+  }
   const base = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
   return base + Math.random() * 0.25 * base;
 }
@@ -606,21 +769,18 @@ export function abortableSleep(
 export async function readWorkerResponseText(
   response: Response,
   signal?: AbortSignal,
-  maxBytes = 64 * 1024,
+  maxBytes = WORKER_ERROR_BODY_MAX_BYTES,
 ): Promise<string> {
   const reader = response.body?.getReader();
   if (!reader) return "";
   const chunks: Uint8Array[] = [];
   let bytes = 0;
-  const onAbort = (): void => {
-    void reader.cancel(signal?.reason).catch(() => {});
-  };
-  signal?.addEventListener("abort", onAbort, { once: true });
   try {
     while (bytes < maxBytes) {
-      signal?.throwIfAborted();
-      const { done, value } = await reader.read();
-      signal?.throwIfAborted();
+      const { done, value } = await readStreamChunk(reader, {
+        signal,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+      });
       if (done) break;
       if (!value) continue;
       const chunk = value.subarray(0, maxBytes - bytes);
@@ -631,10 +791,276 @@ export async function readWorkerResponseText(
     if (signal?.aborted) throw signal.reason;
     return "(no body)";
   } finally {
-    signal?.removeEventListener("abort", onAbort);
-    void reader.cancel().catch(() => {});
+    cancelAndReleaseReader(reader);
   }
+  // This is bounded diagnostic text, not semantic response JSON. Replacement
+  // decoding preserves useful error classification when malformed bytes or a
+  // multibyte code point land at the truncation boundary.
   return new TextDecoder().decode(Buffer.concat(chunks));
+}
+
+class WorkerResponseTooLargeError extends SSEStreamLimitError {
+  constructor() {
+    super(`worker response exceeded ${MAX_WORKER_RESPONSE_BYTES} byte limit`);
+    this.name = "WorkerResponseTooLargeError";
+  }
+}
+
+class WorkerRequestTooLargeError extends Error {
+  readonly bytes: number;
+
+  constructor(bytes: number) {
+    super(`worker request exceeded ${MAX_WORKER_REQUEST_BYTES} byte limit`);
+    this.name = "WorkerRequestTooLargeError";
+    this.bytes = bytes;
+  }
+}
+
+class WorkerTransportFailureError extends Error {
+  readonly kind: string;
+  readonly code?: string;
+
+  constructor(error: unknown) {
+    const kind = transportErrorKind(error);
+    const code = transportErrorCode(error);
+    super(
+      `Worker transport failure: kind=${kind}${code ? ` code=${code}` : ""}`,
+    );
+    this.name = "WorkerTransportFailureError";
+    this.kind = kind;
+    this.code = code;
+  }
+}
+
+function enforceWorkerRequestLimit<T extends { body: string }>(request: T): T {
+  const bytes = Buffer.byteLength(request.body);
+  if (bytes > MAX_WORKER_REQUEST_BYTES) {
+    throw new WorkerRequestTooLargeError(bytes);
+  }
+  return request;
+}
+
+type WorkerSuccessBody =
+  | { isSSE: true; response: Response }
+  | { isSSE: false; text: string };
+
+function replayWorkerStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  prefix: Uint8Array[],
+  signal?: AbortSignal,
+): Response {
+  let prefixIndex = 0;
+  let bytes = 0;
+  let finished = false;
+  let overflow = false;
+
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (finished) return;
+        try {
+          if (overflow) throw new WorkerResponseTooLargeError();
+          const result =
+            prefixIndex < prefix.length
+              ? { done: false as const, value: prefix[prefixIndex++] }
+              : await readStreamChunk(reader, {
+                  signal,
+                  inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+                });
+          signal?.throwIfAborted();
+          if (result.done) {
+            finished = true;
+            reader.releaseLock();
+            controller.close();
+            return;
+          }
+          const remaining = MAX_WORKER_RESPONSE_BYTES - bytes;
+          if (result.value.byteLength > remaining) {
+            if (remaining === 0) throw new WorkerResponseTooLargeError();
+            overflow = true;
+            bytes += remaining;
+            controller.enqueue(result.value.subarray(0, remaining));
+            return;
+          }
+          bytes += result.value.byteLength;
+          controller.enqueue(result.value);
+        } catch (error) {
+          finished = true;
+          void reader.cancel(error).catch(() => {});
+          try {
+            reader.releaseLock();
+          } catch {
+            // Cancellation remains non-blocking if a runtime keeps read pending.
+          }
+          controller.error(error);
+        }
+      },
+      cancel(reason) {
+        finished = true;
+        void reader.cancel(reason).catch(() => {});
+        try {
+          reader.releaseLock();
+        } catch {
+          // Never await an uncooperative source cancellation.
+        }
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+async function readCompleteWorkerBody(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  prefix: Uint8Array[],
+  signal?: AbortSignal,
+  onBodyBytes?: () => void,
+): Promise<string> {
+  const chunks = [...prefix];
+  let bytes = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  try {
+    if (bytes > MAX_WORKER_RESPONSE_BYTES) {
+      throw new WorkerResponseTooLargeError();
+    }
+    for (;;) {
+      const { done, value } = await readStreamChunk(reader, {
+        signal,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+      });
+      if (done) break;
+      if (!value) continue;
+      if (value.byteLength > 0) onBodyBytes?.();
+      bytes += value.byteLength;
+      if (bytes > MAX_WORKER_RESPONSE_BYTES) {
+        throw new WorkerResponseTooLargeError();
+      }
+      chunks.push(value);
+    }
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(
+        Buffer.concat(chunks),
+      );
+    } catch {
+      throw new Error("malformed worker response UTF-8");
+    }
+  } finally {
+    void reader.cancel().catch(() => {});
+    try {
+      reader.releaseLock();
+    } catch {
+      // See readWorkerResponseText: never wait on provider cancellation.
+    }
+  }
+}
+
+async function inspectWorkerSuccessBody(
+  response: Response,
+  signal?: AbortSignal,
+  onNonSSEBodyBytes?: () => void,
+): Promise<WorkerSuccessBody> {
+  const reader = response.body?.getReader();
+  if (!reader) return { isSSE: false, text: "" };
+  const contentType = response.headers.get("content-type") ?? "";
+  const prefix: Uint8Array[] = [];
+  let prefixBytes = 0;
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let sniffToken = "";
+  let skippingLeadingWhitespace = true;
+
+  const sniffSSEPrefix = (chunk: Uint8Array): boolean | null => {
+    const text = decoder.decode(chunk, { stream: true });
+    for (const char of text) {
+      if (skippingLeadingWhitespace) {
+        if (char === "\uFEFF" || /\s/.test(char)) continue;
+        if (char === ":") return true;
+        skippingLeadingWhitespace = false;
+      }
+      sniffToken += char;
+      const sseFields = ["data:", "event:", "id:", "retry:"];
+      if (sseFields.some((field) => field.startsWith(sniffToken))) {
+        if (sseFields.includes(sniffToken)) return true;
+        continue;
+      }
+      return false;
+    }
+    return null;
+  };
+
+  if (looksLikeSSE(contentType, "")) {
+    return {
+      isSSE: true,
+      response: replayWorkerStream(reader, prefix, signal),
+    };
+  }
+
+  try {
+    while (prefixBytes < WORKER_RESPONSE_SNIFF_BYTES) {
+      const { done, value } = await readStreamChunk(reader, {
+        signal,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+      });
+      if (done) {
+        if (prefixBytes > MAX_WORKER_RESPONSE_BYTES) {
+          throw new WorkerResponseTooLargeError();
+        }
+        reader.releaseLock();
+        if (prefix.some((chunk) => chunk.byteLength > 0)) {
+          onNonSSEBodyBytes?.();
+        }
+        let text: string;
+        try {
+          text = new TextDecoder("utf-8", { fatal: true }).decode(
+            Buffer.concat(prefix),
+          );
+        } catch {
+          throw new Error("malformed worker response UTF-8");
+        }
+        return {
+          isSSE: false,
+          text,
+        };
+      }
+      if (!value) continue;
+      prefix.push(value);
+      const sniffBytes = Math.min(
+        value.byteLength,
+        WORKER_RESPONSE_SNIFF_BYTES - prefixBytes,
+      );
+      prefixBytes += sniffBytes;
+      let ssePrefix: boolean | null;
+      try {
+        ssePrefix = sniffSSEPrefix(value.subarray(0, sniffBytes));
+      } catch {
+        onNonSSEBodyBytes?.();
+        throw new Error("malformed worker response UTF-8");
+      }
+      if (ssePrefix) {
+        return {
+          isSSE: true,
+          response: replayWorkerStream(reader, prefix, signal),
+        };
+      }
+      if (ssePrefix === false) break;
+    }
+
+    if (prefix.some((chunk) => chunk.byteLength > 0)) onNonSSEBodyBytes?.();
+    return {
+      isSSE: false,
+      text: await readCompleteWorkerBody(
+        reader,
+        prefix,
+        signal,
+        onNonSSEBodyBytes,
+      ),
+    };
+  } catch (error) {
+    void reader.cancel(error).catch(() => {});
+    try {
+      reader.releaseLock();
+    } catch {
+      // Never await an uncooperative response-body cancellation.
+    }
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -644,8 +1070,9 @@ export async function readWorkerResponseText(
 /** OpenAI Chat Completions response shape (subset we need). */
 type OpenAIChatResponse = {
   choices?: Array<{
+    index?: number;
     message?: {
-      content?: string;
+      content?: string | null | Array<Record<string, unknown>>;
       // Reasoning models (DeepSeek, Qwen-thinking, Nemotron, MiniMax, etc.)
       // commonly served on aggregators like OpenCode Zen put their answer in a
       // reasoning field and leave `content` empty/null. We read these as a
@@ -654,17 +1081,27 @@ type OpenAIChatResponse = {
       // `reasoning` is the OpenRouter/others field.
       reasoning_content?: string;
       reasoning?: string;
+      refusal?: string | null;
+      tool_calls?: Array<{ id?: string; function?: unknown }>;
     };
-    finish_reason?: string;
+    finish_reason?: string | null;
+    native_finish_reason?: string | null;
   }>;
-  model?: string;
+  model?: string | null;
   usage?: {
     prompt_tokens?: number;
     completion_tokens?: number;
+    total_tokens?: number;
     prompt_tokens_details?: {
       cached_tokens?: number;
       cache_write_tokens?: number;
-    };
+    } | null;
+    completion_tokens_details?: {
+      reasoning_tokens?: number;
+      audio_tokens?: number;
+      accepted_prediction_tokens?: number;
+      rejected_prediction_tokens?: number;
+    } | null;
   };
 };
 
@@ -710,6 +1147,7 @@ export function disjointOpenAIInputTokens(
 export function normalizeOpenAIUsage(
   usage: OpenAIChatResponse["usage"],
 ): AnthropicUsage {
+  validateOpenAIUsage(usage, "malformed OpenAI usage");
   const cachedTokens = usage?.prompt_tokens_details?.cached_tokens ?? 0;
   const cacheWriteTokens =
     usage?.prompt_tokens_details?.cache_write_tokens ?? 0;
@@ -738,7 +1176,7 @@ export function normalizeOpenAIUsage(
  * `/backend-api` serves ONLY the Responses API (`/codex/responses`), so it gets
  * a dedicated `"openai-codex-responses"` worker protocol that speaks Responses.
  */
-type WorkerProtocol =
+export type WorkerProtocol =
   | "anthropic"
   | "openai"
   | "openai-responses"
@@ -747,12 +1185,164 @@ type WorkerProtocol =
   | "gemini";
 
 /** Upstream URL, wire protocol, and provider label for a resolved target. */
-type ProviderTarget = {
+export type ProviderTarget = {
   url: string;
   protocol: WorkerProtocol;
   /** Provider label for Sentry spans and logging. */
   providerName: string;
 };
+
+type WorkerProtocolFamily = "anthropic" | "openai" | "vertex" | "gemini";
+
+/** URL supplies lowercase/IDNA semantics; remove one optional DNS root dot. */
+export function normalizedWorkerHostname(url: string): string | null {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    return hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
+  } catch {
+    return null;
+  }
+}
+
+const WORKER_PROVIDER_ALIAS_FAMILIES: readonly ReadonlySet<string>[] = [
+  new Set(["vertex", "google-vertex", "google-vertex-anthropic"]),
+  new Set(["bedrock", "amazon-bedrock"]),
+];
+
+const WORKER_PROVIDER_PROTOCOL_CAPABILITIES: Readonly<
+  Record<string, ReadonlySet<WorkerProtocolFamily>>
+> = {
+  bedrock: new Set(["anthropic"]),
+  "amazon-bedrock": new Set(["anthropic"]),
+  vertex: new Set(["vertex"]),
+  // The generic Vertex provider can serve native Gemini as well as the
+  // configured Claude rawPredict route. The Anthropic-specific identity may not.
+  "google-vertex": new Set(["vertex", "gemini"]),
+  "google-vertex-anthropic": new Set(["vertex"]),
+};
+
+/** Canonical ID for explicitly supported provider aliases; unrelated IDs stay distinct. */
+export function canonicalWorkerProviderID(providerID: string): string {
+  for (const family of WORKER_PROVIDER_ALIAS_FAMILIES) {
+    if (family.has(providerID)) return [...family][0];
+  }
+  return providerID;
+}
+
+function workerProviderAliasIDs(providerID: string): readonly string[] {
+  for (const family of WORKER_PROVIDER_ALIAS_FAMILIES) {
+    if (family.has(providerID)) {
+      return [providerID, ...[...family].filter((id) => id !== providerID)];
+    }
+  }
+  return [providerID];
+}
+
+function workerProvidersEquivalent(left: string, right: string): boolean {
+  return canonicalWorkerProviderID(left) === canonicalWorkerProviderID(right);
+}
+
+function workerProviderSupportsProtocol(
+  providerID: string,
+  protocol: WorkerProtocol,
+): boolean {
+  const capabilities = WORKER_PROVIDER_PROTOCOL_CAPABILITIES[providerID];
+  return capabilities?.has(workerProtocolFamily(protocol)) ?? true;
+}
+
+function workerProtocolFamily(value: WorkerProtocol): WorkerProtocolFamily {
+  if (value === "vertex") return "vertex";
+  if (value === "gemini") return "gemini";
+  if (
+    value === "openai" ||
+    value === "openai-responses" ||
+    value === "openai-codex-responses"
+  ) {
+    return "openai";
+  }
+  return "anthropic";
+}
+
+/** Trusted canonical origin capabilities. Unknown hosts require provenance. */
+export function workerOriginProtocolFamilies(
+  url: string,
+): ReadonlySet<WorkerProtocolFamily> | null {
+  try {
+    const parsed = new URL(url);
+    const host = normalizedWorkerHostname(url);
+    if (host === null) return new Set();
+    const knownHost =
+      host === "api.anthropic.com" ||
+      host === "api.openai.com" ||
+      host === "chatgpt.com" ||
+      host === "generativelanguage.googleapis.com" ||
+      vertexRegionFromUrl(host) !== null;
+    if (
+      knownHost &&
+      (parsed.protocol !== "https:" ||
+        (parsed.port !== "" && parsed.port !== "443"))
+    ) {
+      return new Set();
+    }
+    if (host === "api.anthropic.com") return new Set(["anthropic"]);
+    if (host === "api.openai.com") return new Set(["openai"]);
+    if (host === "chatgpt.com") {
+      return /(?:^|\/)backend-api(?:\/|$)/.test(parsed.pathname)
+        ? new Set(["openai"])
+        : new Set();
+    }
+    // Google's Developer API serves native Gemini and an OpenAI-compatible
+    // facade on the same canonical origin.
+    if (host === "generativelanguage.googleapis.com") {
+      return new Set(["gemini", "openai"]);
+    }
+    // Vertex hosts serve Claude rawPredict (`vertex`) and native Gemini
+    // generateContent under project/location paths.
+    if (vertexRegionFromUrl(host) !== null) {
+      return new Set(["vertex", "gemini"]);
+    }
+    return null;
+  } catch {
+    return new Set();
+  }
+}
+
+function workerOriginProviderIDs(url: string): ReadonlySet<string> | null {
+  try {
+    const parsed = new URL(url);
+    const host = normalizedWorkerHostname(url);
+    if (host === null) return new Set();
+    const knownHost =
+      host === "api.anthropic.com" ||
+      host === "api.openai.com" ||
+      host === "chatgpt.com" ||
+      host === "generativelanguage.googleapis.com" ||
+      vertexRegionFromUrl(host) !== null;
+    if (
+      knownHost &&
+      (parsed.protocol !== "https:" ||
+        (parsed.port !== "" && parsed.port !== "443"))
+    ) {
+      return new Set();
+    }
+    if (host === "api.anthropic.com") return new Set(["anthropic"]);
+    if (host === "api.openai.com") return new Set(["openai"]);
+    if (host === "chatgpt.com") {
+      return /(?:^|\/)backend-api(?:\/|$)/.test(parsed.pathname)
+        ? new Set(["openai", "openai-codex"])
+        : new Set();
+    }
+    if (host === "generativelanguage.googleapis.com") {
+      return new Set(["google"]);
+    }
+    if (vertexRegionFromUrl(host) !== null) {
+      return new Set(["vertex", "google-vertex", "google-vertex-anthropic"]);
+    }
+    return null;
+  } catch {
+    return new Set();
+  }
+}
 
 /**
  * Resolve the wire protocol for a worker request.
@@ -903,8 +1493,8 @@ function isResponsesOnlyModel(modelID: string): boolean {
 function isChatGPTBackend(url: string | URL | undefined): boolean {
   if (!url) return false;
   try {
-    const host = typeof url === "string" ? new URL(url).hostname : url.hostname;
-    return host === "chatgpt.com";
+    const target = typeof url === "string" ? new URL(url) : url;
+    return /(?:^|\/)backend-api(?:\/|$)/.test(target.pathname);
   } catch {
     return false;
   }
@@ -926,30 +1516,72 @@ function isChatGPTBackend(url: string | URL | undefined): boolean {
  * @param modelProviderID  The worker model's provider (authoritative for routing)
  * @param overrideProviderID  The session/override provider, if known
  */
-function resolveTarget(
+export function resolveTarget(
   upstreams: { anthropic: string; openai: string },
   protocol: WorkerProtocol,
   upstreamOverride: string | undefined,
   modelProviderID: string,
   overrideProviderID?: string,
 ): ProviderTarget & { routeUnavailable?: boolean } {
+  const unavailable = (): ProviderTarget & { routeUnavailable: true } => ({
+    url: "",
+    protocol,
+    providerName: modelProviderID,
+    routeUnavailable: true,
+  });
+  const normalizedTargetUrl = (url: string): string => {
+    const families = workerOriginProtocolFamilies(url);
+    if (families !== null && families.size > 0) {
+      const parsed = new URL(url);
+      const hostname = normalizedWorkerHostname(url);
+      if (hostname) parsed.hostname = hostname;
+      return parsed.toString().replace(/\/$/, "");
+    }
+    return url.replace(/\/$/, "");
+  };
+  const canonicalOriginIsCompatible = (url: string): boolean => {
+    const families = workerOriginProtocolFamilies(url);
+    const providerIDs = workerOriginProviderIDs(url);
+    return (
+      (families === null || families.has(workerProtocolFamily(protocol))) &&
+      (providerIDs === null ||
+        [...providerIDs].some((providerID) =>
+          workerProvidersEquivalent(providerID, modelProviderID),
+        ))
+    );
+  };
+  if (!workerProviderSupportsProtocol(modelProviderID, protocol)) {
+    return unavailable();
+  }
+  if (
+    (modelProviderID === "openai" &&
+      workerProtocolFamily(protocol) !== "openai") ||
+    (modelProviderID === "anthropic" &&
+      workerProtocolFamily(protocol) !== "anthropic")
+  ) {
+    return unavailable();
+  }
   // Honor the session override ONLY when we have positive evidence it belongs
   // to this worker model's provider:
-  //  - overrideProviderID matches the model's provider (the normal case), OR
-  //  - overrideProviderID is unknown AND the model provider does NOT have its
-  //    own distinct provider route (so there's no safer endpoint to prefer —
-  //    e.g. the model provider IS the override's, or it's an aggregator).
-  // When overrideProviderID is unknown but the model HAS its own route (e.g.
-  // minimax → api.minimax.io), we do NOT trust the foreign override — we route
-  // by the model's own provider below. This fails safe: a future caller that
-  // sets `upstreamUrl` without `upstreamProviderID` cannot silently re-open the
-  // cross-provider collusion (the production minimax→Anthropic 401 loop).
-  const overrideMatchesModel = overrideProviderID
-    ? overrideProviderID === modelProviderID
-    : resolveProviderRoute(modelProviderID)?.url == null;
+  //  - overrideProviderID matches the model's provider (the normal case).
+  // An absent provider label is not evidence of ownership: trusting an
+  // unlabelled URL would let an arbitrary endpoint receive the model provider's
+  // credential, especially for route-less/custom providers. Without explicit
+  // provenance, ignore the override and use a trusted static route or fail
+  // closed below.
+  const overrideMatchesModel =
+    overrideProviderID !== undefined &&
+    workerProvidersEquivalent(overrideProviderID, modelProviderID);
   if (upstreamOverride && overrideMatchesModel) {
+    if (!workerProviderSupportsProtocol(overrideProviderID, protocol)) {
+      return unavailable();
+    }
+    // Unknown/custom aliases are accepted only with this exact provider
+    // provenance. Canonical origins remain authoritative and cannot be
+    // relabelled into another protocol family.
+    if (!canonicalOriginIsCompatible(upstreamOverride)) return unavailable();
     return {
-      url: upstreamOverride.replace(/\/$/, ""),
+      url: normalizedTargetUrl(upstreamOverride),
       protocol,
       // Prefer the actual provider label over the protocol. `overrideMatchesModel`
       // guarantees the override and worker model share a provider, so either the
@@ -982,8 +1614,9 @@ function resolveTarget(
       // Codex has no static default upstream — fall back to its provider route.
       const route = resolveProviderRoute("openai-codex");
       if (route?.url) {
+        if (!canonicalOriginIsCompatible(route.url)) return unavailable();
         return {
-          url: route.url.replace(/\/$/, ""),
+          url: normalizedTargetUrl(route.url),
           protocol,
           providerName: "openai-codex",
         };
@@ -991,8 +1624,25 @@ function resolveTarget(
     } else {
       const route = resolveProviderRoute(modelProviderID);
       if (route?.url) {
+        const routeFamily = route.protocol
+          ? workerProtocolFamily(
+              route.protocol === "openai-responses"
+                ? "openai-responses"
+                : route.protocol,
+            )
+          : undefined;
+        const canonicalFamilies = workerOriginProtocolFamilies(route.url);
+        if (
+          (canonicalFamilies !== null &&
+            !canonicalFamilies.has(workerProtocolFamily(protocol))) ||
+          (canonicalFamilies === null &&
+            routeFamily !== undefined &&
+            routeFamily !== workerProtocolFamily(protocol))
+        ) {
+          return unavailable();
+        }
         return {
-          url: route.url.replace(/\/$/, ""),
+          url: normalizedTargetUrl(route.url),
           protocol,
           providerName: modelProviderID,
         };
@@ -1001,22 +1651,29 @@ function resolveTarget(
     // No route URL for this provider (unknown, or a local provider needing an
     // explicit LORE_UPSTREAM_<PROVIDER>). Signal the caller to fail closed —
     // we must NOT fall back to a foreign default endpoint.
-    return {
-      url: "",
-      protocol,
-      providerName: modelProviderID,
-      routeUnavailable: true,
-    };
+    return unavailable();
   }
-  if (protocol === "openai") {
+  if (modelProviderID === "openai") {
+    if (workerProtocolFamily(protocol) !== "openai" || !upstreams.openai) {
+      return unavailable();
+    }
+    if (!canonicalOriginIsCompatible(upstreams.openai)) return unavailable();
     return {
-      url: upstreams.openai.replace(/\/$/, ""),
+      url: normalizedTargetUrl(upstreams.openai),
       protocol,
       providerName: "openai",
     };
   }
+  if (
+    modelProviderID !== "anthropic" ||
+    workerProtocolFamily(protocol) !== "anthropic" ||
+    !upstreams.anthropic ||
+    !canonicalOriginIsCompatible(upstreams.anthropic)
+  ) {
+    return unavailable();
+  }
   return {
-    url: upstreams.anthropic.replace(/\/$/, ""),
+    url: normalizedTargetUrl(upstreams.anthropic),
     protocol,
     providerName: "anthropic",
   };
@@ -1309,35 +1966,124 @@ function buildGeminiWorkerRequest(
 }
 
 /** Parse a native Gemini `generateContent` worker response into `{text,usage,model}`. */
-function parseGeminiWorkerResponse(data: {
-  candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
-  usageMetadata?: {
-    promptTokenCount?: number;
-    candidatesTokenCount?: number;
-    cachedContentTokenCount?: number;
-  };
-  modelVersion?: string;
+export function parseGeminiWorkerResponse(data: {
+  candidates?: unknown;
+  usageMetadata?: unknown;
+  modelVersion?: unknown;
 }): {
   text: string | null;
   usage: AnthropicUsage | null;
   model: string | null;
 } {
-  const parts = data.candidates?.[0]?.content?.parts ?? [];
+  const malformed = (): never => {
+    throw new Error("malformed Gemini response body");
+  };
+  if (data.candidates !== undefined && !Array.isArray(data.candidates)) {
+    malformed();
+  }
+  const candidates = (data.candidates ?? []) as unknown[];
+  for (const candidate of candidates) {
+    const toolIdentities = new Set<string>();
+    if (!isRecord(candidate)) malformed();
+    const typedCandidate = candidate as Record<string, unknown>;
+    if (
+      typedCandidate.index !== undefined &&
+      (!Number.isSafeInteger(typedCandidate.index) ||
+        (typedCandidate.index as number) < 0)
+    ) {
+      malformed();
+    }
+    if (
+      typedCandidate.finishReason !== undefined &&
+      typedCandidate.finishReason !== null &&
+      typeof typedCandidate.finishReason !== "string"
+    ) {
+      malformed();
+    }
+    if (
+      typedCandidate.tokenCount !== undefined &&
+      (!Number.isSafeInteger(typedCandidate.tokenCount) ||
+        (typedCandidate.tokenCount as number) < 0)
+    ) {
+      malformed();
+    }
+    if (typedCandidate.content === undefined) continue;
+    if (!isRecord(typedCandidate.content)) malformed();
+    const typedContent = typedCandidate.content as Record<string, unknown>;
+    if (
+      typedContent.role !== undefined &&
+      typeof typedContent.role !== "string"
+    ) {
+      malformed();
+    }
+    const parts = typedContent.parts;
+    if (parts === undefined) continue;
+    if (!Array.isArray(parts)) malformed();
+    for (const part of parts as unknown[]) {
+      if (!isRecord(part)) malformed();
+      const typedPart = part as Record<string, unknown>;
+      if (
+        typedPart.text !== undefined &&
+        typedPart.functionCall !== undefined
+      ) {
+        malformed();
+      }
+      if (typedPart.text !== undefined && typeof typedPart.text !== "string") {
+        malformed();
+      }
+      if (
+        typedPart.thought !== undefined &&
+        typeof typedPart.thought !== "boolean"
+      ) {
+        malformed();
+      }
+      if (typedPart.functionCall !== undefined) {
+        if (!isRecord(typedPart.functionCall)) malformed();
+        validateGeminiFunctionCallIdentity(
+          typedPart.functionCall,
+          toolIdentities,
+          "malformed Gemini response body",
+        );
+      }
+    }
+  }
+
+  const usageMetadata = validateGeminiUsageMetadata(
+    data.usageMetadata,
+    "malformed Gemini response body",
+  );
+  if (
+    data.modelVersion !== undefined &&
+    data.modelVersion !== null &&
+    typeof data.modelVersion !== "string"
+  ) {
+    malformed();
+  }
+
+  const first = candidates[0] as Record<string, unknown> | undefined;
+  const content = first?.content as Record<string, unknown> | undefined;
+  const parts = (content?.parts ?? []) as Array<Record<string, unknown>>;
   const text =
     parts
       .filter((p) => typeof p.text === "string")
       .map((p) => p.text)
       .join("") || null;
-  const um = data.usageMetadata;
-  const usage: AnthropicUsage | null = um
+  const normalizedUsage = usageMetadata
+    ? geminiUsageFromMetadata(usageMetadata)
+    : null;
+  const usage: AnthropicUsage | null = normalizedUsage
     ? {
-        input_tokens: um.promptTokenCount ?? 0,
-        output_tokens: um.candidatesTokenCount ?? 0,
-        cache_read_input_tokens: um.cachedContentTokenCount ?? 0,
+        input_tokens: normalizedUsage.inputTokens,
+        output_tokens: normalizedUsage.outputTokens,
+        cache_read_input_tokens: normalizedUsage.cacheReadInputTokens ?? 0,
         cache_creation_input_tokens: 0,
       }
     : null;
-  return { text, usage, model: data.modelVersion ?? null };
+  return {
+    text,
+    usage,
+    model: typeof data.modelVersion === "string" ? data.modelVersion : null,
+  };
 }
 
 /**
@@ -1453,16 +2199,118 @@ function buildOpenAIResponsesWorkerRequest(
   };
 }
 
+function validateAnthropicContentBlock(block: unknown): void {
+  const malformed = (): never => {
+    throw new Error("malformed Anthropic response body");
+  };
+  if (
+    !isRecord(block) ||
+    typeof block.type !== "string" ||
+    !ANTHROPIC_CONTENT_BLOCK_TYPES.has(block.type)
+  ) {
+    malformed();
+  }
+  const typedBlock = block as Record<string, unknown>;
+  switch (typedBlock.type) {
+    case "text":
+      if (typeof typedBlock.text !== "string") malformed();
+      break;
+    case "thinking":
+      if (
+        typeof typedBlock.thinking !== "string" ||
+        (typedBlock.signature !== undefined &&
+          typeof typedBlock.signature !== "string")
+      ) {
+        malformed();
+      }
+      break;
+    case "redacted_thinking":
+      if (typeof typedBlock.data !== "string") malformed();
+      break;
+    case "tool_use":
+    case "server_tool_use":
+      if (
+        typeof typedBlock.id !== "string" ||
+        typeof typedBlock.name !== "string" ||
+        (typedBlock.type === "tool_use"
+          ? !isRecord(typedBlock.input)
+          : typedBlock.input === undefined)
+      ) {
+        malformed();
+      }
+      break;
+    case "container_upload":
+      if (typeof typedBlock.file_id !== "string") malformed();
+      break;
+    case "web_search_tool_result":
+    case "web_fetch_tool_result":
+    case "code_execution_tool_result":
+    case "bash_code_execution_tool_result":
+    case "text_editor_code_execution_tool_result":
+    case "tool_search_tool_result":
+      if (
+        typeof typedBlock.tool_use_id !== "string" ||
+        typedBlock.content == null
+      ) {
+        malformed();
+      }
+      break;
+    case "fallback":
+      // A fallback block is a provider boundary marker and has no worker text.
+      break;
+  }
+}
+
 /** Extract text response from an Anthropic Messages API response. */
 export function parseAnthropicResponse(data: {
-  content?: Array<{ type: string; text?: string; thinking?: string }>;
-  model?: string;
+  content?: Array<
+    Record<string, unknown> & {
+      type: string;
+      text?: string;
+      thinking?: string;
+    }
+  >;
+  model?: string | null;
   usage?: AnthropicUsage;
+  stop_reason?: unknown;
 }): {
   text: string | null;
   usage: AnthropicUsage | null;
   model: string | null;
 } {
+  if (data.content !== undefined && !Array.isArray(data.content)) {
+    throw new Error("malformed Anthropic response body");
+  }
+  const toolIdentities = new Set<string>();
+  for (const block of data.content ?? []) {
+    validateAnthropicContentBlock(block);
+    if (block.type === "tool_use" || block.type === "server_tool_use") {
+      const id = (block as { id?: unknown }).id;
+      if (typeof id !== "string" || !id || toolIdentities.has(id)) {
+        throw new Error("malformed Anthropic response body");
+      }
+      toolIdentities.add(id);
+    }
+  }
+  if (
+    data.model !== undefined &&
+    data.model !== null &&
+    typeof data.model !== "string"
+  ) {
+    throw new Error("malformed Anthropic response body");
+  }
+  if (
+    data.stop_reason !== undefined &&
+    (typeof data.stop_reason !== "string" ||
+      !ANTHROPIC_STOP_REASONS.has(data.stop_reason))
+  ) {
+    throw new Error("malformed Anthropic response body");
+  }
+  validateAnthropicUsage(data.usage, {
+    message: "malformed Anthropic response body",
+    requireInput: true,
+    requireOutput: true,
+  });
   const textBlock = data.content?.find(
     (b) => b.type === "text" && typeof b.text === "string",
   );
@@ -1480,7 +2328,7 @@ export function parseAnthropicResponse(data: {
   return {
     text,
     usage: data.usage ?? null,
-    model: data.model ?? null,
+    model: typeof data.model === "string" ? data.model : null,
   };
 }
 
@@ -1490,7 +2338,97 @@ export function parseOpenAIResponse(data: OpenAIChatResponse): {
   usage: AnthropicUsage | null;
   model: string | null;
 } {
+  if (data.choices !== undefined && !Array.isArray(data.choices)) {
+    throw new Error("malformed OpenAI response body");
+  }
+  const logicalChoiceIndices = new Set<number>();
+  for (let position = 0; position < (data.choices?.length ?? 0); position++) {
+    const choice = data.choices?.[position];
+    if (!isRecord(choice)) throw new Error("malformed OpenAI response body");
+    const logicalIndex = choice.index === undefined ? position : choice.index;
+    if (
+      !Number.isSafeInteger(logicalIndex) ||
+      logicalIndex < 0 ||
+      logicalChoiceIndices.has(logicalIndex)
+    ) {
+      throw new Error("malformed OpenAI response body");
+    }
+    logicalChoiceIndices.add(logicalIndex);
+  }
+  for (const choice of data.choices ?? []) {
+    const toolIdentities = new Set<string>();
+    if (!isRecord(choice)) throw new Error("malformed OpenAI response body");
+    if (
+      choice.index !== undefined &&
+      (!Number.isSafeInteger(choice.index) || choice.index < 0)
+    ) {
+      throw new Error("malformed OpenAI response body");
+    }
+    if (
+      (choice.finish_reason !== undefined &&
+        choice.finish_reason !== null &&
+        typeof choice.finish_reason !== "string") ||
+      (choice.native_finish_reason !== undefined &&
+        choice.native_finish_reason !== null &&
+        typeof choice.native_finish_reason !== "string")
+    ) {
+      throw new Error("malformed OpenAI response body");
+    }
+    if (choice.message === undefined) continue;
+    if (!isRecord(choice.message)) {
+      throw new Error("malformed OpenAI response body");
+    }
+    const message = choice.message;
+    if (
+      message.content !== undefined &&
+      message.content !== null &&
+      typeof message.content !== "string" &&
+      !Array.isArray(message.content)
+    ) {
+      throw new Error("malformed OpenAI response body");
+    }
+    if (
+      Array.isArray(message.content) &&
+      message.content.some((part) => !isRecord(part))
+    ) {
+      throw new Error("malformed OpenAI response body");
+    }
+    for (const field of [
+      "reasoning_content",
+      "reasoning",
+      "refusal",
+    ] as const) {
+      if (
+        message[field] !== undefined &&
+        message[field] !== null &&
+        typeof message[field] !== "string"
+      ) {
+        throw new Error("malformed OpenAI response body");
+      }
+    }
+    const toolCalls = message.tool_calls;
+    if (toolCalls !== undefined && !Array.isArray(toolCalls)) {
+      throw new Error("malformed OpenAI response body");
+    }
+    for (const call of toolCalls ?? []) {
+      if (!isRecord(call) || typeof call.id !== "string" || !call.id) {
+        throw new Error("malformed OpenAI response body");
+      }
+      if (toolIdentities.has(call.id)) {
+        throw new Error("malformed OpenAI response body");
+      }
+      toolIdentities.add(call.id);
+    }
+  }
   const message = data.choices?.[0]?.message;
+  if (
+    data.model !== undefined &&
+    data.model !== null &&
+    typeof data.model !== "string"
+  ) {
+    throw new Error("malformed OpenAI response body");
+  }
+  validateOpenAIUsage(data.usage, "malformed OpenAI response body");
   // reasoning models put the answer in reasoning fields — never treat a present
   // reasoning body as no-response. Prefer real `content`; fall back to
   // `reasoning_content` (DeepSeek/Qwen) then `reasoning` (OpenRouter/others)
@@ -1506,11 +2444,14 @@ export function parseOpenAIResponse(data: OpenAIChatResponse): {
         ? message.reasoning
         : null;
   const text =
-    typeof content === "string" && content.length > 0 ? content : reasoning;
+    typeof content === "string" && content.length > 0
+      ? content
+      : reasoning ||
+        (typeof message?.refusal === "string" ? message.refusal : null);
   return {
     text: text ?? null,
     usage: data.usage ? normalizeOpenAIUsage(data.usage) : null,
-    model: data.model ?? null,
+    model: typeof data.model === "string" ? data.model : null,
   };
 }
 
@@ -1522,12 +2463,21 @@ export function parseOpenAIResponse(data: OpenAIChatResponse): {
 export function parseResponsesWorkerResponse(data: {
   output?: Array<{
     type?: string;
-    content?: Array<{ type?: string; text?: string }>;
+    id?: string;
+    call_id?: string;
+    name?: string;
+    arguments?: string;
+    content?: Array<{
+      type?: string;
+      text?: string;
+      refusal?: string;
+    }>;
   }>;
   output_text?: string;
   usage?: {
     input_tokens?: number;
     output_tokens?: number;
+    total_tokens?: number;
     // Responses API reports cache details under `input_tokens_details`;
     // OpenAI-compatible providers may use `prompt_tokens_details` instead.
     input_tokens_details?: {
@@ -1538,17 +2488,116 @@ export function parseResponsesWorkerResponse(data: {
       cached_tokens?: number;
       cache_write_tokens?: number;
     };
+    output_tokens_details?: {
+      reasoning_tokens?: number;
+      audio_tokens?: number;
+      accepted_prediction_tokens?: number;
+      rejected_prediction_tokens?: number;
+    };
   };
-  model?: string;
+  model?: string | null;
+  status?: string;
+  incomplete_details?: { reason?: string } | null;
 }): {
   text: string | null;
   usage: AnthropicUsage | null;
   model: string | null;
+  incompleteDetails?: { reason: string } | null;
 } {
+  if (
+    data.status !== undefined &&
+    data.status !== "completed" &&
+    data.status !== "incomplete"
+  ) {
+    throw new Error("non-success Responses response status");
+  }
+  const incompleteDetails = data.incomplete_details;
+  if (
+    incompleteDetails !== undefined &&
+    incompleteDetails !== null &&
+    (!isRecord(incompleteDetails) ||
+      typeof incompleteDetails.reason !== "string" ||
+      incompleteDetails.reason.length === 0)
+  ) {
+    throw new Error("malformed Responses response body");
+  }
+  if (incompleteDetails != null && data.status !== "incomplete") {
+    throw new Error("malformed Responses response body");
+  }
+  if (data.output !== undefined && !Array.isArray(data.output)) {
+    throw new Error("malformed Responses response body");
+  }
+  const toolIdentities = new Set<string>();
+  const outputItemIds = new Set<string>();
+  for (const item of data.output ?? []) {
+    if (!isRecord(item)) throw new Error("malformed Responses response body");
+    if (item.type !== undefined && typeof item.type !== "string") {
+      throw new Error("malformed Responses response body");
+    }
+    if (
+      typeof item.id !== "string" ||
+      item.id.length === 0 ||
+      outputItemIds.has(item.id)
+    ) {
+      throw new Error("malformed Responses response body");
+    }
+    outputItemIds.add(item.id);
+    if (item.type === "function_call") {
+      const identity = item.call_id;
+      if (
+        typeof identity !== "string" ||
+        identity.length === 0 ||
+        toolIdentities.has(identity) ||
+        typeof item.name !== "string" ||
+        typeof item.arguments !== "string"
+      ) {
+        throw new Error("malformed Responses response body");
+      }
+      toolIdentities.add(identity);
+    }
+    if (item.content !== undefined && !Array.isArray(item.content)) {
+      throw new Error("malformed Responses response body");
+    }
+    for (const part of item.content ?? []) {
+      if (!isRecord(part)) {
+        throw new Error("malformed Responses response body");
+      }
+      if (part.type !== undefined && typeof part.type !== "string") {
+        throw new Error("malformed Responses response body");
+      }
+      if (part.type === "output_text" && typeof part.text !== "string") {
+        throw new Error("malformed Responses response body");
+      }
+      if (part.type === "refusal" && typeof part.refusal !== "string") {
+        throw new Error("malformed Responses response body");
+      }
+    }
+  }
+  if (
+    data.output_text !== undefined &&
+    data.output_text !== null &&
+    typeof data.output_text !== "string"
+  ) {
+    throw new Error("malformed Responses response body");
+  }
+  if (
+    data.model !== undefined &&
+    data.model !== null &&
+    typeof data.model !== "string"
+  ) {
+    throw new Error("malformed Responses response body");
+  }
+  const validatedUsage = validateResponsesUsage(
+    data.usage,
+    "malformed Responses response body",
+  );
+
   // Prefer the convenience `output_text` aggregate when present; otherwise
   // concatenate text parts from message output items.
   let text: string | null =
-    typeof data.output_text === "string" ? data.output_text : null;
+    typeof data.output_text === "string" && data.output_text.length > 0
+      ? data.output_text
+      : null;
   if (text === null && Array.isArray(data.output)) {
     const parts: string[] = [];
     for (const item of data.output) {
@@ -1556,6 +2605,11 @@ export function parseResponsesWorkerResponse(data: {
       for (const part of item.content) {
         if (part?.type === "output_text" && typeof part.text === "string") {
           parts.push(part.text);
+        } else if (
+          part?.type === "refusal" &&
+          typeof part.refusal === "string"
+        ) {
+          parts.push(part.refusal);
         }
       }
     }
@@ -1563,26 +2617,51 @@ export function parseResponsesWorkerResponse(data: {
   }
 
   let usage: AnthropicUsage | null = null;
-  if (data.usage) {
-    const details =
-      data.usage.input_tokens_details ?? data.usage.prompt_tokens_details;
-    const cachedTokens = details?.cached_tokens;
-    const cacheWriteTokens = details?.cache_write_tokens;
+  if (validatedUsage) {
+    const rawDetails =
+      validatedUsage.input_tokens_details ??
+      validatedUsage.prompt_tokens_details;
+    const details = isRecord(rawDetails) ? rawDetails : undefined;
+    const cachedTokens =
+      typeof details?.cached_tokens === "number"
+        ? details.cached_tokens
+        : undefined;
+    const cacheWriteTokens =
+      typeof details?.cache_write_tokens === "number"
+        ? details.cache_write_tokens
+        : undefined;
     usage = {
       // input_tokens is inclusive of cache reads/writes; convert to the
       // gateway's disjoint convention so cache tokens aren't double-counted.
       input_tokens: disjointOpenAIInputTokens(
-        data.usage.input_tokens,
+        typeof validatedUsage.input_tokens === "number"
+          ? validatedUsage.input_tokens
+          : undefined,
         cachedTokens,
         cacheWriteTokens,
       ),
-      output_tokens: data.usage.output_tokens ?? 0,
+      output_tokens:
+        typeof validatedUsage.output_tokens === "number"
+          ? validatedUsage.output_tokens
+          : 0,
       cache_read_input_tokens: cachedTokens ?? 0,
       cache_creation_input_tokens: cacheWriteTokens ?? 0,
     };
   }
 
-  return { text, usage, model: data.model ?? null };
+  return {
+    text,
+    usage,
+    model: typeof data.model === "string" ? data.model : null,
+    ...(incompleteDetails === undefined
+      ? {}
+      : {
+          incompleteDetails:
+            incompleteDetails === null
+              ? null
+              : { reason: incompleteDetails.reason as string },
+        }),
+  };
 }
 
 /**
@@ -1607,9 +2686,10 @@ async function buildVertexWorkerRequest(
   temperature?: number,
   disableThinking = false,
   reasoningEffort?: ReasoningEffort,
+  signal?: AbortSignal,
 ): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   const region = vertexRegionFromUrl(target.url) ?? "global";
-  const project = await resolveVertexProject(vertexProject ?? "");
+  const project = await resolveVertexProject(vertexProject ?? "", signal);
   if (!project) {
     throw new Error(
       "Vertex worker: no GCP project. Set GOOGLE_CLOUD_PROJECT (or " +
@@ -1618,7 +2698,7 @@ async function buildVertexWorkerRequest(
     );
   }
   const vertexModel = toVertexModelId(model.modelID);
-  const token = await getVertexAccessToken();
+  const token = await getVertexAccessToken(signal);
   const vertexThinkingBudget = anthropicThinkingBudget(reasoningEffort) ?? 0;
   const vertexThinkingEnabled = vertexThinkingBudget > 0;
   // Worker system prompt is static across bursts → cache it. Use bare ephemeral
@@ -1684,6 +2764,7 @@ async function buildWorkerRequest(
   vertexProject?: string,
   disableThinking = false,
   reasoningEffort?: ReasoningEffort,
+  signal?: AbortSignal,
 ): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   switch (target.protocol) {
     case "openai-codex-responses":
@@ -1730,6 +2811,7 @@ async function buildWorkerRequest(
         temperature,
         disableThinking,
         reasoningEffort,
+        signal,
       );
     case "gemini":
       return buildGeminiWorkerRequest(
@@ -1798,75 +2880,56 @@ function parseWorkerResponse(
 function accumulateWorkerSSE(
   protocol: WorkerProtocol,
   response: Response,
+  signal?: AbortSignal,
+  onSemanticContent?: () => void,
 ): Promise<GatewayResponse> {
   switch (protocol) {
     case "openai-codex-responses":
-      return accumulateResponsesSSEStream(response);
+      return accumulateResponsesSSEStream(response, {
+        validation: "codex",
+        stopAtTerminal: true,
+        signal,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+        onSemanticContent,
+      });
     case "openai-responses":
       // OpenAI Responses API uses the same wire-shape SSE stream as the
       // Codex-Responses path (`event: response.*` deltas). Reuse the existing
       // accumulator.
-      return accumulateResponsesSSEStream(response);
+      return accumulateResponsesSSEStream(response, {
+        validation: "public",
+        stopAtTerminal: true,
+        signal,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+        onSemanticContent,
+      });
     case "gemini":
-      return accumulateGeminiSSEStream(response);
+      return accumulateGeminiSSEStream(response, {
+        signal,
+        stopAtTerminal: true,
+        strict: true,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+        onSemanticContent,
+      });
     case "openai":
-      return accumulateOpenAISSEStream(response);
+      return accumulateOpenAISSEStream(response, {
+        signal,
+        stopAtTerminal: true,
+        strict: true,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+        onSemanticContent,
+        consumeUntilDone: true,
+      });
     default:
       // Anthropic wire (incl. Vertex/Bedrock-mantle) SSE.
-      return accumulateSSEResponse(response);
+      return accumulateSSEResponse(response, {
+        signal,
+        stopAtTerminal: true,
+        strict: true,
+        inactivityMs: WORKER_RESPONSE_INACTIVITY_MS,
+        onSemanticContent,
+      });
   }
-}
-
-/**
- * Validate a buffered Responses worker stream before treating an empty result
- * as a model-capability signal. The shared accumulator deliberately tolerates
- * malformed events for foreground pass-through, but workers must fail closed:
- * skipped deltas or a response.failed terminal are upstream failures, never
- * evidence that the model cannot answer.
- */
-function validateResponsesWorkerSSE(body: string): string | null {
-  let terminalStatus: string | null = null;
-
-  for (const frame of body.split(/\r?\n\r?\n/)) {
-    let event = "message";
-    const dataLines: string[] = [];
-    for (const line of frame.split(/\r?\n/)) {
-      if (line.startsWith("event:")) {
-        event = line.slice(6).trim();
-      } else if (line.startsWith("data:")) {
-        dataLines.push(line.slice(5).trimStart());
-      }
-    }
-
-    const data = dataLines.join("\n");
-    if (!data || data === "[DONE]") continue;
-
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(data) as Record<string, unknown>;
-    } catch {
-      return `malformed ${event || "unnamed"} event`;
-    }
-
-    if (event === "response.failed") {
-      return "response.failed terminal";
-    }
-    if (
-      event === "response.completed" ||
-      event === "response.done" ||
-      event === "response.incomplete"
-    ) {
-      const response = parsed.response as Record<string, unknown> | undefined;
-      terminalStatus =
-        typeof response?.status === "string" ? response.status : null;
-    }
-  }
-
-  if (!terminalStatus) return "missing terminal response status";
-  if (terminalStatus === "failed" || terminalStatus === "cancelled") {
-    return `terminal response status=${terminalStatus}`;
-  }
-  return null;
 }
 
 /**
@@ -1899,6 +2962,23 @@ export function gatewayResponseToWorkerResult(resp: GatewayResponse): {
           b.type === "thinking",
       )
       .map((b) => b.thinking)
+      .join("") ||
+    resp.content
+      .flatMap((block) => {
+        if (block.type !== "opaque") return [];
+        const content = block.raw.content;
+        if (!Array.isArray(content)) return [];
+        return content
+          .filter(
+            (part): part is Record<string, unknown> =>
+              !!part && typeof part === "object" && !Array.isArray(part),
+          )
+          .map((part) =>
+            part.type === "refusal" && typeof part.refusal === "string"
+              ? part.refusal
+              : "",
+          );
+      })
       .join("");
   const usage: AnthropicUsage | null = resp.usage
     ? {
@@ -1915,7 +2995,7 @@ export function gatewayResponseToWorkerResult(resp: GatewayResponse): {
  * Summarize an upstream worker response body for diagnostics when the parser
  * found no usable text. Reports which fields were present (content vs the
  * reasoning/thinking fallbacks), the finish_reason, and a truncated body
- * sample — without dumping the full (potentially large) payload. This lets us
+ * shape summary without dumping response values. This lets us
  * classify an empty `no-response` as a genuinely empty completion, a
  * reasoning-field shape we don't read, or a truncation (`finish_reason:
  * "length"`), instead of an opaque failure.
@@ -1939,13 +3019,21 @@ function extractFinishReason(rawData: unknown): string | undefined {
         native_finish_reason?: string;
       }>;
       stop_reason?: string;
+      status?: string;
+      incomplete_details?: { reason?: string } | null;
     };
-    return (
+    const reason =
       d.choices?.[0]?.finish_reason ??
       d.choices?.[0]?.native_finish_reason ??
       d.stop_reason ??
-      undefined
-    );
+      (d.status === "incomplete" &&
+      d.incomplete_details?.reason === "max_output_tokens"
+        ? "length"
+        : d.status === "incomplete"
+          ? d.incomplete_details?.reason
+          : undefined) ??
+      undefined;
+    return reason === "refusal" ? normalizeAnthropicStopReason(reason) : reason;
   } catch {
     return undefined;
   }
@@ -2001,7 +3089,7 @@ function extractBodyErrorCode(rawData: unknown): number | null {
   return null;
 }
 
-function describeEmptyWorkerResponse(rawData: unknown): string {
+export function describeEmptyWorkerResponse(rawData: unknown): string {
   const fields: string[] = [];
   let finishReason: string | undefined;
   try {
@@ -2026,21 +3114,24 @@ function describeEmptyWorkerResponse(rawData: unknown): string {
       finishReason = d.choices?.[0]?.finish_reason;
     }
     if (Array.isArray(d.content)) {
-      for (const b of d.content) if (b.type) fields.push(`block:${b.type}`);
+      fields.push(`blocks:${d.content.length}`);
     }
   } catch {
     // ignore — best-effort introspection
   }
-  let sample = "";
-  try {
-    sample = JSON.stringify(rawData).slice(0, 300);
-  } catch {
-    sample = "(unserializable)";
-  }
+  const knownFinishReasons = new Set([
+    "stop",
+    "end_turn",
+    "length",
+    "max_tokens",
+    "max_output_tokens",
+    "content_filter",
+    "tool_calls",
+    "tool_use",
+  ]);
   return (
     `fields=[${fields.join(",") || "none"}]` +
-    ` finish_reason=${finishReason ?? "n/a"}` +
-    ` body=${sample}`
+    ` finish_reason=${finishReason && knownFinishReasons.has(finishReason) ? finishReason : finishReason ? "unknown" : "n/a"}`
   );
 }
 
@@ -2106,9 +3197,9 @@ export function createGatewayLLMClient(
       // successful or different-failure call.
       lastWorkerError = undefined;
       // `model` is mutable: on a 400 model-not-supported the retry loop swaps
-      // in a same-provider backup (workerModelCandidates). Backups never change
-      // provider, so target/protocol/credential stay valid — only the body's
-      // model id changes.
+      // in a same-provider backup (workerModelCandidates). Provider credentials
+      // remain valid, but protocol/target are re-resolved because one provider
+      // may serve different models on different APIs.
       let model = opts?.model ?? defaultModel;
 
       // Skip models already known to produce no usable worker output. Two
@@ -2138,7 +3229,7 @@ export function createGatewayLLMClient(
         }
       }
       if (candidateBlocked(model)) {
-        lastWorkerError = `all ${model.providerID} worker model candidates blocked (likely auth, model-not-supported, or worker-incapable)`;
+        lastWorkerError = `all ${diagnosticToken(model.providerID)} worker model candidates blocked (likely auth, model-not-supported, or worker-incapable)`;
         return null;
       }
 
@@ -2151,21 +3242,15 @@ export function createGatewayLLMClient(
       // provider route instead. This keeps protocol, URL, and credential all
       // consistent with the worker model's provider.
       const sameProviderAsSession =
-        !opts?.upstreamProviderID ||
-        opts.upstreamProviderID === model.providerID;
-      const protocol = resolveWorkerProtocol(
+        opts?.upstreamProviderID !== undefined &&
+        workerProvidersEquivalent(opts.upstreamProviderID, model.providerID);
+      let protocol = resolveWorkerProtocol(
         model.providerID,
         sameProviderAsSession ? opts?.protocol : undefined,
         model.modelID,
-        // Pass the session's upstream URL so a `providerID="openai"` worker
-        // targeting the ChatGPT subscription backend is routed to
-        // `openai-codex-responses` (see `isChatGPTBackend` in this module).
-        // Cross-provider workers (sameProviderAsSession === false) use the
-        // model's own route, not the session override, so passing the
-        // override here is safe — the URL we test against is the URL the
-        // worker would actually hit. This preserves the pre-existing
-        // cross-provider safety from `resolveTarget` below.
-        upstreamOverride,
+        // Only inspect the session URL for same-provider workers. A foreign
+        // `/backend-api` URL must not change the model provider's protocol.
+        sameProviderAsSession ? upstreamOverride : undefined,
       );
 
       // Vertex authenticates with lore's own GCP OAuth2 bearer token (minted
@@ -2177,9 +3262,17 @@ export function createGatewayLLMClient(
       // background distillation/curation for such sessions). Synthesize a
       // placeholder so the shared worker pipeline proceeds; it is never sent
       // upstream (the vertex builder constructs its own headers and ignores it).
-      const cred =
-        getAuth(opts?.sessionID, model.providerID) ??
-        (protocol === "vertex" ? { scheme: "bearer", value: "" } : null);
+      let credentialProviderID = model.providerID;
+      let cred: AuthCredential | null = null;
+      for (const providerID of workerProviderAliasIDs(model.providerID)) {
+        if (!workerProviderSupportsProtocol(providerID, protocol)) continue;
+        cred = getAuth(opts?.sessionID, providerID);
+        if (cred) {
+          credentialProviderID = providerID;
+          break;
+        }
+      }
+      cred ??= protocol === "vertex" ? { scheme: "bearer", value: "" } : null;
       if (!cred) {
         log.warn("no auth credentials available for worker call");
         recordWorkerFailure(
@@ -2187,10 +3280,10 @@ export function createGatewayLLMClient(
           opts?.workerID ?? "unknown",
           "no-auth",
         );
-        lastWorkerError = `no auth credentials available for ${model.providerID} (set LORE_WORKER_API_KEY, ANTHROPIC_API_KEY, or similar)`;
+        lastWorkerError = `no auth credentials available for ${diagnosticToken(model.providerID)} (set LORE_WORKER_API_KEY, ANTHROPIC_API_KEY, or similar)`;
         return null;
       }
-      const target = resolveTarget(
+      let target = resolveTarget(
         upstreams,
         protocol,
         upstreamOverride,
@@ -2208,8 +3301,8 @@ export function createGatewayLLMClient(
       // on hidden reasoning and returning empty `finish_reason:"length"`. The
       // Anthropic/Vertex builders suppress this by sending
       // `thinking:{type:"disabled"}` (see `effectiveDisableThinking`), so they
-      // need no floor; the OpenAI and native-Gemini builders have no such lever
-      // (Gemini 2.5 reasons by default and counts thinking against
+      // need no floor; the OpenAI Chat/Responses and native-Gemini builders
+      // have no such lever (Gemini 2.5 reasons by default and counts thinking against
       // `maxOutputTokens`), so we raise the budget to the reasoning floor here.
       // Applied to the LOOP variable (not just the builder) so the floored value
       // is the retry's baseline — a subsequent `finish_reason:"length"` bumps
@@ -2217,15 +3310,21 @@ export function createGatewayLLMClient(
       // model's output limit. `off`/undefined effort + non-reasoning model → 0
       // floor → caller budget unchanged.
       const floorsReasoningBudget =
-        target.protocol === "openai" || target.protocol === "gemini";
+        target.protocol === "openai" ||
+        target.protocol === "openai-responses" ||
+        target.protocol === "gemini";
       const rawMaxTokens = opts?.maxTokens ?? DEFAULT_WORKER_MAX_TOKENS;
+      const outputTokenCeiling = workerLengthRetryCeiling(model.modelID);
       const reasoningFloor = floorsReasoningBudget
         ? Math.min(
             workerReasoningHeadroomFloor(model, opts?.reasoningEffort),
-            workerLengthRetryCeiling(model.modelID),
+            outputTokenCeiling,
           )
         : 0;
-      let maxTokens = Math.max(rawMaxTokens, reasoningFloor);
+      let maxTokens = Math.min(
+        Math.max(rawMaxTokens, reasoningFloor),
+        outputTokenCeiling,
+      );
 
       // Cross-provider fail-closed: the worker model's provider has no route
       // URL (unknown provider, or a local provider missing its explicit
@@ -2234,8 +3333,8 @@ export function createGatewayLLMClient(
       // Skip the call, record it, and soft-pause so it doesn't re-fire.
       if (target.routeUnavailable || !target.url) {
         log.warn(
-          `worker cross-provider: no route for model provider="${model.providerID}" ` +
-            `(model=${model.modelID}, worker=${opts?.workerID ?? "unknown"}, ` +
+          `worker cross-provider: no route for model provider="${diagnosticToken(model.providerID)}" ` +
+            `(model=${diagnosticToken(model.modelID)}, worker=${diagnosticToken(opts?.workerID)}, ` +
             `session=${opts?.sessionID?.slice(0, 16) ?? "none"}) — skipping`,
         );
         recordWorkerFailure(
@@ -2244,7 +3343,7 @@ export function createGatewayLLMClient(
           "cross-provider",
         );
         if (opts?.sessionID) markWorkerPaused(opts.sessionID);
-        lastWorkerError = `no upstream route for ${model.providerID} — provider is unknown or unconfigured (check LORE_*_URL or models.dev cache)`;
+        lastWorkerError = `no upstream route for ${diagnosticToken(model.providerID)} — provider is unknown or unconfigured (check LORE_*_URL or models.dev cache)`;
         return null;
       }
 
@@ -2278,7 +3377,8 @@ export function createGatewayLLMClient(
         const isAnthropicKey = cred.value.startsWith("sk-ant-");
         if (target.protocol === "anthropic" && !isAnthropicKey) {
           log.warn(
-            `worker protocol mismatch: ${target.protocol} target with non-Anthropic API key — skipping (model=${model.modelID}, worker=${opts?.workerID ?? "unknown"})`,
+            `worker protocol mismatch: ${target.protocol} target with non-Anthropic API key — skipping ` +
+              `(model=${diagnosticToken(model.modelID)}, worker=${diagnosticToken(opts?.workerID)})`,
           );
           recordWorkerFailure(
             opts?.sessionID ?? "_unknown",
@@ -2288,9 +3388,15 @@ export function createGatewayLLMClient(
           lastWorkerError = `protocol mismatch: ${target.protocol} target but credential is not an Anthropic key (set ANTHROPIC_API_KEY or use an anthropic/* model)`;
           return null;
         }
-        if (target.protocol === "openai" && isAnthropicKey) {
+        if (
+          (target.protocol === "openai" ||
+            target.protocol === "openai-responses" ||
+            target.protocol === "openai-codex-responses") &&
+          isAnthropicKey
+        ) {
           log.warn(
-            `worker protocol mismatch: ${target.protocol} target with Anthropic API key — skipping (model=${model.modelID}, worker=${opts?.workerID ?? "unknown"})`,
+            `worker protocol mismatch: ${target.protocol} target with Anthropic API key — skipping ` +
+              `(model=${diagnosticToken(model.modelID)}, worker=${diagnosticToken(opts?.workerID)})`,
           );
           recordWorkerFailure(
             opts?.sessionID ?? "_unknown",
@@ -2342,39 +3448,98 @@ export function createGatewayLLMClient(
       // non-null values) so the closure keeps the `if (!cred)` guard's narrowing.
       let activeCred: AuthCredential = cred;
 
-      // Build protocol-specific request
-      let req = await buildWorkerRequest(
-        target,
-        activeCred,
-        model,
-        system,
-        user,
-        maxTokens,
-        opts?.sessionID,
-        effectiveTemperature,
-        factoryVertexProject,
-        effectiveDisableThinking,
-        reasoningEffort,
-      );
+      // One deadline covers async request construction (including Vertex ADC
+      // discovery/token minting), every fetch, every retry rebuild, and backoff.
+      const deadlineController = new AbortController();
+      const deadlineTimer = setTimeout(() => {
+        deadlineController.abort(
+          new DOMException("Worker request deadline exceeded", "TimeoutError"),
+        );
+      }, WORKER_REQUEST_TIMEOUT_MS);
+      const requestSignal = opts?.signal
+        ? AbortSignal.any([opts.signal, deadlineController.signal])
+        : deadlineController.signal;
+
+      const promptSourceBytes =
+        Buffer.byteLength(system) + Buffer.byteLength(user);
+      if (promptSourceBytes > MAX_WORKER_PROMPT_SOURCE_BYTES) {
+        log.warn(
+          `worker prompt rejected before serialization: prompt_bytes=${promptSourceBytes} ` +
+            `limit_bytes=${MAX_WORKER_PROMPT_SOURCE_BYTES}`,
+        );
+        recordWorkerFailure(
+          opts?.sessionID ?? "_unknown",
+          opts?.workerID ?? "unknown",
+          "upstream-error",
+        );
+        lastWorkerError = `worker prompt exceeded ${MAX_WORKER_PROMPT_SOURCE_BYTES} byte limit`;
+        clearTimeout(deadlineTimer);
+        return null;
+      }
+
+      const buildCurrentRequest = async () =>
+        enforceWorkerRequestLimit(
+          await buildWorkerRequest(
+            target,
+            activeCred,
+            model,
+            system,
+            user,
+            maxTokens,
+            opts?.sessionID,
+            effectiveTemperature,
+            factoryVertexProject,
+            effectiveDisableThinking,
+            reasoningEffort,
+            requestSignal,
+          ),
+        );
+
+      // Build and cap the serialized body before opening a connection. The cap
+      // is re-applied by every request rebuild below (auth/model/param retries).
+      let req: Awaited<ReturnType<typeof buildCurrentRequest>>;
+      try {
+        req = await buildCurrentRequest();
+      } catch (error) {
+        if (requestSignal.aborted) {
+          clearTimeout(deadlineTimer);
+          throw requestSignal.reason;
+        }
+        if (!(error instanceof WorkerRequestTooLargeError)) {
+          clearTimeout(deadlineTimer);
+          throw error;
+        }
+        log.warn(
+          `worker request rejected before fetch: request_bytes=${error.bytes} ` +
+            `limit_bytes=${MAX_WORKER_REQUEST_BYTES}`,
+        );
+        recordWorkerFailure(
+          opts?.sessionID ?? "_unknown",
+          opts?.workerID ?? "unknown",
+          "upstream-error",
+        );
+        lastWorkerError = error.message;
+        clearTimeout(deadlineTimer);
+        return null;
+      }
 
       // Track this call so temporal capture can skip it
       const callID = `gw-worker-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       activeWorkerCalls.add(callID);
 
       const urgent = opts?.urgent === true;
-
       try {
         // Wrap the entire retry loop in a gen_ai.chat span so it captures
         // real wall-clock duration including retries and backoff delays.
         return await Sentry.startSpan(
           {
             op: "gen_ai.chat",
-            name: `chat ${model.modelID}`,
+            name: `chat ${diagnosticToken(model.modelID)}`,
             attributes: {
               "gen_ai.operation.name": "chat",
-              "gen_ai.request.model": model.modelID,
-              "gen_ai.provider.name": target.providerName,
-              "lore.worker_id": opts?.workerID ?? "unknown",
+              "gen_ai.request.model": diagnosticToken(model.modelID),
+              "gen_ai.provider.name": diagnosticToken(target.providerName),
+              "lore.worker_id": diagnosticToken(opts?.workerID),
               "lore.call_type": "direct",
               "lore.urgent": urgent,
             },
@@ -2417,30 +3582,62 @@ export function createGatewayLLMClient(
             // is wasteful.
             const maxRetries = maxRetriesFor();
 
+            const retryPostHeaderTransportFailure = async (
+              error: SSEStreamTransportError,
+              response: Response,
+              attempt: number,
+            ): Promise<void> => {
+              cancelWorkerResponseForRetry(response, error);
+              if (requestSignal.aborted) throw requestSignal.reason;
+              if (attempt >= maxRetries) {
+                throw new WorkerTransportFailureError(error);
+              }
+              const delay = backoffMs(attempt, null);
+              retryCount++;
+              totalDelayMs += delay;
+              const code = transportErrorCode(error);
+              log.warn(
+                `worker response transport failure ` +
+                  `(kind=${transportErrorKind(error)}${code ? ` code=${code}` : ""}, ` +
+                  `attempt=${attempt + 1}/${maxRetries + 1}, ` +
+                  `origin=${sanitizedWorkerOrigin(req.url)}), retrying in ${delay}ms`,
+              );
+              await abortableSleep(delay, requestSignal);
+            };
+
             // Retry loop for transient errors (429, 5xx)
             for (let attempt = 0; ; attempt++) {
               let response: Response;
               try {
-                response = await upstreamFetch(req.url, {
-                  method: "POST",
-                  headers: req.headers,
-                  signal: opts?.signal,
-                  // The request body may carry `thinking:{type:"disabled"}` for
-                  // Claude workers (built above) to SUPPRESS thinking — it never
-                  // ENABLES it. opts.thinking is not forwarded.
-                  body: req.body,
-                });
+                response = await responseAgainstAbort(
+                  () =>
+                    upstreamFetch(req.url, {
+                      method: "POST",
+                      headers: req.headers,
+                      signal: requestSignal,
+                      // The request body may carry `thinking:{type:"disabled"}` for
+                      // Claude workers (built above) to SUPPRESS thinking — it never
+                      // ENABLES it. opts.thinking is not forwarded.
+                      body: req.body,
+                    }),
+                  requestSignal,
+                );
               } catch (e) {
                 if (opts?.signal?.aborted) throw opts.signal.reason;
+                if (requestSignal.aborted) throw requestSignal.reason;
                 // Network/fetch error — retry if attempts remain
                 if (attempt < maxRetries) {
                   const delay = backoffMs(attempt, null);
                   retryCount++;
                   totalDelayMs += delay;
+                  const code = transportErrorCode(e);
                   log.warn(
-                    `worker request network error (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms`,
+                    `worker request transport failure ` +
+                      `(kind=${transportErrorKind(e)}${code ? ` code=${code}` : ""}, ` +
+                      `attempt=${attempt + 1}/${maxRetries + 1}, ` +
+                      `origin=${sanitizedWorkerOrigin(req.url)}), retrying in ${delay}ms`,
                   );
-                  await abortableSleep(delay, opts?.signal);
+                  await abortableSleep(delay, requestSignal);
                   continue;
                 }
                 // Enrich span before rethrowing
@@ -2448,7 +3645,7 @@ export function createGatewayLLMClient(
                   span.setAttribute("lore.retry.count", retryCount);
                   span.setAttribute("lore.retry.total_delay_ms", totalDelayMs);
                 }
-                throw e; // exhausted retries — rethrow to outer catch
+                throw new WorkerTransportFailureError(e);
               }
 
               finalStatus = response.status;
@@ -2476,41 +3673,76 @@ export function createGatewayLLMClient(
                 // ..." text — LOREAI-GATEWAY-38 / -1P). A streamed body is a
                 // success, so the JSON error-envelope check below never applies
                 // to it (bodyErrCode stays null → the block is skipped).
-                const ct = response.headers.get("content-type") ?? "";
-                const bodyText = await readWorkerResponseText(
-                  response,
-                  opts?.signal,
-                );
-                const isSSE = looksLikeSSE(ct, bodyText);
-                if (
-                  isSSE &&
-                  (target.protocol === "openai-codex-responses" ||
-                    target.protocol === "openai-responses")
-                ) {
-                  const streamFailure = validateResponsesWorkerSSE(bodyText);
-                  if (streamFailure) {
-                    log.error(
-                      `worker upstream returned invalid Responses SSE — ${streamFailure}` +
-                        ` — model=${model.providerID}/${model.modelID}` +
-                        ` worker=${opts?.workerID ?? "unknown"}` +
-                        ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
+                const upstreamOrigin = sanitizedWorkerOrigin(req.url);
+                const contentType = response.headers.get("content-type") ?? "";
+                const rejectInvalidWorkerBody = (error: unknown): null => {
+                  const detail = safeWorkerBodyErrorDetail(error);
+                  log.error(
+                    `worker upstream returned invalid ${target.protocol} response — ${detail}` +
+                      ` — upstream=${upstreamOrigin}` +
+                      ` model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}` +
+                      ` worker=${diagnosticToken(opts?.workerID)}` +
+                      ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
+                  );
+                  span.setStatus({
+                    code: 2,
+                    message: "invalid worker response",
+                  });
+                  recordWorkerFailure(
+                    opts?.sessionID ?? "_unknown",
+                    opts?.workerID ?? "unknown",
+                    "upstream-error",
+                  );
+                  lastWorkerError = `${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}: invalid ${target.protocol} response (${detail})`;
+                  return null;
+                };
+
+                let successBody: WorkerSuccessBody;
+                let semanticContentConsumed = false;
+                try {
+                  successBody = await inspectWorkerSuccessBody(
+                    response,
+                    requestSignal,
+                    () => {
+                      semanticContentConsumed = true;
+                    },
+                  );
+                } catch (error) {
+                  if (opts?.signal?.aborted) throw opts.signal.reason;
+                  if (requestSignal.aborted) throw requestSignal.reason;
+                  if (error instanceof SSEStreamTransportError) {
+                    if (semanticContentConsumed) {
+                      throw new WorkerTransportFailureError(error);
+                    }
+                    await retryPostHeaderTransportFailure(
+                      error,
+                      response,
+                      attempt,
                     );
-                    span.setStatus({
-                      code: 2,
-                      message: "invalid Responses SSE",
-                    });
-                    recordWorkerFailure(
-                      opts?.sessionID ?? "_unknown",
-                      opts?.workerID ?? "unknown",
-                      "upstream-error",
-                    );
-                    lastWorkerError = `${model.providerID}/${model.modelID}: invalid Responses SSE (${streamFailure})`;
-                    return null;
+                    continue;
+                  }
+                  return rejectInvalidWorkerBody(error);
+                }
+                const isSSE = successBody.isSSE;
+                const bodyText = successBody.isSSE ? "" : successBody.text;
+                let rawData: Record<string, unknown> = {};
+                if (!successBody.isSSE) {
+                  try {
+                    const parsedBody: unknown = JSON.parse(bodyText);
+                    if (
+                      !parsedBody ||
+                      typeof parsedBody !== "object" ||
+                      Array.isArray(parsedBody)
+                    ) {
+                      throw new Error(
+                        "worker JSON response root must be an object",
+                      );
+                    }
+                    rawData = parsedBody as Record<string, unknown>;
+                  } catch (error) {
+                    return rejectInvalidWorkerBody(error);
                   }
                 }
-                const rawData: Record<string, unknown> = isSSE
-                  ? {}
-                  : (JSON.parse(bodyText) as Record<string, unknown>);
 
                 // A 2xx whose body is a provider error envelope (e.g. OpenRouter
                 // surfacing an upstream timeout as HTTP 200 + {error:{code:504}})
@@ -2544,9 +3776,11 @@ export function createGatewayLLMClient(
                     log.warn(
                       `worker upstream returned HTTP 200 with an embedded ${bodyErrCode} ` +
                         `error (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms ` +
-                        `— model=${model.providerID}/${model.modelID} worker=${opts?.workerID ?? "unknown"}`,
+                        `— model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} ` +
+                        `worker=${diagnosticToken(opts?.workerID)} origin=${upstreamOrigin}`,
                     );
-                    await abortableSleep(delay, opts?.signal);
+                    cancelWorkerResponseForRetry(response, bodyErrCode);
+                    await abortableSleep(delay, requestSignal);
                     continue;
                   }
                   // Exhausted. Mirror the HTTP-level exhaustion path for full
@@ -2559,9 +3793,11 @@ export function createGatewayLLMClient(
                   // transient error, which must not mark a capable model incapable.
                   log.warn(
                     `worker upstream embedded ${bodyErrCode} error persisted after ` +
-                      `${maxRetries + 1} attempts — model=${model.providerID}/${model.modelID} ` +
-                      `worker=${opts?.workerID ?? "unknown"} ` +
-                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
+                      `${maxRetries + 1} attempts — ` +
+                      `model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} ` +
+                      `worker=${diagnosticToken(opts?.workerID)} ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"} ` +
+                      `origin=${upstreamOrigin}`,
                   );
                   Sentry.captureException(
                     new Error(
@@ -2581,8 +3817,9 @@ export function createGatewayLLMClient(
                         attempts: maxRetries + 1,
                         totalDelayMs,
                         lastRetryAfterMs,
-                        model: model.modelID,
-                        workerID: opts?.workerID ?? "unknown",
+                        model: diagnosticToken(model.modelID),
+                        workerID: diagnosticToken(opts?.workerID),
+                        origin: upstreamOrigin,
                       },
                     },
                   );
@@ -2630,10 +3867,12 @@ export function createGatewayLLMClient(
                   isDataPolicyBlocked404(bodyErrCode, bodyText)
                 ) {
                   log.warn(
-                    `worker model ${model.providerID}/${model.modelID} blocked by account data policy ` +
+                    `worker model ${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} ` +
+                      `blocked by account data policy ` +
                       `(HTTP 200 error-envelope) — blocklisting and re-resolving ` +
-                      `(worker=${opts?.workerID ?? "unknown"}, ` +
-                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}): ${bodyText.slice(0, 160)}`,
+                      `(worker=${diagnosticToken(opts?.workerID)}, ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}, ` +
+                      `origin=${upstreamOrigin})`,
                   );
                   markWorkerIncapable(model.providerID, model.modelID);
                   if (model.modelID.endsWith(":free")) {
@@ -2648,7 +3887,7 @@ export function createGatewayLLMClient(
                     opts?.workerID ?? "unknown",
                     "data-policy",
                   );
-                  lastWorkerError = `HTTP 200/404: data policy blocked — ${model.providerID}/${model.modelID} unavailable (account has not opted in)`;
+                  lastWorkerError = `HTTP 200/404: data policy blocked — ${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} unavailable (account has not opted in)`;
                   return null;
                 }
 
@@ -2667,17 +3906,41 @@ export function createGatewayLLMClient(
                   usage: AnthropicUsage | null;
                   model: string | null;
                 };
-                if (isSSE) {
-                  const gwResp = await accumulateWorkerSSE(
-                    target.protocol,
-                    new Response(bodyText, {
-                      headers: { "content-type": "text/event-stream" },
-                    }),
-                  );
+                if (successBody.isSSE) {
+                  let gwResp: GatewayResponse;
+                  try {
+                    gwResp = await accumulateWorkerSSE(
+                      target.protocol,
+                      successBody.response,
+                      requestSignal,
+                      () => {
+                        semanticContentConsumed = true;
+                      },
+                    );
+                  } catch (error) {
+                    if (opts?.signal?.aborted) throw opts.signal.reason;
+                    if (requestSignal.aborted) throw requestSignal.reason;
+                    if (error instanceof SSEStreamTransportError) {
+                      if (semanticContentConsumed) {
+                        throw new WorkerTransportFailureError(error);
+                      }
+                      await retryPostHeaderTransportFailure(
+                        error,
+                        response,
+                        attempt,
+                      );
+                      continue;
+                    }
+                    return rejectInvalidWorkerBody(error);
+                  }
                   sseStopReason = gwResp.stopReason;
                   parsed = gatewayResponseToWorkerResult(gwResp);
                 } else {
-                  parsed = parseWorkerResponse(target.protocol, rawData);
+                  try {
+                    parsed = parseWorkerResponse(target.protocol, rawData);
+                  } catch (error) {
+                    return rejectInvalidWorkerBody(error);
+                  }
                 }
 
                 // Set usage attributes on the span
@@ -2740,9 +4003,9 @@ export function createGatewayLLMClient(
                   ? sseStopReason
                   : extractFinishReason(rawData);
                 log.warn(
-                  `worker empty response (HTTP ${response.status}, ct=${ct || "?"}) ` +
-                    `— model=${model.providerID}/${model.modelID} ` +
-                    `worker=${opts?.workerID ?? "unknown"} ` +
+                  `worker empty response (HTTP ${response.status}, ct=${diagnosticContentKind(contentType)}) ` +
+                    `— model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} ` +
+                    `worker=${diagnosticToken(opts?.workerID)} ` +
                     `session=${opts?.sessionID?.slice(0, 16) ?? "none"} ` +
                     `— ${describeEmptyWorkerResponse(rawData)}`,
                 );
@@ -2777,22 +4040,11 @@ export function createGatewayLLMClient(
                   log.warn(
                     `worker empty response was a budget truncation (finish_reason=${finishReason}) ` +
                       `— retrying once with max_tokens ${maxTokens} → ${bumped} ` +
-                      `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"})`,
+                      `(model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}, ` +
+                      `worker=${diagnosticToken(opts?.workerID)})`,
                   );
                   maxTokens = bumped;
-                  req = await buildWorkerRequest(
-                    target,
-                    activeCred,
-                    model,
-                    system,
-                    user,
-                    maxTokens,
-                    opts?.sessionID,
-                    effectiveTemperature,
-                    factoryVertexProject,
-                    effectiveDisableThinking,
-                    reasoningEffort,
-                  );
+                  req = await buildCurrentRequest();
                   // Re-apply a runtime beta strip if one already happened this
                   // call (rebuilding restores the freshly-built header set) —
                   // mirrors the temperature-strip rebuild below.
@@ -2826,7 +4078,7 @@ export function createGatewayLLMClient(
                     opts?.workerID ?? "unknown",
                     "worker-incapable",
                   );
-                  lastWorkerError = `worker incapable: ${model.providerID}/${model.modelID} produced no usable text`;
+                  lastWorkerError = `worker incapable: ${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} produced no usable text`;
                   return null;
                 }
 
@@ -2840,31 +4092,19 @@ export function createGatewayLLMClient(
                   opts?.workerID ?? "unknown",
                   "no-response",
                 );
-                lastWorkerError = `${model.providerID}/${model.modelID}: no usable text in response (finish=${finishReason ?? "n/a"})`;
+                lastWorkerError = `${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}: no usable text in response (finish=${diagnosticFinishReason(finishReason)})`;
                 return null;
               }
 
               // --- Auth error: 401/403 — mark stale, re-resolve, retry once ---
               if (AUTH_ERROR_CODES.has(response.status)) {
-                const text = await readWorkerResponseText(
-                  response,
-                  opts?.signal,
-                );
-
-                // Always record the auth failure so the worker-health ladder
-                // sees it even for session-less paths (the adapter is the
-                // single owner of transport-failure attribution).
-                recordWorkerFailure(
-                  opts?.sessionID ?? "_unknown",
-                  opts?.workerID ?? "unknown",
-                  "auth-rejected",
-                );
+                await readWorkerResponseText(response, requestSignal);
                 // Mark this provider's credential stale so resolveAuth()
                 // falls through to global — but only for THIS provider,
                 // not other providers on the same session. Requires a real
                 // session ID (staleness is per-session state).
                 if (opts?.sessionID) {
-                  markAuthStale(opts.sessionID, model.providerID);
+                  markAuthStale(opts.sessionID, credentialProviderID);
                 } else {
                   // Session-less worker (e.g. entity-rebuild) — mark the
                   // global fallback as stale so resolveAuth(undefined)
@@ -2875,7 +4115,10 @@ export function createGatewayLLMClient(
                 }
 
                 // Re-resolve: credential may have been refreshed by a concurrent client request
-                const freshCred = getAuth(opts?.sessionID, model.providerID);
+                const freshCred = getAuth(
+                  opts?.sessionID,
+                  credentialProviderID,
+                );
                 const credentialChanged =
                   !!freshCred && freshCred.value !== cred.value;
                 if (credentialChanged && attempt === 0) {
@@ -2884,24 +4127,22 @@ export function createGatewayLLMClient(
                   // uses the fresh key, then rebuild request and retry once.
                   activeCred = freshCred;
                   log.info(
-                    `worker auth error ${response.status}, credential refreshed — retrying: ${text.slice(0, 200)}`,
+                    `worker auth error status=${response.status}, credential refreshed — retrying ` +
+                      `(origin=${sanitizedWorkerOrigin(req.url)})`,
                   );
-                  req = await buildWorkerRequest(
-                    target,
-                    activeCred,
-                    model,
-                    system,
-                    user,
-                    maxTokens,
-                    opts?.sessionID,
-                    effectiveTemperature,
-                    factoryVertexProject,
-                    effectiveDisableThinking,
-                    reasoningEffort,
-                  );
+                  req = await buildCurrentRequest();
                   retryCount++;
                   continue;
                 }
+
+                // Only the terminal auth failure reaches worker health. A
+                // rejected stale credential that refreshes successfully is an
+                // intermediate attempt, not a failed worker call.
+                recordWorkerFailure(
+                  opts?.sessionID ?? "_unknown",
+                  opts?.workerID ?? "unknown",
+                  "auth-rejected",
+                );
 
                 // No fresh credential or retry also failed — bail.
                 //
@@ -2913,24 +4154,16 @@ export function createGatewayLLMClient(
                 // status to the user via getLastWorkerError() (PR
                 // #1542/#1544); we don't need log.error to also scream.
                 //
-                // Truncate the response body (200 chars) — openrouter
-                // returns multi-KB JSON error blobs that produce
-                // unreadable log lines and bloat log files. The Sentry
-                // capture below keeps the truncated body for debugging
-                // but only the structured fields (status, model, etc.)
-                // are searchable.
-                const bodySample =
-                  text.length > 200 ? text.slice(0, 199) + "…" : text;
                 log.warn(
-                  `worker upstream auth error: ${response.status} ${response.statusText}` +
-                    ` — url=${target.url} model=${model.providerID}/${model.modelID}` +
-                    ` cred=${cred.scheme} worker=${opts?.workerID ?? "unknown"}` +
-                    ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}` +
-                    ` — ${bodySample}`,
+                  `worker upstream auth error: status=${response.status}` +
+                    ` origin=${sanitizedWorkerOrigin(req.url)}` +
+                    ` model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}` +
+                    ` cred=${cred.scheme} worker=${diagnosticToken(opts?.workerID)}` +
+                    ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
                 );
                 Sentry.captureException(
                   new Error(
-                    `Worker upstream auth error: ${response.status} ${response.statusText}`,
+                    `Worker upstream auth error: HTTP ${response.status}`,
                   ),
                   {
                     fingerprint: [
@@ -2940,12 +4173,12 @@ export function createGatewayLLMClient(
                     ],
                     extra: {
                       status: response.status,
-                      model: model.modelID,
-                      workerID: opts?.workerID ?? "unknown",
+                      model: diagnosticToken(model.modelID),
+                      workerID: diagnosticToken(opts?.workerID),
                       sessionID: opts?.sessionID?.slice(0, 16),
+                      origin: sanitizedWorkerOrigin(req.url),
                       credentialChanged,
                       freshCredAvailable: !!freshCred,
-                      bodySample,
                     },
                   },
                 );
@@ -2961,14 +4194,7 @@ export function createGatewayLLMClient(
                 // still lets one probe through per 5 min so a refreshed
                 // credential recovers automatically. Urgent calls are exempt.
                 if (opts?.sessionID) markWorkerPaused(opts.sessionID);
-                // Surface the auth error to the chain's diagnostic. Even
-                // though the chain uses `abortedByAuth` (not lastError) for
-                // the per-candidate reason, including it here makes the
-                // FINAL "First error:" line more informative when a run
-                // is dominated by auth failures. Reuse the `text` variable
-                // already read at line 2491 (response body is a one-shot
-                // stream — calling .text() twice would return "").
-                lastWorkerError = `HTTP ${response.status}: ${text.slice(0, 200)}`;
+                lastWorkerError = `HTTP ${response.status}: authentication rejected`;
                 return null;
               }
 
@@ -2982,16 +4208,13 @@ export function createGatewayLLMClient(
               //    so the distiller/curator stop retrying every turn (a probe
               //    is allowed once per circuit interval to detect a top-up).
               if (INSUFFICIENT_CREDIT_CODES.has(response.status)) {
-                const text = await readWorkerResponseText(
-                  response,
-                  opts?.signal,
-                );
+                await readWorkerResponseText(response, requestSignal);
                 log.warn(
-                  `worker upstream insufficient credit: ${response.status} ${response.statusText}` +
-                    ` — model=${model.providerID}/${model.modelID}` +
-                    ` worker=${opts?.workerID ?? "unknown"}` +
-                    ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}` +
-                    ` — ${text.slice(0, 200)}`,
+                  `worker upstream insufficient credit: status=${response.status}` +
+                    ` origin=${sanitizedWorkerOrigin(req.url)}` +
+                    ` model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}` +
+                    ` worker=${diagnosticToken(opts?.workerID)}` +
+                    ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
                 );
                 if (opts?.sessionID) {
                   markWorkerPaused(opts.sessionID);
@@ -3014,7 +4237,7 @@ export function createGatewayLLMClient(
               if (!TRANSIENT_CODES.has(response.status)) {
                 const text = await readWorkerResponseText(
                   response,
-                  opts?.signal,
+                  requestSignal,
                 );
 
                 // 400 + a beta-related complaint → the request carries a beta
@@ -3037,7 +4260,8 @@ export function createGatewayLLMClient(
                   req = { ...req, headers: stripBetaHeaders(req.headers) };
                   log.warn(
                     `worker 400 looks long-context-beta-related — retrying once without the context-1m beta ` +
-                      `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
+                      `(model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}, ` +
+                      `worker=${diagnosticToken(opts?.workerID)}, origin=${sanitizedWorkerOrigin(req.url)})`,
                   );
                   retryCount++;
                   continue;
@@ -3060,19 +4284,7 @@ export function createGatewayLLMClient(
                 ) {
                   temperatureStripped = true;
                   effectiveTemperature = undefined;
-                  req = await buildWorkerRequest(
-                    target,
-                    activeCred,
-                    model,
-                    system,
-                    user,
-                    maxTokens,
-                    opts?.sessionID,
-                    effectiveTemperature,
-                    factoryVertexProject,
-                    effectiveDisableThinking,
-                    reasoningEffort,
-                  );
+                  req = await buildCurrentRequest();
                   // Rebuilding restores the freshly-built header set, which
                   // resurrects a beta we may have already stripped at runtime.
                   // The upfront filter strips `context-1m` unconditionally for
@@ -3087,7 +4299,8 @@ export function createGatewayLLMClient(
                   }
                   log.warn(
                     `worker 400 reports temperature is unsupported — retrying once without the temperature param ` +
-                      `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
+                      `(model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}, ` +
+                      `worker=${diagnosticToken(opts?.workerID)}, origin=${sanitizedWorkerOrigin(req.url)})`,
                   );
                   retryCount++;
                   continue;
@@ -3110,19 +4323,7 @@ export function createGatewayLLMClient(
                 ) {
                   thinkingStripped = true;
                   effectiveDisableThinking = false;
-                  req = await buildWorkerRequest(
-                    target,
-                    activeCred,
-                    model,
-                    system,
-                    user,
-                    maxTokens,
-                    opts?.sessionID,
-                    effectiveTemperature,
-                    factoryVertexProject,
-                    effectiveDisableThinking,
-                    reasoningEffort,
-                  );
+                  req = await buildCurrentRequest();
                   // Preserve a runtime beta strip across this rebuild (same
                   // reasoning as the temperature-strip path above).
                   if (betaStripped) {
@@ -3130,7 +4331,8 @@ export function createGatewayLLMClient(
                   }
                   log.warn(
                     `worker 400 reports thinking is unsupported — retrying once without the thinking param ` +
-                      `(model=${model.providerID}/${model.modelID}, worker=${opts?.workerID ?? "unknown"}): ${text.slice(0, 160)}`,
+                      `(model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}, ` +
+                      `worker=${diagnosticToken(opts?.workerID)}, origin=${sanitizedWorkerOrigin(req.url)})`,
                   );
                   retryCount++;
                   continue;
@@ -3149,9 +4351,11 @@ export function createGatewayLLMClient(
                 // worker call against that sibling is the recovery probe.
                 if (isDataPolicyBlocked404(response.status, text)) {
                   log.warn(
-                    `worker model ${model.providerID}/${model.modelID} blocked by account data policy (404) — ` +
-                      `blocklisting and re-resolving (worker=${opts?.workerID ?? "unknown"}, ` +
-                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}): ${text.slice(0, 160)}`,
+                    `worker model ${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} ` +
+                      `blocked by account data policy (404) — ` +
+                      `blocklisting and re-resolving (worker=${diagnosticToken(opts?.workerID)}, ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}, ` +
+                      `origin=${sanitizedWorkerOrigin(req.url)})`,
                   );
                   markWorkerIncapable(model.providerID, model.modelID);
                   if (model.modelID.endsWith(":free")) {
@@ -3168,7 +4372,7 @@ export function createGatewayLLMClient(
                   );
                   // Do NOT markWorkerPaused: the fix is re-resolution to a
                   // different model, not pausing the session's workers.
-                  lastWorkerError = `HTTP ${response.status}: data policy blocked — ${model.providerID}/${model.modelID} unavailable (account has not opted in)`;
+                  lastWorkerError = `HTTP ${response.status}: data policy blocked — ${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} unavailable (account has not opted in)`;
                   return null;
                 }
 
@@ -3189,25 +4393,67 @@ export function createGatewayLLMClient(
                   // length-checked above, so a value is guaranteed.
                   const next = modelFallbacks.shift() ?? model;
                   log.warn(
-                    `worker model ${model.providerID}/${model.modelID} not supported on this account (400) — ` +
-                      `falling back to ${next.providerID}/${next.modelID} ` +
-                      `(worker=${opts?.workerID ?? "unknown"}, ` +
-                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}): ${text.slice(0, 160)}`,
+                    `worker model ${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)} ` +
+                      `not supported on this account (400) — ` +
+                      `falling back to ${diagnosticToken(next.providerID)}/${diagnosticToken(next.modelID)} ` +
+                      `(worker=${diagnosticToken(opts?.workerID)}, ` +
+                      `session=${opts?.sessionID?.slice(0, 16) ?? "none"}, ` +
+                      `origin=${sanitizedWorkerOrigin(req.url)})`,
                   );
                   model = next;
-                  req = await buildWorkerRequest(
-                    target,
-                    activeCred,
-                    model,
-                    system,
-                    user,
-                    maxTokens,
-                    opts?.sessionID,
-                    effectiveTemperature,
-                    factoryVertexProject,
-                    effectiveDisableThinking,
-                    reasoningEffort,
+                  // Protocol and target are model-dependent even within one
+                  // provider (GitHub Copilot serves gpt-5.6 on Responses but
+                  // gpt-5-mini on Chat Completions). Re-resolve the complete
+                  // route before rebuilding so URL, body, parser, and model
+                  // controls all describe the fallback model.
+                  protocol = resolveWorkerProtocol(
+                    model.providerID,
+                    sameProviderAsSession ? opts?.protocol : undefined,
+                    model.modelID,
+                    sameProviderAsSession ? upstreamOverride : undefined,
                   );
+                  target = resolveTarget(
+                    upstreams,
+                    protocol,
+                    upstreamOverride,
+                    model.providerID,
+                    opts?.upstreamProviderID,
+                  );
+                  if (target.routeUnavailable || !target.url) {
+                    lastWorkerError = `no upstream route for ${diagnosticToken(model.providerID)} fallback`;
+                    return null;
+                  }
+                  const fallbackFloorsReasoningBudget =
+                    target.protocol === "openai" ||
+                    target.protocol === "openai-responses" ||
+                    target.protocol === "gemini";
+                  const fallbackReasoningFloor = fallbackFloorsReasoningBudget
+                    ? Math.min(
+                        workerReasoningHeadroomFloor(
+                          model,
+                          opts?.reasoningEffort,
+                        ),
+                        workerLengthRetryCeiling(model.modelID),
+                      )
+                    : 0;
+                  maxTokens = Math.min(
+                    Math.max(rawMaxTokens, fallbackReasoningFloor),
+                    workerLengthRetryCeiling(model.modelID),
+                  );
+                  effectiveTemperature =
+                    isTemperatureUnsupportedModel(model) ||
+                    modelRejectsTemperatureByData(model.modelID)
+                      ? undefined
+                      : opts?.temperature;
+                  effectiveDisableThinking =
+                    (target.protocol === "anthropic" ||
+                      target.protocol === "vertex") &&
+                    workerThinkingOnByDefault(model) &&
+                    !isThinkingUnsupportedModel(model);
+                  temperatureStripped = false;
+                  thinkingStripped = false;
+                  lengthRetried = false;
+                  req = await buildCurrentRequest();
                   // Preserve any runtime beta strip across the rebuild (same
                   // reasoning as the temperature/thinking rebuilds above).
                   if (betaStripped) {
@@ -3225,11 +4471,11 @@ export function createGatewayLLMClient(
                 }
 
                 log.error(
-                  `worker upstream request failed: ${response.status} ${response.statusText}` +
-                    ` — url=${target.url} model=${model.providerID}/${model.modelID}` +
-                    ` cred=${cred.scheme} worker=${opts?.workerID ?? "unknown"}` +
-                    ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}` +
-                    ` — ${text}`,
+                  `worker upstream request failed: status=${response.status}` +
+                    ` origin=${sanitizedWorkerOrigin(req.url)}` +
+                    ` model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}` +
+                    ` cred=${cred.scheme} worker=${diagnosticToken(opts?.workerID)}` +
+                    ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}`,
                 );
                 span.setStatus({ code: 2, message: `HTTP ${response.status}` });
                 recordWorkerFailure(
@@ -3242,7 +4488,7 @@ export function createGatewayLLMClient(
                 // isWorkerCreditPaused() still probes once per 5 min so a fixed
                 // request recovers. Urgent calls are pause-exempt.
                 if (opts?.sessionID) markWorkerPaused(opts.sessionID);
-                lastWorkerError = `HTTP ${response.status}: non-transient upstream error for ${model.providerID}/${model.modelID} — ${text.slice(0, 200)}`;
+                lastWorkerError = `HTTP ${response.status}: non-transient upstream error for ${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}`;
                 return null;
               }
 
@@ -3270,13 +4516,16 @@ export function createGatewayLLMClient(
                 totalDelayMs += delay;
                 if (retryAfter != null) lastRetryAfterMs = retryAfter;
                 log.warn(
-                  `worker upstream ${response.status} (attempt ${attempt + 1}/${maxRetries + 1}), ` +
+                  `worker upstream status=${response.status} ` +
+                    `(attempt ${attempt + 1}/${maxRetries + 1}, ` +
+                    `origin=${sanitizedWorkerOrigin(req.url)}), ` +
                     `retrying in ${delay}ms` +
                     (retryAfter != null
                       ? ` (retry-after: ${Math.round(retryAfter / 1000)}s)`
                       : ""),
                 );
-                await abortableSleep(delay, opts?.signal);
+                cancelWorkerResponseForRetry(response, response.status);
+                await abortableSleep(delay, requestSignal);
                 continue;
               }
 
@@ -3290,13 +4539,13 @@ export function createGatewayLLMClient(
               // LORE_DEBUG) to avoid alarming red `[lore]` noise; non-urgent
               // background exhaustion stays at `error` since it can indicate a
               // sustained problem worth investigating.
-              const text = await readWorkerResponseText(response, opts?.signal);
+              await readWorkerResponseText(response, requestSignal);
               const exhaustionMsg =
-                `worker upstream request failed after ${maxRetries + 1} attempts: ${response.status} ${response.statusText}` +
-                ` — url=${target.url} model=${model.providerID}/${model.modelID}` +
-                ` cred=${cred.scheme} worker=${opts?.workerID ?? "unknown"}` +
-                ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}` +
-                ` — ${text}`;
+                `worker upstream request failed after ${maxRetries + 1} attempts:` +
+                ` status=${response.status} origin=${sanitizedWorkerOrigin(req.url)}` +
+                ` model=${diagnosticToken(model.providerID)}/${diagnosticToken(model.modelID)}` +
+                ` cred=${cred.scheme} worker=${diagnosticToken(opts?.workerID)}` +
+                ` session=${opts?.sessionID?.slice(0, 16) ?? "none"}`;
               if (urgent) {
                 log.warn(exhaustionMsg);
               } else {
@@ -3306,7 +4555,7 @@ export function createGatewayLLMClient(
               // Capture as Sentry error for alerting
               Sentry.captureException(
                 new Error(
-                  `Worker upstream exhausted ${maxRetries + 1} retries: ${response.status} ${response.statusText}`,
+                  `Worker upstream exhausted ${maxRetries + 1} retries: HTTP ${response.status}`,
                 ),
                 {
                   fingerprint: [
@@ -3319,8 +4568,9 @@ export function createGatewayLLMClient(
                     attempts: maxRetries + 1,
                     totalDelayMs,
                     lastRetryAfterMs,
-                    model: model.modelID,
-                    workerID: opts?.workerID ?? "unknown",
+                    model: diagnosticToken(model.modelID),
+                    workerID: diagnosticToken(opts?.workerID),
+                    origin: sanitizedWorkerOrigin(req.url),
                   },
                 },
               );
@@ -3341,22 +4591,33 @@ export function createGatewayLLMClient(
                 opts?.workerID ?? "unknown",
                 response.status === 429 ? "rate-limit" : "upstream-error",
               );
-              // Surface the final HTTP status + a body sample to the chain's
-              // diagnostic so the user sees WHY (e.g. "HTTP 400: model not
-              // found") instead of the opaque "did not answer". Use `text`
-              // (the response body) rather than `response.statusText` —
-              // HTTP/2 responses don't include reason phrases, so
-              // statusText is empty and produces unhelpful messages.
-              lastWorkerError = `HTTP ${response.status}: ${text || response.statusText || "no body"}`;
+              lastWorkerError = `HTTP ${response.status}: transient upstream error exhausted retries`;
               return null;
             }
           },
         );
       } catch (e) {
+        // Preserve the caller's exact abort reason regardless of its class.
+        if (opts?.signal?.aborted) throw opts.signal.reason;
+        if (e instanceof DOMException && e.name === "TimeoutError") throw e;
+
+        if (e instanceof WorkerRequestTooLargeError) {
+          recordWorkerFailure(
+            opts?.sessionID ?? "_unknown",
+            opts?.workerID ?? "unknown",
+            "upstream-error",
+          );
+          log.warn(
+            `worker request rebuild rejected: request_bytes=${e.bytes} ` +
+              `limit_bytes=${MAX_WORKER_REQUEST_BYTES}`,
+          );
+          lastWorkerError = e.message;
+          return null;
+        }
+
         // Client disconnect / abort is benign — downgrade from error to info
         // to avoid Sentry noise from normal connection lifecycle events.
         const isAbort = e instanceof DOMException && e.name === "AbortError";
-        if (isAbort && opts?.signal?.aborted) throw e;
         // Network/timeout error — no response was received. Record here so the
         // adapter remains the single owner of transport-failure attribution
         // (core workers no longer record on a null return).
@@ -3365,23 +4626,25 @@ export function createGatewayLLMClient(
           opts?.workerID ?? "unknown",
           "no-response",
         );
-        // Surface the ACTUAL exception message to the chain's diagnostic. The
-        // catch block is reached on any uncaught throw — the message gives the
-        // user the real reason (timeout, DNS failure, fetch error, etc.)
-        // instead of a generic "network error" placeholder. We use
-        // `??=` to preserve any earlier specific error (e.g. set by the
-        // retry-loop or data-policy path) rather than overwriting it with
-        // something less informative.
         if (isAbort) {
           log.info("worker prompt aborted (client disconnect or shutdown)");
           lastWorkerError ??= "client disconnect or shutdown";
         } else {
-          log.error("worker prompt failed:", e);
-          const msg = e instanceof Error ? e.message : String(e);
-          lastWorkerError ??= `network error: no response from ${model.providerID} (${msg.slice(0, 200)})`;
+          const kind = transportErrorKind(e);
+          const code = transportErrorCode(e);
+          log.error(
+            `worker prompt transport failure: kind=${kind}` +
+              (code ? ` code=${code}` : "") +
+              ` origin=${sanitizedWorkerOrigin(req.url)}` +
+              ` provider=${diagnosticToken(model.providerID)}`,
+          );
+          lastWorkerError ??=
+            `network error: no response from ${diagnosticToken(model.providerID)}` +
+            ` (kind=${kind}${code ? `, code=${code}` : ""})`;
         }
         return null;
       } finally {
+        clearTimeout(deadlineTimer);
         activeWorkerCalls.delete(callID);
       }
     },

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -197,6 +197,11 @@ import {
   translateAnthropicStreamToGemini,
 } from "./stream/gemini";
 import {
+  safeTokenSum,
+  validateOpenAIUsage,
+  validateResponsesUsage,
+} from "./usage-validation";
+import {
   accumulateSSEResponse,
   createStreamAccumulator,
   createRecallAwareAccumulator,
@@ -206,6 +211,10 @@ import {
   buildKeepaliveCompactionStream,
   buildSSEMarkerMessage,
   formatSSEEvent,
+  AnthropicSSEValidator,
+  cancelAndReleaseReader,
+  readStreamChunk,
+  DEFAULT_MAX_SSE_FRAMES,
   type StreamAccumulator,
   type RecallAwareAccumulator,
 } from "./stream/anthropic";
@@ -342,6 +351,7 @@ import {
   recallAnchorContext,
 } from "./recall";
 import { upstreamFetch } from "./fetch";
+import { promiseAgainstAbort, responseAgainstAbort } from "./abort-race";
 import {
   buildUpstreamRouteContext,
   decodeRequestBody,
@@ -3621,13 +3631,19 @@ function syntheticToolUseResponse(
       },
     });
     if (req.protocol === "openai") {
-      return translateAnthropicStreamToOpenAI(anthropicSSE);
+      return translateAnthropicStreamToOpenAI(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     if (req.protocol === "openai-responses") {
-      return translateAnthropicStreamToResponses(anthropicSSE);
+      return translateAnthropicStreamToResponses(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     if (req.protocol === "gemini") {
-      return translateAnthropicStreamToGemini(anthropicSSE);
+      return translateAnthropicStreamToGemini(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     return anthropicSSE;
   }
@@ -4536,18 +4552,26 @@ async function forwardToUpstream(
   // whichever protocol the client sent — preserve the ingress protocol.
   // Direct providers (DeepSeek, Groq, etc.) specify their protocol explicitly
   // so the gateway can translate (e.g., Claude Code → OpenAI-only backend).
+  const nativeIngressAnthropicOverride =
+    providerID != null && providerRouteUsable?.protocol === "anthropic";
   const effectiveProtocol =
     req.protocol === "openai-responses"
-      ? "openai-responses"
+      ? nativeIngressAnthropicOverride
+        ? "anthropic"
+        : "openai-responses"
       : req.protocol === "gemini"
-        ? // A native Gemini ingress ALWAYS stays gemini. The provider route still
+        ? // A native Gemini ingress normally stays gemini. The provider route still
           // supplies the upstream URL (e.g. X-Lore-Provider: google →
           // generativelanguage), but its protocol must not downgrade a native
           // generateContent request: the `gemini-` model-prefix route and the
           // `google` provider route are both the OpenAI-compat layer
           // (protocol "openai"), which would wrongly re-translate to Chat
           // Completions. opencode/pi's @ai-sdk/google speaks native generateContent.
-          "gemini"
+          // An explicit Anthropic-wire provider is the narrow exception: meta
+          // calls use the strict Anthropic→Gemini translator below.
+          nativeIngressAnthropicOverride
+          ? "anthropic"
+          : "gemini"
         : (providerRouteUsable?.protocol ??
           modelRoute?.protocol ??
           req.protocol);
@@ -4694,7 +4718,7 @@ async function forwardToUpstream(
       : cache;
     const result = buildAnthropicRequest(req, effectiveCache);
 
-    const project = await resolveVertexProject(config.vertexProject);
+    const project = await resolveVertexProject(config.vertexProject, signal);
     if (!project) {
       throw new Error(
         "Vertex: no GCP project configured. Set GOOGLE_CLOUD_PROJECT (or " +
@@ -4708,7 +4732,7 @@ async function forwardToUpstream(
     // override else config, rawPredict URL, toVertexBody, and stripping the
     // api.anthropic.com-only headers + setting the bearer) is a pure helper so
     // it can be unit-tested in isolation — see buildVertexUpstream.
-    const token = await getVertexAccessToken();
+    const token = await getVertexAccessToken(signal);
     const vt = buildVertexUpstream({
       anthropicHeaders: result.headers,
       anthropicBody: result.body as Record<string, unknown>,
@@ -4863,27 +4887,35 @@ async function forwardToUpstream(
   const effectiveInterceptor = interceptor ?? activeInterceptor;
 
   if (effectiveInterceptor) {
-    const response = await effectiveInterceptor(
-      body,
-      req.model,
-      req.stream,
+    const response = await responseAgainstAbort(
       () =>
-        upstreamFetch(url, {
-          method: "POST",
-          headers,
-          body: upstreamBody,
-          signal,
-        }),
+        effectiveInterceptor(body, req.model, req.stream, () =>
+          responseAgainstAbort(
+            () =>
+              upstreamFetch(url, {
+                method: "POST",
+                headers,
+                body: upstreamBody,
+                signal,
+              }),
+            signal,
+          ),
+        ),
+      signal,
     );
     return { response, serializedBody, effectiveProtocol };
   }
 
-  const response = await upstreamFetch(url, {
-    method: "POST",
-    headers,
-    body: upstreamBody,
+  const response = await responseAgainstAbort(
+    () =>
+      upstreamFetch(url, {
+        method: "POST",
+        headers,
+        body: upstreamBody,
+        signal,
+      }),
     signal,
-  });
+  );
   return { response, serializedBody, effectiveProtocol };
 }
 
@@ -4932,7 +4964,7 @@ function maxReportedUsageForModelID(
  *  - **Case 2 (mixed tools)**: suppresses recall blocks, stores the pending
  *    result for injection into the next request.
  */
-function buildStreamingResponse(
+export function buildStreamingResponse(
   upstreamResponse: Response,
   onComplete: (response: GatewayResponse) => void,
   recallContext?: {
@@ -4980,6 +5012,7 @@ function buildStreamingResponse(
   sessionID?: string,
   /** Per-model client-usage cap (anti-compaction). Defaults to the 200K cap. */
   maxReportedUsage: number = DEFAULT_MAX_REPORTED_USAGE,
+  signal?: AbortSignal,
 ): Response {
   const recallAccum = recallContext
     ? createRecallAwareAccumulator(RECALL_TOOL_NAME, {
@@ -4999,6 +5032,31 @@ function buildStreamingResponse(
   // Client-disconnect detection: shared between start() and cancel()
   let cancelled = false;
   let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let resumeDemand: (() => void) | undefined;
+  const recallAbort = new AbortController();
+  const streamSignal = signal
+    ? AbortSignal.any([signal, recallAbort.signal])
+    : recallAbort.signal;
+  const onStreamAbort = (): void => {
+    resumeDemand?.();
+    resumeDemand = undefined;
+    if (signal?.aborted && !recallAbort.signal.aborted) {
+      recallAbort.abort(signal.reason);
+    }
+    if (activeReader) cancelAndReleaseReader(activeReader, streamSignal.reason);
+    else
+      void upstreamResponse.body?.cancel(streamSignal.reason).catch(() => {});
+  };
+  streamSignal.addEventListener("abort", onStreamAbort, { once: true });
+  if (streamSignal.aborted) onStreamAbort();
+  const recallDeadline = setTimeout(
+    () =>
+      recallAbort.abort(
+        new DOMException("recall stream deadline exceeded", "TimeoutError"),
+      ),
+    FOREGROUND_REQUEST_TIMEOUT_MS,
+  );
+  const clearRecallDeadline = (): void => clearTimeout(recallDeadline);
 
   // --- Keepalive ping timer ---
   // Emits SSE `ping` events on the client-facing stream when no upstream
@@ -5014,9 +5072,23 @@ function buildStreamingResponse(
   let keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
 
   const stream = new ReadableStream({
-    async start(controller) {
+    start(controller) {
       // Guard helpers for client-disconnect safety
-      const safeEnqueue = (data: Uint8Array): boolean => {
+      const waitForDemand = async (): Promise<void> => {
+        while (
+          !cancelled &&
+          !streamSignal.aborted &&
+          (controller.desiredSize ?? 1) <= 0
+        ) {
+          await new Promise<void>((resolve) => {
+            resumeDemand = resolve;
+          });
+        }
+        streamSignal.throwIfAborted();
+      };
+      const safeEnqueue = async (data: Uint8Array): Promise<boolean> => {
+        if (cancelled) return false;
+        await waitForDemand();
         if (cancelled) return false;
         try {
           controller.enqueue(data);
@@ -5027,6 +5099,8 @@ function buildStreamingResponse(
         }
       };
       const safeClose = (): void => {
+        clearRecallDeadline();
+        streamSignal.removeEventListener("abort", onStreamAbort);
         if (cancelled) return;
         try {
           controller.close();
@@ -5040,7 +5114,7 @@ function buildStreamingResponse(
         if (keepaliveTimer) clearTimeout(keepaliveTimer);
         keepaliveTimer = setTimeout(function tick() {
           if (cancelled) return;
-          safeEnqueue(pingEvent);
+          if ((controller.desiredSize ?? 1) > 0) void safeEnqueue(pingEvent);
           // Re-arm: keep pinging every KEEPALIVE_INACTIVITY_MS until an
           // upstream event arrives (which calls resetKeepalive) or the
           // stream closes (which calls clearKeepalive).
@@ -5051,422 +5125,563 @@ function buildStreamingResponse(
         if (keepaliveTimer) clearTimeout(keepaliveTimer);
         keepaliveTimer = null;
       };
-      try {
-        // Parse and forward upstream SSE events
-        if (!upstreamResponse.body) {
-          throw new Error("Upstream response has no body");
-        }
-        const reader = upstreamResponse.body.getReader();
-        activeReader = reader;
+      void (async () => {
+        try {
+          // Parse and forward upstream SSE events
+          if (!upstreamResponse.body) {
+            throw new Error("Upstream response has no body");
+          }
+          const reader = upstreamResponse.body.getReader();
+          activeReader = reader;
 
-        // When a warning needs to be prepended to the response, we emit a
-        // synthetic text content block after any leading thinking blocks,
-        // then offset all subsequent real content block indices by 1.
-        // The accumulator sees the original (un-offset) data so postResponse()
-        // gets the clean response — only the client stream has the warning.
-        // Thinking blocks are forwarded at their original indices to preserve
-        // the expected ordering (clients may inspect the first block's type).
-        let warningEmitted = false;
-        let inThinking = false;
-        let warningBlockIndex = 0; // incremented past thinking blocks
-        const warningOffset = warningText ? 1 : 0;
+          // When a warning needs to be prepended to the response, we emit a
+          // synthetic text content block after any leading thinking blocks,
+          // then offset all subsequent real content block indices by 1.
+          // The accumulator sees the original (un-offset) data so postResponse()
+          // gets the clean response — only the client stream has the warning.
+          // Thinking blocks are forwarded at their original indices to preserve
+          // the expected ordering (clients may inspect the first block's type).
+          let warningEmitted = false;
+          let inThinking = false;
+          let warningBlockIndex = 0; // incremented past thinking blocks
+          const warningOffset = warningText ? 1 : 0;
 
-        resetKeepalive();
-        const eventStream = parseSSEStream(reader);
-        for await (const { event, data } of eventStream) {
-          resetKeepalive(); // upstream is alive — reset inactivity timer
-          const forwarded = accumulator.processEvent(event, data);
-          if (forwarded) {
-            // --- Warning injection: skip thinking blocks, inject before first text/tool block ---
-            if (warningText && !warningEmitted) {
-              if (event === "message_start" || event === "ping") {
-                // Forward as-is, no action needed
-                if (!safeEnqueue(encoder.encode(forwarded))) break;
-                continue;
-              }
-
-              // Track thinking blocks — forward at original indices, no offset
-              if (event === "content_block_start") {
-                try {
-                  const parsed = JSON.parse(data);
-                  if (parsed.content_block?.type === "thinking") {
-                    inThinking = true;
-                    warningBlockIndex++;
-                    if (!safeEnqueue(encoder.encode(forwarded))) break;
-                    continue;
-                  }
-                } catch {
-                  /* fall through to inject */
+          resetKeepalive();
+          const validator = new AnthropicSSEValidator();
+          const eventStream = parseSSEStream(reader, {
+            signal: streamSignal,
+            inactivityMs: FOREGROUND_SSE_INACTIVITY_MS,
+            requireEventTerminator: true,
+            fatalUtf8: true,
+            maxFrames: DEFAULT_MAX_SSE_FRAMES,
+            maxTotalBytes: MAX_FOREGROUND_RESPONSE_BYTES,
+          });
+          for await (const { event, data } of eventStream) {
+            resetKeepalive(); // upstream is alive — reset inactivity timer
+            validator.process(event, data);
+            const forwarded = accumulator.processEvent(event, data);
+            if (forwarded) {
+              // --- Warning injection: skip thinking blocks, inject before first text/tool block ---
+              if (warningText && !warningEmitted) {
+                if (event === "message_start" || event === "ping") {
+                  // Forward as-is, no action needed
+                  if (!(await safeEnqueue(encoder.encode(forwarded)))) break;
+                  continue;
                 }
-              }
-              if (inThinking) {
-                if (event === "content_block_stop") inThinking = false;
-                if (!safeEnqueue(encoder.encode(forwarded))) break;
-                continue;
-              }
 
-              // First non-thinking content block — inject warning before it
-              const blockStart = JSON.stringify({
-                type: "content_block_start",
-                index: warningBlockIndex,
-                content_block: { type: "text", text: "" },
-              });
-              const blockDelta = JSON.stringify({
-                type: "content_block_delta",
-                index: warningBlockIndex,
-                delta: { type: "text_delta", text: warningText },
-              });
-              const blockStop = JSON.stringify({
-                type: "content_block_stop",
-                index: warningBlockIndex,
-              });
-              const warningSSE =
-                `event: content_block_start\ndata: ${blockStart}\n\n` +
-                `event: content_block_delta\ndata: ${blockDelta}\n\n` +
-                `event: content_block_stop\ndata: ${blockStop}\n\n`;
-              if (!safeEnqueue(encoder.encode(warningSSE))) break;
-              warningEmitted = true;
-              // Fall through to offset and forward this event
-            }
-
-            // Offset content block indices to account for the injected warning block
-            let toSend = forwarded;
-            if (warningOffset > 0 && warningEmitted) {
-              toSend = forwarded.replace(
-                /^(data: )(.+)$/m,
-                (_, prefix, jsonStr) => {
+                // Track thinking blocks — forward at original indices, no offset
+                if (event === "content_block_start") {
                   try {
-                    const obj = JSON.parse(jsonStr);
-                    if (typeof obj.index === "number") {
-                      obj.index += warningOffset;
-                      return prefix + JSON.stringify(obj);
+                    const parsed = JSON.parse(data);
+                    if (parsed.content_block?.type === "thinking") {
+                      inThinking = true;
+                      warningBlockIndex++;
+                      if (!(await safeEnqueue(encoder.encode(forwarded))))
+                        break;
+                      continue;
                     }
                   } catch {
-                    /* not JSON — leave as-is */
+                    /* fall through to inject */
                   }
-                  return prefix + jsonStr;
+                }
+                if (inThinking) {
+                  if (event === "content_block_stop") inThinking = false;
+                  if (!(await safeEnqueue(encoder.encode(forwarded)))) break;
+                  continue;
+                }
+
+                // First non-thinking content block — inject warning before it
+                const blockStart = JSON.stringify({
+                  type: "content_block_start",
+                  index: warningBlockIndex,
+                  content_block: { type: "text", text: "" },
+                });
+                const blockDelta = JSON.stringify({
+                  type: "content_block_delta",
+                  index: warningBlockIndex,
+                  delta: { type: "text_delta", text: warningText },
+                });
+                const blockStop = JSON.stringify({
+                  type: "content_block_stop",
+                  index: warningBlockIndex,
+                });
+                const warningSSE =
+                  `event: content_block_start\ndata: ${blockStart}\n\n` +
+                  `event: content_block_delta\ndata: ${blockDelta}\n\n` +
+                  `event: content_block_stop\ndata: ${blockStop}\n\n`;
+                if (!(await safeEnqueue(encoder.encode(warningSSE)))) break;
+                warningEmitted = true;
+                // Fall through to offset and forward this event
+              }
+
+              // Offset content block indices to account for the injected warning block
+              let toSend = forwarded;
+              if (warningOffset > 0 && warningEmitted) {
+                toSend = forwarded.replace(
+                  /^(data: )(.+)$/m,
+                  (_, prefix, jsonStr) => {
+                    try {
+                      const obj = JSON.parse(jsonStr);
+                      if (typeof obj.index === "number") {
+                        obj.index += warningOffset;
+                        return prefix + JSON.stringify(obj);
+                      }
+                    } catch {
+                      /* not JSON — leave as-is */
+                    }
+                    return prefix + jsonStr;
+                  },
+                );
+              }
+              if (!(await safeEnqueue(encoder.encode(toSend)))) break;
+            }
+            if (validator.isDone()) break;
+          }
+          cancelAndReleaseReader(reader);
+          if (activeReader === reader) activeReader = null;
+          if (!cancelled) validator.assertDone();
+
+          // --- Recall interception (streaming) ---
+          // Loop allows the model to call recall multiple times (e.g. drill
+          // down into t:<id> source citations). Uses RecallAwareAccumulator
+          // for each continuation stream to detect further recall calls.
+          if (recallAccum?.hasRecall() && recallContext) {
+            let currentAccum: RecallAwareAccumulator = recallAccum;
+            let currentResp = recallAccum.getResponse();
+            let currentBlockOffset = warningOffset; // accumulates across iterations
+            let currentModifiedReq = recallContext.modifiedReq;
+            let recallDepth = 0;
+
+            // Snapshot IDs already in LTM context (system[1] catalog + durable
+            // delta) so recall can hint "N of K results already in LTM" when the
+            // model would otherwise treat redundant hits as new info and emit
+            // a silent 3-token stop.
+            const alreadyInLtmIds = buildAlreadyInLtmIds(
+              recallContext.stableLtmText,
+              recallContext.pendingKnowledgeDelta,
+            );
+
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              const recallBlock = findRecallToolUse(currentResp);
+              if (!recallBlock) break;
+
+              recallDepth++;
+              const { result, input } = await promiseAgainstAbort(
+                () =>
+                  executeRecall(
+                    recallBlock,
+                    recallContext.sessionState.projectPath,
+                    recallContext.sessionState.sessionID,
+                    getLLMClient(recallContext.config),
+                    alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
+                    streamSignal,
+                  ),
+                streamSignal,
+              );
+
+              const scope = input.scope ?? "all";
+
+              // Store recall result for marker round-trip expansion
+              const anchorId = crypto.randomUUID();
+              const storeKey = `anchor:${anchorId}`;
+              const position = currentResp.content.indexOf(recallBlock);
+              const markerPrefix = recallContext.clientSpeaksAnthropic
+                ? currentResp.content.filter(
+                    (block) =>
+                      block.type !== "tool_use" || block.id !== recallBlock.id,
+                  )
+                : currentResp.content.slice(0, position);
+              const anchorContextId = recallAnchorContext(
+                recallContext.clientMessages,
+                recallContext.clientMessages.length,
+                [...recallVisibleContent, ...markerPrefix],
+              );
+              const companionToolUses = currentResp.content.flatMap(
+                (block, index) => {
+                  if (
+                    block.type !== "tool_use" ||
+                    block.id === recallBlock.id
+                  ) {
+                    return [];
+                  }
+                  return [
+                    {
+                      id: block.id,
+                      name: block.name,
+                      input: block.input,
+                      side:
+                        recallContext.clientSpeaksAnthropic || index < position
+                          ? ("before" as const)
+                          : ("after" as const),
+                    },
+                  ];
                 },
               );
-            }
-            if (!safeEnqueue(encoder.encode(toSend))) break;
-          }
-        }
-
-        // --- Recall interception (streaming) ---
-        // Loop allows the model to call recall multiple times (e.g. drill
-        // down into t:<id> source citations). Uses RecallAwareAccumulator
-        // for each continuation stream to detect further recall calls.
-        if (recallAccum?.hasRecall() && recallContext) {
-          let currentAccum: RecallAwareAccumulator = recallAccum;
-          let currentResp = recallAccum.getResponse();
-          let currentBlockOffset = warningOffset; // accumulates across iterations
-          let currentModifiedReq = recallContext.modifiedReq;
-          let recallDepth = 0;
-
-          // Snapshot IDs already in LTM context (system[1] catalog + durable
-          // delta) so recall can hint "N of K results already in LTM" when the
-          // model would otherwise treat redundant hits as new info and emit
-          // a silent 3-token stop.
-          const alreadyInLtmIds = buildAlreadyInLtmIds(
-            recallContext.stableLtmText,
-            recallContext.pendingKnowledgeDelta,
-          );
-
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            const recallBlock = findRecallToolUse(currentResp);
-            if (!recallBlock) break;
-
-            recallDepth++;
-            const { result, input } = await executeRecall(
-              recallBlock,
-              recallContext.sessionState.projectPath,
-              recallContext.sessionState.sessionID,
-              getLLMClient(recallContext.config),
-              alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
-            );
-
-            const scope = input.scope ?? "all";
-
-            // Store recall result for marker round-trip expansion
-            const anchorId = crypto.randomUUID();
-            const storeKey = `anchor:${anchorId}`;
-            const position = currentResp.content.indexOf(recallBlock);
-            const markerPrefix = recallContext.clientSpeaksAnthropic
-              ? currentResp.content.filter(
-                  (block) =>
-                    block.type !== "tool_use" || block.id !== recallBlock.id,
-                )
-              : currentResp.content.slice(0, position);
-            const anchorContextId = recallAnchorContext(
-              recallContext.clientMessages,
-              recallContext.clientMessages.length,
-              [...recallVisibleContent, ...markerPrefix],
-            );
-            const companionToolUses = currentResp.content.flatMap(
-              (block, index) => {
-                if (block.type !== "tool_use" || block.id === recallBlock.id) {
-                  return [];
-                }
-                return [
-                  {
-                    id: block.id,
-                    name: block.name,
-                    input: block.input,
-                    side:
-                      recallContext.clientSpeaksAnthropic || index < position
-                        ? ("before" as const)
-                        : ("after" as const),
-                  },
-                ];
-              },
-            );
-            addRecallStoreEntry(
-              recallContext.sessionState.recallStore,
-              storeKey,
-              {
-                toolUseId: recallBlock.id,
-                anchorId,
-                anchorContextId,
-                input,
-                position,
-                result,
-                ...(companionToolUses.length > 0 ? { companionToolUses } : {}),
-              },
-            );
-            // Persist the store (v46) so the marker still expands byte-identically
-            // after a gateway restart instead of leaking raw marker text upstream.
-            saveSessionTracking(recallContext.sessionState.sessionID, {
-              recallStore: serializeRecallStore(
+              addRecallStoreEntry(
                 recallContext.sessionState.recallStore,
-              ),
-            });
-
-            // Emit marker — split into its own SSE message envelope for Anthropic-native
-            // clients (so the marker renders as a DISTINCT assistant message in
-            // the transcript, not inline with the model's preamble); for
-            // non-Anthropic clients (OpenAI Chat Completions / Responses /
-            // Gemini), emit it as a SYNTHETIC text content block in the Anthropic SSE.
-            // The OpenAI/Responses/Gemini adapters (stream/openai.ts, stream/openai-responses.ts,
-            // stream/gemini.ts) each translate text content blocks into their native
-            // streaming format automatically — so the marker reaches the OpenAI client
-            // as a delta.content chunk, the Responses client as an output_text delta,
-            // and the Gemini client as a text part. This preserves the recall context
-            // across turns (the client's persisted transcript has SOMETHING for
-            // expandRecallMarkers to find next turn, fixing the silent-recall-loss bug
-            // that would result from dropping the marker entirely for these clients).
-            const markerText = buildAnchoredRecallMarker(
-              input.query,
-              scope,
-              input.id,
-              anchorId,
-            );
-            if (recallContext.clientSpeaksAnthropic) {
-              recallVisibleContent.push(...markerPrefix, {
-                type: "text",
-                text: markerText,
+                storeKey,
+                {
+                  toolUseId: recallBlock.id,
+                  anchorId,
+                  anchorContextId,
+                  input,
+                  position,
+                  result,
+                  ...(companionToolUses.length > 0
+                    ? { companionToolUses }
+                    : {}),
+                },
+              );
+              // Persist the store (v46) so the marker still expands byte-identically
+              // after a gateway restart instead of leaking raw marker text upstream.
+              saveSessionTracking(recallContext.sessionState.sessionID, {
+                recallStore: serializeRecallStore(
+                  recallContext.sessionState.recallStore,
+                ),
               });
-            } else {
-              recallVisibleContent.push(
-                ...currentResp.content.map((block) =>
-                  block.type === "tool_use" && block.id === recallBlock.id
-                    ? { type: "text" as const, text: markerText }
-                    : block,
-                ),
+
+              // Emit marker — split into its own SSE message envelope for Anthropic-native
+              // clients (so the marker renders as a DISTINCT assistant message in
+              // the transcript, not inline with the model's preamble); for
+              // non-Anthropic clients (OpenAI Chat Completions / Responses /
+              // Gemini), emit it as a SYNTHETIC text content block in the Anthropic SSE.
+              // The OpenAI/Responses/Gemini adapters (stream/openai.ts, stream/openai-responses.ts,
+              // stream/gemini.ts) each translate text content blocks into their native
+              // streaming format automatically — so the marker reaches the OpenAI client
+              // as a delta.content chunk, the Responses client as an output_text delta,
+              // and the Gemini client as a text part. This preserves the recall context
+              // across turns (the client's persisted transcript has SOMETHING for
+              // expandRecallMarkers to find next turn, fixing the silent-recall-loss bug
+              // that would result from dropping the marker entirely for these clients).
+              const markerText = buildAnchoredRecallMarker(
+                input.query,
+                scope,
+                input.id,
+                anchorId,
               );
-            }
-            let syntheticMarker: string;
-            if (recallContext.clientSpeaksAnthropic) {
-              const syntheticMessageId = `lore_marker_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
-              syntheticMarker = buildSSEMarkerMessage(
-                syntheticMessageId,
-                currentResp.model,
-                markerText,
-              );
-            } else {
-              // Inline synthetic text block at the index where the recall
-              // tool_use was suppressed. Existing translators forward text
-              // blocks to the client's native streaming format — see
-              // stream/openai.ts:225-239 (text_delta → delta.content chunk),
-              // stream/openai-responses.ts (text → output_text delta), and
-              // stream/gemini.ts (buffered → text part in aggregated frame).
-              const markerIdx =
-                currentAccum.clientBlockCount() + currentBlockOffset;
-              syntheticMarker = [
-                formatSSEEvent(
-                  "content_block_start",
-                  JSON.stringify({
-                    type: "content_block_start",
-                    index: markerIdx,
-                    content_block: { type: "text", text: "" },
-                  }),
-                ),
-                formatSSEEvent(
-                  "content_block_delta",
-                  JSON.stringify({
-                    type: "content_block_delta",
-                    index: markerIdx,
-                    delta: { type: "text_delta", text: markerText },
-                  }),
-                ),
-                formatSSEEvent(
-                  "content_block_stop",
-                  JSON.stringify({
-                    type: "content_block_stop",
-                    index: markerIdx,
-                  }),
-                ),
-              ].join("");
-            }
-            // For Anthropic-native clients, the marker is a SEPARATE SSE
-            // message envelope (own message_start/message_stop). The original
-            // envelope (preamble) must close BEFORE the marker opens —
-            // otherwise the wire has two message_start events with no closing
-            // message_stop between them, which is malformed Anthropic SSE.
-            // Forward the original's held-back message_delta + message_stop
-            // FIRST, then emit the marker. Use `takeHeldBackEvents()` so the
-            // mixed-tools terminal-close branch can't double-emit the same
-            // events.
-            // For non-Anthropic clients, the marker is inline so the original
-            // envelope stays open — held-back events are forwarded LATER
-            // (after the follow-up completes, in the recall-only success
-            // path at pipeline.ts:~4960).
-            if (recallContext.clientSpeaksAnthropic) {
-              const originalHeldBack = currentAccum.takeHeldBackEvents();
-              if (originalHeldBack) {
-                if (!safeEnqueue(encoder.encode(originalHeldBack))) {
-                  clearKeepalive();
-                  return;
+              if (recallContext.clientSpeaksAnthropic) {
+                recallVisibleContent.push(...markerPrefix, {
+                  type: "text",
+                  text: markerText,
+                });
+              } else {
+                recallVisibleContent.push(
+                  ...currentResp.content.map((block) =>
+                    block.type === "tool_use" && block.id === recallBlock.id
+                      ? { type: "text" as const, text: markerText }
+                      : block,
+                  ),
+                );
+              }
+              let syntheticMarker: string;
+              if (recallContext.clientSpeaksAnthropic) {
+                const syntheticMessageId = `lore_marker_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+                syntheticMarker = buildSSEMarkerMessage(
+                  syntheticMessageId,
+                  currentResp.model,
+                  markerText,
+                );
+              } else {
+                // Inline synthetic text block at the index where the recall
+                // tool_use was suppressed. Existing translators forward text
+                // blocks to the client's native streaming format — see
+                // stream/openai.ts:225-239 (text_delta → delta.content chunk),
+                // stream/openai-responses.ts (text → output_text delta), and
+                // stream/gemini.ts (buffered → text part in aggregated frame).
+                const markerIdx =
+                  currentAccum.clientBlockCount() + currentBlockOffset;
+                syntheticMarker = [
+                  formatSSEEvent(
+                    "content_block_start",
+                    JSON.stringify({
+                      type: "content_block_start",
+                      index: markerIdx,
+                      content_block: { type: "text", text: "" },
+                    }),
+                  ),
+                  formatSSEEvent(
+                    "content_block_delta",
+                    JSON.stringify({
+                      type: "content_block_delta",
+                      index: markerIdx,
+                      delta: { type: "text_delta", text: markerText },
+                    }),
+                  ),
+                  formatSSEEvent(
+                    "content_block_stop",
+                    JSON.stringify({
+                      type: "content_block_stop",
+                      index: markerIdx,
+                    }),
+                  ),
+                ].join("");
+              }
+              // For Anthropic-native clients, the marker is a SEPARATE SSE
+              // message envelope (own message_start/message_stop). The original
+              // envelope (preamble) must close BEFORE the marker opens —
+              // otherwise the wire has two message_start events with no closing
+              // message_stop between them, which is malformed Anthropic SSE.
+              // Forward the original's held-back message_delta + message_stop
+              // FIRST, then emit the marker. Use `takeHeldBackEvents()` so the
+              // mixed-tools terminal-close branch can't double-emit the same
+              // events.
+              // For non-Anthropic clients, the marker is inline so the original
+              // envelope stays open — held-back events are forwarded LATER
+              // (after the follow-up completes, in the recall-only success
+              // path at pipeline.ts:~4960).
+              if (recallContext.clientSpeaksAnthropic) {
+                const originalHeldBack = currentAccum.takeHeldBackEvents();
+                if (originalHeldBack) {
+                  if (!(await safeEnqueue(encoder.encode(originalHeldBack)))) {
+                    clearKeepalive();
+                    return;
+                  }
                 }
               }
-            }
 
-            if (!safeEnqueue(encoder.encode(syntheticMarker))) {
-              clearKeepalive();
-              return;
-            }
+              if (!(await safeEnqueue(encoder.encode(syntheticMarker)))) {
+                clearKeepalive();
+                return;
+              }
 
-            if (currentAccum.hasOtherTools()) {
-              // Mixed tools — forward held-back events, close stream
+              if (currentAccum.hasOtherTools()) {
+                // Mixed tools — forward held-back events, close stream
+                log.info(
+                  `recall (stream, mixed, depth=${recallDepth}): stored result for session ` +
+                    `${recallContext.sessionState.sessionID.slice(0, 16)}`,
+                );
+
+                // For non-Anthropic clients, the marker is inline (envelope
+                // stays open), so the held-back events close the envelope at
+                // stream end. For Anthropic clients, the held-back was already
+                // consumed (via takeHeldBackEvents) before the marker emission
+                // above — so takeHeldBackEvents() returns "" here, no-op.
+                const heldBack = currentAccum.takeHeldBackEvents();
+                if (heldBack) {
+                  await safeEnqueue(encoder.encode(heldBack));
+                }
+
+                const markerResp = replaceRecallWithMarker(
+                  currentResp,
+                  new Map([[recallBlock.id, markerText]]),
+                );
+                clearKeepalive();
+                onComplete(markerResp);
+                safeClose();
+                return;
+              }
+
+              // Recall-only — send follow-up, pipe continuation
               log.info(
-                `recall (stream, mixed, depth=${recallDepth}): stored result for session ` +
+                `recall (stream, depth=${recallDepth}): executing follow-up for session ` +
                   `${recallContext.sessionState.sessionID.slice(0, 16)}`,
               );
 
-              // For non-Anthropic clients, the marker is inline (envelope
-              // stays open), so the held-back events close the envelope at
-              // stream end. For Anthropic clients, the held-back was already
-              // consumed (via takeHeldBackEvents) before the marker emission
-              // above — so takeHeldBackEvents() returns "" here, no-op.
-              const heldBack = currentAccum.takeHeldBackEvents();
-              if (heldBack) {
-                safeEnqueue(encoder.encode(heldBack));
-              }
+              // Build (stream:true) + forward + assert-SSE + get reader in one
+              // coupled call so the follow-up's stream flag can never diverge
+              // from how the continuation is consumed (parseSSEStream below).
+              // Disable conversation caching on the follow-up: the appended
+              // recall result makes the prefix diverge from the next real turn,
+              // so the cache write would be wasted money.
+              const streamingRecallCtx: RecallFollowUpCtx = {
+                forward: (r, signal) =>
+                  forwardToUpstream(
+                    r,
+                    recallContext.config,
+                    undefined,
+                    {
+                      ...recallContext.cacheOptions,
+                      cacheConversation: false,
+                    },
+                    signal,
+                  ),
+                // JSON parsing is unused on the streaming path (assertSSEResponse
+                // guarantees an SSE body); provide a guard that throws if reached.
+                parseJSON: () => {
+                  throw new Error(
+                    "parseJSON must not be called on the streaming recall path",
+                  );
+                },
+              };
 
-              const markerResp = replaceRecallWithMarker(
-                currentResp,
-                new Map([[recallBlock.id, markerText]]),
-              );
-              clearKeepalive();
-              onComplete(markerResp);
-              safeClose();
-              return;
-            }
-
-            // Recall-only — send follow-up, pipe continuation
-            log.info(
-              `recall (stream, depth=${recallDepth}): executing follow-up for session ` +
-                `${recallContext.sessionState.sessionID.slice(0, 16)}`,
-            );
-
-            // Build (stream:true) + forward + assert-SSE + get reader in one
-            // coupled call so the follow-up's stream flag can never diverge
-            // from how the continuation is consumed (parseSSEStream below).
-            // Disable conversation caching on the follow-up: the appended
-            // recall result makes the prefix diverge from the next real turn,
-            // so the cache write would be wasted money.
-            const streamingRecallCtx: RecallFollowUpCtx = {
-              forward: (r, signal) =>
-                forwardToUpstream(
-                  r,
-                  recallContext.config,
-                  undefined,
-                  {
-                    ...recallContext.cacheOptions,
-                    cacheConversation: false,
-                  },
-                  signal,
-                ),
-              // JSON parsing is unused on the streaming path (assertSSEResponse
-              // guarantees an SSE body); provide a guard that throws if reached.
-              parseJSON: () => {
-                throw new Error(
-                  "parseJSON must not be called on the streaming recall path",
+              let streamingFollowUp: Awaited<
+                ReturnType<typeof runRecallFollowUpStreaming>
+              >;
+              try {
+                streamingFollowUp = await runRecallFollowUpStreaming(
+                  streamingRecallCtx,
+                  currentModifiedReq,
+                  currentResp,
+                  result,
+                  recallBlock,
+                  streamSignal,
                 );
-              },
-            };
-
-            let streamingFollowUp: Awaited<
-              ReturnType<typeof runRecallFollowUpStreaming>
-            >;
-            try {
-              streamingFollowUp = await runRecallFollowUpStreaming(
-                streamingRecallCtx,
-                currentModifiedReq,
-                currentResp,
-                result,
-                recallBlock,
-              );
-            } catch (fetchErr) {
-              log.error(
-                `recall follow-up fetch error (depth=${recallDepth}) for session ${recallContext.sessionState.sessionID.slice(0, 16)}:`,
-                fetchErr,
-              );
-              // takeHeldBackEvents() — for Anthropic this is a no-op
-              // (already consumed before the marker envelope emission
-              // above); for non-Anthropic the held-back closes the
-              // (still-open) envelope here.
-              const heldBack = currentAccum.takeHeldBackEvents();
-              if (heldBack) {
-                safeEnqueue(encoder.encode(heldBack));
+              } catch (fetchErr) {
+                log.error(
+                  `recall follow-up fetch error (depth=${recallDepth}) for session ${recallContext.sessionState.sessionID.slice(0, 16)}:`,
+                  fetchErr,
+                );
+                // takeHeldBackEvents() — for Anthropic this is a no-op
+                // (already consumed before the marker envelope emission
+                // above); for non-Anthropic the held-back closes the
+                // (still-open) envelope here.
+                const heldBack = currentAccum.takeHeldBackEvents();
+                if (heldBack) {
+                  await safeEnqueue(encoder.encode(heldBack));
+                }
+                const markerResp = replaceRecallWithMarker(
+                  currentResp,
+                  new Map([[recallBlock.id, markerText]]),
+                );
+                clearKeepalive();
+                onComplete(markerResp);
+                safeClose();
+                return;
               }
-              const markerResp = replaceRecallWithMarker(
-                currentResp,
-                new Map([[recallBlock.id, markerText]]),
-              );
-              clearKeepalive();
-              onComplete(markerResp);
-              safeClose();
-              return;
-            }
 
-            if (!streamingFollowUp.ok) {
-              log.error(
-                `recall follow-up upstream error: ${streamingFollowUp.status ?? "?"} ${streamingFollowUp.detail}`,
-                new Error(
-                  `recall follow-up upstream ${streamingFollowUp.status ?? "?"}`,
-                ),
+              if (!streamingFollowUp.ok) {
+                log.error(
+                  `recall follow-up upstream error: ${streamingFollowUp.status ?? "?"} ${streamingFollowUp.detail}`,
+                  new Error(
+                    `recall follow-up upstream ${streamingFollowUp.status ?? "?"}`,
+                  ),
+                );
+                captureToolPairing400({
+                  status: streamingFollowUp.status ?? 0,
+                  errorBody: streamingFollowUp.detail,
+                  messages: currentModifiedReq.messages,
+                  // Layer is not in scope on the streaming recall continuation;
+                  // -1 signals "unknown" while still tagging the error class.
+                  layer: -1,
+                  model: currentModifiedReq.model,
+                  sessionID: recallContext.sessionState.sessionID,
+                });
+                // takeHeldBackEvents() — for Anthropic this is a no-op
+                // (already consumed before the marker envelope emission
+                // above); for non-Anthropic the held-back closes the
+                // (still-open) envelope here.
+                const heldBack = currentAccum.takeHeldBackEvents();
+                if (heldBack) {
+                  await safeEnqueue(encoder.encode(heldBack));
+                }
+                const markerResp = replaceRecallWithMarker(
+                  currentResp,
+                  new Map([[recallBlock.id, markerText]]),
+                );
+                clearKeepalive();
+                onComplete(markerResp);
+                safeClose();
+                return;
+              }
+
+              const followUp = streamingFollowUp.followUp;
+              log.info(
+                `recall follow-up response (depth=${recallDepth}): session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
               );
-              captureToolPairing400({
-                status: streamingFollowUp.status ?? 0,
-                errorBody: streamingFollowUp.detail,
-                messages: currentModifiedReq.messages,
-                // Layer is not in scope on the streaming recall continuation;
-                // -1 signals "unknown" while still tagging the error class.
-                layer: -1,
-                model: currentModifiedReq.model,
-                sessionID: recallContext.sessionState.sessionID,
+
+              // Pipe the continuation stream through a recall-aware accumulator.
+              // For Anthropic-native clients:
+              //  - The marker is its own SSE message envelope (separate
+              //    message_start/message_stop), so the continuation's content_block_start
+              //    indices start at 0 in its own message — blockOffset=0.
+              //  - The continuation must open with its OWN message_start (don't suppress).
+              //    The original envelope's message_start/message_stop were already closed
+              //    by the explicit held-back forwarding just before the marker envelope.
+              //
+              // For non-Anthropic clients:
+              //  - The marker is an inline synthetic text block, so the original envelope
+              //    stays open throughout the marker and the continuation. The continuation
+              //    extends the original envelope — blockOffset includes the marker block,
+              //    and the continuation's message_start is suppressed (single-message
+              //    stream per OpenAI Chat Completions / Responses / Gemini).
+              const contBlockOffset = recallContext.clientSpeaksAnthropic
+                ? 0
+                : currentAccum.clientBlockCount() + currentBlockOffset + 1;
+              const contAccum = createRecallAwareAccumulator(RECALL_TOOL_NAME, {
+                scaleClientUsage: true,
+                maxReportedUsage,
+                blockOffset: contBlockOffset,
+                suppressMessageStart: !recallContext.clientSpeaksAnthropic,
               });
-              // takeHeldBackEvents() — for Anthropic this is a no-op
-              // (already consumed before the marker envelope emission
-              // above); for non-Anthropic the held-back closes the
-              // (still-open) envelope here.
-              const heldBack = currentAccum.takeHeldBackEvents();
-              if (heldBack) {
-                safeEnqueue(encoder.encode(heldBack));
+              const contReader = streamingFollowUp.reader;
+              activeReader = contReader;
+
+              const continuationValidator = new AnthropicSSEValidator();
+              try {
+                for await (const {
+                  event: contEvent,
+                  data: contData,
+                } of parseSSEStream(contReader, {
+                  signal: streamSignal,
+                  inactivityMs: FOREGROUND_SSE_INACTIVITY_MS,
+                  requireEventTerminator: true,
+                  fatalUtf8: true,
+                  maxFrames: DEFAULT_MAX_SSE_FRAMES,
+                  maxTotalBytes: MAX_FOREGROUND_RESPONSE_BYTES,
+                })) {
+                  resetKeepalive(); // continuation stream alive — reset timer
+                  continuationValidator.process(contEvent, contData);
+                  const forwarded = contAccum.processEvent(contEvent, contData);
+                  if (forwarded) {
+                    // Forward non-recall, non-held-back events to client.
+                    // message_delta usage scaling is handled by a separate pass
+                    // below only for the final continuation's terminal events.
+                    if (!(await safeEnqueue(encoder.encode(forwarded)))) break;
+                  }
+                  if (continuationValidator.isDone()) break;
+                }
+              } finally {
+                cancelAndReleaseReader(contReader, streamSignal.reason);
+                if (activeReader === contReader) activeReader = null;
               }
+              if (!cancelled) continuationValidator.assertDone();
+
+              log.info(
+                `recall follow-up stream complete (depth=${recallDepth}): ` +
+                  `session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
+              );
+
+              // Check if continuation contained recall — if so, loop
+              if (contAccum.hasRecall() && recallDepth < MAX_RECALL_DEPTH) {
+                currentAccum = contAccum;
+                currentResp = contAccum.getResponse();
+                currentBlockOffset = contBlockOffset;
+                currentModifiedReq = followUp;
+                continue; // Loop: execute the new recall, emit marker, follow up
+              }
+
+              // No more recall (or depth exhausted) — forward terminal events, close
+              if (contAccum.hasRecall()) {
+                log.warn(
+                  `recall depth exhausted (${MAX_RECALL_DEPTH}) in streaming path`,
+                );
+              }
+
+              // For non-Anthropic clients: the original (preamble) envelope is
+              // kept open throughout the inline marker and the follow-up
+              // continuation. The continuation's terminal message_delta +
+              // message_stop (held back in contAccum below) close the original
+              // envelope inline as the stream ends. Forwarding the preamble's
+              // held-back here would duplicate the close event and break the
+              // OpenAI wire (extra [DONE] sentinel + contradictory
+              // finish_reason). For Anthropic clients, the preamble's
+              // held-back was already consumed before the marker envelope
+              // emission above — contAccum's held-back is the relevant close.
+              // Use takeHeldBackEvents() (not peek) so the held-back is
+              // atomically consumed: defense-in-depth against any future code
+              // path that might read contAccum's heldBack again (e.g. a
+              // refactor that re-enters the drill-down loop or replays the
+              // accumulator). In the current control flow the heldBack is read
+              // exactly once — this just makes the consume semantics explicit.
+              const heldBack = contAccum.takeHeldBackEvents();
+              if (heldBack) {
+                // Scale usage in held-back message_delta for anti-compaction
+                await safeEnqueue(encoder.encode(heldBack));
+              }
+
               const markerResp = replaceRecallWithMarker(
-                currentResp,
+                contAccum.hasRecall() ? contAccum.getResponse() : currentResp,
                 new Map([[recallBlock.id, markerText]]),
               );
               clearKeepalive();
@@ -5474,144 +5689,60 @@ function buildStreamingResponse(
               safeClose();
               return;
             }
+          }
 
-            const followUp = streamingFollowUp.followUp;
-            log.info(
-              `recall follow-up response (depth=${recallDepth}): session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
-            );
-
-            // Pipe the continuation stream through a recall-aware accumulator.
-            // For Anthropic-native clients:
-            //  - The marker is its own SSE message envelope (separate
-            //    message_start/message_stop), so the continuation's content_block_start
-            //    indices start at 0 in its own message — blockOffset=0.
-            //  - The continuation must open with its OWN message_start (don't suppress).
-            //    The original envelope's message_start/message_stop were already closed
-            //    by the explicit held-back forwarding just before the marker envelope.
-            //
-            // For non-Anthropic clients:
-            //  - The marker is an inline synthetic text block, so the original envelope
-            //    stays open throughout the marker and the continuation. The continuation
-            //    extends the original envelope — blockOffset includes the marker block,
-            //    and the continuation's message_start is suppressed (single-message
-            //    stream per OpenAI Chat Completions / Responses / Gemini).
-            const contBlockOffset = recallContext.clientSpeaksAnthropic
-              ? 0
-              : currentAccum.clientBlockCount() + currentBlockOffset + 1;
-            const contAccum = createRecallAwareAccumulator(RECALL_TOOL_NAME, {
-              scaleClientUsage: true,
-              maxReportedUsage,
-              blockOffset: contBlockOffset,
-              suppressMessageStart: !recallContext.clientSpeaksAnthropic,
+          // No recall — normal path
+          clearKeepalive();
+          const response = accumulator.getResponse();
+          onComplete(response);
+          safeClose();
+        } catch (err) {
+          streamSignal.removeEventListener("abort", onStreamAbort);
+          clearKeepalive();
+          clearRecallDeadline();
+          if (activeReader) {
+            cancelAndReleaseReader(activeReader, err);
+            activeReader = null;
+          }
+          // Client disconnect / abort is benign — downgrade from error to info
+          // to avoid Sentry noise from normal connection lifecycle events.
+          const isAbort =
+            err instanceof DOMException && err.name === "AbortError";
+          if (isAbort) {
+            log.info("streaming pipeline aborted (client disconnect)");
+            // Only surfaces to Sentry if the host was under pressure at abort time.
+            captureClientAbortUnderPressure({
+              startMs: streamStartMs,
+              route: "stream",
+              sessionID,
             });
-            const contReader = streamingFollowUp.reader;
-            activeReader = contReader;
-
-            for await (const {
-              event: contEvent,
-              data: contData,
-            } of parseSSEStream(contReader)) {
-              resetKeepalive(); // continuation stream alive — reset timer
-              const forwarded = contAccum.processEvent(contEvent, contData);
-              if (forwarded) {
-                // Forward non-recall, non-held-back events to client.
-                // message_delta usage scaling is handled by a separate pass
-                // below only for the final continuation's terminal events.
-                if (!safeEnqueue(encoder.encode(forwarded))) break;
-              }
-            }
-
-            log.info(
-              `recall follow-up stream complete (depth=${recallDepth}): ` +
-                `session=${recallContext.sessionState.sessionID.slice(0, 16)}`,
-            );
-
-            // Check if continuation contained recall — if so, loop
-            if (contAccum.hasRecall() && recallDepth < MAX_RECALL_DEPTH) {
-              currentAccum = contAccum;
-              currentResp = contAccum.getResponse();
-              currentBlockOffset = contBlockOffset;
-              currentModifiedReq = followUp;
-              continue; // Loop: execute the new recall, emit marker, follow up
-            }
-
-            // No more recall (or depth exhausted) — forward terminal events, close
-            if (contAccum.hasRecall()) {
-              log.warn(
-                `recall depth exhausted (${MAX_RECALL_DEPTH}) in streaming path`,
-              );
-            }
-
-            // For non-Anthropic clients: the original (preamble) envelope is
-            // kept open throughout the inline marker and the follow-up
-            // continuation. The continuation's terminal message_delta +
-            // message_stop (held back in contAccum below) close the original
-            // envelope inline as the stream ends. Forwarding the preamble's
-            // held-back here would duplicate the close event and break the
-            // OpenAI wire (extra [DONE] sentinel + contradictory
-            // finish_reason). For Anthropic clients, the preamble's
-            // held-back was already consumed before the marker envelope
-            // emission above — contAccum's held-back is the relevant close.
-            // Use takeHeldBackEvents() (not peek) so the held-back is
-            // atomically consumed: defense-in-depth against any future code
-            // path that might read contAccum's heldBack again (e.g. a
-            // refactor that re-enters the drill-down loop or replays the
-            // accumulator). In the current control flow the heldBack is read
-            // exactly once — this just makes the consume semantics explicit.
-            const heldBack = contAccum.takeHeldBackEvents();
-            if (heldBack) {
-              // Scale usage in held-back message_delta for anti-compaction
-              safeEnqueue(encoder.encode(heldBack));
-            }
-
-            const markerResp = replaceRecallWithMarker(
-              contAccum.hasRecall() ? contAccum.getResponse() : currentResp,
-              new Map([[recallBlock.id, markerText]]),
-            );
-            clearKeepalive();
-            onComplete(markerResp);
-            safeClose();
-            return;
+          } else {
+            log.error("streaming pipeline error:", err);
+          }
+          try {
+            controller.error(err);
+          } catch {
+            // Controller already closed or cancelled — error already logged above
           }
         }
-
-        // No recall — normal path
-        clearKeepalive();
-        const response = accumulator.getResponse();
-        onComplete(response);
-        safeClose();
-      } catch (err) {
-        clearKeepalive();
-        // Client disconnect / abort is benign — downgrade from error to info
-        // to avoid Sentry noise from normal connection lifecycle events.
-        const isAbort =
-          err instanceof DOMException && err.name === "AbortError";
-        if (isAbort) {
-          log.info("streaming pipeline aborted (client disconnect)");
-          // Only surfaces to Sentry if the host was under pressure at abort time.
-          captureClientAbortUnderPressure({
-            startMs: streamStartMs,
-            route: "stream",
-            sessionID,
-          });
-        } else {
-          log.error("streaming pipeline error:", err);
-        }
-        try {
-          controller.error(err);
-        } catch {
-          // Controller already closed or cancelled — error already logged above
-        }
-      }
+      })();
+    },
+    pull() {
+      resumeDemand?.();
+      resumeDemand = undefined;
     },
     cancel() {
+      resumeDemand?.();
+      resumeDemand = undefined;
       if (keepaliveTimer) clearTimeout(keepaliveTimer);
       keepaliveTimer = null;
       cancelled = true;
-      try {
-        void activeReader?.cancel();
-      } catch {
-        /* ignore */
+      streamSignal.removeEventListener("abort", onStreamAbort);
+      clearRecallDeadline();
+      recallAbort.abort(new DOMException("client disconnected", "AbortError"));
+      if (activeReader) {
+        cancelAndReleaseReader(activeReader);
+        activeReader = null;
       }
     },
   });
@@ -5665,6 +5796,8 @@ export function streamResponsesRecallAware(
     maxRetainedStateBytes?: number;
     maxStreamBytes?: number;
     maxSSEFrames?: number;
+    /** Caller abort combined with the stream's client-disconnect controller. */
+    signal?: AbortSignal;
     /**
      * Called when a `recall` function_call is fully parsed. Runs the recall
      * (LTM search + optional LLM result) and returns the pieces needed to
@@ -5838,7 +5971,7 @@ export function streamResponsesRecallAware(
   let hiddenRecallBytes = 0;
   const maxSSEFrames = opts.maxSSEFrames ?? 100_000;
   const frameCounter = { count: 0 };
-  const sseInactivityMs = 120_000;
+  const sseInactivityMs = FOREGROUND_SSE_INACTIVITY_MS;
 
   const parseRecallArguments = (
     value: unknown,
@@ -5967,7 +6100,9 @@ export function streamResponsesRecallAware(
   let cancelled = false;
   let terminalDelivered = false;
   const abortController = new AbortController();
-  const signal = abortController.signal;
+  const signal = opts.signal
+    ? AbortSignal.any([opts.signal, abortController.signal])
+    : abortController.signal;
   let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
 
   const outputIndexForEvent = (
@@ -7142,7 +7277,7 @@ export function streamResponsesRecallAware(
     const cancelLateReader = async (): Promise<void> => {
       try {
         const late = await operation;
-        await late.reader.cancel();
+        cancelAndReleaseReader(late.reader, signal.reason);
       } catch {
         // The aborted request no longer observes the callback result.
       }
@@ -7167,7 +7302,7 @@ export function streamResponsesRecallAware(
       signal.removeEventListener("abort", onAbort);
     }
     if (signal.aborted) {
-      void result.reader.cancel().catch(() => {});
+      cancelAndReleaseReader(result.reader, signal.reason);
       throw signal.reason;
     }
     return result;
@@ -7374,15 +7509,32 @@ export function streamResponsesRecallAware(
   }
 
   let resumeDemand: (() => void) | undefined;
+  const cleanupAbort = (): void =>
+    signal.removeEventListener("abort", onStreamAbort);
+  const onStreamAbort = (): void => {
+    resumeDemand?.();
+    resumeDemand = undefined;
+    if (keepaliveTimer) clearTimeout(keepaliveTimer);
+    keepaliveTimer = null;
+    if (activeReader) cancelAndReleaseReader(activeReader, signal.reason);
+    else void upstreamResponse.body?.cancel(signal.reason).catch(() => {});
+  };
+  signal.addEventListener("abort", onStreamAbort, { once: true });
+  if (signal.aborted) onStreamAbort();
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       void (async () => {
         const waitForDemand = async (): Promise<void> => {
-          while (!cancelled && (controller.desiredSize ?? 1) <= 0) {
+          while (
+            !cancelled &&
+            !signal.aborted &&
+            (controller.desiredSize ?? 1) <= 0
+          ) {
             await new Promise<void>((resolve) => {
               resumeDemand = resolve;
             });
           }
+          signal.throwIfAborted();
         };
         const safeEnqueue = async (chunk: Uint8Array): Promise<boolean> => {
           if (cancelled) return false;
@@ -7397,6 +7549,7 @@ export function streamResponsesRecallAware(
           }
         };
         const safeClose = (): void => {
+          cleanupAbort();
           if (cancelled) return;
           try {
             controller.close();
@@ -7404,15 +7557,26 @@ export function streamResponsesRecallAware(
             // Already closed/cancelled
           }
         };
+        const safeError = (error: unknown): void => {
+          cleanupAbort();
+          if (cancelled) return;
+          try {
+            controller.error(error);
+          } catch {
+            // Already closed/cancelled.
+          }
+        };
 
         const resetKeepalive = (): void => {
           if (keepaliveTimer) clearTimeout(keepaliveTimer);
           keepaliveTimer = setTimeout(function tick() {
-            if (cancelled) return;
+            if (cancelled || signal.aborted) return;
             if ((controller.desiredSize ?? 1) > 0) {
               void safeEnqueue(keepaliveComment);
             }
-            keepaliveTimer = setTimeout(tick, KEEPALIVE_INACTIVITY_MS);
+            if (!signal.aborted) {
+              keepaliveTimer = setTimeout(tick, KEEPALIVE_INACTIVITY_MS);
+            }
           }, KEEPALIVE_INACTIVITY_MS);
         };
         const clearKeepalive = (): void => {
@@ -7616,7 +7780,7 @@ export function streamResponsesRecallAware(
                   ))
                 )
                   break;
-                void reader.cancel().catch(() => {});
+                cancelAndReleaseReader(reader, signal.reason);
                 principalReader = null;
                 clearKeepalive();
                 finish(finalizeResponsesAcc(state));
@@ -7970,7 +8134,7 @@ export function streamResponsesRecallAware(
                           }
                         }
                       } finally {
-                        void follow.reader.cancel().catch(() => {});
+                        cancelAndReleaseReader(follow.reader, signal.reason);
                       }
                       const mergeContinuation = (): void => {
                         for (const item of contState.rawItems.values()) {
@@ -8205,7 +8369,7 @@ export function streamResponsesRecallAware(
               for (const commit of pendingCommits.splice(0)) commit();
               transactionRollbacks.length = 0;
               transactionBaseline = undefined;
-              void reader.cancel().catch(() => {});
+              cancelAndReleaseReader(reader, signal.reason);
               principalReader = null;
               safeClose();
               return;
@@ -8230,10 +8394,14 @@ export function streamResponsesRecallAware(
         } catch (err) {
           rollbackTransaction();
           if (principalReader) {
-            void principalReader.cancel().catch(() => {});
+            cancelAndReleaseReader(principalReader, signal.reason);
           }
           principalReader = null;
           clearKeepalive();
+          if (opts.signal?.aborted && !cancelled) {
+            safeError(opts.signal.reason);
+            return;
+          }
           if (terminalDelivered) {
             safeClose();
             return;
@@ -8245,7 +8413,11 @@ export function streamResponsesRecallAware(
               `openai-responses recall-aware stream aborted${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
             );
             if (cancelled || signal.aborted) {
-              safeClose();
+              if (opts.signal?.aborted && !cancelled) {
+                safeError(opts.signal.reason);
+              } else {
+                safeClose();
+              }
               return;
             }
           } else {
@@ -8291,7 +8463,16 @@ export function streamResponsesRecallAware(
           finish(failedResponse);
           safeClose();
         }
-      })();
+      })().catch((error) => {
+        cleanupAbort();
+        if (keepaliveTimer) clearTimeout(keepaliveTimer);
+        keepaliveTimer = null;
+        try {
+          controller.error(error);
+        } catch {
+          // Already closed/cancelled.
+        }
+      });
     },
 
     pull() {
@@ -8302,20 +8483,14 @@ export function streamResponsesRecallAware(
       resumeDemand?.();
       resumeDemand = undefined;
       cancelled = true;
+      cleanupAbort();
       rollbackTransaction();
       abortController.abort(
         new DOMException("Responses client disconnected", "AbortError"),
       );
       if (keepaliveTimer) clearTimeout(keepaliveTimer);
-      try {
-        if (activeReader) {
-          void activeReader.cancel();
-        } else {
-          void upstreamResponse.body?.cancel();
-        }
-      } catch {
-        // Best-effort cancellation
-      }
+      if (activeReader) cancelAndReleaseReader(activeReader, signal.reason);
+      else void upstreamResponse.body?.cancel(signal.reason).catch(() => {});
     },
   });
 
@@ -8337,7 +8512,98 @@ export function streamResponsesRecallAware(
  *  - "openai": OpenAI Chat Completions API format
  *  - "openai-responses": OpenAI Responses API format
  */
-async function accumulateNonStreamResponse(
+const MAX_FOREGROUND_RESPONSE_BYTES = 4 * 1024 * 1024;
+const MAX_FOREGROUND_ERROR_BYTES = 64 * 1024;
+const FOREGROUND_SSE_INACTIVITY_MS = 120_000;
+
+export async function readForegroundBody(
+  response: Response,
+  diagnostic: boolean,
+  onTruncated?: () => void,
+  signal?: AbortSignal,
+): Promise<string> {
+  const limit = diagnostic
+    ? MAX_FOREGROUND_ERROR_BYTES
+    : MAX_FOREGROUND_RESPONSE_BYTES;
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await readStreamChunk(reader, { signal });
+      if (done) break;
+      if (!value) continue;
+      const remaining = limit - bytes;
+      if (value.byteLength >= remaining) {
+        if (!diagnostic) {
+          if (value.byteLength > remaining) {
+            throw new Error(`foreground response exceeded ${limit} byte limit`);
+          }
+        } else {
+          // Reaching the cap is conservatively treated as truncation: proving
+          // exact EOF would require one more read, which may stall forever.
+          onTruncated?.();
+          if (remaining > 0) chunks.push(value.subarray(0, remaining));
+          bytes += Math.max(0, remaining);
+          break;
+        }
+      }
+      chunks.push(value);
+      bytes += value.byteLength;
+    }
+    const body = Buffer.concat(chunks);
+    if (diagnostic) return new TextDecoder().decode(body);
+    try {
+      return new TextDecoder("utf-8", { fatal: true }).decode(body);
+    } catch {
+      throw new Error("malformed upstream response UTF-8");
+    }
+  } finally {
+    cancelAndReleaseReader(reader);
+  }
+}
+
+async function preserveUpstreamErrorResponse(
+  response: Response,
+  signal?: AbortSignal,
+): Promise<Response> {
+  let truncated = false;
+  const body = await readForegroundBody(
+    response,
+    true,
+    () => {
+      truncated = true;
+    },
+    signal,
+  );
+  const headers = new Headers(response.headers);
+  // The retained body may be shorter than the provider's original payload.
+  for (const name of [
+    "connection",
+    "content-encoding",
+    "content-length",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "set-cookie",
+    "set-cookie2",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+  ]) {
+    headers.delete(name);
+  }
+  if (truncated) headers.set("x-lore-body-truncated", "true");
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function accumulateNonStreamResponse(
   upstreamResponse: Response,
   protocol:
     | "anthropic"
@@ -8345,6 +8611,8 @@ async function accumulateNonStreamResponse(
     | "openai-responses"
     | "vertex"
     | "gemini" = "anthropic",
+  codex = false,
+  signal?: AbortSignal,
 ): Promise<GatewayResponse> {
   // Some providers (the ChatGPT/Copilot/Codex backend, DeepSeek) return an SSE
   // stream even when stream: false was sent — sometimes WITHOUT the
@@ -8355,21 +8623,43 @@ async function accumulateNonStreamResponse(
   // "data: {...}" / "event: ..." text — LOREAI-GATEWAY-38 / -1P). Otherwise
   // parse the single JSON body.
   const contentType = upstreamResponse.headers.get("content-type") ?? "";
-  const body = await upstreamResponse.text();
+  const body = await readForegroundBody(
+    upstreamResponse,
+    false,
+    undefined,
+    signal,
+  );
   if (looksLikeSSE(contentType, body)) {
     const sse = new Response(body, {
       headers: { "content-type": "text/event-stream" },
     });
     switch (protocol) {
       case "openai":
-        return accumulateOpenAISSEStream(sse);
+        return accumulateOpenAISSEStream(sse, {
+          signal,
+          strict: true,
+          stopAtTerminal: true,
+          consumeUntilDone: true,
+        });
       case "openai-responses":
-        return accumulateResponsesSSEStream(sse);
+        return accumulateResponsesSSEStream(sse, {
+          signal,
+          validation: codex ? "codex" : "public",
+          stopAtTerminal: true,
+        });
       case "gemini":
-        return accumulateGeminiSSEStream(sse);
+        return accumulateGeminiSSEStream(sse, {
+          signal,
+          strict: true,
+          stopAtTerminal: true,
+        });
       default:
         // Anthropic wire (incl. Vertex/Bedrock-mantle) SSE.
-        return accumulateSSEResponse(sse);
+        return accumulateSSEResponse(sse, {
+          signal,
+          strict: true,
+          stopAtTerminal: true,
+        });
     }
   }
 
@@ -8395,7 +8685,82 @@ export function accumulateOpenAINonStreamJSON(
   json: Record<string, unknown>,
 ): GatewayResponse {
   const content: GatewayContentBlock[] = [];
+  if (json.choices !== undefined && !Array.isArray(json.choices)) {
+    throw new Error("malformed OpenAI response choice");
+  }
   const choices = json.choices as Array<Record<string, unknown>> | undefined;
+  const logicalChoiceIndices = new Set<number>();
+  for (let position = 0; position < (choices?.length ?? 0); position++) {
+    const choice = choices?.[position];
+    if (!choice || typeof choice !== "object" || Array.isArray(choice)) {
+      throw new Error("malformed OpenAI response choice");
+    }
+    const logicalIndex =
+      choice.index === undefined ? position : (choice.index as number);
+    if (
+      !Number.isSafeInteger(logicalIndex) ||
+      logicalIndex < 0 ||
+      logicalChoiceIndices.has(logicalIndex)
+    ) {
+      throw new Error("malformed OpenAI response choice");
+    }
+    logicalChoiceIndices.add(logicalIndex);
+  }
+  for (const choice of choices ?? []) {
+    const choiceToolIdentities = new Set<string>();
+    if (
+      !choice ||
+      typeof choice !== "object" ||
+      Array.isArray(choice) ||
+      (choice.index !== undefined &&
+        (!Number.isSafeInteger(choice.index) ||
+          (choice.index as number) < 0)) ||
+      (choice.finish_reason !== undefined &&
+        choice.finish_reason !== null &&
+        typeof choice.finish_reason !== "string") ||
+      !choice.message ||
+      typeof choice.message !== "object" ||
+      Array.isArray(choice.message)
+    ) {
+      throw new Error("malformed OpenAI response choice");
+    }
+    const candidateMessage = choice.message as Record<string, unknown>;
+    if (
+      (candidateMessage.content !== undefined &&
+        candidateMessage.content !== null &&
+        typeof candidateMessage.content !== "string") ||
+      (candidateMessage.role !== undefined &&
+        typeof candidateMessage.role !== "string")
+    ) {
+      throw new Error("malformed OpenAI response choice");
+    }
+    const candidateCalls = candidateMessage?.tool_calls;
+    if (candidateCalls === undefined) continue;
+    if (!Array.isArray(candidateCalls)) {
+      throw new Error("malformed OpenAI response tool identity");
+    }
+    for (const call of candidateCalls) {
+      if (!call || typeof call !== "object" || Array.isArray(call)) {
+        throw new Error("malformed OpenAI response choice");
+      }
+      const typedCall = call as Record<string, unknown>;
+      const fn = typedCall.function;
+      if (
+        !fn ||
+        typeof fn !== "object" ||
+        Array.isArray(fn) ||
+        typeof (fn as Record<string, unknown>).name !== "string" ||
+        typeof (fn as Record<string, unknown>).arguments !== "string"
+      ) {
+        throw new Error("malformed OpenAI response choice");
+      }
+      const id = asString(typedCall.id);
+      if (!id || choiceToolIdentities.has(id)) {
+        throw new Error("malformed OpenAI response tool identity");
+      }
+      choiceToolIdentities.add(id);
+    }
+  }
   const firstChoice = choices?.[0];
   const message = firstChoice?.message as Record<string, unknown> | undefined;
 
@@ -8408,6 +8773,7 @@ export function accumulateOpenAINonStreamJSON(
       | Array<Record<string, unknown>>
       | undefined;
     if (toolCalls) {
+      const toolIdentities = new Set<string>();
       for (const tc of toolCalls) {
         const fn = tc.function as Record<string, unknown> | undefined;
         let input: unknown = {};
@@ -8418,9 +8784,14 @@ export function accumulateOpenAINonStreamJSON(
             input = fn.arguments;
           }
         }
+        const id = asString(tc.id);
+        if (!id || toolIdentities.has(id)) {
+          throw new Error("malformed OpenAI response tool identity");
+        }
+        toolIdentities.add(id);
         content.push({
           type: "tool_use",
-          id: asString(tc.id),
+          id,
           name: asString(fn?.name),
           input,
         });
@@ -8435,7 +8806,10 @@ export function accumulateOpenAINonStreamJSON(
   else if (finishReason === "length") stopReason = "max_tokens";
   else if (finishReason === "tool_calls") stopReason = "tool_use";
 
-  const usage = json.usage as Record<string, unknown> | undefined;
+  const usage = validateOpenAIUsage(
+    json.usage,
+    "malformed OpenAI response usage",
+  );
   const promptTokensDetails = usage?.prompt_tokens_details as
     | Record<string, number>
     | undefined;
@@ -8475,7 +8849,14 @@ export function accumulateResponsesNonStreamJSON(
   );
 
   if (replayableOutput) {
+    const toolIdentities = new Set<string>();
+    const outputItemIds = new Set<string>();
     for (const item of replayableOutput) {
+      const itemId = asString(item.id);
+      if (!itemId || outputItemIds.has(itemId)) {
+        throw new Error("malformed Responses response item identity");
+      }
+      outputItemIds.add(itemId);
       if (item.type === "message") {
         const msgContent = item.content as
           | Array<Record<string, unknown>>
@@ -8496,9 +8877,14 @@ export function accumulateResponsesNonStreamJSON(
             input = item.arguments;
           }
         }
+        const id = asString(item.call_id ?? item.id);
+        if (!id || toolIdentities.has(id)) {
+          throw new Error("malformed Responses response tool identity");
+        }
+        toolIdentities.add(id);
         content.push({
           type: "tool_use",
-          id: asString(item.call_id ?? item.id),
+          id,
           name: asString(item.name),
           input,
         });
@@ -8514,7 +8900,10 @@ export function accumulateResponsesNonStreamJSON(
     stopReason = "tool_use";
   }
 
-  const usage = json.usage as Record<string, unknown> | undefined;
+  const usage = validateResponsesUsage(
+    json.usage,
+    "malformed Responses response usage",
+  );
   // Responses API reports cache details under `input_tokens_details`; fall back
   // to `prompt_tokens_details` (Chat Completions shape) for resilience across
   // OpenAI-compatible providers.
@@ -8649,28 +9038,6 @@ export function responsesAnchorContext(
     ...visibleContent,
     ...responsesProvenanceContent(response, new Map(), stopBeforeToolUseId),
   ]);
-}
-
-/**
- * Accumulate a streaming upstream Anthropic SSE response into a GatewayResponse.
- *
- * Used for Anthropic requests where we need to convert the accumulated
- * response to another format before returning to the client.
- */
-async function _accumulateStreamResponse(
-  upstreamResponse: Response,
-): Promise<GatewayResponse> {
-  const accumulator = createStreamAccumulator();
-  if (!upstreamResponse.body) {
-    throw new Error("Upstream response has no body");
-  }
-  const reader = upstreamResponse.body.getReader();
-
-  for await (const { event, data } of parseSSEStream(reader)) {
-    accumulator.processEvent(event, data);
-  }
-
-  return accumulator.getResponse();
 }
 
 /**
@@ -9678,9 +10045,11 @@ export async function generateCompactionSummary(opts: {
   config: GatewayConfig;
   previousSummary?: string;
   sessionUpstream?: { providerID?: string; modelID?: string };
+  signal?: AbortSignal;
 }): Promise<string | null> {
   const { projectPath, sessionID, config, previousSummary, sessionUpstream } =
     opts;
+  opts.signal?.throwIfAborted();
 
   // 1. Bring distillations current. Compaction does NOT make a dedicated
   //    "compaction" LLM call anymore — its only LLM work is distilling the
@@ -9692,28 +10061,37 @@ export async function generateCompactionSummary(opts: {
   if (temporal.undistilledCount(projectPath, sessionID) > 0) {
     const llm = getLLMClient(config);
     const model = getWorkerModel(sessionUpstream);
-    await distillation.run({
-      llm,
-      projectPath,
-      sessionID,
-      model,
-      force: true,
-      urgent: true,
-      callType: "direct",
-      workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
-      // #627 Phase 1: stamp the session's gitHead on urgent-compaction rows.
-      // Compaction is invoked via HTTP intercept or /v1/compact, so we look up
-      // the session by ID rather than threading state through the call.
-      metadata: buildSessionMetadata(sessions.get(sessionID)?.gitHead),
-    });
+    await promiseAgainstAbort(
+      () =>
+        distillation.run({
+          llm,
+          projectPath,
+          sessionID,
+          model,
+          force: true,
+          urgent: true,
+          callType: "direct",
+          signal: opts.signal,
+          workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
+          // #627 Phase 1: stamp the session's gitHead on urgent-compaction rows.
+          // Compaction is invoked via HTTP intercept or /v1/compact, so we look up
+          // the session by ID rather than threading state through the call.
+          metadata: buildSessionMetadata(sessions.get(sessionID)?.gitHead),
+        }),
+      opts.signal,
+    );
   }
 
   // 2. Load distillation summaries + long-term knowledge.
   const distillations = distillation.loadForSession(projectPath, sessionID);
   const cfg = loreConfig();
   const entries = cfg.knowledge.enabled
-    ? await ltm.forProjectOffloaded(projectPath, cfg.crossProject)
+    ? await promiseAgainstAbort(
+        () => ltm.forProjectOffloaded(projectPath, cfg.crossProject),
+        opts.signal,
+      )
     : [];
+  opts.signal?.throwIfAborted();
   const knowledge = entries.length
     ? formatKnowledge(
         entries.map((e) => ({
@@ -9746,7 +10124,7 @@ export async function generateCompactionSummary(opts: {
 // Case 1: Compaction interception
 // ---------------------------------------------------------------------------
 
-async function handleCompaction(
+async function handleCompactionInner(
   req: GatewayRequest,
   config: GatewayConfig,
 ): Promise<Response> {
@@ -9796,6 +10174,7 @@ async function handleCompaction(
     config,
     previousSummary: extractPreviousSummary(req),
     sessionUpstream: sessionState.lastUpstream,
+    signal: req.signal,
   });
 
   if (req.stream) {
@@ -9826,13 +10205,19 @@ async function handleCompaction(
     // Always Anthropic SSE — wrap for OpenAI-protocol clients (their
     // translators skip pings).
     if (req.protocol === "openai") {
-      return translateAnthropicStreamToOpenAI(anthropicSSE);
+      return translateAnthropicStreamToOpenAI(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     if (req.protocol === "openai-responses") {
-      return translateAnthropicStreamToResponses(anthropicSSE);
+      return translateAnthropicStreamToResponses(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     if (req.protocol === "gemini") {
-      return translateAnthropicStreamToGemini(anthropicSSE);
+      return translateAnthropicStreamToGemini(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     return anthropicSSE;
   }
@@ -9854,6 +10239,23 @@ async function handleCompaction(
     undefined,
     requestEnablesLongContext(req),
   );
+}
+
+async function handleCompaction(
+  req: GatewayRequest,
+  config: GatewayConfig,
+): Promise<Response> {
+  const abortScope = createForegroundAbortScope(req.signal);
+  try {
+    const response = await handleCompactionInner(
+      { ...req, signal: abortScope.signal },
+      config,
+    );
+    return wrapBodyWithCleanup(response, abortScope.dispose, abortScope.signal);
+  } catch (error) {
+    abortScope.dispose();
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -9955,10 +10357,28 @@ export function shouldCancelCompactionFromBudget(
  *                     `cfg.compaction = { auto: false, prune: false }` — the
  *                     gateway manages the window, not the host agent.
  */
-export async function handleCompactEndpoint(
+async function handleCompactEndpointInner(
   req: Request,
   config: GatewayConfig,
+  signal: AbortSignal,
 ): Promise<Response> {
+  // Authenticate from headers before touching a potentially unbounded or
+  // stalled upload. This endpoint always requires a provider credential.
+  const rawHeaders: Record<string, string> = {};
+  req.headers.forEach((value, key) => {
+    rawHeaders[key] = value;
+  });
+  const credential = extractAuth(rawHeaders);
+  if (!credential) {
+    return new Response(
+      JSON.stringify({
+        error: "unauthorized",
+        message: "A provider credential is required",
+      }),
+      { status: 401, headers: { "content-type": "application/json" } },
+    );
+  }
+
   let body: {
     project_path?: string;
     previous_summary?: string;
@@ -9966,7 +10386,7 @@ export async function handleCompactEndpoint(
   };
   try {
     // Decode any Content-Encoding (e.g. zstd) before JSON-parsing.
-    body = JSON.parse(await decodeRequestBody(req)) as typeof body;
+    body = JSON.parse(await decodeRequestBody(req, signal)) as typeof body;
   } catch {
     return new Response(
       JSON.stringify({
@@ -9989,21 +10409,7 @@ export async function handleCompactEndpoint(
   }
 
   // Extract git remote from header if available (Pi plugin injects this).
-  const rawHeaders: Record<string, string> = {};
-  req.headers.forEach((value, key) => {
-    rawHeaders[key] = value;
-  });
   const gitRemote = extractGitRemoteHeader(rawHeaders);
-  const credential = extractAuth(rawHeaders);
-  if (!credential) {
-    return new Response(
-      JSON.stringify({
-        error: "unauthorized",
-        message: "A provider credential is required",
-      }),
-      { status: 401, headers: { "content-type": "application/json" } },
-    );
-  }
 
   // Build a minimal GatewayRequest for session identification.
   // Only rawHeaders and messages are used by identifySession().
@@ -10109,6 +10515,7 @@ export async function handleCompactEndpoint(
           ? body.previous_summary
           : undefined,
       sessionUpstream: state?.lastUpstream,
+      signal,
     });
 
     if (summary == null) {
@@ -10145,6 +10552,24 @@ export async function handleCompactEndpoint(
   }
 }
 
+export async function handleCompactEndpoint(
+  req: Request,
+  config: GatewayConfig,
+): Promise<Response> {
+  const abortScope = createForegroundAbortScope(req.signal);
+  try {
+    const response = await handleCompactEndpointInner(
+      req,
+      config,
+      abortScope.signal,
+    );
+    return wrapBodyWithCleanup(response, abortScope.dispose, abortScope.signal);
+  } catch (error) {
+    abortScope.dispose();
+    throw error;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Case 1c: Codex compaction endpoint (POST /v1/responses/compact)
 // ---------------------------------------------------------------------------
@@ -10162,15 +10587,27 @@ export async function handleCompactEndpoint(
  *  3. On success: return a Responses-API-style compacted output.
  *  4. On failure: passthrough to the upstream OpenAI API.
  */
-export async function handleResponsesCompactEndpoint(
+async function handleResponsesCompactEndpointInner(
   req: Request,
   config: GatewayConfig,
+  signal: AbortSignal,
 ): Promise<Response> {
   // Read the body as text so we can both parse it and replay it for passthrough.
   // Decode any Content-Encoding (Codex sends zstd by default) first — otherwise
   // the raw compressed bytes fail to JSON.parse and the passthrough replays
   // undecodable bytes upstream.
-  const bodyText = await decodeRequestBody(req);
+  let bodyText: string;
+  try {
+    bodyText = await decodeRequestBody(req, signal);
+  } catch {
+    return new Response(
+      JSON.stringify({
+        error: "invalid_request",
+        message: "Invalid JSON body",
+      }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
   let body: Record<string, unknown>;
   try {
     body = JSON.parse(bodyText) as Record<string, unknown>;
@@ -10200,7 +10637,12 @@ export async function handleResponsesCompactEndpoint(
     log.warn(
       "responses/compact: failed to parse request body — falling back to upstream",
     );
-    return await passthroughResponsesCompact(bodyText, rawHeaders, config);
+    return await passthroughResponsesCompact(
+      bodyText,
+      rawHeaders,
+      config,
+      signal,
+    );
   }
 
   const pathResult = getProjectPath(gatewayReq.system, rawHeaders);
@@ -10224,6 +10666,7 @@ export async function handleResponsesCompactEndpoint(
         projectPath: pathResult.path,
         sessionID,
         config,
+        signal,
       });
 
       if (summary != null) {
@@ -10270,17 +10713,42 @@ export async function handleResponsesCompactEndpoint(
   }
 
   // Fallback: passthrough to upstream OpenAI /v1/responses/compact
-  return await passthroughResponsesCompact(bodyText, rawHeaders, config);
+  return await passthroughResponsesCompact(
+    bodyText,
+    rawHeaders,
+    config,
+    signal,
+  );
+}
+
+export async function handleResponsesCompactEndpoint(
+  req: Request,
+  config: GatewayConfig,
+): Promise<Response> {
+  const abortScope = createForegroundAbortScope(req.signal);
+  try {
+    const response = await handleResponsesCompactEndpointInner(
+      req,
+      config,
+      abortScope.signal,
+    );
+    return wrapBodyWithCleanup(response, abortScope.dispose, abortScope.signal);
+  } catch (error) {
+    abortScope.dispose();
+    throw error;
+  }
 }
 
 /**
  * Forward a compaction request to the upstream OpenAI API as-is.
  */
-async function passthroughResponsesCompact(
+export async function passthroughResponsesCompact(
   bodyText: string,
   rawHeaders: Record<string, string>,
   config: GatewayConfig,
+  callerSignal?: AbortSignal,
 ): Promise<Response> {
+  const abortScope = createForegroundAbortScope(callerSignal);
   const upstreamUrl = `${config.upstreamOpenAI}/v1/responses/compact`;
   const headers: Record<string, string> = {
     "content-type": "application/json",
@@ -10322,17 +10790,19 @@ async function passthroughResponsesCompact(
   applyUpstreamExtraHeaders(headers, config.upstreamExtraHeaders);
 
   try {
-    const upstream = await upstreamFetch(upstreamUrl, {
-      method: "POST",
-      headers,
-      body: passthroughBody,
-    });
-    return new Response(upstream.body, {
-      status: upstream.status,
-      statusText: upstream.statusText,
-      headers: new Headers(upstream.headers),
-    });
+    const upstream = await responseAgainstAbort(
+      () =>
+        upstreamFetch(upstreamUrl, {
+          method: "POST",
+          headers,
+          body: passthroughBody,
+          signal: abortScope.signal,
+        }),
+      abortScope.signal,
+    );
+    return wrapBodyWithCleanup(upstream, abortScope.dispose, abortScope.signal);
   } catch (err) {
+    abortScope.dispose();
     const msg = err instanceof Error ? err.message : "Upstream unreachable";
     log.error("responses/compact upstream passthrough error:", err);
     return new Response(
@@ -10349,14 +10819,320 @@ async function passthroughResponsesCompact(
 // Case 2: Meta request passthrough (title gen, summaries, categorization, etc.)
 // ---------------------------------------------------------------------------
 
+const FOREGROUND_REQUEST_TIMEOUT_MS = 300_000;
+
+export function abortAwareDelay(
+  delayMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (delayMs <= 0) return Promise.resolve();
+  signal?.throwIfAborted();
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => signal?.removeEventListener("abort", onAbort);
+    const finish = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanup();
+      operation();
+    };
+    const onAbort = (): void => finish(() => reject(signal?.reason));
+    const timer = setTimeout(() => finish(resolve), delayMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+}
+
+export async function completeBudgetThrottleDelay(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+  record: () => void,
+): Promise<void> {
+  await abortAwareDelay(delayMs, signal);
+  signal?.throwIfAborted();
+  record();
+}
+
+export function createForegroundAbortScope(caller?: AbortSignal): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  const controller = new AbortController();
+  const onCallerAbort = () => controller.abort(caller?.reason);
+  caller?.addEventListener("abort", onCallerAbort, { once: true });
+  if (caller?.aborted) onCallerAbort();
+  const timer = setTimeout(
+    () =>
+      controller.abort(
+        new DOMException("foreground request timed out", "TimeoutError"),
+      ),
+    FOREGROUND_REQUEST_TIMEOUT_MS,
+  );
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      clearTimeout(timer);
+      caller?.removeEventListener("abort", onCallerAbort);
+    },
+  };
+}
+
+export function wrapBodyWithCleanup(
+  response: Response,
+  cleanup: () => void,
+  signal?: AbortSignal,
+): Response {
+  if (!response.body) {
+    cleanup();
+    return response;
+  }
+  const reader = response.body.getReader();
+  let finished = false;
+  let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const onAbort = (): void => {
+    if (finished) return;
+    const reason = signal?.reason;
+    finish();
+    cancelAndReleaseReader(reader, reason);
+    try {
+      bodyController?.error(reason);
+    } catch {
+      // Already closed/cancelled.
+    }
+  };
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    signal?.removeEventListener("abort", onAbort);
+    cleanup();
+  };
+  const body = new ReadableStream<Uint8Array>(
+    {
+      start(controller) {
+        bodyController = controller;
+      },
+      async pull(controller) {
+        try {
+          const { done, value } = await readStreamChunk(reader, { signal });
+          if (done) {
+            finish();
+            try {
+              reader.releaseLock();
+            } catch {
+              // The stream completed with no pending read in normal runtimes.
+            }
+            controller.close();
+          } else if (value) {
+            controller.enqueue(value);
+          }
+        } catch (error) {
+          finish();
+          cancelAndReleaseReader(reader, error);
+          controller.error(error);
+        }
+      },
+      cancel(reason) {
+        finish();
+        cancelAndReleaseReader(reader, reason);
+      },
+    },
+    // Do not read ahead while a terminal-aware downstream parser is handling
+    // the current chunk. It may cancel at that terminal while the transport
+    // remains open, and a speculative read can otherwise strand the wrapper.
+    { highWaterMark: 0 },
+  );
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted) onAbort();
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+export function validatedMetaStream(
+  response: Response,
+  protocol: "anthropic" | "openai" | "openai-responses" | "gemini",
+  codex: boolean,
+  signal?: AbortSignal,
+): Response {
+  if (protocol === "openai-responses") {
+    return streamResponsesPassthrough(
+      response,
+      () => {},
+      undefined,
+      codex ? "codex" : "public",
+      signal,
+    );
+  }
+  const abort = new AbortController();
+  let downstreamCancelled = false;
+  let externalAborted = false;
+  let pumpStarted = false;
+  let resumeDemand: (() => void) | undefined;
+  const cleanup = (): void => {
+    signal?.removeEventListener("abort", onAbort);
+  };
+  const onAbort = () => {
+    externalAborted = true;
+    resumeDemand?.();
+    resumeDemand = undefined;
+    abort.abort(signal?.reason);
+    if (!pumpStarted)
+      void response.body?.cancel(signal?.reason).catch(() => {});
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted) onAbort();
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let settled = false;
+      const waitForDemand = async (): Promise<void> => {
+        while (
+          !downstreamCancelled &&
+          !externalAborted &&
+          (controller.desiredSize ?? 1) <= 0
+        ) {
+          await new Promise<void>((resolve) => {
+            resumeDemand = resolve;
+          });
+        }
+        if (externalAborted) throw signal?.reason;
+      };
+      const forward = async (event: string, data: string): Promise<void> => {
+        await waitForDemand();
+        const wire =
+          event === "message"
+            ? `data: ${data}\n\n`
+            : formatSSEEvent(event, data);
+        controller.enqueue(encoder.encode(wire));
+      };
+      const safeClose = (): void => {
+        if (downstreamCancelled || settled) return;
+        settled = true;
+        cleanup();
+        try {
+          controller.close();
+        } catch {
+          // Already closed/cancelled.
+        }
+      };
+      const safeError = (error: unknown): void => {
+        if (downstreamCancelled || settled) return;
+        settled = true;
+        cleanup();
+        try {
+          controller.error(error);
+        } catch {
+          // Already closed/cancelled.
+        }
+      };
+      const pump = async (): Promise<void> => {
+        pumpStarted = true;
+        if (downstreamCancelled) return;
+        try {
+          if (protocol === "anthropic") {
+            if (!response.body)
+              throw new Error("Upstream response has no body");
+            const reader = response.body.getReader();
+            const validator = new AnthropicSSEValidator();
+            try {
+              for await (const { event, data } of parseSSEStream(reader, {
+                signal: abort.signal,
+                requireEventTerminator: true,
+                fatalUtf8: true,
+                maxFrames: DEFAULT_MAX_SSE_FRAMES,
+                maxTotalBytes: MAX_FOREGROUND_RESPONSE_BYTES,
+              })) {
+                validator.process(event, data);
+                await forward(event, data);
+                if (validator.isDone()) break;
+              }
+              validator.assertDone();
+            } finally {
+              cancelAndReleaseReader(reader);
+            }
+          } else if (protocol === "openai") {
+            await accumulateOpenAISSEStream(response, {
+              signal: abort.signal,
+              strict: true,
+              stopAtTerminal: true,
+              consumeUntilDone: true,
+              onValidatedEvent: forward,
+            });
+          } else {
+            await accumulateGeminiSSEStream(response, {
+              signal: abort.signal,
+              strict: true,
+              stopAtTerminal: true,
+              onValidatedEvent: forward,
+            });
+          }
+          safeClose();
+        } catch (error) {
+          if (downstreamCancelled) {
+            cleanup();
+            return;
+          }
+          safeError(externalAborted ? (signal?.reason ?? error) : error);
+        }
+      };
+      queueMicrotask(() => void pump().catch((error) => safeError(error)));
+    },
+    pull() {
+      resumeDemand?.();
+      resumeDemand = undefined;
+    },
+    cancel(reason) {
+      resumeDemand?.();
+      resumeDemand = undefined;
+      downstreamCancelled = true;
+      abort.abort(new DOMException("client disconnected", "AbortError"));
+      cleanup();
+      if (!pumpStarted) void response.body?.cancel(reason).catch(() => {});
+    },
+  });
+  return new Response(stream, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 async function handlePassthrough(
   req: GatewayRequest,
   config: GatewayConfig,
 ): Promise<Response> {
   setSentryLightContext({ model: req.model });
 
-  const { response: upstreamResponse, effectiveProtocol } =
-    await forwardToUpstream(req, config);
+  const abortScope = createForegroundAbortScope(req.signal);
+  let forwarded: UpstreamResult;
+  try {
+    forwarded = await forwardToUpstream(
+      req,
+      config,
+      undefined,
+      undefined,
+      abortScope.signal,
+    );
+  } catch (error) {
+    abortScope.dispose();
+    throw error;
+  }
+  const effectiveProtocol = forwarded.effectiveProtocol;
+  const upstreamResponse = wrapBodyWithCleanup(
+    forwarded.response,
+    abortScope.dispose,
+    abortScope.signal,
+  );
+
+  // Meta/side-channel calls must preserve provider errors as ordinary HTTP
+  // responses. Running a 4xx/429 body through an SSE validator would launder
+  // it into status 200 or a synthetic stream failure.
+  if (!upstreamResponse.ok) {
+    return preserveUpstreamErrorResponse(upstreamResponse, abortScope.signal);
+  }
 
   // Vertex speaks the native Anthropic wire format (Anthropic SSE for streaming
   // and the native Anthropic JSON shape for non-streaming), so for passthrough
@@ -10374,15 +11150,19 @@ async function handlePassthrough(
   // to a different protocol (e.g., OpenAI client → Anthropic upstream).
   if (wireProtocol === req.protocol) {
     if (req.stream && upstreamResponse.body) {
-      return new Response(upstreamResponse.body, {
-        status: upstreamResponse.status,
-        headers: {
-          "content-type":
-            upstreamResponse.headers.get("content-type") ?? "text/event-stream",
-        },
-      });
+      return validatedMetaStream(
+        upstreamResponse,
+        wireProtocol,
+        req.codex === true,
+        abortScope.signal,
+      );
     }
-    const body = await upstreamResponse.text();
+    const body = await readForegroundBody(
+      upstreamResponse,
+      false,
+      undefined,
+      abortScope.signal,
+    );
     return new Response(body, {
       status: upstreamResponse.status,
       headers: { "content-type": "application/json" },
@@ -10404,20 +11184,50 @@ async function handlePassthrough(
         },
       });
       if (req.protocol === "openai") {
-        return translateAnthropicStreamToOpenAI(anthropicSSE);
+        return translateAnthropicStreamToOpenAI(anthropicSSE, {
+          strict: true,
+          signal: abortScope.signal,
+        });
       }
       if (req.protocol === "openai-responses") {
-        return translateAnthropicStreamToResponses(anthropicSSE);
+        return translateAnthropicStreamToResponses(anthropicSSE, {
+          strict: true,
+          signal: abortScope.signal,
+        });
       }
       if (req.protocol === "gemini") {
-        return translateAnthropicStreamToGemini(anthropicSSE);
+        return translateAnthropicStreamToGemini(anthropicSSE, {
+          strict: true,
+          signal: abortScope.signal,
+        });
       }
     }
     // Other cross-protocol streaming combos: accumulate + re-emit
-    const resp = await accumulateNonStreamResponse(
-      upstreamResponse,
-      wireProtocol,
-    );
+    const resp =
+      wireProtocol === "openai"
+        ? await accumulateOpenAISSEStream(upstreamResponse, {
+            signal: abortScope.signal,
+            strict: true,
+            stopAtTerminal: true,
+            consumeUntilDone: true,
+          })
+        : wireProtocol === "openai-responses"
+          ? await accumulateResponsesSSEStream(upstreamResponse, {
+              signal: abortScope.signal,
+              validation: req.codex === true ? "codex" : "public",
+              stopAtTerminal: true,
+            })
+          : wireProtocol === "gemini"
+            ? await accumulateGeminiSSEStream(upstreamResponse, {
+                signal: abortScope.signal,
+                strict: true,
+                stopAtTerminal: true,
+              })
+            : await accumulateSSEResponse(upstreamResponse, {
+                signal: abortScope.signal,
+                strict: true,
+                stopAtTerminal: true,
+              });
     return nonStreamHttpResponse(
       resp,
       req.protocol,
@@ -10431,6 +11241,8 @@ async function handlePassthrough(
   const resp = await accumulateNonStreamResponse(
     upstreamResponse,
     wireProtocol,
+    req.codex === true,
+    abortScope.signal,
   );
   return nonStreamHttpResponse(
     resp,
@@ -10500,6 +11312,50 @@ export function decideSkipCompact(
 // ---------------------------------------------------------------------------
 // Case 3: Normal conversation turn — full pipeline
 // ---------------------------------------------------------------------------
+
+export function mergeRecallUsage(
+  current: GatewayUsage,
+  continuation: GatewayUsage,
+): GatewayUsage {
+  const merged: GatewayUsage = {
+    inputTokens: safeTokenSum(
+      [current.inputTokens, continuation.inputTokens],
+      "recall usage token overflow",
+    ),
+    outputTokens: safeTokenSum(
+      [current.outputTokens, continuation.outputTokens],
+      "recall usage token overflow",
+    ),
+  };
+  if (
+    current.cacheReadInputTokens !== undefined ||
+    continuation.cacheReadInputTokens !== undefined
+  ) {
+    merged.cacheReadInputTokens = safeTokenSum(
+      [current.cacheReadInputTokens, continuation.cacheReadInputTokens],
+      "recall usage token overflow",
+    );
+  }
+  if (
+    current.cacheCreationInputTokens !== undefined ||
+    continuation.cacheCreationInputTokens !== undefined
+  ) {
+    merged.cacheCreationInputTokens = safeTokenSum(
+      [current.cacheCreationInputTokens, continuation.cacheCreationInputTokens],
+      "recall usage token overflow",
+    );
+  }
+  safeTokenSum(
+    [
+      merged.inputTokens,
+      merged.outputTokens,
+      merged.cacheReadInputTokens,
+      merged.cacheCreationInputTokens,
+    ],
+    "recall usage token overflow",
+  );
+  return merged;
+}
 
 async function handleConversationTurn(
   req: GatewayRequest,
@@ -12121,6 +12977,11 @@ async function handleConversationTurn(
     distilledPrefixLength: result.distilledTokens > 0 ? 2 : 0,
   };
 
+  // The throttle is part of the foreground request's absolute lifetime. Start
+  // the shared scope before delaying so the 300-second deadline includes both
+  // the wait and every later upstream/recall phase.
+  const foregroundAbort = createForegroundAbortScope(modifiedReq.signal);
+
   // --- Daily budget + OAuth quota throttle ---
   // Apply an invisible proxy-level sleep to slow the agent when approaching
   // the daily budget OR the Anthropic OAuth quota. The sleep is capped to
@@ -12161,13 +13022,21 @@ async function handleConversationTurn(
             `spend=$${getDailySpend().spend.toFixed(2)} ` +
             `rate=$${getCostRate().toFixed(2)}/hr`,
         );
-        await new Promise((resolve) => setTimeout(resolve, actualDelay * 1000));
-
-        // Track throttle event on session costs
-        const costs = getSessionCosts(sessionID);
-        if (costs) {
-          costs.throttle.events++;
-          costs.throttle.totalDelayMs += actualDelay * 1000;
+        try {
+          await completeBudgetThrottleDelay(
+            actualDelay * 1000,
+            foregroundAbort.signal,
+            () => {
+              const costs = getSessionCosts(sessionID);
+              if (costs) {
+                costs.throttle.events++;
+                costs.throttle.totalDelayMs += actualDelay * 1000;
+              }
+            },
+          );
+        } catch (error) {
+          foregroundAbort.dispose();
+          throw error;
         }
       }
     }
@@ -12201,14 +13070,53 @@ async function handleConversationTurn(
     },
   });
 
-  const {
-    response: upstreamResponse,
-    serializedBody: requestBody,
-    effectiveProtocol,
-  } = await forwardToUpstream(modifiedReq, config, undefined, cacheOptions);
+  let upstreamResult: UpstreamResult;
+  try {
+    upstreamResult = await forwardToUpstream(
+      modifiedReq,
+      config,
+      undefined,
+      cacheOptions,
+      foregroundAbort.signal,
+    );
+  } catch (error) {
+    foregroundAbort.dispose();
+    throw error;
+  }
+  const upstreamResponse = wrapBodyWithCleanup(
+    upstreamResult.response,
+    () => {},
+    foregroundAbort.signal,
+  );
+  let foregroundOwnershipTransferred = false;
+  const finishForeground = (response: Response): Response => {
+    if (foregroundOwnershipTransferred) return response;
+    foregroundOwnershipTransferred = true;
+    return wrapBodyWithCleanup(
+      response,
+      foregroundAbort.dispose,
+      foregroundAbort.signal,
+    );
+  };
+  const awaitForeground = async <T>(operation: Promise<T>): Promise<T> => {
+    try {
+      return await operation;
+    } catch (error) {
+      if (!foregroundOwnershipTransferred) foregroundAbort.dispose();
+      throw error;
+    }
+  };
+  const { serializedBody: requestBody, effectiveProtocol } = upstreamResult;
 
   if (!upstreamResponse.ok) {
-    const errorBody = await upstreamResponse.text();
+    const errorBody = await awaitForeground(
+      readForegroundBody(
+        upstreamResponse,
+        true,
+        undefined,
+        foregroundAbort.signal,
+      ),
+    );
     // Friendly diagnostic suffix for a pass-through 429 misread as a Lore bug.
     // 🔴 credScheme is the LOAD-BEARING exclusion for Bedrock: Bedrock also
     // reports effectiveProtocol === "anthropic", so the protocol gate does NOT
@@ -12268,10 +13176,12 @@ async function handleConversationTurn(
       message: `HTTP ${upstreamResponse.status}`,
     });
     genAiSpan.end();
-    return new Response(errorBody, {
-      status: upstreamResponse.status,
-      headers: { "content-type": "application/json" },
-    });
+    return finishForeground(
+      new Response(errorBody, {
+        status: upstreamResponse.status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
   }
 
   // Run the recall-interception loop over an already-accumulated
@@ -12310,12 +13220,17 @@ async function handleConversationTurn(
       recallDepth++;
       const recallBlock = findRecallToolUse(currentResp);
       if (!recallBlock) break;
-      const { result, input } = await executeRecall(
-        recallBlock,
-        sessionState.projectPath,
-        sessionState.sessionID,
-        getLLMClient(config),
-        alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
+      const { result, input } = await promiseAgainstAbort(
+        () =>
+          executeRecall(
+            recallBlock,
+            sessionState.projectPath,
+            sessionState.sessionID,
+            getLLMClient(config),
+            alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
+            foregroundAbort.signal,
+          ),
+        foregroundAbort.signal,
       );
 
       // Store recall result for marker round-trip expansion
@@ -12409,13 +13324,25 @@ async function handleConversationTurn(
         `recall (non-stream, depth=${recallDepth}, codex=${followUpRequiresStream}): executing follow-up for session ${sessionState.sessionID.slice(0, 16)}`,
       );
       const jsonRecallCtx: RecallFollowUpCtx = {
-        forward: (r) =>
-          forwardToUpstream(r, config, undefined, {
-            ...cacheOptions,
-            cacheConversation: false,
+        forward: (r, signal) =>
+          forwardToUpstream(
+            r,
+            config,
+            undefined,
+            {
+              ...cacheOptions,
+              cacheConversation: false,
+            },
+            signal,
+          ),
+        parseJSON: (response, protocol, signal) =>
+          accumulateNonStreamResponse(response, protocol, false, signal),
+        parseSSE: (response, signal) =>
+          accumulateResponsesSSEStream(response, {
+            signal,
+            validation: currentModifiedReq.codex ? "codex" : "public",
+            stopAtTerminal: true,
           }),
-        parseJSON: accumulateNonStreamResponse,
-        parseSSE: accumulateResponsesSSEStream,
       };
       let jsonFollowUp: Awaited<ReturnType<typeof runRecallFollowUpJSON>>;
       try {
@@ -12426,6 +13353,7 @@ async function handleConversationTurn(
               currentResp,
               result,
               recallBlock,
+              foregroundAbort.signal,
             )
           : await runRecallFollowUpJSON(
               jsonRecallCtx,
@@ -12433,6 +13361,7 @@ async function handleConversationTurn(
               currentResp,
               result,
               recallBlock,
+              foregroundAbort.signal,
             );
       } catch (fetchErr) {
         log.error(
@@ -12500,18 +13429,10 @@ async function handleConversationTurn(
 
       // Accumulate usage from this iteration
       const contUsage = continuationResp.usage ?? ZERO_USAGE;
-      cumulativeUsage.inputTokens += contUsage.inputTokens;
-      cumulativeUsage.outputTokens += contUsage.outputTokens;
-      if (contUsage.cacheReadInputTokens) {
-        cumulativeUsage.cacheReadInputTokens =
-          (cumulativeUsage.cacheReadInputTokens ?? 0) +
-          contUsage.cacheReadInputTokens;
-      }
-      if (contUsage.cacheCreationInputTokens) {
-        cumulativeUsage.cacheCreationInputTokens =
-          (cumulativeUsage.cacheCreationInputTokens ?? 0) +
-          contUsage.cacheCreationInputTokens;
-      }
+      Object.assign(
+        cumulativeUsage,
+        mergeRecallUsage(cumulativeUsage, contUsage),
+      );
 
       // Update for next iteration
       currentModifiedReq = followUp;
@@ -12579,6 +13500,8 @@ async function handleConversationTurn(
       longContext,
     );
   };
+  const finishWithRecall = async (resp: GatewayResponse): Promise<Response> =>
+    finishForeground(await awaitForeground(finalizeWithRecall(resp)));
 
   if (req.stream && upstreamResponse.body) {
     // Non-Anthropic upstream streaming responses need their own accumulator
@@ -12608,8 +13531,182 @@ async function handleConversationTurn(
         if (hasRecallTool) {
           let responsesRecallRequest = modifiedReq;
           const responsesVisibleContent: GatewayContentBlock[] = [];
-          return streamResponsesRecallAware(upstreamResponse, {
-            onComplete: (resp) =>
+          return finishForeground(
+            streamResponsesRecallAware(upstreamResponse, {
+              onComplete: (resp) =>
+                postResponse(
+                  req,
+                  resp,
+                  sessionState,
+                  config,
+                  requestBody,
+                  genAiSpan,
+                ),
+              sessionID: sessionState.sessionID,
+              maxRecallDepth: MAX_RECALL_DEPTH,
+              signal: foregroundAbort.signal,
+              onRecall: async ({
+                query,
+                scope,
+                id,
+                toolUseId,
+                contentPosition,
+                acc,
+                signal,
+              }) => {
+                const alreadyInLtm = buildAlreadyInLtmIds(
+                  stableLtmText,
+                  pendingKnowledgeDelta,
+                );
+                const { result, input } = await executeRecall(
+                  {
+                    type: "tool_use",
+                    id: `recall_stream_${query}_${scope ?? ""}_${id ?? ""}`,
+                    name: RECALL_TOOL_NAME,
+                    input: { query, scope, id },
+                  },
+                  sessionState.projectPath,
+                  sessionState.sessionID,
+                  getLLMClient(config),
+                  alreadyInLtm.size > 0 ? alreadyInLtm : undefined,
+                  signal,
+                );
+                const recallBlock = acc.content[contentPosition];
+                if (
+                  recallBlock?.type !== "tool_use" ||
+                  recallBlock.id !== toolUseId ||
+                  recallBlock.name !== RECALL_TOOL_NAME
+                ) {
+                  throw new Error(
+                    "recall execution: recall block not found in accumulated response",
+                  );
+                }
+                const anchorId = crypto.randomUUID();
+                const position = contentPosition;
+                const anchorContextId = responsesAnchorContext(
+                  recallClientMessages,
+                  responsesVisibleContent,
+                  acc,
+                  recallBlock.id,
+                );
+                const companionToolUses = acc.content.flatMap(
+                  (block, index) => {
+                    if (block.type !== "tool_use" || block.id === toolUseId) {
+                      return [];
+                    }
+                    const side: "before" | "after" =
+                      index < position ? "before" : "after";
+                    return [
+                      {
+                        id: block.id,
+                        name: block.name,
+                        input: block.input,
+                        side,
+                      },
+                    ];
+                  },
+                );
+                const storeKey = `anchor:${anchorId}`;
+                const storedRecall = {
+                  toolUseId,
+                  anchorId,
+                  anchorContextId,
+                  input,
+                  position,
+                  result,
+                  ...(companionToolUses.length > 0
+                    ? { companionToolUses }
+                    : {}),
+                } satisfies StoredRecall;
+                const persistStore = (): void => {
+                  saveSessionTracking(sessionState.sessionID, {
+                    recallStore: serializeRecallStore(sessionState.recallStore),
+                  });
+                };
+                const anchorText = buildRecallAnchor(anchorId);
+                responsesVisibleContent.push(
+                  ...responsesProvenanceContent(
+                    acc,
+                    new Map([[toolUseId, anchorText]]),
+                  ),
+                );
+                return {
+                  anchorText,
+                  resultText: result,
+                  commit: () => {
+                    addRecallStoreEntry(
+                      sessionState.recallStore,
+                      storeKey,
+                      storedRecall,
+                    );
+                    persistStore();
+                  },
+                  rollback: () => {
+                    if (sessionState.recallStore.delete(storeKey))
+                      persistStore();
+                  },
+                };
+              },
+              runFollowUp: async ({
+                acc,
+                resultText,
+                toolUseId,
+                contentPosition,
+                signal,
+              }) => {
+                // Reconstruct the recall tool_use block for the follow-up request.
+                const recallBlock = acc.content[contentPosition];
+                if (
+                  recallBlock?.type !== "tool_use" ||
+                  recallBlock.id !== toolUseId ||
+                  recallBlock.name !== RECALL_TOOL_NAME
+                ) {
+                  throw new Error(
+                    "recall follow-up: recall block not found in accumulated response",
+                  );
+                }
+                const followUpCtx: RecallFollowUpCtx = {
+                  forward: (r, followUpSignal) =>
+                    forwardToUpstream(
+                      r,
+                      config,
+                      undefined,
+                      {
+                        ...cacheOptions,
+                        cacheConversation: false,
+                      },
+                      followUpSignal,
+                    ),
+                  parseJSON: () => {
+                    throw new Error(
+                      "parseJSON must not be called on the streaming recall path",
+                    );
+                  },
+                };
+                const follow = await runRecallFollowUpStreaming(
+                  followUpCtx,
+                  responsesRecallRequest,
+                  acc,
+                  resultText,
+                  recallBlock,
+                  signal,
+                );
+                if (!follow.ok) {
+                  throw new Error(
+                    `recall follow-up upstream error: ${follow.status ?? "?"}`,
+                  );
+                }
+                responsesRecallRequest = follow.followUp;
+                return { reader: follow.reader };
+              },
+            }),
+          );
+        }
+        // No recall tool — plain passthrough.
+        return finishForeground(
+          streamResponsesPassthrough(
+            upstreamResponse,
+            (resp) =>
               postResponse(
                 req,
                 resp,
@@ -12618,192 +13715,49 @@ async function handleConversationTurn(
                 requestBody,
                 genAiSpan,
               ),
-            sessionID: sessionState.sessionID,
-            maxRecallDepth: MAX_RECALL_DEPTH,
-            onRecall: async ({
-              query,
-              scope,
-              id,
-              toolUseId,
-              contentPosition,
-              acc,
-              signal,
-            }) => {
-              const alreadyInLtm = buildAlreadyInLtmIds(
-                stableLtmText,
-                pendingKnowledgeDelta,
-              );
-              const { result, input } = await executeRecall(
-                {
-                  type: "tool_use",
-                  id: `recall_stream_${query}_${scope ?? ""}_${id ?? ""}`,
-                  name: RECALL_TOOL_NAME,
-                  input: { query, scope, id },
-                },
-                sessionState.projectPath,
-                sessionState.sessionID,
-                getLLMClient(config),
-                alreadyInLtm.size > 0 ? alreadyInLtm : undefined,
-                signal,
-              );
-              const recallBlock = acc.content[contentPosition];
-              if (
-                recallBlock?.type !== "tool_use" ||
-                recallBlock.id !== toolUseId ||
-                recallBlock.name !== RECALL_TOOL_NAME
-              ) {
-                throw new Error(
-                  "recall execution: recall block not found in accumulated response",
-                );
-              }
-              const anchorId = crypto.randomUUID();
-              const position = contentPosition;
-              const anchorContextId = responsesAnchorContext(
-                recallClientMessages,
-                responsesVisibleContent,
-                acc,
-                recallBlock.id,
-              );
-              const companionToolUses = acc.content.flatMap((block, index) => {
-                if (block.type !== "tool_use" || block.id === toolUseId) {
-                  return [];
-                }
-                const side: "before" | "after" =
-                  index < position ? "before" : "after";
-                return [
-                  {
-                    id: block.id,
-                    name: block.name,
-                    input: block.input,
-                    side,
-                  },
-                ];
-              });
-              const storeKey = `anchor:${anchorId}`;
-              const storedRecall = {
-                toolUseId,
-                anchorId,
-                anchorContextId,
-                input,
-                position,
-                result,
-                ...(companionToolUses.length > 0 ? { companionToolUses } : {}),
-              } satisfies StoredRecall;
-              const persistStore = (): void => {
-                saveSessionTracking(sessionState.sessionID, {
-                  recallStore: serializeRecallStore(sessionState.recallStore),
-                });
-              };
-              const anchorText = buildRecallAnchor(anchorId);
-              responsesVisibleContent.push(
-                ...responsesProvenanceContent(
-                  acc,
-                  new Map([[toolUseId, anchorText]]),
-                ),
-              );
-              return {
-                anchorText,
-                resultText: result,
-                commit: () => {
-                  addRecallStoreEntry(
-                    sessionState.recallStore,
-                    storeKey,
-                    storedRecall,
-                  );
-                  persistStore();
-                },
-                rollback: () => {
-                  if (sessionState.recallStore.delete(storeKey)) persistStore();
-                },
-              };
-            },
-            runFollowUp: async ({
-              acc,
-              resultText,
-              toolUseId,
-              contentPosition,
-              signal,
-            }) => {
-              // Reconstruct the recall tool_use block for the follow-up request.
-              const recallBlock = acc.content[contentPosition];
-              if (
-                recallBlock?.type !== "tool_use" ||
-                recallBlock.id !== toolUseId ||
-                recallBlock.name !== RECALL_TOOL_NAME
-              ) {
-                throw new Error(
-                  "recall follow-up: recall block not found in accumulated response",
-                );
-              }
-              const followUpCtx: RecallFollowUpCtx = {
-                forward: (r, followUpSignal) =>
-                  forwardToUpstream(
-                    r,
-                    config,
-                    undefined,
-                    {
-                      ...cacheOptions,
-                      cacheConversation: false,
-                    },
-                    followUpSignal,
-                  ),
-                parseJSON: () => {
-                  throw new Error(
-                    "parseJSON must not be called on the streaming recall path",
-                  );
-                },
-              };
-              const follow = await runRecallFollowUpStreaming(
-                followUpCtx,
-                responsesRecallRequest,
-                acc,
-                resultText,
-                recallBlock,
-                signal,
-              );
-              if (!follow.ok) {
-                throw new Error(
-                  `recall follow-up upstream error: ${follow.status ?? "?"}`,
-                );
-              }
-              responsesRecallRequest = follow.followUp;
-              return { reader: follow.reader };
-            },
-          });
-        }
-        // No recall tool — plain passthrough.
-        return streamResponsesPassthrough(
-          upstreamResponse,
-          (resp) =>
-            postResponse(
-              req,
-              resp,
-              sessionState,
-              config,
-              requestBody,
-              genAiSpan,
-            ),
-          sessionState.sessionID,
+            sessionState.sessionID,
+            req.codex ? "codex" : "public",
+            foregroundAbort.signal,
+          ),
         );
       }
       // Warning to inject, or a non-Responses client: buffer the full
       // upstream, run recall interception, then re-emit.
-      const resp = await accumulateResponsesSSEStream(upstreamResponse);
-      return finalizeWithRecall(resp);
+      const resp = await awaitForeground(
+        accumulateResponsesSSEStream(upstreamResponse, {
+          signal: foregroundAbort.signal,
+          validation: req.codex ? "codex" : "public",
+          stopAtTerminal: true,
+        }),
+      );
+      return finishWithRecall(resp);
     }
 
     if (effectiveProtocol === "openai") {
       // OpenAI Chat Completions streaming — accumulate and return as
       // non-streaming Anthropic format (same pattern as non-stream path).
-      const resp = await accumulateOpenAISSEStream(upstreamResponse);
-      return finalizeWithRecall(resp);
+      const resp = await awaitForeground(
+        accumulateOpenAISSEStream(upstreamResponse, {
+          signal: foregroundAbort.signal,
+          strict: true,
+          stopAtTerminal: true,
+          consumeUntilDone: true,
+        }),
+      );
+      return finishWithRecall(resp);
     }
 
     if (effectiveProtocol === "gemini") {
       // Gemini native streaming — accumulate the SSE frames, then re-emit via
       // the recall-aware finalizer (same buffered pattern as the OpenAI paths).
-      const resp = await accumulateGeminiSSEStream(upstreamResponse);
-      return finalizeWithRecall(resp);
+      const resp = await awaitForeground(
+        accumulateGeminiSSEStream(upstreamResponse, {
+          signal: foregroundAbort.signal,
+          strict: true,
+          stopAtTerminal: true,
+        }),
+      );
+      return finishWithRecall(resp);
     }
 
     // Anthropic streaming: forward events and accumulate in parallel.
@@ -12834,27 +13788,44 @@ async function handleConversationTurn(
       // else 200K — so a 1M-capable model the client meters against 200K can't
       // cross its ~167K auto-compact threshold (#910 regression; MiniMax-M3).
       maxReportedUsageForModelID(req.model, requestEnablesLongContext(req)),
+      foregroundAbort.signal,
     );
     // Translate to client's wire format if needed. When the upstream is
     // Anthropic but the client speaks OpenAI, wrap the Anthropic SSE stream.
     if (req.protocol === "openai") {
-      return translateAnthropicStreamToOpenAI(anthropicSSE);
+      return finishForeground(
+        translateAnthropicStreamToOpenAI(anthropicSSE, {
+          signal: foregroundAbort.signal,
+        }),
+      );
     }
     if (req.protocol === "openai-responses") {
-      return translateAnthropicStreamToResponses(anthropicSSE);
+      return finishForeground(
+        translateAnthropicStreamToResponses(anthropicSSE, {
+          signal: foregroundAbort.signal,
+        }),
+      );
     }
     if (req.protocol === "gemini") {
-      return translateAnthropicStreamToGemini(anthropicSSE);
+      return finishForeground(
+        translateAnthropicStreamToGemini(anthropicSSE, {
+          signal: foregroundAbort.signal,
+        }),
+      );
     }
-    return anthropicSSE;
+    return finishForeground(anthropicSSE);
   }
 
   // Non-streaming: dispatch to correct accumulator based on upstream protocol.
-  const resp = await accumulateNonStreamResponse(
-    upstreamResponse,
-    effectiveProtocol,
+  const resp = await awaitForeground(
+    accumulateNonStreamResponse(
+      upstreamResponse,
+      effectiveProtocol,
+      modifiedReq.codex === true,
+      foregroundAbort.signal,
+    ),
   );
-  return finalizeWithRecall(resp);
+  return finishWithRecall(resp);
 }
 
 // ---------------------------------------------------------------------------
@@ -12953,6 +13924,7 @@ export function loreMessagesToGateway(
             type: "tool";
             tool: string;
             callID: string;
+            toolName?: string;
             state: {
               status: string;
               input?: unknown;
@@ -12966,6 +13938,7 @@ export function loreMessagesToGateway(
             content.push({
               type: "tool_result",
               toolUseId: toolPart.callID,
+              ...(toolPart.toolName ? { toolName: toolPart.toolName } : {}),
               content: toolResultContent(toolPart.state),
             });
           } else {
@@ -12983,12 +13956,14 @@ export function loreMessagesToGateway(
               pendingToolResults.push({
                 type: "tool_result",
                 toolUseId: toolPart.callID,
+                toolName: toolPart.toolName ?? toolPart.tool,
                 content: toolResultContent(toolPart.state),
               });
             } else if (toolPart.state.status === "error") {
               pendingToolResults.push({
                 type: "tool_result",
                 toolUseId: toolPart.callID,
+                toolName: toolPart.toolName ?? toolPart.tool,
                 content: toolResultContent(toolPart.state),
                 isError: true,
               });
@@ -13493,13 +14468,19 @@ function slashResponse(
     // Build Anthropic SSE, then translate to client's format if needed
     const anthropicSSE = streamHttpResponse(resp);
     if (req.protocol === "openai") {
-      return translateAnthropicStreamToOpenAI(anthropicSSE);
+      return translateAnthropicStreamToOpenAI(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     if (req.protocol === "openai-responses") {
-      return translateAnthropicStreamToResponses(anthropicSSE);
+      return translateAnthropicStreamToResponses(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     if (req.protocol === "gemini") {
-      return translateAnthropicStreamToGemini(anthropicSSE);
+      return translateAnthropicStreamToGemini(anthropicSSE, {
+        signal: req.signal,
+      });
     }
     return anthropicSSE;
   }
@@ -13567,11 +14548,16 @@ function errorResponse(status: number, message: string): Response {
  * treats it as a failed generation, not a dropped connection.
  */
 export function earlyFlushStreamingResponse(
-  run: () => Promise<Response>,
+  run: (signal: AbortSignal) => Promise<Response>,
   modelId: string,
+  signal?: AbortSignal,
 ): Response {
   const encoder = new TextEncoder();
   const keepalive = encoder.encode(`: lore preparing\n\n`);
+  const downstreamAbort = new AbortController();
+  const operationSignal = signal
+    ? AbortSignal.any([signal, downstreamAbort.signal])
+    : downstreamAbort.signal;
 
   /**
    * Emit a canonical `response.failed` envelope matching the shape used by
@@ -13598,79 +14584,89 @@ export function earlyFlushStreamingResponse(
     );
   }
 
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let cancelled = false;
+  let finished = false;
+
+  const finish = (
+    controller: ReadableStreamDefaultController<Uint8Array>,
+  ): void => {
+    if (finished) return;
+    finished = true;
+    if (reader) cancelAndReleaseReader(reader);
+    try {
+      controller.close();
+    } catch {
+      /* already closed */
+    }
+  };
+
   return new Response(
     new ReadableStream({
-      async start(controller) {
+      start(controller) {
+        // Fill the initial queue with only the keepalive. The pipeline starts
+        // from pull() after the downstream consumes it, preserving backpressure.
+        controller.enqueue(keepalive);
+      },
+      async pull(controller) {
+        if (cancelled || finished) return;
         try {
-          // Enqueue the keepalive comment FIRST so the server flushes headers
-          // before the (potentially slow) pipeline work below runs.
-          controller.enqueue(keepalive);
-          const inner = await run();
-          if (
-            !inner.body ||
-            !inner.headers.get("content-type")?.includes("text/event-stream")
-          ) {
-            // The inner response has no streamable SSE body (e.g. an error
-            // Response with a plain string body). Surface as response.failed.
-            const status = inner.status;
-            const text = await inner.text().catch(() => "");
-            try {
-              controller.enqueue(
-                emitFailed(`${status}: ${text.slice(0, 500)}`),
-              );
-            } catch {
-              /* client gone */
+          if (!reader) {
+            const inner = await responseAgainstAbort(
+              () => run(operationSignal),
+              operationSignal,
+            );
+            if (cancelled) {
+              void inner.body?.cancel().catch(() => {});
+              return;
             }
-            try {
-              controller.close();
-            } catch {
-              /* already closed */
-            }
-            return;
-          }
-          const reader = inner.body.getReader();
-          let cancelled = false;
-          try {
-            for (;;) {
-              const { done, value } = await reader.read();
-              if (done) break;
-              if (cancelled) continue;
-              try {
-                controller.enqueue(value);
-              } catch {
-                // Client disconnected — cancel the upstream stream so the
-                // gateway doesn't keep reading until the OS times out.
-                cancelled = true;
-                reader.cancel().catch(() => {});
-                break;
+            if (
+              !inner.body ||
+              !inner.headers.get("content-type")?.includes("text/event-stream")
+            ) {
+              // The inner response has no streamable SSE body (e.g. an error
+              // Response with a plain string body). Surface as response.failed.
+              const status = inner.status;
+              const text = await readForegroundBody(
+                inner,
+                true,
+                undefined,
+                operationSignal,
+              ).catch(() => "");
+              if (!cancelled) {
+                controller.enqueue(
+                  emitFailed(`${status}: ${text.slice(0, 500)}`),
+                );
+                finish(controller);
               }
+              return;
             }
-          } finally {
-            try {
-              reader.cancel().catch(() => {});
-            } catch {
-              /* already released */
-            }
+            reader = inner.body.getReader();
           }
-          try {
-            controller.close();
-          } catch {
-            /* already closed */
-          }
+          const chunk = await readStreamChunk(reader, {
+            signal: operationSignal,
+          });
+          if (cancelled) return;
+          if (chunk.done) finish(controller);
+          else controller.enqueue(chunk.value);
         } catch (err) {
           const message =
             err instanceof Error ? err.message : "unknown gateway error";
-          try {
+          if (!cancelled) {
             controller.enqueue(emitFailed(message));
-          } catch {
-            /* client gone */
-          }
-          try {
-            controller.close();
-          } catch {
-            /* already closed */
+            finish(controller);
           }
         }
+      },
+      cancel(reason) {
+        cancelled = true;
+        finished = true;
+        if (!downstreamAbort.signal.aborted) {
+          downstreamAbort.abort(
+            reason ?? new DOMException("response cancelled", "AbortError"),
+          );
+        }
+        if (reader) cancelAndReleaseReader(reader, reason);
       },
     }),
     {
@@ -13785,8 +14781,9 @@ export async function handleRequest(
     // keepalive while the gateway prepares.
     if (req.stream && req.protocol === "openai-responses") {
       return earlyFlushStreamingResponse(
-        () => handleConversationTurn(req, config),
+        (signal) => handleConversationTurn({ ...req, signal }, config),
         req.model,
+        req.signal,
       );
     }
     return await handleConversationTurn(req, config);

--- a/packages/gateway/src/recall.ts
+++ b/packages/gateway/src/recall.ts
@@ -38,6 +38,8 @@ import type {
   RecallStore,
   StoredRecall,
 } from "./translate/types";
+import { promiseAgainstAbort } from "./abort-race";
+import { cancelAndReleaseReader } from "./stream/anthropic";
 import { looksLikeSSE } from "./translate/types";
 
 // ---------------------------------------------------------------------------
@@ -735,6 +737,7 @@ export function expandRecallMarkers(
         {
           type: "tool_result",
           toolUseId: stored.toolUseId,
+          toolName: RECALL_TOOL_NAME,
           content: [{ type: "text", text: stored.result }],
         },
       ],
@@ -762,6 +765,7 @@ export function expandRecallMarkers(
         nextMsg.content.splice(resultIndex, 0, {
           type: "tool_result",
           toolUseId: stored.toolUseId,
+          toolName: RECALL_TOOL_NAME,
           content: [{ type: "text", text: stored.result }],
         });
       } else {
@@ -861,11 +865,48 @@ function parseRecallInput(block: GatewayToolUseBlock): {
   scope: RecallScope;
   id?: string;
 } {
-  const input = block.input as Record<string, unknown>;
+  const input = block.input;
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Recall input must be an object");
+  }
+  const record = input as Record<string, unknown>;
+  if (record.query !== undefined && typeof record.query !== "string") {
+    throw new Error("Recall query must be a string");
+  }
+  if (
+    record.id !== undefined &&
+    (typeof record.id !== "string" || !record.id)
+  ) {
+    throw new Error("Recall id must be a non-empty string");
+  }
+  const query = record.query ?? "";
+  if (!query.trim() && !record.id) {
+    throw new Error("Recall query or id is required");
+  }
+  const validScopes: ReadonlySet<string> = new Set([
+    "all",
+    "session",
+    "project",
+    "knowledge",
+  ]);
+  if (
+    record.scope !== undefined &&
+    (typeof record.scope !== "string" || !validScopes.has(record.scope))
+  ) {
+    throw new Error("Invalid recall scope");
+  }
+  if (
+    record.limit !== undefined &&
+    (!Number.isSafeInteger(record.limit) ||
+      (record.limit as number) < 1 ||
+      (record.limit as number) > 50)
+  ) {
+    throw new Error("Recall limit must be an integer from 1 to 50");
+  }
   return {
-    query: typeof input.query === "string" ? input.query : "",
-    scope: (input.scope as RecallScope) ?? "all",
-    ...(typeof input.id === "string" && input.id ? { id: input.id } : {}),
+    query,
+    scope: (record.scope as RecallScope | undefined) ?? "all",
+    ...(typeof record.id === "string" && record.id ? { id: record.id } : {}),
   };
 }
 
@@ -891,10 +932,13 @@ export async function executeRecall(
   result: string;
   input: { query: string; scope?: RecallScope; id?: string };
 }> {
-  const { query, scope, id } = parseRecallInput(block);
-  const cfg = loreConfig();
+  let query = "";
+  let scope: RecallScope = "all";
+  let id: string | undefined;
 
   try {
+    ({ query, scope, id } = parseRecallInput(block));
+    const cfg = loreConfig();
     signal?.throwIfAborted();
     const result = await runRecall({
       query,
@@ -953,13 +997,17 @@ export interface RecallFollowUpCtx {
   parseJSON: (
     response: Response,
     protocol: RecallProtocol,
+    signal?: AbortSignal,
   ) => Promise<GatewayResponse>;
   /**
    * Accumulate a streaming (SSE) upstream response into a GatewayResponse.
    * Required only by `runRecallFollowUpStreamAccumulated` (the `openai-codex`
    * path, whose ChatGPT backend mandates streaming).
    */
-  parseSSE?: (response: Response) => Promise<GatewayResponse>;
+  parseSSE?: (
+    response: Response,
+    signal?: AbortSignal,
+  ) => Promise<GatewayResponse>;
 }
 
 /**
@@ -1042,6 +1090,7 @@ export function buildRecallFollowUpRequest(
       {
         type: "tool_result",
         toolUseId: recallToolUseBlock.id,
+        toolName: recallToolUseBlock.name,
         content: [
           { type: "text", text: recallResult || "[No results found.]" },
         ],
@@ -1094,15 +1143,14 @@ async function ensureSSEResponse(
   const probeSignal = signal
     ? AbortSignal.any([signal, AbortSignal.timeout(10_000)])
     : AbortSignal.timeout(10_000);
-  const probeAborted = new Promise<never>((_resolve, reject) => {
-    probeSignal.addEventListener("abort", () => reject(probeSignal.reason), {
-      once: true,
-    });
-  });
   let chunks = 0;
+  let preserveReplay = false;
   try {
     while (probedBytes < maxProbeBytes && chunks < maxProbeChunks) {
-      const { done, value } = await Promise.race([reader.read(), probeAborted]);
+      const { done, value } = await promiseAgainstAbort(
+        () => reader.read(),
+        probeSignal,
+      );
       if (done) break;
       chunks++;
       if (value) {
@@ -1121,21 +1169,28 @@ async function ensureSSEResponse(
         head = head.slice(newline + 1).trimStart();
       }
       if (looksLikeSSE(ct, head)) {
-        void reader.cancel();
-        return new Response(replay, {
+        const replayResponse = new Response(replay, {
           status: response.status,
           statusText: response.statusText,
           headers: response.headers,
         });
+        preserveReplay = true;
+        return replayResponse;
       }
       if (head && !"data:".startsWith(head) && !"event:".startsWith(head)) {
         break;
       }
     }
   } finally {
-    void reader.cancel();
+    cancelAndReleaseReader(reader, probeSignal.reason);
+    if (!preserveReplay) {
+      try {
+        void replay.cancel(probeSignal.reason).catch(() => {});
+      } catch {
+        // Both tee branches are best-effort and must never delay the caller.
+      }
+    }
   }
-  void replay.cancel();
   throw new Error(
     `recall follow-up expected SSE but got "${ct}" and a non-SSE body`,
   );
@@ -1151,14 +1206,13 @@ async function readResponseTextLimited(
   const decoder = new TextDecoder();
   let text = "";
   let readBytes = 0;
-  const onAbort = (): void => {
-    void reader.cancel(signal?.reason).catch(() => {});
-  };
-  signal?.addEventListener("abort", onAbort, { once: true });
   try {
     while (readBytes < maxBytes) {
       signal?.throwIfAborted();
-      const { done, value } = await reader.read();
+      const { done, value } = await promiseAgainstAbort(
+        () => reader.read(),
+        signal,
+      );
       signal?.throwIfAborted();
       if (done) break;
       if (!value) continue;
@@ -1167,8 +1221,7 @@ async function readResponseTextLimited(
       text += decoder.decode(chunk, { stream: readBytes < maxBytes });
     }
   } finally {
-    signal?.removeEventListener("abort", onAbort);
-    void reader.cancel().catch(() => {});
+    cancelAndReleaseReader(reader, signal?.reason);
   }
   return text;
 }
@@ -1185,6 +1238,26 @@ function assertJSONResponse(response: Response): void {
     throw new Error(
       `recall follow-up expected JSON but got SSE — stream flag/consumer mismatch`,
     );
+  }
+}
+
+async function parseFollowUpAgainstAbort<T>(
+  response: Response,
+  parse: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const onAbort = (): void => {
+    try {
+      void response.body?.cancel(signal?.reason).catch(() => {});
+    } catch {
+      // A parser may already own the body reader; it receives the same signal.
+    }
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    return await promiseAgainstAbort(parse, signal);
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
   }
 }
 
@@ -1241,7 +1314,17 @@ export async function runRecallFollowUpStreaming(
     recallToolUseBlock,
     /* stream */ true,
   );
-  const { response } = await ctx.forward(followUp, signal);
+  const { response } = await promiseAgainstAbort(
+    () => ctx.forward(followUp, signal),
+    signal,
+    ({ response: lateResponse }) => {
+      try {
+        void lateResponse.body?.cancel(signal?.reason).catch(() => {});
+      } catch {
+        // Late follow-up cleanup is best-effort.
+      }
+    },
+  );
   if (!response.ok) {
     let detail = "";
     try {
@@ -1273,6 +1356,7 @@ export async function runRecallFollowUpJSON(
   resp: GatewayResponse,
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
+  signal?: AbortSignal,
 ): Promise<RecallFollowUpJSON | RecallFollowUpError> {
   const followUp = buildRecallFollowUpRequest(
     originalReq,
@@ -1281,13 +1365,33 @@ export async function runRecallFollowUpJSON(
     recallToolUseBlock,
     /* stream */ false,
   );
-  const { response, effectiveProtocol } = await ctx.forward(followUp);
+  const { response, effectiveProtocol } = await promiseAgainstAbort(
+    () => ctx.forward(followUp, signal),
+    signal,
+    ({ response: lateResponse }) => {
+      try {
+        void lateResponse.body?.cancel(signal?.reason).catch(() => {});
+      } catch {
+        // Late body may already be locked by the abandoned operation.
+      }
+    },
+  );
   if (!response.ok) {
-    const detail = await readResponseTextLimited(response).catch(() => "");
+    let detail = "";
+    try {
+      detail = await readResponseTextLimited(response, 500, signal);
+    } catch (error) {
+      if (signal?.aborted) throw signal.reason;
+      log.warn("recall follow-up error body could not be read:", error);
+    }
     return { ok: false, status: response.status, detail };
   }
   assertJSONResponse(response);
-  const continuation = await ctx.parseJSON(response, effectiveProtocol);
+  const continuation = await parseFollowUpAgainstAbort(
+    response,
+    () => ctx.parseJSON(response, effectiveProtocol, signal),
+    signal,
+  );
   return { ok: true, continuation, followUp };
 }
 
@@ -1314,8 +1418,10 @@ export async function runRecallFollowUpStreamAccumulated(
   resp: GatewayResponse,
   recallResult: string,
   recallToolUseBlock: GatewayToolUseBlock,
+  signal?: AbortSignal,
 ): Promise<RecallFollowUpJSON | RecallFollowUpError> {
-  if (!ctx.parseSSE) {
+  const parseSSE = ctx.parseSSE;
+  if (!parseSSE) {
     throw new Error(
       "runRecallFollowUpStreamAccumulated requires ctx.parseSSE to accumulate the streamed continuation",
     );
@@ -1327,13 +1433,33 @@ export async function runRecallFollowUpStreamAccumulated(
     recallToolUseBlock,
     /* stream */ true,
   );
-  const { response } = await ctx.forward(followUp);
+  const { response } = await promiseAgainstAbort(
+    () => ctx.forward(followUp, signal),
+    signal,
+    ({ response: lateResponse }) => {
+      try {
+        void lateResponse.body?.cancel(signal?.reason).catch(() => {});
+      } catch {
+        // Late body may already be locked by the abandoned operation.
+      }
+    },
+  );
   if (!response.ok) {
-    const detail = await readResponseTextLimited(response).catch(() => "");
+    let detail = "";
+    try {
+      detail = await readResponseTextLimited(response, 500, signal);
+    } catch (error) {
+      if (signal?.aborted) throw signal.reason;
+      log.warn("recall follow-up error body could not be read:", error);
+    }
     return { ok: false, status: response.status, detail };
   }
-  const sseResponse = await ensureSSEResponse(response);
-  const continuation = await ctx.parseSSE(sseResponse);
+  const sseResponse = await ensureSSEResponse(response, signal);
+  const continuation = await parseFollowUpAgainstAbort(
+    sseResponse,
+    () => parseSSE(sseResponse, signal),
+    signal,
+  );
   return { ok: true, continuation, followUp };
 }
 

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -41,8 +41,12 @@ import {
   handleRequest,
   handleCompactEndpoint,
   handleResponsesCompactEndpoint,
+  createForegroundAbortScope,
+  wrapBodyWithCleanup,
 } from "./pipeline";
 import { upstreamFetch } from "./fetch";
+import { responseAgainstAbort } from "./abort-race";
+import { cancelAndReleaseReader, readStreamChunk } from "./stream/anthropic";
 import { decodeRequestBody } from "./http-body";
 import {
   BEDROCK_RUNTIME_PATH_RE,
@@ -117,6 +121,34 @@ function errorResponse(
   );
 }
 
+function requestWithSignal(req: Request, signal: AbortSignal): Request {
+  return new Request(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: req.body,
+    signal,
+    ...(req.body ? { duplex: "half" } : {}),
+  });
+}
+
+export async function handleForegroundBodyRoute(
+  req: Request,
+  handle: (scopedRequest: Request) => Promise<Response>,
+): Promise<Response> {
+  const abortScope = createForegroundAbortScope(req.signal);
+  try {
+    const scopedRequest = requestWithSignal(req, abortScope.signal);
+    const response = await responseAgainstAbort(
+      () => handle(scopedRequest),
+      abortScope.signal,
+    );
+    return wrapBodyWithCleanup(response, abortScope.dispose, abortScope.signal);
+  } catch (error) {
+    abortScope.dispose();
+    throw error;
+  }
+}
+
 /**
  * Detect a WebSocket upgrade request.
  *
@@ -176,6 +208,7 @@ async function handleAnthropicMessages(
   let gatewayReq: GatewayRequest;
   try {
     gatewayReq = parseAnthropicRequest(body, headersToRecord(req.headers));
+    gatewayReq.signal = req.signal;
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Failed to parse request";
     return errorResponse(400, "invalid_request_error", msg);
@@ -196,10 +229,11 @@ async function handleAnthropicMessages(
 // calling GET /v1/models will have their request forwarded to Anthropic,
 // which will likely reject the OpenAI API key. A proper fix would route
 // based on auth header type, but that's a separate enhancement.
-async function handleModelsPassthrough(
+export async function handleModelsPassthrough(
   req: Request,
   config: GatewayConfig,
 ): Promise<Response> {
+  const abortScope = createForegroundAbortScope(req.signal);
   try {
     // Forward auth headers from the original request so upstream
     // providers that require authentication don't reject with 401.
@@ -219,20 +253,23 @@ async function handleModelsPassthrough(
       headers[key] = value;
     }
 
-    const upstream = await upstreamFetch(
-      `${config.upstreamAnthropic}/v1/models`,
-      {
-        headers,
-      },
+    const upstream = await responseAgainstAbort(
+      () =>
+        upstreamFetch(`${config.upstreamAnthropic}/v1/models`, {
+          headers,
+          signal: abortScope.signal,
+        }),
+      abortScope.signal,
     );
     // Clone to a new Response so we can append CORS headers
-    const response = new Response(upstream.body, {
-      status: upstream.status,
-      statusText: upstream.statusText,
-      headers: new Headers(upstream.headers),
-    });
+    const response = wrapBodyWithCleanup(
+      upstream,
+      abortScope.dispose,
+      abortScope.signal,
+    );
     return withCors(response);
   } catch (e) {
+    abortScope.dispose();
     const msg = e instanceof Error ? e.message : "Upstream unreachable";
     return errorResponse(502, "api_error", `Failed to fetch models: ${msg}`);
   }
@@ -277,6 +314,7 @@ async function handleOpenAIChatCompletions(
   let gatewayReq: GatewayRequest;
   try {
     gatewayReq = parseOpenAIRequest(body, headersToRecord(req.headers));
+    gatewayReq.signal = req.signal;
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Failed to parse request";
     return errorResponse(400, "invalid_request_error", msg);
@@ -332,6 +370,7 @@ async function handleGeminiGenerateContent(
   let gatewayReq: GatewayRequest;
   try {
     gatewayReq = parseGeminiRequest(body, headers, model, stream);
+    gatewayReq.signal = req.signal;
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Failed to parse request";
     return errorResponse(400, "invalid_request_error", msg);
@@ -367,6 +406,7 @@ async function handleOpenAIResponses(
       body,
       headersToRecord(req.headers),
     );
+    gatewayReq.signal = req.signal;
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Failed to parse request";
     return errorResponse(400, "invalid_request_error", msg);
@@ -407,6 +447,7 @@ async function handleOpenAICodexResponses(
   let gatewayReq: GatewayRequest;
   try {
     gatewayReq = parseOpenAICodexRequest(body, headersToRecord(req.headers));
+    gatewayReq.signal = req.signal;
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Failed to parse request";
     return errorResponse(400, "invalid_request_error", msg);
@@ -498,7 +539,9 @@ export async function startServer(config: GatewayConfig): Promise<{
     try {
       // POST /v1/messages — Anthropic protocol
       if (method === "POST" && pathname === "/v1/messages") {
-        return await handleAnthropicMessages(req, config);
+        return await handleForegroundBodyRoute(req, (scoped) =>
+          handleAnthropicMessages(scoped, config),
+        );
       }
 
       // POST /v1/chat/completions — OpenAI protocol.
@@ -510,7 +553,9 @@ export async function startServer(config: GatewayConfig): Promise<{
         (pathname === "/v1/chat/completions" ||
           pathname === "/chat/completions")
       ) {
-        return await handleOpenAIChatCompletions(req, config);
+        return await handleForegroundBodyRoute(req, (scoped) =>
+          handleOpenAIChatCompletions(scoped, config),
+        );
       }
 
       // POST /v1beta/models/{model}:generateContent (or :streamGenerateContent)
@@ -519,23 +564,31 @@ export async function startServer(config: GatewayConfig): Promise<{
       if (method === "POST") {
         const gm = pathname.match(GEMINI_PATH_RE);
         if (gm) {
-          return await handleGeminiGenerateContent(
-            req,
-            config,
-            gm[1],
-            gm[2] === "streamGenerateContent",
+          return await handleForegroundBodyRoute(req, (scoped) =>
+            handleGeminiGenerateContent(
+              scoped,
+              config,
+              gm[1],
+              gm[2] === "streamGenerateContent",
+            ),
           );
         }
       }
 
       // POST /v1/responses/compact — Codex compaction (Responses API)
       if (method === "POST" && pathname === "/v1/responses/compact") {
-        return withCors(await handleResponsesCompactEndpoint(req, config));
+        return withCors(
+          await handleForegroundBodyRoute(req, (scoped) =>
+            handleResponsesCompactEndpoint(scoped, config),
+          ),
+        );
       }
 
       // POST /v1/codex/responses — Codex (ChatGPT) ingress (Responses format)
       if (method === "POST" && pathname === "/v1/codex/responses") {
-        return await handleOpenAICodexResponses(req, config);
+        return await handleForegroundBodyRoute(req, (scoped) =>
+          handleOpenAICodexResponses(scoped, config),
+        );
       }
 
       // POST /v1/responses — OpenAI Responses API protocol.
@@ -545,12 +598,18 @@ export async function startServer(config: GatewayConfig): Promise<{
       // against api.githubcopilot.com (its endpoints omit /v1). Wiring that needs
       // a host-aware responses path (like buildOpenAIChatCompletionsUrl) first.
       if (method === "POST" && pathname === "/v1/responses") {
-        return await handleOpenAIResponses(req, config);
+        return await handleForegroundBodyRoute(req, (scoped) =>
+          handleOpenAIResponses(scoped, config),
+        );
       }
 
       // POST /v1/compact — explicit compaction summary (Pi plugin, etc.)
       if (method === "POST" && pathname === "/v1/compact") {
-        return withCors(await handleCompactEndpoint(req, config));
+        return withCors(
+          await handleForegroundBodyRoute(req, (scoped) =>
+            handleCompactEndpoint(scoped, config),
+          ),
+        );
       }
 
       // POST /v1/model/{modelId}/{verb} — Bedrock Runtime API passthrough.
@@ -859,6 +918,107 @@ export function bracketHost(host: string): string {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 }
 
+export function bindNodeIngressAbort(
+  nodeReq: IncomingMessage,
+  nodeRes: ServerResponse,
+): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  const abort = (reason: unknown): void => {
+    if (!controller.signal.aborted) controller.abort(reason);
+  };
+  const onRequestAborted = (): void =>
+    abort(new DOMException("client request aborted", "AbortError"));
+  const onRequestClose = (): void => {
+    if (!nodeReq.complete) onRequestAborted();
+  };
+  const onRequestError = (error: Error): void => abort(error);
+  const onResponseClose = (): void => {
+    if (!nodeRes.writableEnded) {
+      abort(new DOMException("client response closed", "AbortError"));
+    }
+  };
+  const onResponseError = (error: Error): void => abort(error);
+  const onSocketClose = (): void => {
+    if (!nodeRes.writableEnded) {
+      abort(new DOMException("client socket closed", "AbortError"));
+    }
+  };
+  const onSocketError = (error: Error): void => abort(error);
+  nodeReq.on("aborted", onRequestAborted);
+  nodeReq.on("close", onRequestClose);
+  nodeReq.on("error", onRequestError);
+  nodeRes.on("close", onResponseClose);
+  nodeRes.on("error", onResponseError);
+  nodeReq.socket.on("close", onSocketClose);
+  nodeReq.socket.on("error", onSocketError);
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      nodeReq.removeListener("aborted", onRequestAborted);
+      nodeReq.removeListener("close", onRequestClose);
+      nodeReq.removeListener("error", onRequestError);
+      nodeRes.removeListener("close", onResponseClose);
+      nodeRes.removeListener("error", onResponseError);
+      nodeReq.socket.removeListener("close", onSocketClose);
+      nodeReq.socket.removeListener("error", onSocketError);
+    },
+  };
+}
+
+export function waitForNodeResponseDrain(
+  nodeRes: ServerResponse,
+  signal: AbortSignal,
+): Promise<void> {
+  signal.throwIfAborted();
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      nodeRes.removeListener("drain", onDrain);
+      signal.removeEventListener("abort", onAbort);
+    };
+    const finish = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      operation();
+    };
+    const onDrain = (): void => finish(resolve);
+    const onAbort = (): void => finish(() => reject(signal.reason));
+    nodeRes.on("drain", onDrain);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+}
+
+export function waitForNodeResponseCompletion(
+  nodeRes: ServerResponse,
+  signal: AbortSignal,
+): Promise<void> {
+  if (nodeRes.writableFinished || nodeRes.destroyed) return Promise.resolve();
+  signal.throwIfAborted();
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => {
+      nodeRes.removeListener("finish", onFinish);
+      nodeRes.removeListener("close", onClose);
+      signal.removeEventListener("abort", onAbort);
+    };
+    const finish = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      operation();
+    };
+    const onFinish = (): void => finish(resolve);
+    const onClose = (): void => finish(resolve);
+    const onAbort = (): void => finish(() => reject(signal.reason));
+    nodeRes.on("finish", onFinish);
+    nodeRes.on("close", onClose);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+  });
+}
+
 /**
  * Convert a node:http `IncomingMessage` to a Web `Request`, run the shared
  * `fetch` handler, and stream the resulting Web `Response` back over the
@@ -868,13 +1028,15 @@ export function bracketHost(host: string): string {
  * `Response` (streaming or buffered), we write the status + headers, then
  * pipe the body chunk-by-chunk to keep long-lived SSE streams alive.
  */
-async function handleNodeRequest(
+export async function handleNodeRequest(
   nodeReq: IncomingMessage,
   nodeRes: ServerResponse,
   fetch: (req: Request) => Response | Promise<Response>,
   host: string,
   port: number,
 ): Promise<void> {
+  const ingressAbort = bindNodeIngressAbort(nodeReq, nodeRes);
+  let responseStarted = false;
   try {
     const url = `http://${bracketHost(host)}:${port}${nodeReq.url ?? "/"}`;
 
@@ -887,41 +1049,76 @@ async function handleNodeRequest(
       method: nodeReq.method,
       headers: nodeReq.headers as Record<string, string>,
       body,
+      signal: ingressAbort.signal,
       // @ts-expect-error — required for Node.js request body streaming
       duplex: "half",
     });
 
-    const response = await fetch(req);
+    const response = await responseAgainstAbort(
+      () => Promise.resolve(fetch(req)),
+      ingressAbort.signal,
+    );
 
     const headerEntries: [string, string][] = [];
     response.headers.forEach((value, key) => {
       headerEntries.push([key, value]);
     });
     nodeRes.writeHead(response.status, Object.fromEntries(headerEntries));
+    responseStarted = true;
 
     if (response.body) {
       const reader = response.body.getReader();
       try {
         while (true) {
-          const { done, value } = await reader.read();
+          const { done, value } = await readStreamChunk(reader, {
+            signal: ingressAbort.signal,
+          });
           if (done) break;
           // Coerce SharedArrayBuffer-typed Uint8Array views to a regular
           // Buffer — Node's write() expects a string, Buffer, or
           // Uint8Array<ArrayBuffer>, not ArrayBufferLike.
-          nodeRes.write(
+          const canContinue = nodeRes.write(
             Buffer.from(value.buffer, value.byteOffset, value.byteLength),
           );
+          if (!canContinue) {
+            await waitForNodeResponseDrain(nodeRes, ingressAbort.signal);
+          }
         }
       } finally {
-        reader.releaseLock();
+        cancelAndReleaseReader(reader, ingressAbort.signal.reason);
       }
     }
-    nodeRes.end();
-  } catch (err) {
-    log.error("request handler error:", err);
-    if (!nodeRes.headersSent) {
-      nodeRes.writeHead(500, { "content-type": "application/json" });
+    if (!nodeRes.destroyed) {
+      const completed = waitForNodeResponseCompletion(
+        nodeRes,
+        ingressAbort.signal,
+      );
+      nodeRes.end();
+      await completed;
     }
-    nodeRes.end(JSON.stringify({ error: "Internal server error" }));
+  } catch (err) {
+    if (!ingressAbort.signal.aborted) log.error("request handler error:", err);
+    if (
+      !responseStarted &&
+      !nodeRes.headersSent &&
+      !nodeRes.destroyed &&
+      !ingressAbort.signal.aborted
+    ) {
+      try {
+        const completed = waitForNodeResponseCompletion(
+          nodeRes,
+          ingressAbort.signal,
+        );
+        nodeRes.writeHead(500, { "content-type": "application/json" });
+        nodeRes.end(JSON.stringify({ error: "Internal server error" }));
+        await completed;
+      } catch {
+        if (!nodeRes.destroyed) nodeRes.destroy();
+      }
+    } else if (!nodeRes.destroyed) {
+      nodeRes.destroy();
+    }
+  } finally {
+    ingressAbort.cleanup();
   }
 }

--- a/packages/gateway/src/stream/anthropic.ts
+++ b/packages/gateway/src/stream/anthropic.ts
@@ -22,6 +22,13 @@ import {
   estimateTokens,
   scaleUsageForClient,
 } from "../compaction";
+import {
+  ANTHROPIC_CONTENT_BLOCK_TYPES,
+  ANTHROPIC_STOP_REASONS,
+  normalizeAnthropicStopReason,
+  toAnthropicStopReason,
+} from "../anthropic-protocol";
+import { isRecord, validateAnthropicUsage } from "../usage-validation";
 // NOTE: `estimateTokens` re-exported from `compaction.ts` is now the BPE-backed
 // helper from @loreai/core (see packages/core/src/tokenize.ts), no longer the
 // legacy length/4 heuristic.
@@ -38,6 +45,98 @@ export function formatSSEEvent(eventType: string, data: string): string {
 // ---------------------------------------------------------------------------
 // SSE parsing
 // ---------------------------------------------------------------------------
+
+type StreamChunkRead = Awaited<
+  ReturnType<ReadableStreamDefaultReader<Uint8Array>["read"]>
+>;
+
+/**
+ * Foreground and worker SSE streams share this finite frame ceiling. The byte
+ * ceilings bound retained data, while this independently bounds parser work for
+ * tiny frames (including blank and comment-only frames).
+ */
+export const DEFAULT_MAX_SSE_FRAMES = 100_000;
+
+/** A post-header transport failure while reading an SSE response body. */
+export class SSEStreamTransportError extends Error {
+  readonly kind: "inactivity" | "read";
+
+  constructor(
+    kind: "inactivity" | "read",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "SSEStreamTransportError";
+    this.kind = kind;
+  }
+}
+
+/** Deterministic local stream limits must never be reclassified as transport. */
+export class SSEStreamLimitError extends Error {}
+
+/** Read one stream chunk while making abort and inactivity independently fatal. */
+export async function readStreamChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  opts: { signal?: AbortSignal; inactivityMs?: number } = {},
+): Promise<StreamChunkRead> {
+  opts.signal?.throwIfAborted();
+  const reads: Array<Promise<StreamChunkRead>> = [
+    reader.read().catch((error: unknown) => {
+      opts.signal?.throwIfAborted();
+      if (error instanceof SSEStreamLimitError) throw error;
+      throw new SSEStreamTransportError("read", "SSE stream read failed", {
+        cause: error,
+      });
+    }),
+  ];
+  let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
+  let inactivityError: Error | undefined;
+  let onAbort: (() => void) | undefined;
+
+  if (opts.signal) {
+    const signal = opts.signal;
+    reads.push(
+      new Promise<never>((_resolve, reject) => {
+        onAbort = () => {
+          void reader.cancel(signal.reason).catch(() => {});
+          try {
+            signal.throwIfAborted();
+          } catch (error) {
+            reject(error);
+          }
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        if (signal.aborted) onAbort();
+      }),
+    );
+  }
+
+  if (opts.inactivityMs) {
+    reads.push(
+      new Promise<never>((_resolve, reject) => {
+        inactivityTimer = setTimeout(() => {
+          inactivityError = new SSEStreamTransportError(
+            "inactivity",
+            "SSE stream inactivity deadline exceeded",
+          );
+          void reader.cancel(inactivityError).catch(() => {});
+          reject(inactivityError);
+        }, opts.inactivityMs);
+      }),
+    );
+  }
+
+  try {
+    const result = await Promise.race(reads);
+    if (inactivityError) throw inactivityError;
+    opts.signal?.throwIfAborted();
+    return result;
+  } finally {
+    if (onAbort) opts.signal?.removeEventListener("abort", onAbort);
+    if (inactivityTimer) clearTimeout(inactivityTimer);
+  }
+}
 
 /**
  * Parse an SSE byte stream into typed events.
@@ -56,81 +155,185 @@ export async function* parseSSEStream(
     frameCounter?: { count: number };
     inactivityMs?: number;
     signal?: AbortSignal;
+    requireEventTerminator?: boolean;
+    maxTotalBytes?: number;
+    fatalUtf8?: boolean;
   } = {},
 ): AsyncGenerator<{ event: string; data: string }> {
-  const decoder = new TextDecoder();
-  let buffer = "";
+  // Expose BOM code points to the parser; `stripInitialBom` below owns removal
+  // and byte accounting exactly once, including split transport chunks.
+  const decoder = new TextDecoder("utf-8", {
+    fatal: opts.fatalUtf8,
+    ignoreBOM: true,
+  });
+  let bufferParts: string[] = [];
+  let delimiterScanTail = "";
+  let initialBytes: number[] = [];
+  let initialBytesResolved = false;
   let bufferedBytes = 0;
   const maxEventBytes = opts.maxEventBytes ?? 4 * 1024 * 1024;
-  const maxFrames = opts.maxFrames ?? Number.POSITIVE_INFINITY;
+  const maxFrames = opts.maxFrames ?? DEFAULT_MAX_SSE_FRAMES;
   const frameCounter = opts.frameCounter ?? { count: 0 };
+  let totalBytes = 0;
+  const delimiterPattern =
+    "(?:\\r\\n|(?<!\\r)\\n|\\r(?!\\n))(?:\\r\\n|(?<!\\r)\\n|\\r(?!\\n))";
+
+  const appendDecoded = (text: string): boolean => {
+    if (!text) return false;
+    bufferParts.push(text);
+    const scan = delimiterScanTail + text;
+    const found = new RegExp(delimiterPattern).test(scan);
+    // The longest delimiter is four characters, so retaining three detects
+    // every delimiter completed by the next transport chunk without rescanning
+    // the accumulated event.
+    delimiterScanTail = scan.slice(-3);
+    return found;
+  };
+
+  if (!Number.isSafeInteger(maxFrames) || maxFrames < 0) {
+    throw new Error("SSE frame limit must be a non-negative safe integer");
+  }
+
+  const countFrame = (): void => {
+    frameCounter.count++;
+    if (frameCounter.count > maxFrames) {
+      throw new Error(`SSE stream exceeded ${maxFrames} frame limit`);
+    }
+  };
+
+  const stripInitialBom = (
+    value: Uint8Array | undefined,
+    done: boolean,
+  ): Uint8Array | undefined => {
+    if (initialBytesResolved) return value;
+    let offset = 0;
+    while (value && offset < value.byteLength && initialBytes.length < 3) {
+      initialBytes.push(value[offset++]);
+      if (
+        initialBytes[0] !== 0xef ||
+        (initialBytes.length >= 2 && initialBytes[1] !== 0xbb)
+      ) {
+        break;
+      }
+    }
+    if (initialBytes.length === 0 && !done) return undefined;
+    const isBom =
+      initialBytes.length === 3 &&
+      initialBytes[0] === 0xef &&
+      initialBytes[1] === 0xbb &&
+      initialBytes[2] === 0xbf;
+    const prefixMismatch =
+      initialBytes[0] !== 0xef ||
+      (initialBytes.length >= 2 && initialBytes[1] !== 0xbb) ||
+      (initialBytes.length >= 3 && !isBom);
+    if (!isBom && !prefixMismatch && !done) return undefined;
+
+    initialBytesResolved = true;
+    const prefix = isBom ? new Uint8Array() : Uint8Array.from(initialBytes);
+    initialBytes = [];
+    const suffix = value?.subarray(offset) ?? new Uint8Array();
+    if (prefix.byteLength === 0) return suffix;
+    if (suffix.byteLength === 0) return prefix;
+    const combined = new Uint8Array(prefix.byteLength + suffix.byteLength);
+    combined.set(prefix);
+    combined.set(suffix, prefix.byteLength);
+    return combined;
+  };
 
   for (;;) {
-    opts.signal?.throwIfAborted();
-    const read = reader.read();
-    let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
-    const inactivity = new Promise<never>((_resolve, reject) => {
-      if (!opts.inactivityMs) return;
-      inactivityTimer = setTimeout(
-        () => reject(new Error("SSE stream inactivity deadline exceeded")),
-        opts.inactivityMs,
-      );
+    const { done, value } = await readStreamChunk(reader, {
+      signal: opts.signal,
+      inactivityMs: opts.inactivityMs,
     });
-    const { done, value } = await (
-      opts.inactivityMs ? Promise.race([read, inactivity]) : read
-    ).finally(() => {
-      if (inactivityTimer) clearTimeout(inactivityTimer);
-    });
-    if (value) {
-      bufferedBytes += value.byteLength;
-      if (bufferedBytes > maxEventBytes) {
-        throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
+    const payload = stripInitialBom(value, done);
+    let shouldProcess = false;
+    if (payload && payload.byteLength > 0) {
+      totalBytes += payload.byteLength;
+      if (totalBytes > (opts.maxTotalBytes ?? Number.POSITIVE_INFINITY)) {
+        throw new Error("SSE stream exceeded aggregate byte limit");
       }
-      buffer += decoder.decode(value, { stream: true });
+      bufferedBytes += payload.byteLength;
+      try {
+        shouldProcess = appendDecoded(
+          decoder.decode(payload, { stream: true }),
+        );
+      } catch {
+        throw new Error("malformed SSE UTF-8");
+      }
+    }
+    if (done) {
+      try {
+        shouldProcess = appendDecoded(decoder.decode()) || shouldProcess;
+      } catch {
+        throw new Error("malformed SSE UTF-8");
+      }
+    }
+    if (shouldProcess) {
+      // Join only when a complete event exists. An attacker fragmenting one
+      // unterminated event into tiny chunks therefore cannot force repeated
+      // copies and full-prefix delimiter scans.
+      const buffer = bufferParts.join("");
+      const delimiter = new RegExp(delimiterPattern, "g");
+      let consumedChars = 0;
+      let consumedBytes = 0;
+      for (;;) {
+        delimiter.lastIndex = consumedChars;
+        const boundary = delimiter.exec(buffer);
+        if (!boundary) break;
+        const block = buffer.slice(consumedChars, boundary.index);
+        // Every delimiter consumes parser work, even when its block is blank or
+        // comment-only and therefore yields no event to the caller.
+        countFrame();
+        const blockBytes = Buffer.byteLength(block);
+        if (blockBytes > maxEventBytes) {
+          throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
+        }
+        consumedChars = boundary.index + boundary[0].length;
+        consumedBytes += blockBytes + boundary[0].length;
+
+        // Skip empty blocks
+        if (block.trim() === "") continue;
+
+        let eventType = "message";
+        const dataLines: string[] = [];
+
+        for (const line of block.split(/\r\n|\r|\n/)) {
+          if (line.startsWith("event:")) {
+            eventType = line.slice(6).trim();
+          } else if (line.startsWith("data:")) {
+            dataLines.push(line.slice(5).trimStart());
+          }
+          // Lines starting with ':' are comments — ignore
+          // Other lines without known prefix — ignore per SSE spec
+        }
+
+        if (dataLines.length > 0) {
+          yield { event: eventType, data: dataLines.join("\n") };
+        }
+      }
+      if (consumedChars > 0) {
+        const remaining = buffer.slice(consumedChars);
+        bufferParts = remaining ? [remaining] : [];
+        delimiterScanTail = remaining.slice(-3);
+        bufferedBytes -= consumedBytes;
+      }
     }
 
-    // Process complete events (blank-line delimiter; accept LF and CRLF).
-    for (;;) {
-      const boundary = /\r?\n\r?\n/.exec(buffer);
-      if (!boundary) break;
-      const block = buffer.slice(0, boundary.index);
-      frameCounter.count++;
-      if (frameCounter.count > maxFrames) {
-        throw new Error(`SSE stream exceeded ${maxFrames} frame limit`);
-      }
-      if (Buffer.byteLength(block) > maxEventBytes) {
-        throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
-      }
-      buffer = buffer.slice(boundary.index + boundary[0].length);
-      bufferedBytes = Buffer.byteLength(buffer);
-
-      // Skip empty blocks
-      if (block.trim() === "") continue;
-
-      let eventType = "message";
-      const dataLines: string[] = [];
-
-      for (const line of block.split(/\r?\n/)) {
-        if (line.startsWith("event:")) {
-          eventType = line.slice(6).trim();
-        } else if (line.startsWith("data:")) {
-          dataLines.push(line.slice(5).trimStart());
-        }
-        // Lines starting with ':' are comments — ignore
-        // Other lines without known prefix — ignore per SSE spec
-      }
-
-      if (dataLines.length > 0) {
-        yield { event: eventType, data: dataLines.join("\n") };
-      }
+    if (bufferedBytes > maxEventBytes) {
+      throw new Error(`SSE event exceeded ${maxEventBytes} byte limit`);
     }
 
     if (done) {
+      const buffer = bufferParts.join("");
       // Flush any remaining partial block (shouldn't happen with well-formed SSE)
       if (buffer.trim()) {
+        countFrame();
+        if (opts.requireEventTerminator) {
+          throw new Error("unterminated SSE event at EOF");
+        }
         let eventType = "message";
         const dataLines: string[] = [];
-        for (const line of buffer.split(/\r?\n/)) {
+        for (const line of buffer.split(/\r\n|\r|\n/)) {
           if (line.startsWith("event:")) {
             eventType = line.slice(6).trim();
           } else if (line.startsWith("data:")) {
@@ -144,6 +347,28 @@ export async function* parseSSEStream(
       break;
     }
   }
+}
+
+/** Cancel without awaiting hostile sources, and release the reader lock safely. */
+export function cancelAndReleaseReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason?: unknown,
+): void {
+  let cancellation: Promise<void>;
+  try {
+    cancellation = reader.cancel(reason).catch(() => {});
+  } catch {
+    cancellation = Promise.resolve();
+  }
+  const release = (): void => {
+    try {
+      reader.releaseLock();
+    } catch {
+      // A runtime may keep a raced read pending until cancellation settles.
+    }
+  };
+  release();
+  void cancellation.finally(release).catch(() => {});
 }
 
 // ---------------------------------------------------------------------------
@@ -493,7 +718,7 @@ export function createStreamAccumulator(options?: {
   function handleMessageDelta(parsed: Record<string, unknown>): void {
     const delta = parsed.delta as Record<string, unknown> | undefined;
     if (delta && typeof delta.stop_reason === "string") {
-      stopReason = delta.stop_reason;
+      stopReason = normalizeAnthropicStopReason(delta.stop_reason);
     }
 
     // message_delta usage is cumulative output tokens
@@ -902,7 +1127,7 @@ export function buildSSEResponse(resp: GatewayResponse): string {
       JSON.stringify({
         type: "message_delta",
         delta: {
-          stop_reason: resp.stopReason ?? "end_turn",
+          stop_reason: toAnthropicStopReason(resp.stopReason ?? "end_turn"),
           stop_sequence: null,
         },
         usage: { output_tokens: u.outputTokens },
@@ -1418,6 +1643,309 @@ export function createRecallAwareAccumulator(
   };
 }
 
+function malformedAnthropicStream(): never {
+  throw new Error("malformed Anthropic stream event");
+}
+
+function validateAnthropicStreamBlock(block: unknown): string {
+  if (
+    !isRecord(block) ||
+    typeof block.type !== "string" ||
+    !ANTHROPIC_CONTENT_BLOCK_TYPES.has(block.type)
+  ) {
+    malformedAnthropicStream();
+  }
+
+  switch (block.type) {
+    case "text":
+      if (typeof block.text !== "string") malformedAnthropicStream();
+      if (
+        block.citations !== undefined &&
+        block.citations !== null &&
+        (!Array.isArray(block.citations) ||
+          block.citations.some((citation) => !isRecord(citation)))
+      ) {
+        malformedAnthropicStream();
+      }
+      break;
+    case "thinking":
+      if (
+        typeof block.thinking !== "string" ||
+        (block.signature !== undefined && typeof block.signature !== "string")
+      ) {
+        malformedAnthropicStream();
+      }
+      break;
+    case "redacted_thinking":
+      if (typeof block.data !== "string") malformedAnthropicStream();
+      break;
+    case "tool_use":
+      if (
+        typeof block.id !== "string" ||
+        typeof block.name !== "string" ||
+        !isRecord(block.input)
+      ) {
+        malformedAnthropicStream();
+      }
+      break;
+    case "server_tool_use":
+      if (
+        typeof block.id !== "string" ||
+        typeof block.name !== "string" ||
+        block.input === undefined
+      ) {
+        malformedAnthropicStream();
+      }
+      break;
+    case "container_upload":
+      if (typeof block.file_id !== "string") malformedAnthropicStream();
+      break;
+    case "web_search_tool_result":
+    case "web_fetch_tool_result":
+    case "code_execution_tool_result":
+    case "bash_code_execution_tool_result":
+    case "text_editor_code_execution_tool_result":
+    case "tool_search_tool_result":
+      if (typeof block.tool_use_id !== "string" || block.content == null) {
+        malformedAnthropicStream();
+      }
+      break;
+    case "fallback":
+      // Server-side fallback emits only a start/stop boundary block.
+      break;
+  }
+  return block.type;
+}
+
+function validateAnthropicMessageStart(parsed: Record<string, unknown>): void {
+  if (!isRecord(parsed.message)) malformedAnthropicStream();
+  const message = parsed.message;
+  if (
+    typeof message.id !== "string" ||
+    message.type !== "message" ||
+    message.role !== "assistant" ||
+    typeof message.model !== "string" ||
+    !Array.isArray(message.content) ||
+    message.content.length !== 0 ||
+    message.stop_reason !== null ||
+    message.stop_sequence !== null
+  ) {
+    malformedAnthropicStream();
+  }
+  if (
+    message.container !== undefined &&
+    message.container !== null &&
+    !isRecord(message.container)
+  ) {
+    malformedAnthropicStream();
+  }
+  if (
+    message.stop_details !== undefined &&
+    message.stop_details !== null &&
+    !isRecord(message.stop_details)
+  ) {
+    malformedAnthropicStream();
+  }
+  validateAnthropicUsage(message.usage, {
+    message: "malformed Anthropic stream event",
+    required: true,
+    requireInput: true,
+    requireOutput: true,
+  });
+}
+
+function validateAnthropicMessageDelta(
+  parsed: Record<string, unknown>,
+): string | null {
+  if (!isRecord(parsed.delta)) malformedAnthropicStream();
+  const delta = parsed.delta;
+  if (!("stop_reason" in delta)) malformedAnthropicStream();
+  const stopReason = delta.stop_reason;
+  if (
+    stopReason !== null &&
+    (typeof stopReason !== "string" || !ANTHROPIC_STOP_REASONS.has(stopReason))
+  ) {
+    malformedAnthropicStream();
+  }
+  if (
+    delta.stop_sequence !== undefined &&
+    delta.stop_sequence !== null &&
+    typeof delta.stop_sequence !== "string"
+  ) {
+    malformedAnthropicStream();
+  }
+  if (
+    delta.container !== undefined &&
+    delta.container !== null &&
+    !isRecord(delta.container)
+  ) {
+    malformedAnthropicStream();
+  }
+  if (
+    delta.stop_details !== undefined &&
+    delta.stop_details !== null &&
+    !isRecord(delta.stop_details)
+  ) {
+    malformedAnthropicStream();
+  }
+  validateAnthropicUsage(parsed.usage, {
+    message: "malformed Anthropic stream event",
+    required: true,
+    requireOutput: true,
+    allowNullCounts: true,
+  });
+  return typeof stopReason === "string" ? stopReason : null;
+}
+
+/** Incremental strict validator shared by buffered and true-streaming paths. */
+export class AnthropicSSEValidator {
+  private messageStarted = false;
+  private messageDeltaPhase = false;
+  private terminalStopReason: string | null = null;
+  private terminalSeen = false;
+  private readonly activeBlocks = new Set<number>();
+  private readonly seenBlocks = new Set<number>();
+  private readonly blockTypes = new Map<number, string>();
+  private readonly toolUseIds = new Set<string>();
+
+  process(event: string, data: string): void {
+    let parsed: Record<string, unknown>;
+    try {
+      const decoded: unknown = JSON.parse(data);
+      if (!isRecord(decoded)) malformedAnthropicStream();
+      parsed = decoded;
+    } catch {
+      malformedAnthropicStream();
+    }
+    if (this.terminalSeen || parsed.type !== event) malformedAnthropicStream();
+    const index = parsed.index;
+    const validIndex = Number.isSafeInteger(index) && (index as number) >= 0;
+    switch (event) {
+      case "error":
+        throw new Error("Anthropic stream error event");
+      case "ping":
+        break;
+      case "message_start":
+        if (this.messageStarted) malformedAnthropicStream();
+        validateAnthropicMessageStart(parsed);
+        this.messageStarted = true;
+        break;
+      case "content_block_start": {
+        if (
+          !this.messageStarted ||
+          this.messageDeltaPhase ||
+          !validIndex ||
+          this.activeBlocks.has(index as number) ||
+          this.seenBlocks.has(index as number)
+        ) {
+          malformedAnthropicStream();
+        }
+        const blockType = validateAnthropicStreamBlock(parsed.content_block);
+        const block = parsed.content_block as Record<string, unknown>;
+        const hasToolIdentity =
+          blockType === "tool_use" || blockType === "server_tool_use";
+        if (
+          hasToolIdentity &&
+          (!block.id || this.toolUseIds.has(block.id as string))
+        ) {
+          malformedAnthropicStream();
+        }
+        if (hasToolIdentity) this.toolUseIds.add(block.id as string);
+        this.blockTypes.set(index as number, blockType);
+        this.activeBlocks.add(index as number);
+        this.seenBlocks.add(index as number);
+        break;
+      }
+      case "content_block_delta": {
+        if (
+          !validIndex ||
+          !this.activeBlocks.has(index as number) ||
+          !isRecord(parsed.delta)
+        ) {
+          malformedAnthropicStream();
+        }
+        const delta = parsed.delta;
+        switch (delta.type) {
+          case "text_delta":
+            if (typeof delta.text !== "string") malformedAnthropicStream();
+            break;
+          case "thinking_delta":
+            if (typeof delta.thinking !== "string") malformedAnthropicStream();
+            break;
+          case "signature_delta":
+            if (typeof delta.signature !== "string") malformedAnthropicStream();
+            break;
+          case "input_json_delta":
+            if (typeof delta.partial_json !== "string") {
+              malformedAnthropicStream();
+            }
+            break;
+          case "citations_delta":
+            if (!isRecord(delta.citation)) malformedAnthropicStream();
+            break;
+          default:
+            malformedAnthropicStream();
+        }
+        const blockType = this.blockTypes.get(index as number);
+        const validDeltaForBlock =
+          blockType === "text"
+            ? delta.type === "text_delta" || delta.type === "citations_delta"
+            : blockType === "thinking"
+              ? delta.type === "thinking_delta" ||
+                delta.type === "signature_delta"
+              : blockType === "tool_use" || blockType === "server_tool_use"
+                ? delta.type === "input_json_delta"
+                : false;
+        if (!validDeltaForBlock) malformedAnthropicStream();
+        break;
+      }
+      case "content_block_stop":
+        if (!validIndex || !this.activeBlocks.delete(index as number)) {
+          malformedAnthropicStream();
+        }
+        break;
+      case "message_delta": {
+        if (!this.messageStarted || this.activeBlocks.size > 0) {
+          malformedAnthropicStream();
+        }
+        this.messageDeltaPhase = true;
+        const stopReason = validateAnthropicMessageDelta(parsed);
+        if (
+          stopReason !== null &&
+          this.terminalStopReason !== null &&
+          this.terminalStopReason !== stopReason
+        ) {
+          malformedAnthropicStream();
+        }
+        this.terminalStopReason = stopReason ?? this.terminalStopReason;
+        break;
+      }
+      case "message_stop":
+        if (
+          !this.messageStarted ||
+          this.terminalStopReason === null ||
+          this.activeBlocks.size > 0
+        ) {
+          malformedAnthropicStream();
+        }
+        this.terminalSeen = true;
+        break;
+      default:
+        malformedAnthropicStream();
+    }
+  }
+
+  isDone(): boolean {
+    return this.terminalSeen;
+  }
+
+  assertDone(): void {
+    if (!this.terminalSeen) {
+      throw new Error("missing Anthropic message_stop terminal");
+    }
+  }
+}
+
 /**
  * Consume an Anthropic SSE streaming Response and return the accumulated
  * GatewayResponse. Useful when the response needs to be translated to another
@@ -1425,25 +1953,225 @@ export function createRecallAwareAccumulator(
  */
 export async function accumulateSSEResponse(
   response: Response,
+  opts: {
+    signal?: AbortSignal;
+    stopAtTerminal?: boolean;
+    strict?: boolean;
+    inactivityMs?: number;
+    maxFrames?: number;
+    onSemanticContent?: () => void;
+  } = {},
 ): Promise<GatewayResponse> {
   const accumulator = createStreamAccumulator();
-  const text = await response.text();
+  let messageStarted = false;
+  let messageDeltaPhase = false;
+  let terminalStopReason: string | null = null;
+  const activeBlocks = new Set<number>();
+  const seenBlocks = new Set<number>();
+  const blockTypes = new Map<number, string>();
+  const toolUseIds = new Set<string>();
+  const strictValidator = opts.strict ? new AnthropicSSEValidator() : undefined;
+  if (!response.body) throw new Error("Response has no body");
+  const reader = response.body.getReader();
 
-  for (const block of text.split("\n\n")) {
-    if (!block.trim()) continue;
-    let eventType = "message";
-    const dataLines: string[] = [];
-    for (const line of block.split("\n")) {
-      if (line.startsWith("event:")) {
-        eventType = line.slice(6).trim();
-      } else if (line.startsWith("data:")) {
-        dataLines.push(line.slice(5).trimStart());
+  try {
+    for await (const { event, data } of parseSSEStream(reader, {
+      signal: opts.signal,
+      inactivityMs: opts.inactivityMs,
+      requireEventTerminator: opts.strict,
+      fatalUtf8: opts.strict,
+      maxEventBytes: opts.strict ? undefined : Number.POSITIVE_INFINITY,
+      maxFrames: opts.strict
+        ? (opts.maxFrames ?? DEFAULT_MAX_SSE_FRAMES)
+        : opts.maxFrames,
+      maxTotalBytes: opts.strict ? 4 * 1024 * 1024 : undefined,
+    })) {
+      strictValidator?.process(event, data);
+      if (opts.strict) {
+        let parsed: Record<string, unknown>;
+        try {
+          const decoded: unknown = JSON.parse(data);
+          if (!isRecord(decoded)) malformedAnthropicStream();
+          parsed = decoded;
+        } catch {
+          malformedAnthropicStream();
+        }
+        if (parsed.type !== event) malformedAnthropicStream();
+        const index = parsed.index;
+        const validIndex =
+          Number.isSafeInteger(index) && (index as number) >= 0;
+        switch (event) {
+          case "error":
+            throw new Error("Anthropic stream error event");
+          case "ping":
+            break;
+          case "message_start":
+            if (messageStarted) malformedAnthropicStream();
+            validateAnthropicMessageStart(parsed);
+            messageStarted = true;
+            break;
+          case "content_block_start":
+            if (
+              !messageStarted ||
+              messageDeltaPhase ||
+              !validIndex ||
+              activeBlocks.has(index as number) ||
+              seenBlocks.has(index as number)
+            ) {
+              malformedAnthropicStream();
+            }
+            {
+              const blockType = validateAnthropicStreamBlock(
+                parsed.content_block,
+              );
+              const block = parsed.content_block as Record<string, unknown>;
+              const hasToolIdentity =
+                blockType === "tool_use" || blockType === "server_tool_use";
+              if (
+                hasToolIdentity &&
+                (!block.id || toolUseIds.has(block.id as string))
+              ) {
+                malformedAnthropicStream();
+              }
+              if (hasToolIdentity) {
+                toolUseIds.add(block.id as string);
+              }
+              blockTypes.set(index as number, blockType);
+            }
+            activeBlocks.add(index as number);
+            seenBlocks.add(index as number);
+            break;
+          case "content_block_delta":
+            if (
+              !validIndex ||
+              !activeBlocks.has(index as number) ||
+              !isRecord(parsed.delta)
+            ) {
+              malformedAnthropicStream();
+            }
+            {
+              const delta = parsed.delta;
+              switch (delta.type) {
+                case "text_delta":
+                  if (typeof delta.text !== "string") {
+                    malformedAnthropicStream();
+                  }
+                  break;
+                case "thinking_delta":
+                  if (typeof delta.thinking !== "string") {
+                    malformedAnthropicStream();
+                  }
+                  break;
+                case "signature_delta":
+                  if (typeof delta.signature !== "string") {
+                    malformedAnthropicStream();
+                  }
+                  break;
+                case "input_json_delta":
+                  if (typeof delta.partial_json !== "string") {
+                    malformedAnthropicStream();
+                  }
+                  break;
+                case "citations_delta":
+                  if (!isRecord(delta.citation)) malformedAnthropicStream();
+                  break;
+                default:
+                  malformedAnthropicStream();
+              }
+              const blockType = blockTypes.get(index as number);
+              const validDeltaForBlock =
+                blockType === "text"
+                  ? delta.type === "text_delta" ||
+                    delta.type === "citations_delta"
+                  : blockType === "thinking"
+                    ? delta.type === "thinking_delta" ||
+                      delta.type === "signature_delta"
+                    : blockType === "tool_use" ||
+                        blockType === "server_tool_use"
+                      ? delta.type === "input_json_delta"
+                      : false;
+              if (!validDeltaForBlock) malformedAnthropicStream();
+            }
+            break;
+          case "content_block_stop":
+            if (!validIndex || !activeBlocks.delete(index as number)) {
+              malformedAnthropicStream();
+            }
+            break;
+          case "message_delta":
+            if (!messageStarted || activeBlocks.size > 0) {
+              malformedAnthropicStream();
+            }
+            messageDeltaPhase = true;
+            {
+              const stopReason = validateAnthropicMessageDelta(parsed);
+              if (
+                stopReason !== null &&
+                terminalStopReason !== null &&
+                terminalStopReason !== stopReason
+              ) {
+                malformedAnthropicStream();
+              }
+              terminalStopReason = stopReason ?? terminalStopReason;
+            }
+            break;
+          case "message_stop":
+            if (
+              !messageStarted ||
+              terminalStopReason === null ||
+              activeBlocks.size > 0
+            ) {
+              malformedAnthropicStream();
+            }
+            break;
+          default:
+            malformedAnthropicStream();
+        }
       }
+      if (opts.onSemanticContent) {
+        let semantic = false;
+        try {
+          const parsed = JSON.parse(data) as Record<string, unknown>;
+          if (
+            event === "content_block_start" &&
+            isRecord(parsed.content_block)
+          ) {
+            const block = parsed.content_block;
+            semantic =
+              block.type === "tool_use" ||
+              block.type === "server_tool_use" ||
+              (block.type === "text" &&
+                typeof block.text === "string" &&
+                block.text.length > 0) ||
+              (block.type === "thinking" &&
+                typeof block.thinking === "string" &&
+                block.thinking.length > 0);
+          } else if (
+            event === "content_block_delta" &&
+            isRecord(parsed.delta)
+          ) {
+            semantic = [
+              parsed.delta.text,
+              parsed.delta.thinking,
+              parsed.delta.partial_json,
+            ].some((value) => typeof value === "string" && value.length > 0);
+          }
+        } catch {
+          // Strict parsing above owns malformed JSON diagnostics.
+        }
+        if (semantic) opts.onSemanticContent();
+      }
+      accumulator.processEvent(event, data);
+      if (opts.stopAtTerminal && accumulator.isDone()) break;
     }
-    if (dataLines.length > 0) {
-      accumulator.processEvent(eventType, dataLines.join("\n"));
-    }
+  } finally {
+    cancelAndReleaseReader(reader);
   }
+
+  if (opts.stopAtTerminal && !accumulator.isDone()) {
+    throw new Error("missing Anthropic message_stop terminal");
+  }
+  if (opts.stopAtTerminal) strictValidator?.assertDone();
 
   return accumulator.getResponse();
 }

--- a/packages/gateway/src/stream/gemini.ts
+++ b/packages/gateway/src/stream/gemini.ts
@@ -25,8 +25,15 @@ import {
   buildGeminiResponseBody,
   geminiUsageFromMetadata,
   mapGeminiFinishReason,
+  validateGeminiFunctionCallIdentity,
 } from "../translate/gemini";
-import { parseSSEStream, createStreamAccumulator } from "./anthropic";
+import {
+  DEFAULT_MAX_SSE_FRAMES,
+  parseSSEStream,
+  accumulateSSEResponse,
+  cancelAndReleaseReader,
+} from "./anthropic";
+import { isRecord, validateGeminiUsageMetadata } from "../usage-validation";
 
 type GeminiPart = Record<string, unknown>;
 
@@ -38,6 +45,15 @@ type GeminiPart = Record<string, unknown>;
  */
 export async function accumulateGeminiSSEStream(
   upstreamResponse: Response,
+  opts: {
+    signal?: AbortSignal;
+    stopAtTerminal?: boolean;
+    strict?: boolean;
+    inactivityMs?: number;
+    maxFrames?: number;
+    onSemanticContent?: () => void;
+    onValidatedEvent?: (event: string, data: string) => void | Promise<void>;
+  } = {},
 ): Promise<GatewayResponse> {
   if (!upstreamResponse.body) {
     throw new Error("Upstream response has no body");
@@ -45,49 +61,226 @@ export async function accumulateGeminiSSEStream(
 
   let textContent = "";
   let thinkingContent = "";
-  const toolUses: Array<{ name: string; input: unknown }> = [];
+  const toolUses: Array<{ id: string; name: string; input: unknown }> = [];
   let finishReason: unknown;
   let model = "";
   let responseId = "";
   let usage: GatewayUsage = { ...ZERO_USAGE };
+  let terminalSeen = false;
+  const toolIdentitiesByCandidate = new Map<number, Set<string>>();
 
   const reader = upstreamResponse.body.getReader();
-  for await (const { data } of parseSSEStream(reader)) {
-    if (!data || data === "[DONE]") continue;
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(data) as Record<string, unknown>;
-    } catch {
-      continue;
-    }
+  try {
+    for await (const { event, data } of parseSSEStream(reader, {
+      signal: opts.signal,
+      inactivityMs: opts.inactivityMs,
+      requireEventTerminator: opts.strict,
+      fatalUtf8: opts.strict,
+      maxFrames: opts.strict
+        ? (opts.maxFrames ?? DEFAULT_MAX_SSE_FRAMES)
+        : opts.maxFrames,
+      maxTotalBytes: opts.strict ? 4 * 1024 * 1024 : undefined,
+    })) {
+      if (!data || data === "[DONE]") continue;
+      let parsed: Record<string, unknown>;
+      try {
+        const decoded: unknown = JSON.parse(data);
+        if (!isRecord(decoded)) {
+          if (opts.strict) throw new Error("malformed Gemini stream event");
+          continue;
+        }
+        parsed = decoded;
+      } catch {
+        if (opts.strict) throw new Error("malformed Gemini stream event");
+        continue;
+      }
 
-    if (typeof parsed.modelVersion === "string") model = parsed.modelVersion;
-    if (typeof parsed.responseId === "string") responseId = parsed.responseId;
+      if (opts.strict) {
+        const malformed = (): never => {
+          throw new Error("malformed Gemini stream event");
+        };
+        if (
+          parsed.candidates !== undefined &&
+          !Array.isArray(parsed.candidates)
+        ) {
+          malformed();
+        }
+        if (Array.isArray(parsed.candidates)) {
+          for (const [
+            candidatePosition,
+            candidate,
+          ] of parsed.candidates.entries()) {
+            if (!isRecord(candidate)) malformed();
+            if (
+              candidate.index !== undefined &&
+              (!Number.isSafeInteger(candidate.index) ||
+                (candidate.index as number) < 0)
+            ) {
+              malformed();
+            }
+            if (
+              candidate.finishReason !== undefined &&
+              candidate.finishReason !== null &&
+              typeof candidate.finishReason !== "string"
+            ) {
+              malformed();
+            }
+            if (
+              candidate.tokenCount !== undefined &&
+              (!Number.isSafeInteger(candidate.tokenCount) ||
+                (candidate.tokenCount as number) < 0)
+            ) {
+              malformed();
+            }
+            const candidateIndex =
+              typeof candidate.index === "number"
+                ? candidate.index
+                : candidatePosition;
+            let toolIdentities = toolIdentitiesByCandidate.get(candidateIndex);
+            if (!toolIdentities) {
+              toolIdentities = new Set<string>();
+              toolIdentitiesByCandidate.set(candidateIndex, toolIdentities);
+            }
+            if (candidate.content === undefined) continue;
+            if (!isRecord(candidate.content)) malformed();
+            if (
+              candidate.content.role !== undefined &&
+              typeof candidate.content.role !== "string"
+            ) {
+              malformed();
+            }
+            const candidateParts = candidate.content.parts;
+            if (candidateParts === undefined) continue;
+            if (!Array.isArray(candidateParts)) malformed();
+            for (const part of candidateParts) {
+              if (!isRecord(part)) malformed();
+              if (part.text !== undefined && part.functionCall !== undefined) {
+                malformed();
+              }
+              if (part.text !== undefined && typeof part.text !== "string") {
+                malformed();
+              }
+              if (
+                part.thought !== undefined &&
+                typeof part.thought !== "boolean"
+              ) {
+                malformed();
+              }
+              if (part.functionCall === undefined) continue;
+              validateGeminiFunctionCallIdentity(
+                part.functionCall,
+                toolIdentities,
+                "malformed Gemini stream event",
+              );
+            }
+          }
+        }
+        validateGeminiUsageMetadata(
+          parsed.usageMetadata,
+          "malformed Gemini stream event",
+        );
+        if (parsed.promptFeedback !== undefined) {
+          if (!isRecord(parsed.promptFeedback)) malformed();
+          const promptFeedback = parsed.promptFeedback as Record<
+            string,
+            unknown
+          >;
+          if (
+            promptFeedback.blockReason !== undefined &&
+            typeof promptFeedback.blockReason !== "string"
+          ) {
+            malformed();
+          }
+        }
+      }
 
-    const candidates = Array.isArray(parsed.candidates)
-      ? parsed.candidates
-      : [];
-    const first = (candidates[0] ?? {}) as Record<string, unknown>;
-    const content = (first.content ?? {}) as Record<string, unknown>;
-    const parts = Array.isArray(content.parts)
-      ? (content.parts as GeminiPart[])
-      : [];
-    for (const p of parts) {
-      if (typeof p.text === "string") {
-        // Keep reasoning-summary parts (`thought: true`) out of the visible
-        // answer text — accumulate them into a separate thinking block.
-        if (p.thought === true) thinkingContent += p.text;
-        else textContent += p.text;
-      } else if (p.functionCall && typeof p.functionCall === "object") {
-        const fc = p.functionCall as { name?: unknown; args?: unknown };
-        toolUses.push({ name: asString(fc.name), input: fc.args ?? {} });
+      if (
+        opts.strict &&
+        ((parsed.modelVersion !== undefined &&
+          typeof parsed.modelVersion !== "string") ||
+          (model &&
+            typeof parsed.modelVersion === "string" &&
+            parsed.modelVersion !== model) ||
+          (parsed.responseId !== undefined &&
+            typeof parsed.responseId !== "string") ||
+          (responseId &&
+            typeof parsed.responseId === "string" &&
+            parsed.responseId !== responseId))
+      ) {
+        throw new Error("malformed Gemini stream event");
+      }
+      if (typeof parsed.modelVersion === "string") model = parsed.modelVersion;
+      if (typeof parsed.responseId === "string") responseId = parsed.responseId;
+
+      const candidates = Array.isArray(parsed.candidates)
+        ? parsed.candidates
+        : [];
+      const promptFeedback = isRecord(parsed.promptFeedback)
+        ? parsed.promptFeedback
+        : undefined;
+      if (
+        candidates.length === 0 &&
+        typeof promptFeedback?.blockReason === "string" &&
+        promptFeedback.blockReason
+      ) {
+        finishReason = promptFeedback.blockReason;
+      }
+      const first = isRecord(candidates[0]) ? candidates[0] : {};
+      const content = isRecord(first.content) ? first.content : {};
+      const parts = Array.isArray(content.parts)
+        ? (content.parts as GeminiPart[])
+        : [];
+      for (const p of parts) {
+        if (typeof p.text === "string") {
+          if (p.text) opts.onSemanticContent?.();
+          // Keep reasoning-summary parts (`thought: true`) out of the visible
+          // answer text — accumulate them into a separate thinking block.
+          if (p.thought === true) thinkingContent += p.text;
+          else textContent += p.text;
+        } else if (p.functionCall && typeof p.functionCall === "object") {
+          opts.onSemanticContent?.();
+          const fc = p.functionCall as {
+            id?: unknown;
+            name?: unknown;
+            args?: unknown;
+          };
+          const name = asString(fc.name);
+          toolUses.push({
+            id: asString(fc.id) || name,
+            name,
+            input: fc.args ?? {},
+          });
+        }
+      }
+      if (first.finishReason != null) finishReason = first.finishReason;
+
+      // streamGenerateContent reports cumulative usageMetadata on the same
+      // candidate frame that carries finishReason. The API has no OpenAI-style
+      // legal usage-only frame after that terminal, so stopAtTerminal
+      // intentionally cancels transport tail instead of waiting indefinitely.
+      // Last non-null usage before/on that frame wins.
+      const um = validateGeminiUsageMetadata(
+        parsed.usageMetadata,
+        "malformed Gemini stream event",
+      );
+      if (um) usage = geminiUsageFromMetadata(um);
+      await opts.onValidatedEvent?.(event, data);
+      if (
+        opts.stopAtTerminal &&
+        typeof finishReason === "string" &&
+        finishReason !== "" &&
+        finishReason !== "FINISH_REASON_UNSPECIFIED"
+      ) {
+        terminalSeen = true;
+        break;
       }
     }
-    if (first.finishReason != null) finishReason = first.finishReason;
+  } finally {
+    cancelAndReleaseReader(reader);
+  }
 
-    // usageMetadata is cumulative across frames; last non-null wins.
-    const um = parsed.usageMetadata as Record<string, unknown> | undefined;
-    if (um) usage = geminiUsageFromMetadata(um);
+  if (opts.stopAtTerminal && !terminalSeen) {
+    throw new Error("missing Gemini finishReason terminal");
   }
 
   const blocks: GatewayContentBlock[] = [];
@@ -97,7 +290,7 @@ export async function accumulateGeminiSSEStream(
   for (const tu of toolUses) {
     blocks.push({
       type: "tool_use",
-      id: tu.name,
+      id: tu.id,
       name: tu.name,
       input: tu.input,
     });
@@ -121,26 +314,91 @@ export async function accumulateGeminiSSEStream(
  */
 export function translateAnthropicStreamToGemini(
   anthropicResponse: Response,
+  opts: { strict?: boolean; signal?: AbortSignal } = {},
 ): Response {
-  const stream = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      const encoder = new TextEncoder();
-      const accumulator = createStreamAccumulator();
+  const downstreamAbort = new AbortController();
+  const signal = opts.signal
+    ? AbortSignal.any([opts.signal, downstreamAbort.signal])
+    : downstreamAbort.signal;
+  let pumpStarted = false;
+  let settled = false;
+  let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const cleanup = (): void =>
+    opts.signal?.removeEventListener("abort", onAbort);
+  const onAbort = (): void => {
+    if (settled) return;
+    settled = true;
+    const reason = opts.signal?.reason;
+    downstreamAbort.abort(reason);
+    if (!pumpStarted) {
       try {
-        if (anthropicResponse.body) {
-          const reader = anthropicResponse.body.getReader();
-          for await (const { event, data } of parseSSEStream(reader)) {
-            accumulator.processEvent(event, data);
+        void anthropicResponse.body?.cancel(reason).catch(() => {});
+      } catch {
+        // Best-effort cancellation before reader acquisition.
+      }
+    }
+    cleanup();
+    try {
+      streamController?.error(reason);
+    } catch {
+      // Already closed/cancelled.
+    }
+  };
+  const stream = new ReadableStream<Uint8Array>(
+    {
+      start(controller) {
+        streamController = controller;
+        opts.signal?.addEventListener("abort", onAbort, { once: true });
+        if (opts.signal?.aborted) onAbort();
+      },
+      pull(controller) {
+        if (pumpStarted) return;
+        pumpStarted = true;
+        const encoder = new TextEncoder();
+        const pump = async (): Promise<void> => {
+          try {
+            const resp = await accumulateSSEResponse(anthropicResponse, {
+              signal,
+              strict: opts.strict,
+              stopAtTerminal: opts.strict,
+            });
+            if (settled) return;
+            const body = buildGeminiResponseBody(resp);
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(body)}\n\n`),
+            );
+            settled = true;
+            cleanup();
+            controller.close();
+          } catch (error) {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            controller.error(error);
+          }
+        };
+        queueMicrotask(() => void pump().catch(() => {}));
+      },
+      cancel(reason) {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        downstreamAbort.abort(reason);
+        if (!pumpStarted) {
+          try {
+            void anthropicResponse.body?.cancel(reason).catch(() => {});
+          } catch {
+            // Best-effort cancellation before reader acquisition.
           }
         }
-        const resp = accumulator.getResponse();
-        const body = buildGeminiResponseBody(resp);
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(body)}\n\n`));
-      } finally {
-        controller.close();
-      }
+      },
     },
-  });
+    {
+      // Do not consume/buffer the Anthropic source until a downstream read asks
+      // for the single aggregated Gemini frame.
+      highWaterMark: 0,
+    },
+  );
 
   return new Response(stream, {
     status: 200,

--- a/packages/gateway/src/stream/openai-responses.ts
+++ b/packages/gateway/src/stream/openai-responses.ts
@@ -21,7 +21,18 @@ import {
   type GatewayResponse,
   type GatewayUsage,
 } from "../translate/types";
-import { parseSSEStream, createStreamAccumulator } from "./anthropic";
+import {
+  DEFAULT_MAX_SSE_FRAMES,
+  AnthropicSSEValidator,
+  parseSSEStream,
+  createStreamAccumulator,
+  cancelAndReleaseReader,
+} from "./anthropic";
+import {
+  isRecord as isUsageRecord,
+  safeTokenSum,
+  validateResponsesUsage,
+} from "../usage-validation";
 
 // ---------------------------------------------------------------------------
 // Stream accumulator — shared per-event core
@@ -46,6 +57,18 @@ export interface ResponsesAccState {
   terminalResponse?: Record<string, unknown>;
   /** Original upstream output items, retained for terminal rebuilds. */
   rawItems: Map<number, Record<string, unknown>>;
+  /** Strict-mode identity indexes. Each identity belongs to one output item. */
+  itemIndexById: Map<string, number>;
+  callIndexById: Map<string, number>;
+  effectiveToolIndexById: Map<string, number>;
+  nextOutputIndex: number;
+  activeTextItems: Set<number>;
+  activeToolItems: Set<number>;
+  unboundTextItems: Set<number>;
+  unboundToolItems: Set<number>;
+  textDoneItems: Set<number>;
+  refusalDoneItems: Set<number>;
+  argumentDoneItems: Set<number>;
   /** Accumulating output items indexed by output_index. */
   items: Map<
     number,
@@ -74,6 +97,17 @@ export function makeResponsesAccState(): ResponsesAccState {
     usage: { inputTokens: 0, outputTokens: 0 },
     items: new Map(),
     rawItems: new Map(),
+    itemIndexById: new Map(),
+    callIndexById: new Map(),
+    effectiveToolIndexById: new Map(),
+    nextOutputIndex: 0,
+    activeTextItems: new Set(),
+    activeToolItems: new Set(),
+    unboundTextItems: new Set(),
+    unboundToolItems: new Set(),
+    textDoneItems: new Set(),
+    refusalDoneItems: new Set(),
+    argumentDoneItems: new Set(),
   };
 }
 
@@ -102,14 +136,19 @@ export function applyResponsesEvent(
       const item = parsed.item as Record<string, unknown> | undefined;
       if (typeof outputIndex !== "number" || !item) break;
       state.rawItems.set(outputIndex, { ...item });
+      state.nextOutputIndex = Math.max(state.nextOutputIndex, outputIndex + 1);
 
       if (item.type === "message") {
+        state.activeTextItems.add(outputIndex);
+        if (!asString(item.id)) state.unboundTextItems.add(outputIndex);
         state.items.set(outputIndex, {
           type: "text",
           id: asString(item.id),
           text: "",
         });
       } else if (item.type === "function_call") {
+        state.activeToolItems.add(outputIndex);
+        if (!asString(item.id)) state.unboundToolItems.add(outputIndex);
         state.items.set(outputIndex, {
           type: "tool_use",
           id: asString(item.id),
@@ -230,67 +269,48 @@ export function applyResponsesEvent(
         if (typeof resp.model === "string") state.model = resp.model;
         if (typeof resp.status === "string") {
           state.stopReason = mapStatusToStopReason(resp.status);
+          if (resp.status === "incomplete") {
+            const details = resp.incomplete_details as
+              | Record<string, unknown>
+              | undefined;
+            if (details?.reason === "content_filter") {
+              state.stopReason = "content_filter";
+            }
+          }
         }
 
-        const respUsage = resp.usage as Record<string, unknown> | undefined;
+        const respUsage = validateResponsesUsage(
+          resp.usage,
+          "malformed Responses usage",
+        );
         if (respUsage) {
-          const assertTokenCount = (value: unknown, field: string): void => {
-            if (
-              value !== undefined &&
-              (!Number.isSafeInteger(value) || (value as number) < 0)
-            ) {
-              throw new Error(`invalid Responses usage ${field}`);
-            }
-          };
-          assertTokenCount(respUsage.output_tokens, "output_tokens");
-          assertTokenCount(respUsage.input_tokens, "input_tokens");
-          assertTokenCount(respUsage.total_tokens, "total_tokens");
-          if (
-            typeof respUsage.input_tokens === "number" &&
-            typeof respUsage.output_tokens === "number" &&
-            !Number.isSafeInteger(
-              respUsage.input_tokens + respUsage.output_tokens,
-            )
-          ) {
-            throw new Error("Responses usage total token overflow");
-          }
           if (typeof respUsage.output_tokens === "number") {
             state.usage.outputTokens = respUsage.output_tokens;
           }
           // Responses API reports cache details under `input_tokens_details`;
           // fall back to `prompt_tokens_details` for OpenAI-compatible providers.
-          const promptDetails = (respUsage.input_tokens_details ??
-            respUsage.prompt_tokens_details) as
-            | Record<string, number>
-            | undefined;
-          assertTokenCount(promptDetails?.cached_tokens, "cached_tokens");
-          assertTokenCount(
-            promptDetails?.cache_write_tokens,
-            "cache_write_tokens",
+          const rawPromptDetails =
+            respUsage.input_tokens_details ?? respUsage.prompt_tokens_details;
+          const promptDetails = isUsageRecord(rawPromptDetails)
+            ? rawPromptDetails
+            : undefined;
+          const cachedTokens =
+            typeof promptDetails?.cached_tokens === "number"
+              ? promptDetails.cached_tokens
+              : 0;
+          const cacheWriteTokens =
+            typeof promptDetails?.cache_write_tokens === "number"
+              ? promptDetails.cache_write_tokens
+              : 0;
+          const cacheTokens = safeTokenSum(
+            [cachedTokens, cacheWriteTokens],
+            "malformed Responses usage",
           );
-          const cachedTokens = promptDetails?.cached_tokens ?? 0;
-          const cacheWriteTokens = promptDetails?.cache_write_tokens ?? 0;
-          const cacheTokens = cachedTokens + cacheWriteTokens;
-          if (!Number.isSafeInteger(cacheTokens)) {
-            throw new Error("Responses usage cache token overflow");
+          if (typeof promptDetails?.cached_tokens === "number") {
+            state.usage.cacheReadInputTokens = cachedTokens;
           }
-          if (
-            typeof respUsage.input_tokens === "number" &&
-            cacheTokens > respUsage.input_tokens
-          ) {
-            throw new Error("Responses usage cache tokens exceed input tokens");
-          }
-          if (cacheTokens > 0 && typeof respUsage.input_tokens !== "number") {
-            throw new Error(
-              "Responses usage cache tokens require input_tokens",
-            );
-          }
-          if (promptDetails?.cached_tokens !== undefined) {
-            state.usage.cacheReadInputTokens = promptDetails.cached_tokens;
-          }
-          if (promptDetails?.cache_write_tokens !== undefined) {
-            state.usage.cacheCreationInputTokens =
-              promptDetails.cache_write_tokens;
+          if (typeof promptDetails?.cache_write_tokens === "number") {
+            state.usage.cacheCreationInputTokens = cacheWriteTokens;
           }
           if (typeof respUsage.input_tokens === "number") {
             // input_tokens is inclusive of cache reads/writes; subtract them
@@ -400,6 +420,864 @@ export function finalizeResponsesAcc(
 // Stream accumulator (buffered)
 // ---------------------------------------------------------------------------
 
+function validatePublicResponsesEvent(
+  state: ResponsesAccState,
+  event: string,
+  parsed: Record<string, unknown>,
+  maxSparseIndex: number,
+): void {
+  const outputIndex = parsed.output_index;
+  const validOutputIndex =
+    Number.isSafeInteger(outputIndex) &&
+    (outputIndex as number) >= 0 &&
+    (outputIndex as number) < maxSparseIndex;
+  const item = validOutputIndex
+    ? state.items.get(outputIndex as number)
+    : undefined;
+  const malformed = (): never => {
+    throw new Error("malformed Responses stream event");
+  };
+
+  if (parsed.type !== undefined && parsed.type !== event) malformed();
+  if (
+    parsed.sequence_number !== undefined &&
+    (!Number.isSafeInteger(parsed.sequence_number) ||
+      (parsed.sequence_number as number) < 0)
+  ) {
+    malformed();
+  }
+  if (
+    event === "response.created" ||
+    event === "response.in_progress" ||
+    event === "response.failed" ||
+    event === "response.completed" ||
+    event === "response.incomplete" ||
+    event === "response.done"
+  ) {
+    const response = parsed.response as Record<string, unknown> | undefined;
+    if (!response || typeof response !== "object" || Array.isArray(response)) {
+      throw new Error("malformed Responses terminal event");
+    }
+    if (state.id && response.id !== undefined && response.id !== state.id) {
+      throw new Error("malformed Responses terminal event");
+    }
+    if (
+      state.model &&
+      response.model !== undefined &&
+      response.model !== state.model
+    ) {
+      throw new Error("malformed Responses terminal event");
+    }
+    if (
+      event === "response.created" &&
+      response.status !== undefined &&
+      response.status !== "in_progress" &&
+      response.status !== "queued"
+    ) {
+      malformed();
+    }
+    if (
+      event === "response.in_progress" &&
+      response.status !== undefined &&
+      response.status !== "in_progress"
+    ) {
+      malformed();
+    }
+  }
+  if (
+    validOutputIndex &&
+    (event === "response.output_text.delta" ||
+      event === "response.output_text.done" ||
+      event === "response.refusal.delta" ||
+      event === "response.refusal.done" ||
+      event === "response.function_call_arguments.delta" ||
+      event === "response.function_call_arguments.done")
+  ) {
+    const addedItem = state.rawItems.get(outputIndex as number);
+    if (parsed.item_id !== undefined && parsed.item_id !== addedItem?.id) {
+      malformed();
+    }
+    if (
+      parsed.content_index !== undefined &&
+      (!Number.isSafeInteger(parsed.content_index) ||
+        (parsed.content_index as number) < 0 ||
+        (parsed.content_index as number) >= maxSparseIndex)
+    ) {
+      malformed();
+    }
+  }
+
+  switch (event) {
+    case "response.output_item.added": {
+      const addedItem = parsed.item as Record<string, unknown> | undefined;
+      const addedCallID =
+        addedItem?.type === "function_call" ? addedItem.call_id : undefined;
+      if (
+        !validOutputIndex ||
+        !addedItem ||
+        typeof addedItem !== "object" ||
+        Array.isArray(addedItem) ||
+        typeof addedItem.type !== "string" ||
+        (addedItem.type === "message" && typeof addedItem.id !== "string") ||
+        (addedItem.type === "message" &&
+          addedItem.status !== undefined &&
+          addedItem.status !== "in_progress") ||
+        (addedItem.type === "function_call" &&
+          (typeof addedItem.id !== "string" ||
+            addedItem.id.length === 0 ||
+            typeof addedCallID !== "string" ||
+            addedCallID.length === 0 ||
+            typeof addedItem.name !== "string" ||
+            addedItem.name.length === 0 ||
+            typeof addedItem.arguments !== "string")) ||
+        state.rawItems.has(outputIndex as number) ||
+        (typeof addedItem.id === "string" &&
+          state.itemIndexById.has(addedItem.id)) ||
+        (typeof addedCallID === "string" &&
+          state.callIndexById.has(addedCallID))
+      ) {
+        malformed();
+      }
+      if (typeof addedItem?.id === "string") {
+        state.itemIndexById.set(addedItem.id, outputIndex as number);
+      }
+      if (typeof addedCallID === "string") {
+        state.callIndexById.set(addedCallID, outputIndex as number);
+      }
+      break;
+    }
+    case "response.output_item.done": {
+      const doneItem = parsed.item as Record<string, unknown> | undefined;
+      const addedItem = validOutputIndex
+        ? state.rawItems.get(outputIndex as number)
+        : undefined;
+      if (
+        !validOutputIndex ||
+        !doneItem ||
+        typeof doneItem !== "object" ||
+        Array.isArray(doneItem) ||
+        typeof doneItem.type !== "string" ||
+        (doneItem.type === "message" && typeof doneItem.id !== "string") ||
+        (doneItem.type === "message" &&
+          doneItem.status !== undefined &&
+          doneItem.status !== "completed" &&
+          doneItem.status !== "incomplete") ||
+        (doneItem.type === "function_call" &&
+          (typeof doneItem.id !== "string" ||
+            doneItem.id.length === 0 ||
+            typeof doneItem.call_id !== "string" ||
+            doneItem.call_id.length === 0 ||
+            typeof doneItem.name !== "string" ||
+            doneItem.name.length === 0 ||
+            typeof doneItem.arguments !== "string")) ||
+        !addedItem ||
+        doneItem.type !== addedItem.type ||
+        (typeof addedItem.id === "string" && doneItem.id !== addedItem.id) ||
+        (addedItem.type === "function_call" &&
+          (doneItem.call_id !== addedItem.call_id ||
+            doneItem.name !== addedItem.name)) ||
+        (typeof doneItem.id === "string" &&
+          state.itemIndexById.get(doneItem.id) !== outputIndex) ||
+        (typeof doneItem.call_id === "string" &&
+          state.callIndexById.get(doneItem.call_id) !== outputIndex)
+      ) {
+        malformed();
+      }
+      break;
+    }
+    case "response.content_part.added":
+    case "response.content_part.done":
+      if (
+        !validOutputIndex ||
+        !state.rawItems.has(outputIndex as number) ||
+        !Number.isSafeInteger(parsed.content_index) ||
+        (parsed.content_index as number) < 0 ||
+        (parsed.content_index as number) >= maxSparseIndex ||
+        (parsed.item_id !== undefined &&
+          parsed.item_id !== state.rawItems.get(outputIndex as number)?.id) ||
+        !parsed.part ||
+        typeof parsed.part !== "object" ||
+        Array.isArray(parsed.part)
+      ) {
+        malformed();
+      }
+      break;
+    case "response.output_text.delta":
+      if (!validOutputIndex || typeof parsed.delta !== "string") malformed();
+      if (item?.type !== "text") malformed();
+      break;
+    case "response.output_text.done":
+      if (!validOutputIndex || typeof parsed.text !== "string") malformed();
+      if (item?.type !== "text") malformed();
+      break;
+    case "response.refusal.delta":
+      if (!validOutputIndex || typeof parsed.delta !== "string") malformed();
+      if (item?.type !== "text") malformed();
+      break;
+    case "response.refusal.done":
+      if (!validOutputIndex || typeof parsed.refusal !== "string") malformed();
+      if (item?.type !== "text") malformed();
+      break;
+    case "response.function_call_arguments.delta":
+      if (!validOutputIndex || typeof parsed.delta !== "string") malformed();
+      if (item?.type !== "tool_use") malformed();
+      break;
+    case "response.function_call_arguments.done":
+      if (!validOutputIndex || typeof parsed.arguments !== "string")
+        malformed();
+      if (item?.type !== "tool_use") malformed();
+      break;
+  }
+}
+
+/** `public` enforces OpenAI's lifecycle; `codex` validates ChatGPT's sparse variant. */
+export type ResponsesValidationMode = "public" | "codex";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function malformedResponsesEvent(): never {
+  throw new Error("malformed Responses stream event");
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function reconcileCodexIdentity(earlier: unknown, final: unknown): string {
+  const earlierValue = isNonEmptyString(earlier) ? earlier : "";
+  const finalValue = isNonEmptyString(final) ? final : "";
+  if (earlierValue && finalValue && earlierValue !== finalValue) {
+    malformedResponsesEvent();
+  }
+  return finalValue || earlierValue;
+}
+
+function codexItemKind(
+  item: Record<string, unknown>,
+): "text" | "tool_use" | null {
+  if (item.type === "message") return "text";
+  if (item.type === "function_call") return "tool_use";
+  return null;
+}
+
+function codexEventItemKind(event: string): "text" | "tool_use" | null {
+  if (
+    event === "response.output_text.delta" ||
+    event === "response.output_text.done" ||
+    event === "response.refusal.delta" ||
+    event === "response.refusal.done" ||
+    event === "response.content_part.added" ||
+    event === "response.content_part.done"
+  ) {
+    return "text";
+  }
+  if (
+    event === "response.function_call_arguments.delta" ||
+    event === "response.function_call_arguments.done"
+  ) {
+    return "tool_use";
+  }
+  return null;
+}
+
+function responsesEventHasSemanticContent(
+  event: string,
+  parsed: Record<string, unknown>,
+): boolean {
+  if (
+    event === "response.output_item.added" ||
+    event === "response.output_item.done"
+  ) {
+    const item = isRecord(parsed.item) ? parsed.item : undefined;
+    if (item?.type === "function_call") return true;
+    if (item?.type === "message" && Array.isArray(item.content)) {
+      return item.content.some(
+        (part) =>
+          isRecord(part) &&
+          ((typeof part.text === "string" && part.text.length > 0) ||
+            (typeof part.refusal === "string" && part.refusal.length > 0)),
+      );
+    }
+  }
+  if (
+    event === "response.output_text.delta" ||
+    event === "response.output_text.done" ||
+    event === "response.refusal.delta" ||
+    event === "response.refusal.done" ||
+    event === "response.function_call_arguments.delta" ||
+    event === "response.function_call_arguments.done"
+  ) {
+    return [parsed.delta, parsed.text, parsed.refusal, parsed.arguments].some(
+      (value) => typeof value === "string" && value.length > 0,
+    );
+  }
+  if (event.startsWith("response.reasoning")) {
+    const part = isRecord(parsed.part) ? parsed.part : undefined;
+    return [parsed.delta, parsed.text, parsed.summary_text, part?.text].some(
+      (value) => typeof value === "string" && value.length > 0,
+    );
+  }
+  return false;
+}
+
+function nextResponsesOutputIndex(
+  state: ResponsesAccState,
+  maxSparseIndex: number,
+): number {
+  let index = state.nextOutputIndex;
+  while (index < maxSparseIndex && state.rawItems.has(index)) index += 1;
+  if (index >= maxSparseIndex) malformedResponsesEvent();
+  state.nextOutputIndex = index + 1;
+  return index;
+}
+
+function findResponsesItemById(
+  state: ResponsesAccState,
+  itemId: string,
+): number | undefined {
+  return state.itemIndexById.get(itemId);
+}
+
+function bindResponsesIdentity(
+  index: Map<string, number>,
+  identity: string,
+  outputIndex: number,
+): void {
+  const existingIndex = index.get(identity);
+  if (existingIndex !== undefined && existingIndex !== outputIndex) {
+    malformedResponsesEvent();
+  }
+  index.set(identity, outputIndex);
+}
+
+function codexItemSet(
+  state: ResponsesAccState,
+  kind: "text" | "tool_use",
+  unbound = false,
+): Set<number> {
+  if (kind === "text") {
+    return unbound ? state.unboundTextItems : state.activeTextItems;
+  }
+  return unbound ? state.unboundToolItems : state.activeToolItems;
+}
+
+function soleCodexItem(items: Set<number>): number | undefined {
+  return items.size === 1 ? items.values().next().value : undefined;
+}
+
+function bindCodexEffectiveToolIdentity(
+  state: ResponsesAccState,
+  outputIndex: number,
+  identity: string,
+  previousIdentity?: string,
+): void {
+  const normalized = state.items.get(outputIndex);
+  if (normalized?.type !== "tool_use" || !identity) {
+    malformedResponsesEvent();
+  }
+  const previous = previousIdentity ?? (normalized.callId || normalized.id);
+  if (
+    previous &&
+    previous !== identity &&
+    state.effectiveToolIndexById.get(previous) === outputIndex
+  ) {
+    state.effectiveToolIndexById.delete(previous);
+  }
+  bindResponsesIdentity(state.effectiveToolIndexById, identity, outputIndex);
+}
+
+function validateCodexOutputItem(
+  event: "response.output_item.added" | "response.output_item.done",
+  item: unknown,
+): asserts item is Record<string, unknown> {
+  if (!isRecord(item) || typeof item.type !== "string") {
+    malformedResponsesEvent();
+  }
+  for (const field of ["id", "status"] as const) {
+    if (item[field] !== undefined && typeof item[field] !== "string") {
+      malformedResponsesEvent();
+    }
+  }
+  if (
+    event === "response.output_item.added" &&
+    item.status !== undefined &&
+    item.status !== "in_progress"
+  ) {
+    malformedResponsesEvent();
+  }
+  if (
+    event === "response.output_item.done" &&
+    item.status !== undefined &&
+    item.status !== "completed" &&
+    item.status !== "incomplete"
+  ) {
+    malformedResponsesEvent();
+  }
+  if (item.type === "message" && item.content !== undefined) {
+    if (!Array.isArray(item.content)) malformedResponsesEvent();
+    for (const part of item.content) {
+      if (!isRecord(part)) malformedResponsesEvent();
+      if (part.type !== undefined && typeof part.type !== "string") {
+        malformedResponsesEvent();
+      }
+      if (
+        part.type === "output_text" &&
+        part.text !== undefined &&
+        typeof part.text !== "string"
+      ) {
+        malformedResponsesEvent();
+      }
+      if (
+        part.type === "refusal" &&
+        part.refusal !== undefined &&
+        typeof part.refusal !== "string"
+      ) {
+        malformedResponsesEvent();
+      }
+    }
+  }
+  if (item.type === "function_call") {
+    for (const field of ["call_id", "name", "arguments"] as const) {
+      if (item[field] !== undefined && typeof item[field] !== "string") {
+        malformedResponsesEvent();
+      }
+    }
+  }
+}
+
+function createImplicitCodexItem(
+  state: ResponsesAccState,
+  outputIndex: number,
+  itemId: string,
+  kind: "text" | "tool_use",
+): void {
+  const item =
+    kind === "text"
+      ? { type: "message", id: itemId, role: "assistant" }
+      : {
+          type: "function_call",
+          id: itemId,
+          call_id: "",
+          name: "",
+          arguments: "",
+        };
+  applyResponsesEvent(state, "response.output_item.added", {
+    output_index: outputIndex,
+    item,
+  });
+  bindResponsesIdentity(state.itemIndexById, itemId, outputIndex);
+}
+
+function bindCodexItemId(
+  state: ResponsesAccState,
+  outputIndex: number,
+  itemId: string,
+): void {
+  bindResponsesIdentity(state.itemIndexById, itemId, outputIndex);
+  state.unboundTextItems.delete(outputIndex);
+  state.unboundToolItems.delete(outputIndex);
+  const rawItem = state.rawItems.get(outputIndex);
+  if (!rawItem) malformedResponsesEvent();
+  if (isNonEmptyString(rawItem.id) && rawItem.id !== itemId) {
+    malformedResponsesEvent();
+  }
+  rawItem.id = itemId;
+  const normalized = state.items.get(outputIndex);
+  if (normalized) {
+    if (isNonEmptyString(normalized.id) && normalized.id !== itemId) {
+      malformedResponsesEvent();
+    }
+    normalized.id = itemId;
+    if (normalized.type === "tool_use" && !normalized.callId) {
+      bindCodexEffectiveToolIdentity(state, outputIndex, itemId);
+    }
+  }
+}
+
+function reconcileCodexDoneItem(
+  state: ResponsesAccState,
+  outputIndex: number,
+  item: Record<string, unknown>,
+): void {
+  const existing = state.rawItems.get(outputIndex);
+  if (!existing) malformedResponsesEvent();
+
+  const itemId = reconcileCodexIdentity(existing.id, item.id);
+  if (itemId) bindCodexItemId(state, outputIndex, itemId);
+  if (itemId || existing.id !== undefined || item.id !== undefined) {
+    item.id = itemId;
+  }
+
+  if (item.type !== "function_call") return;
+  const normalized = state.items.get(outputIndex);
+  if (normalized?.type !== "tool_use") malformedResponsesEvent();
+
+  const previousEffectiveIdentity = normalized.callId || normalized.id;
+  normalized.callId = reconcileCodexIdentity(normalized.callId, item.call_id);
+  if (normalized.callId) {
+    bindResponsesIdentity(state.callIndexById, normalized.callId, outputIndex);
+    bindCodexEffectiveToolIdentity(
+      state,
+      outputIndex,
+      normalized.callId,
+      previousEffectiveIdentity,
+    );
+  }
+  normalized.name = reconcileCodexIdentity(normalized.name, item.name);
+  if (
+    state.argumentDoneItems.has(outputIndex) &&
+    item.arguments !== undefined &&
+    item.arguments !== normalized.args
+  ) {
+    malformedResponsesEvent();
+  }
+  if (item.arguments !== undefined) {
+    normalized.args = item.arguments as string;
+  }
+
+  // Keep the final raw item complete when ChatGPT omits fields that were
+  // already established by sparse added/delta events.
+  item.call_id = normalized.callId;
+  item.name = normalized.name;
+  item.arguments = normalized.args;
+}
+
+function normalizeCodexDataEvent(
+  state: ResponsesAccState,
+  event: string,
+  parsed: Record<string, unknown>,
+  maxSparseIndex: number,
+): void {
+  const kind = codexEventItemKind(event);
+  if (!kind) return;
+
+  const providedIndex = parsed.output_index as number | undefined;
+  const itemId = parsed.item_id as string | undefined;
+  const itemIndex =
+    itemId !== undefined ? findResponsesItemById(state, itemId) : undefined;
+  if (
+    providedIndex !== undefined &&
+    itemIndex !== undefined &&
+    providedIndex !== itemIndex
+  ) {
+    malformedResponsesEvent();
+  }
+
+  let outputIndex = providedIndex ?? itemIndex;
+  if (outputIndex === undefined && itemId !== undefined) {
+    const unbound = soleCodexItem(codexItemSet(state, kind, true));
+    if (unbound !== undefined) {
+      outputIndex = unbound;
+      bindCodexItemId(state, outputIndex, itemId);
+    } else {
+      outputIndex = nextResponsesOutputIndex(state, maxSparseIndex);
+      createImplicitCodexItem(state, outputIndex, itemId, kind);
+    }
+  } else if (outputIndex === undefined) {
+    outputIndex = soleCodexItem(codexItemSet(state, kind));
+    if (outputIndex === undefined) malformedResponsesEvent();
+  }
+
+  const normalized = state.items.get(outputIndex);
+  if (!normalized) {
+    if (itemId === undefined || state.rawItems.has(outputIndex)) {
+      malformedResponsesEvent();
+    }
+    createImplicitCodexItem(state, outputIndex, itemId, kind);
+  } else if (normalized.type !== kind) {
+    malformedResponsesEvent();
+  } else if (itemId !== undefined) {
+    bindCodexItemId(state, outputIndex, itemId);
+  }
+  parsed.output_index = outputIndex;
+}
+
+function normalizeCodexItemEvent(
+  state: ResponsesAccState,
+  event: "response.output_item.added" | "response.output_item.done",
+  parsed: Record<string, unknown>,
+  maxSparseIndex: number,
+): void {
+  validateCodexOutputItem(event, parsed.item);
+  const item = parsed.item;
+  if (
+    isNonEmptyString(parsed.item_id) &&
+    isNonEmptyString(item.id) &&
+    parsed.item_id !== item.id
+  ) {
+    malformedResponsesEvent();
+  }
+  if (!isNonEmptyString(item.id) && isNonEmptyString(parsed.item_id)) {
+    item.id = parsed.item_id;
+  }
+
+  const itemId = isNonEmptyString(item.id) ? item.id : undefined;
+  const itemIndex =
+    itemId !== undefined ? findResponsesItemById(state, itemId) : undefined;
+  const providedIndex = parsed.output_index as number | undefined;
+  if (
+    providedIndex !== undefined &&
+    itemIndex !== undefined &&
+    providedIndex !== itemIndex
+  ) {
+    malformedResponsesEvent();
+  }
+
+  let outputIndex = providedIndex ?? itemIndex;
+  const kind = codexItemKind(item);
+  if (
+    outputIndex === undefined &&
+    event === "response.output_item.done" &&
+    kind
+  ) {
+    if (itemId === undefined) {
+      outputIndex = soleCodexItem(codexItemSet(state, kind));
+    } else {
+      const unbound = soleCodexItem(codexItemSet(state, kind, true));
+      if (unbound !== undefined) {
+        outputIndex = unbound;
+        bindCodexItemId(state, outputIndex, itemId);
+      } else if (codexItemSet(state, kind).size > 0) {
+        malformedResponsesEvent();
+      }
+    }
+  }
+  outputIndex ??= nextResponsesOutputIndex(state, maxSparseIndex);
+
+  const existing = state.rawItems.get(outputIndex);
+  if (event === "response.output_item.added" && existing) {
+    malformedResponsesEvent();
+  }
+  if (event === "response.output_item.done" && existing) {
+    if (
+      existing.type !== item.type ||
+      (isNonEmptyString(existing.id) &&
+        isNonEmptyString(item.id) &&
+        existing.id !== item.id)
+    ) {
+      malformedResponsesEvent();
+    }
+  } else if (event === "response.output_item.done") {
+    const seedItem = { ...item };
+    delete seedItem.content;
+    applyResponsesEvent(state, "response.output_item.added", {
+      output_index: outputIndex,
+      item: seedItem,
+    });
+  }
+  if (event === "response.output_item.done") {
+    reconcileCodexDoneItem(state, outputIndex, item);
+  } else {
+    if (itemId) {
+      bindResponsesIdentity(state.itemIndexById, itemId, outputIndex);
+      state.unboundTextItems.delete(outputIndex);
+      state.unboundToolItems.delete(outputIndex);
+    }
+    if (item.type === "function_call" && isNonEmptyString(item.call_id)) {
+      bindResponsesIdentity(state.callIndexById, item.call_id, outputIndex);
+    }
+  }
+  parsed.output_index = outputIndex;
+}
+
+function validateCodexResponsesEvent(
+  state: ResponsesAccState,
+  event: string,
+  parsed: Record<string, unknown>,
+  maxSparseIndex: number,
+): void {
+  if (parsed.type !== undefined && parsed.type !== event) {
+    malformedResponsesEvent();
+  }
+  if (
+    parsed.output_index !== undefined &&
+    (!Number.isSafeInteger(parsed.output_index) ||
+      (parsed.output_index as number) < 0 ||
+      (parsed.output_index as number) >= maxSparseIndex)
+  ) {
+    malformedResponsesEvent();
+  }
+  if (
+    parsed.content_index !== undefined &&
+    (!Number.isSafeInteger(parsed.content_index) ||
+      (parsed.content_index as number) < 0 ||
+      (parsed.content_index as number) >= maxSparseIndex)
+  ) {
+    malformedResponsesEvent();
+  }
+  if (
+    parsed.sequence_number !== undefined &&
+    (!Number.isSafeInteger(parsed.sequence_number) ||
+      (parsed.sequence_number as number) < 0)
+  ) {
+    malformedResponsesEvent();
+  }
+  if (parsed.item_id !== undefined && typeof parsed.item_id !== "string") {
+    malformedResponsesEvent();
+  }
+
+  if (
+    event === "response.created" ||
+    event === "response.in_progress" ||
+    event === "response.failed" ||
+    event === "response.completed" ||
+    event === "response.incomplete" ||
+    event === "response.done"
+  ) {
+    if (!isRecord(parsed.response)) {
+      throw new Error("malformed Responses terminal event");
+    }
+    const response = parsed.response;
+    for (const field of ["id", "model", "status"] as const) {
+      if (
+        response[field] !== undefined &&
+        typeof response[field] !== "string"
+      ) {
+        throw new Error("malformed Responses terminal event");
+      }
+    }
+    if (state.id && response.id !== undefined && response.id !== state.id) {
+      throw new Error("malformed Responses terminal event");
+    }
+    if (
+      state.model &&
+      response.model !== undefined &&
+      response.model !== state.model
+    ) {
+      throw new Error("malformed Responses terminal event");
+    }
+    if (
+      event === "response.created" &&
+      response.status !== undefined &&
+      response.status !== "in_progress" &&
+      response.status !== "queued"
+    ) {
+      malformedResponsesEvent();
+    }
+    if (
+      event === "response.in_progress" &&
+      response.status !== undefined &&
+      response.status !== "in_progress"
+    ) {
+      malformedResponsesEvent();
+    }
+  }
+
+  switch (event) {
+    case "response.output_item.added":
+    case "response.output_item.done":
+      normalizeCodexItemEvent(state, event, parsed, maxSparseIndex);
+      break;
+    case "response.content_part.added":
+    case "response.content_part.done":
+      if (!isRecord(parsed.part)) malformedResponsesEvent();
+      normalizeCodexDataEvent(state, event, parsed, maxSparseIndex);
+      break;
+    case "response.output_text.delta":
+      if (typeof parsed.delta !== "string") malformedResponsesEvent();
+      normalizeCodexDataEvent(state, event, parsed, maxSparseIndex);
+      break;
+    case "response.output_text.done":
+      if (typeof parsed.text !== "string") malformedResponsesEvent();
+      normalizeCodexDataEvent(state, event, parsed, maxSparseIndex);
+      break;
+    case "response.refusal.delta":
+      if (typeof parsed.delta !== "string") malformedResponsesEvent();
+      normalizeCodexDataEvent(state, event, parsed, maxSparseIndex);
+      break;
+    case "response.refusal.done":
+      if (typeof parsed.refusal !== "string") malformedResponsesEvent();
+      normalizeCodexDataEvent(state, event, parsed, maxSparseIndex);
+      break;
+    case "response.function_call_arguments.delta":
+      if (typeof parsed.delta !== "string") malformedResponsesEvent();
+      normalizeCodexDataEvent(state, event, parsed, maxSparseIndex);
+      break;
+    case "response.function_call_arguments.done":
+      if (typeof parsed.arguments !== "string") malformedResponsesEvent();
+      normalizeCodexDataEvent(state, event, parsed, maxSparseIndex);
+      break;
+  }
+}
+
+function validatedTerminalStatus(
+  event: "response.completed" | "response.done" | "response.incomplete",
+  parsed: Record<string, unknown>,
+  validation: ResponsesValidationMode,
+): string {
+  const terminal = parsed.response as Record<string, unknown> | undefined;
+  if (!terminal || typeof terminal !== "object" || Array.isArray(terminal)) {
+    throw new Error("malformed Responses terminal event");
+  }
+  if (terminal.status !== undefined && typeof terminal.status !== "string") {
+    throw new Error("malformed Responses terminal event");
+  }
+  const rawDetails = terminal.incomplete_details;
+  if (
+    rawDetails !== undefined &&
+    rawDetails !== null &&
+    !isRecord(rawDetails)
+  ) {
+    throw new Error("malformed Responses terminal event");
+  }
+  const details = isRecord(rawDetails) ? rawDetails : null;
+  if (details?.reason !== undefined && typeof details.reason !== "string") {
+    throw new Error("malformed Responses terminal event");
+  }
+  let status = typeof terminal.status === "string" ? terminal.status : null;
+  if (validation === "public" && (status === null || status === "")) {
+    throw new Error("missing Responses compatibility terminal status");
+  }
+  if (status === null) {
+    status = event === "response.incomplete" ? "incomplete" : "completed";
+  }
+  if (status === "failed" || status === "cancelled") {
+    throw new Error("Responses terminal reported failure");
+  }
+  const valid =
+    validation === "public"
+      ? event === "response.completed"
+        ? status === "completed"
+        : event === "response.incomplete"
+          ? status === "incomplete"
+          : status === "completed" || status === "incomplete"
+      : event === "response.completed"
+        ? status === "completed" || status === "incomplete"
+        : event === "response.incomplete"
+          ? status === "incomplete"
+          : status === "completed" || status === "incomplete";
+  if (!valid) throw new Error("Responses terminal event/status mismatch");
+  if (status === "incomplete") {
+    if (validation === "public") {
+      if (
+        details?.reason !== undefined &&
+        details.reason !== "max_output_tokens" &&
+        details.reason !== "content_filter"
+      ) {
+        throw new Error("malformed Responses terminal event");
+      }
+    }
+  }
+  return status;
+}
+
+function validateFailureTerminal(parsed: Record<string, unknown>): void {
+  if (!isRecord(parsed.response) || parsed.response.status !== "failed") {
+    throw new Error("malformed Responses terminal event");
+  }
+  const error = parsed.response.error;
+  if (error !== undefined && error !== null) {
+    if (!isRecord(error)) throw new Error("malformed Responses terminal event");
+    for (const field of ["type", "code", "message"] as const) {
+      if (error[field] !== undefined && typeof error[field] !== "string") {
+        throw new Error("malformed Responses terminal event");
+      }
+    }
+  }
+}
+
 /**
  * Accumulate an OpenAI Responses API SSE stream into a GatewayResponse.
  *
@@ -407,27 +1285,419 @@ export function finalizeResponsesAcc(
  */
 export async function accumulateResponsesSSEStream(
   response: Response,
+  opts: {
+    /** Omit to preserve the legacy tolerant accumulator behavior. */
+    validation?: ResponsesValidationMode;
+    stopAtTerminal?: boolean;
+    signal?: AbortSignal;
+    inactivityMs?: number;
+    maxFrames?: number;
+    onSemanticContent?: () => void;
+    /** Called only after the event has passed strict validation and mutation. */
+    onValidatedEvent?: (event: string, data: string) => void | Promise<void>;
+    /** Passthrough clients must receive a provider's valid failure terminal. */
+    allowFailureTerminal?: boolean;
+    /** Internal state injection used by validated true passthrough. */
+    state?: ResponsesAccState;
+    onReader?: (reader: ReadableStreamDefaultReader<Uint8Array>) => void;
+  } = {},
 ): Promise<GatewayResponse> {
-  const state = makeResponsesAccState();
+  const state = opts.state ?? makeResponsesAccState();
+  let terminalStatus: string | null = null;
+  const doneItems = new Set<number>();
+  const activeContentParts = new Set<string>();
+  const doneContentParts = new Set<string>();
+  const activeContentIndexByItem = new Map<number, number>();
+  const implicitContentIndexByItem = new Map<number, number>();
+  const terminalContentIndexByItem = new Map<number, number>();
+  const terminalContentParts = new Map<string, "text" | "refusal">();
+  let lastSequenceNumber = -1;
+  // Sparse numeric identities can never need more address space than the
+  // number of frames we are willing to process. Cap even a caller-supplied
+  // frame override at the production ceiling so arithmetic remains practical
+  // and `index + 1` always changes the value.
+  const maxSparseIndex = Math.min(
+    opts.maxFrames ?? DEFAULT_MAX_SSE_FRAMES,
+    DEFAULT_MAX_SSE_FRAMES,
+  );
 
   if (!response.body) {
     throw new Error("Response has no body");
   }
   const reader = response.body.getReader();
+  opts.onReader?.(reader);
 
-  for await (const { event, data } of parseSSEStream(reader)) {
-    // Some Responses API implementations send untyped `data:` lines
-    // without `event:` — skip those.
-    if (!data || data === "[DONE]") continue;
+  try {
+    for await (const { event, data } of parseSSEStream(reader, {
+      signal: opts.signal,
+      inactivityMs: opts.inactivityMs,
+      requireEventTerminator: opts.validation !== undefined,
+      maxFrames: opts.validation
+        ? (opts.maxFrames ?? DEFAULT_MAX_SSE_FRAMES)
+        : opts.maxFrames,
+      maxTotalBytes: opts.validation ? 4 * 1024 * 1024 : undefined,
+      fatalUtf8: opts.validation !== undefined,
+    })) {
+      // Some Responses API implementations send untyped `data:` lines
+      // without `event:` — skip those.
+      if (!data || data === "[DONE]") continue;
 
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(data) as Record<string, unknown>;
-    } catch {
-      continue;
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(data) as Record<string, unknown>;
+      } catch {
+        if (opts.validation) {
+          throw new Error("malformed Responses stream event");
+        }
+        continue;
+      }
+
+      if (opts.validation && !isRecord(parsed)) {
+        throw new Error("malformed Responses stream event");
+      }
+      if (
+        opts.onSemanticContent &&
+        responsesEventHasSemanticContent(event, parsed)
+      ) {
+        opts.onSemanticContent();
+      }
+      if (
+        opts.validation &&
+        event === "response.failed" &&
+        !opts.allowFailureTerminal
+      ) {
+        throw new Error("response.failed terminal");
+      }
+      if (opts.validation === "public") {
+        validatePublicResponsesEvent(state, event, parsed, maxSparseIndex);
+      } else if (opts.validation === "codex") {
+        validateCodexResponsesEvent(state, event, parsed, maxSparseIndex);
+      }
+      if (opts.validation && event === "response.failed") {
+        validateFailureTerminal(parsed);
+      }
+      if (opts.validation && event === "response.output_item.done") {
+        const outputIndex = parsed.output_index as number;
+        const normalized = state.items.get(outputIndex);
+        const doneItem = parsed.item as Record<string, unknown>;
+        if (
+          normalized?.type === "tool_use" &&
+          state.argumentDoneItems.has(outputIndex) &&
+          doneItem.arguments !== normalized.args
+        ) {
+          throw new Error("malformed Responses stream event");
+        }
+        if (normalized?.type === "text" && Array.isArray(doneItem.content)) {
+          for (const part of doneItem.content) {
+            if (!isRecord(part)) continue;
+            if (
+              part.type === "output_text" &&
+              state.textDoneItems.has(outputIndex) &&
+              part.text !== normalized.text
+            ) {
+              throw new Error("malformed Responses stream event");
+            }
+            if (
+              part.type === "refusal" &&
+              state.refusalDoneItems.has(outputIndex) &&
+              part.refusal !== normalized.refusal
+            ) {
+              throw new Error("malformed Responses stream event");
+            }
+          }
+        }
+      }
+      if (opts.validation && parsed.sequence_number !== undefined) {
+        const sequenceNumber = parsed.sequence_number as number;
+        if (sequenceNumber <= lastSequenceNumber) {
+          throw new Error("malformed Responses stream event");
+        }
+        lastSequenceNumber = sequenceNumber;
+      }
+      if (
+        opts.validation &&
+        event === "response.output_item.done" &&
+        doneItems.has(parsed.output_index as number)
+      ) {
+        throw new Error("malformed Responses stream event");
+      }
+      if (
+        opts.validation &&
+        doneItems.has(parsed.output_index as number) &&
+        (event === "response.output_text.delta" ||
+          event === "response.output_text.done" ||
+          event === "response.refusal.delta" ||
+          event === "response.refusal.done" ||
+          event === "response.function_call_arguments.delta" ||
+          event === "response.function_call_arguments.done" ||
+          event === "response.content_part.added" ||
+          event === "response.content_part.done")
+      ) {
+        throw new Error("malformed Responses stream event");
+      }
+      if (
+        opts.validation &&
+        parsed.content_index === undefined &&
+        (event === "response.content_part.added" ||
+          event === "response.content_part.done" ||
+          event === "response.output_text.delta" ||
+          event === "response.output_text.done" ||
+          event === "response.refusal.delta" ||
+          event === "response.refusal.done")
+      ) {
+        const outputIndex = parsed.output_index as number;
+        parsed.content_index =
+          activeContentIndexByItem.get(outputIndex) ??
+          implicitContentIndexByItem.get(outputIndex) ??
+          terminalContentIndexByItem.get(outputIndex) ??
+          0;
+      }
+      if (
+        opts.validation &&
+        (event === "response.content_part.added" ||
+          event === "response.content_part.done")
+      ) {
+        const outputIndex = parsed.output_index as number;
+        const contentIndex = parsed.content_index as number;
+        const key = `${outputIndex}:${contentIndex}`;
+        if (event === "response.content_part.added") {
+          if (
+            activeContentParts.has(key) ||
+            doneContentParts.has(key) ||
+            activeContentIndexByItem.has(outputIndex)
+          ) {
+            throw new Error("malformed Responses stream event");
+          }
+          activeContentParts.add(key);
+          activeContentIndexByItem.set(outputIndex, contentIndex);
+        } else {
+          if (
+            !activeContentParts.delete(key) ||
+            activeContentIndexByItem.get(outputIndex) !== contentIndex
+          ) {
+            throw new Error("malformed Responses stream event");
+          }
+          activeContentIndexByItem.delete(outputIndex);
+          doneContentParts.add(key);
+          const part = parsed.part as Record<string, unknown>;
+          const terminalKind =
+            part.type === "output_text"
+              ? "text"
+              : part.type === "refusal"
+                ? "refusal"
+                : undefined;
+          if (terminalKind) {
+            const normalized = state.items.get(outputIndex);
+            const terminalValue =
+              terminalKind === "text" ? part.text : part.refusal;
+            const accumulatedValue =
+              normalized?.type === "text"
+                ? terminalKind === "text"
+                  ? normalized.text
+                  : normalized.refusal
+                : undefined;
+            const alreadyDone =
+              terminalKind === "text"
+                ? state.textDoneItems.has(outputIndex)
+                : state.refusalDoneItems.has(outputIndex);
+            if (alreadyDone && terminalValue !== accumulatedValue) {
+              throw new Error("malformed Responses stream event");
+            }
+            const existingKind = terminalContentParts.get(key);
+            if (existingKind && existingKind !== terminalKind) {
+              throw new Error("malformed Responses stream event");
+            }
+            terminalContentParts.set(key, terminalKind);
+            terminalContentIndexByItem.set(outputIndex, contentIndex);
+          }
+        }
+      }
+      if (
+        opts.validation &&
+        Number.isSafeInteger(parsed.content_index) &&
+        (event === "response.output_text.delta" ||
+          event === "response.output_text.done" ||
+          event === "response.refusal.delta" ||
+          event === "response.refusal.done")
+      ) {
+        const outputIndex = parsed.output_index as number;
+        const contentIndex = parsed.content_index as number;
+        const expected =
+          activeContentIndexByItem.get(outputIndex) ??
+          implicitContentIndexByItem.get(outputIndex);
+        if (expected !== undefined && expected !== contentIndex) {
+          throw new Error("malformed Responses stream event");
+        }
+        implicitContentIndexByItem.set(outputIndex, contentIndex);
+        const key = `${outputIndex}:${contentIndex}`;
+        if (terminalContentParts.has(key)) {
+          throw new Error("malformed Responses stream event");
+        }
+        if (
+          event === "response.output_text.done" ||
+          event === "response.refusal.done"
+        ) {
+          terminalContentParts.set(
+            key,
+            event === "response.output_text.done" ? "text" : "refusal",
+          );
+          terminalContentIndexByItem.set(outputIndex, contentIndex);
+          implicitContentIndexByItem.delete(outputIndex);
+        }
+      }
+      if (
+        opts.validation &&
+        (event === "response.function_call_arguments.delta" ||
+          event === "response.function_call_arguments.done")
+      ) {
+        const outputIndex = parsed.output_index as number;
+        if (state.argumentDoneItems.has(outputIndex)) {
+          throw new Error("malformed Responses stream event");
+        }
+        if (event === "response.function_call_arguments.done") {
+          state.argumentDoneItems.add(outputIndex);
+        }
+      }
+      if (
+        opts.validation &&
+        event === "response.output_item.done" &&
+        activeContentIndexByItem.has(parsed.output_index as number)
+      ) {
+        throw new Error("malformed Responses stream event");
+      }
+      applyResponsesEvent(state, event, parsed);
+      if (event === "response.output_text.done") {
+        state.textDoneItems.add(parsed.output_index as number);
+      } else if (event === "response.refusal.done") {
+        state.refusalDoneItems.add(parsed.output_index as number);
+      }
+      if (
+        opts.validation === "codex" &&
+        event === "response.output_item.added"
+      ) {
+        const outputIndex = parsed.output_index as number;
+        const item = state.items.get(outputIndex);
+        if (item?.type === "tool_use" && (item.callId || item.id)) {
+          bindCodexEffectiveToolIdentity(
+            state,
+            outputIndex,
+            item.callId || item.id,
+          );
+        }
+      }
+      if (event === "response.output_item.done") {
+        const outputIndex = parsed.output_index as number;
+        doneItems.add(outputIndex);
+        state.activeTextItems.delete(outputIndex);
+        state.activeToolItems.delete(outputIndex);
+        state.unboundTextItems.delete(outputIndex);
+        state.unboundToolItems.delete(outputIndex);
+      }
+      if (
+        event === "response.completed" ||
+        event === "response.done" ||
+        event === "response.incomplete" ||
+        (opts.allowFailureTerminal && event === "response.failed")
+      ) {
+        const terminal = parsed.response as Record<string, unknown> | undefined;
+        if (opts.validation && terminal?.output !== undefined) {
+          if (!Array.isArray(terminal.output)) {
+            throw new Error("malformed Responses terminal event");
+          }
+          const snapshotIndices = new Set<number>();
+          for (const snapshot of terminal.output) {
+            if (!isRecord(snapshot) || !isNonEmptyString(snapshot.id)) {
+              throw new Error("malformed Responses terminal event");
+            }
+            const outputIndex = state.itemIndexById.get(snapshot.id);
+            const accumulated =
+              outputIndex === undefined
+                ? undefined
+                : state.rawItems.get(outputIndex);
+            if (
+              outputIndex === undefined ||
+              !doneItems.has(outputIndex) ||
+              snapshotIndices.has(outputIndex) ||
+              !accumulated ||
+              (snapshot.type !== "item_reference" &&
+                snapshot.type !== accumulated.type)
+            ) {
+              throw new Error("malformed Responses terminal event");
+            }
+            snapshotIndices.add(outputIndex);
+            for (const field of [
+              "call_id",
+              "name",
+              "arguments",
+              "content",
+            ] as const) {
+              if (
+                snapshot[field] !== undefined &&
+                JSON.stringify(snapshot[field]) !==
+                  JSON.stringify(accumulated[field])
+              ) {
+                throw new Error("malformed Responses terminal event");
+              }
+            }
+          }
+          if (
+            snapshotIndices.size !== doneItems.size ||
+            Array.from(doneItems).some((index) => !snapshotIndices.has(index))
+          ) {
+            throw new Error("malformed Responses terminal event");
+          }
+        }
+        terminalStatus = opts.validation
+          ? event === "response.failed"
+            ? "failed"
+            : validatedTerminalStatus(event, parsed, opts.validation)
+          : typeof terminal?.status === "string"
+            ? terminal.status
+            : null;
+        if (
+          opts.validation === "public" &&
+          terminalStatus === "completed" &&
+          terminal?.output === undefined
+        ) {
+          throw new Error("malformed Responses terminal event");
+        }
+        if (
+          opts.validation &&
+          terminalStatus === "incomplete" &&
+          state.stopReason === "end_turn"
+        ) {
+          state.stopReason = mapStatusToStopReason(terminalStatus);
+        }
+        if (
+          opts.validation === "public" &&
+          doneItems.size !== state.rawItems.size
+        ) {
+          throw new Error("incomplete Responses output lifecycle");
+        }
+        if (opts.validation && activeContentParts.size > 0) {
+          throw new Error("incomplete Responses output lifecycle");
+        }
+        if (opts.validation === "codex") {
+          for (const item of state.items.values()) {
+            if (item.type === "tool_use" && !(item.callId || item.id)) {
+              throw new Error("malformed Responses stream event");
+            }
+          }
+        }
+        // The first semantic terminal is authoritative. Any bytes already
+        // delivered after it are transport tail and are discarded on cancel.
+        await opts.onValidatedEvent?.(event, data);
+        if (opts.stopAtTerminal) break;
+        continue;
+      }
+      if (event !== "message") await opts.onValidatedEvent?.(event, data);
     }
+  } finally {
+    cancelAndReleaseReader(reader);
+  }
 
-    applyResponsesEvent(state, event, parsed);
+  if (opts.validation && !terminalStatus) {
+    throw new Error("missing terminal response status");
   }
 
   return finalizeResponsesAcc(state);
@@ -474,12 +1744,31 @@ export function streamResponsesPassthrough(
   upstreamResponse: Response,
   onComplete: (response: GatewayResponse) => void,
   sessionID?: string,
+  validation: ResponsesValidationMode = "public",
+  signal?: AbortSignal,
 ): Response {
   const state = makeResponsesAccState();
   const encoder = new TextEncoder();
 
-  let cancelled = false;
-  let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let downstreamCancelled = false;
+  let externalAborted = false;
+  const cancelController = new AbortController();
+  let activeReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let resumeDemand: (() => void) | undefined;
+  let pumpStarted = false;
+  const onAbort = () => {
+    externalAborted = true;
+    resumeDemand?.();
+    resumeDemand = undefined;
+    cancelController.abort(signal?.reason);
+    if (activeReader) cancelAndReleaseReader(activeReader, signal?.reason);
+    else if (!pumpStarted)
+      void upstreamResponse.body?.cancel(signal?.reason).catch(() => {});
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted) onAbort();
+  const MAX_PASSTHROUGH_RETAINED_BYTES = 4 * 1024 * 1024;
+  let retainedBytes = 0;
 
   // --- Keepalive ---
   // The Responses API has no first-class `ping` event (unlike Anthropic), so we
@@ -492,33 +1781,72 @@ export function streamResponsesPassthrough(
   const keepaliveComment = encoder.encode(`: keepalive\n\n`);
   let keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
   let completed = false;
+  let terminalForwarded = false;
+  const cleanup = (): void => {
+    if (keepaliveTimer) clearTimeout(keepaliveTimer);
+    keepaliveTimer = null;
+    signal?.removeEventListener("abort", onAbort);
+  };
 
   const stream = new ReadableStream<Uint8Array>({
-    async start(controller) {
+    start(controller) {
+      let settled = false;
       const safeEnqueue = (chunk: Uint8Array): boolean => {
-        if (cancelled) return false;
+        if (downstreamCancelled || settled) return false;
+        if (externalAborted) throw signal?.reason;
         try {
           controller.enqueue(chunk);
           return true;
         } catch {
-          cancelled = true;
+          downstreamCancelled = true;
           return false;
         }
       };
+      const waitForDemand = async (): Promise<void> => {
+        while (
+          !downstreamCancelled &&
+          !externalAborted &&
+          (controller.desiredSize ?? 1) <= 0
+        ) {
+          await new Promise<void>((resolve) => {
+            resumeDemand = resolve;
+          });
+        }
+        if (externalAborted) throw signal?.reason;
+      };
       const safeClose = (): void => {
-        if (cancelled) return;
+        if (downstreamCancelled || settled) return;
+        settled = true;
+        cleanup();
         try {
           controller.close();
         } catch {
           // Already closed/cancelled
         }
       };
+      const safeError = (error: unknown): void => {
+        if (downstreamCancelled || settled) return;
+        settled = true;
+        cleanup();
+        try {
+          controller.error(error);
+        } catch {
+          // Already closed/cancelled.
+        }
+      };
 
       const resetKeepalive = (): void => {
         if (keepaliveTimer) clearTimeout(keepaliveTimer);
         keepaliveTimer = setTimeout(function tick() {
-          if (cancelled) return;
-          safeEnqueue(keepaliveComment);
+          if (downstreamCancelled || externalAborted || settled) return;
+          if ((controller.desiredSize ?? 1) > 0) {
+            try {
+              safeEnqueue(keepaliveComment);
+            } catch (error) {
+              safeError(error);
+              return;
+            }
+          }
           keepaliveTimer = setTimeout(tick, KEEPALIVE_INACTIVITY_MS);
         }, KEEPALIVE_INACTIVITY_MS);
       };
@@ -537,102 +1865,137 @@ export function streamResponsesPassthrough(
         }
       };
 
-      try {
-        if (!upstreamResponse.body) {
-          throw new Error("Upstream response has no body");
-        }
-        const reader = upstreamResponse.body.getReader();
-        activeReader = reader;
-
-        resetKeepalive();
-        for await (const { event, data } of parseSSEStream(reader)) {
-          resetKeepalive(); // upstream alive — reset inactivity timer
-
-          // Forward real Responses events to the client as they arrive,
-          // preserving the original data payload (no re-parse/re-serialize →
-          // no field loss). `parseSSEStream` synthesizes `event: "message"` for
-          // untyped `data:` lines and yields the `[DONE]` sentinel — neither
-          // carries Responses semantics, and the buffered path never re-emitted
-          // them, so skip both from client forwarding to keep the wire truly
-          // faithful to a genuine Responses stream.
-          const forwardable =
-            event !== "message" && !!data && data !== "[DONE]";
-          if (
-            forwardable &&
-            !safeEnqueue(encoder.encode(formatResponsesEvent(event, data)))
-          ) {
-            break;
+      const pump = async (): Promise<void> => {
+        pumpStarted = true;
+        if (downstreamCancelled) return;
+        try {
+          resetKeepalive();
+          const accumulated = await accumulateResponsesSSEStream(
+            upstreamResponse,
+            {
+              validation,
+              stopAtTerminal: true,
+              signal: cancelController.signal,
+              allowFailureTerminal: true,
+              state,
+              onReader: (reader) => {
+                activeReader = reader;
+              },
+              onValidatedEvent: async (event, data) => {
+                resetKeepalive();
+                retainedBytes += Buffer.byteLength(data);
+                if (retainedBytes > MAX_PASSTHROUGH_RETAINED_BYTES) {
+                  throw new Error(
+                    "Responses passthrough exceeded retained byte limit",
+                  );
+                }
+                await waitForDemand();
+                if (
+                  downstreamCancelled ||
+                  !safeEnqueue(
+                    encoder.encode(formatResponsesEvent(event, data)),
+                  )
+                ) {
+                  throw new DOMException("client disconnected", "AbortError");
+                }
+                if (
+                  event === "response.completed" ||
+                  event === "response.done" ||
+                  event === "response.incomplete" ||
+                  event === "response.failed"
+                ) {
+                  terminalForwarded = true;
+                }
+              },
+            },
+          );
+          clearKeepalive();
+          if (!completed) {
+            completed = true;
+            onComplete(accumulated);
           }
-
-          // Accumulate in parallel for postResponse / calibration.
-          if (!data || data === "[DONE]") continue;
-          let parsed: Record<string, unknown>;
-          try {
-            parsed = JSON.parse(data) as Record<string, unknown>;
-          } catch {
-            continue;
+          safeClose();
+        } catch (err) {
+          clearKeepalive();
+          if (downstreamCancelled) {
+            cleanup();
+            return;
           }
-          applyResponsesEvent(state, event, parsed);
-        }
-        clearKeepalive();
-        finish();
-        safeClose();
-      } catch (err) {
-        clearKeepalive();
-        log.error(
-          `openai-responses passthrough stream error${
-            sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""
-          }:`,
-          err,
-        );
-        // Emit response.failed so the client doesn't hang waiting for a
-        // terminal event, then still run onComplete with what we accumulated.
-        safeEnqueue(
-          encoder.encode(
-            formatResponsesEvent(
-              "response.failed",
-              JSON.stringify({
-                type: "response.failed",
-                response: {
-                  id: state.id || "resp_error",
-                  object: "response",
-                  created_at: Math.floor(Date.now() / 1000),
-                  model: state.model,
-                  status: "failed",
-                  output: [],
-                  usage: null,
-                  error: {
-                    type: "server_error",
-                    message:
-                      err instanceof Error
-                        ? err.message
-                        : "upstream stream error",
+          if (externalAborted) {
+            safeError(signal?.reason ?? err);
+            return;
+          }
+          log.error(
+            `openai-responses passthrough stream error${
+              sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""
+            }:`,
+            err,
+          );
+          if (terminalForwarded) {
+            // The client already received an authoritative terminal. Never emit
+            // a contradictory second response.failed because local accounting
+            // failed after delivery.
+            safeClose();
+            return;
+          }
+          // Emit response.failed so the client doesn't hang waiting for a
+          // terminal event, then still run onComplete with what we accumulated.
+          await waitForDemand();
+          if (downstreamCancelled) {
+            cleanup();
+            return;
+          }
+          safeEnqueue(
+            encoder.encode(
+              formatResponsesEvent(
+                "response.failed",
+                JSON.stringify({
+                  type: "response.failed",
+                  response: {
+                    id: state.id || "resp_error",
+                    object: "response",
+                    created_at: Math.floor(Date.now() / 1000),
+                    model: state.model,
+                    status: "failed",
+                    output: [],
+                    usage: null,
+                    error: {
+                      type: "server_error",
+                      message:
+                        err instanceof Error
+                          ? err.message
+                          : "upstream stream error",
+                    },
                   },
-                },
-              }),
+                }),
+              ),
             ),
-          ),
-        );
-        finish();
-        safeClose();
-      }
+          );
+          finish();
+          safeClose();
+        }
+      };
+      queueMicrotask(() => void pump().catch((error) => safeError(error)));
     },
 
-    cancel() {
+    pull() {
+      resumeDemand?.();
+      resumeDemand = undefined;
+    },
+
+    cancel(reason) {
+      resumeDemand?.();
+      resumeDemand = undefined;
       // Client disconnected — cancel the upstream reader to stop wasting bandwidth
-      cancelled = true;
+      downstreamCancelled = true;
+      cancelController.abort(
+        new DOMException("client disconnected", "AbortError"),
+      );
       if (keepaliveTimer) clearTimeout(keepaliveTimer);
-      try {
-        // Cancel via the active reader (it holds the body lock); fall back to
-        // the body if the loop hasn't acquired a reader yet.
-        if (activeReader) {
-          void activeReader.cancel();
-        } else {
-          void upstreamResponse.body?.cancel();
-        }
-      } catch {
-        // Best-effort cancellation
-      }
+      cleanup();
+      if (activeReader) cancelAndReleaseReader(activeReader, reason);
+      else if (!pumpStarted)
+        void upstreamResponse.body?.cancel(reason).catch(() => {});
     },
   });
 
@@ -689,6 +2052,7 @@ function mapStatusToStopReason(status: string): string {
  */
 export function translateAnthropicStreamToResponses(
   anthropicResponse: Response,
+  opts: { strict?: boolean; signal?: AbortSignal } = {},
 ): Response {
   const encoder = new TextEncoder();
   // Reuse the Anthropic accumulator internally so we get a complete
@@ -717,14 +2081,50 @@ export function translateAnthropicStreamToResponses(
 
   const outputItems = new Map<number, OutputItem>();
   let cancelled = false;
+  let activeReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let resumeDemand: (() => void) | undefined;
+  let terminalEmitted = false;
+  let downstreamSettled = false;
 
   function emit(eventType: string, data: Record<string, unknown>): string {
     return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
   }
 
   const stream = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      function safeEnqueue(chunk: Uint8Array): boolean {
+    start(controller) {
+      const onAbort = (): void => {
+        cancelled = true;
+        resumeDemand?.();
+        resumeDemand = undefined;
+        const reason = opts.signal?.reason;
+        if (activeReader) cancelAndReleaseReader(activeReader, reason);
+        else void anthropicResponse.body?.cancel(reason).catch(() => {});
+        if (!downstreamSettled) {
+          downstreamSettled = true;
+          try {
+            controller.error(reason);
+          } catch {
+            // Already closed/cancelled.
+          }
+        }
+      };
+      opts.signal?.addEventListener("abort", onAbort, { once: true });
+      if (opts.signal?.aborted) onAbort();
+      const waitForDemand = async (): Promise<void> => {
+        while (
+          !cancelled &&
+          !opts.signal?.aborted &&
+          (controller.desiredSize ?? 1) <= 0
+        ) {
+          await new Promise<void>((resolve) => {
+            resumeDemand = resolve;
+          });
+        }
+        opts.signal?.throwIfAborted();
+      };
+      async function safeEnqueue(chunk: Uint8Array): Promise<boolean> {
+        if (cancelled) return false;
+        await waitForDemand();
         if (cancelled) return false;
         try {
           controller.enqueue(chunk);
@@ -735,429 +2135,497 @@ export function translateAnthropicStreamToResponses(
         }
       }
 
-      try {
-        if (!anthropicResponse.body) {
-          throw new Error("Anthropic response has no body");
-        }
-        const reader = anthropicResponse.body.getReader();
-
-        for await (const { event, data } of parseSSEStream(reader)) {
-          if (cancelled) break;
-
-          // Always feed the accumulator
-          accumulator.processEvent(event, data);
-
-          let parsed: Record<string, unknown>;
-          try {
-            parsed = JSON.parse(data) as Record<string, unknown>;
-          } catch {
-            continue;
+      const pump = async (): Promise<void> => {
+        try {
+          if (!anthropicResponse.body) {
+            throw new Error("Anthropic response has no body");
           }
+          const reader = anthropicResponse.body.getReader();
+          activeReader = reader;
+          const validator = opts.strict ? new AnthropicSSEValidator() : null;
 
-          switch (event) {
-            case "message_start": {
-              const message = parsed.message as
-                | Record<string, unknown>
-                | undefined;
-              if (message) {
-                const rawId = typeof message.id === "string" ? message.id : "";
-                respId = rawId.startsWith("resp_") ? rawId : `resp_${rawId}`;
-                model = typeof message.model === "string" ? message.model : "";
-                created = Math.floor(Date.now() / 1000);
-              }
+          for await (const { event, data } of parseSSEStream(reader, {
+            signal: opts.signal,
+            requireEventTerminator: opts.strict,
+            fatalUtf8: opts.strict,
+            maxFrames: opts.strict ? DEFAULT_MAX_SSE_FRAMES : undefined,
+            maxEventBytes: opts.strict ? 4 * 1024 * 1024 : undefined,
+            maxTotalBytes: opts.strict ? 4 * 1024 * 1024 : undefined,
+          })) {
+            if (cancelled) break;
+            validator?.process(event, data);
 
-              // response.created
-              safeEnqueue(
-                encoder.encode(
-                  emit("response.created", {
-                    type: "response.created",
-                    response: {
-                      id: respId,
-                      object: "response",
-                      created_at: created,
-                      model,
-                      status: "in_progress",
-                      output: [],
-                      usage: null,
-                    },
-                  }),
-                ),
-              );
+            // Always feed the accumulator
+            accumulator.processEvent(event, data);
 
-              // response.in_progress
-              safeEnqueue(
-                encoder.encode(
-                  emit("response.in_progress", {
-                    type: "response.in_progress",
-                    response: {
-                      id: respId,
-                      object: "response",
-                      created_at: created,
-                      model,
-                      status: "in_progress",
-                      output: [],
-                      usage: null,
-                    },
-                  }),
-                ),
-              );
-              break;
+            let parsed: Record<string, unknown>;
+            try {
+              parsed = JSON.parse(data) as Record<string, unknown>;
+            } catch {
+              continue;
             }
 
-            case "content_block_start": {
-              const index = parsed.index as number;
-              if (typeof index !== "number") break;
-
-              const block = parsed.content_block as
-                | Record<string, unknown>
-                | undefined;
-              if (!block || typeof block.type !== "string") break;
-
-              const currentOutputIndex = outputIndex++;
-
-              if (block.type === "text") {
-                const itemId = `msg_${respId}_${currentOutputIndex}`;
-                outputItems.set(index, {
-                  kind: "text",
-                  itemId,
-                  outputIndex: currentOutputIndex,
-                  text: "",
-                });
-
-                // response.output_item.added
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.output_item.added", {
-                      type: "response.output_item.added",
-                      output_index: currentOutputIndex,
-                      item: {
-                        type: "message",
-                        id: itemId,
-                        role: "assistant",
-                        status: "in_progress",
-                        content: [],
-                      },
-                    }),
-                  ),
-                );
-
-                // response.content_part.added
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.content_part.added", {
-                      type: "response.content_part.added",
-                      item_id: itemId,
-                      output_index: currentOutputIndex,
-                      content_index: 0,
-                      part: {
-                        type: "output_text",
-                        text: "",
-                        annotations: [],
-                      },
-                    }),
-                  ),
-                );
-              } else if (block.type === "tool_use") {
-                const callId = typeof block.id === "string" ? block.id : "";
-                const name = typeof block.name === "string" ? block.name : "";
-                const itemId = `fc_${callId}`;
-                outputItems.set(index, {
-                  kind: "tool_use",
-                  itemId,
-                  outputIndex: currentOutputIndex,
-                  callId,
-                  name,
-                  args: "",
-                });
-
-                // response.output_item.added
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.output_item.added", {
-                      type: "response.output_item.added",
-                      output_index: currentOutputIndex,
-                      item: {
-                        type: "function_call",
-                        id: itemId,
-                        call_id: callId,
-                        name,
-                        arguments: "",
-                        status: "in_progress",
-                      },
-                    }),
-                  ),
-                );
-              }
-              // thinking blocks: not represented in Responses API — skip
-              break;
-            }
-
-            case "content_block_delta": {
-              const index = parsed.index as number;
-              if (typeof index !== "number") break;
-
-              const delta = parsed.delta as Record<string, unknown> | undefined;
-              if (!delta || typeof delta.type !== "string") break;
-
-              const item = outputItems.get(index);
-              if (!item) break;
-
-              if (
-                delta.type === "text_delta" &&
-                typeof delta.text === "string" &&
-                item.kind === "text"
-              ) {
-                item.text += delta.text;
-
-                // response.output_text.delta
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.output_text.delta", {
-                      type: "response.output_text.delta",
-                      item_id: item.itemId,
-                      output_index: item.outputIndex,
-                      content_index: 0,
-                      delta: delta.text,
-                    }),
-                  ),
-                );
-              } else if (
-                delta.type === "input_json_delta" &&
-                typeof delta.partial_json === "string" &&
-                item.kind === "tool_use"
-              ) {
-                item.args += delta.partial_json;
-
-                // response.function_call_arguments.delta
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.function_call_arguments.delta", {
-                      type: "response.function_call_arguments.delta",
-                      item_id: item.itemId,
-                      output_index: item.outputIndex,
-                      delta: delta.partial_json,
-                    }),
-                  ),
-                );
-              }
-              break;
-            }
-
-            case "content_block_stop": {
-              const index = parsed.index as number;
-              if (typeof index !== "number") break;
-
-              const item = outputItems.get(index);
-              if (!item) break;
-
-              if (item.kind === "text") {
-                // response.output_text.done
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.output_text.done", {
-                      type: "response.output_text.done",
-                      item_id: item.itemId,
-                      output_index: item.outputIndex,
-                      content_index: 0,
-                      text: item.text,
-                    }),
-                  ),
-                );
-
-                // response.content_part.done
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.content_part.done", {
-                      type: "response.content_part.done",
-                      item_id: item.itemId,
-                      output_index: item.outputIndex,
-                      content_index: 0,
-                      part: {
-                        type: "output_text",
-                        text: item.text,
-                        annotations: [],
-                      },
-                    }),
-                  ),
-                );
-
-                // response.output_item.done
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.output_item.done", {
-                      type: "response.output_item.done",
-                      output_index: item.outputIndex,
-                      item: {
-                        type: "message",
-                        id: item.itemId,
-                        role: "assistant",
-                        status: "completed",
-                        content: [
-                          {
-                            type: "output_text",
-                            text: item.text,
-                            annotations: [],
-                          },
-                        ],
-                      },
-                    }),
-                  ),
-                );
-              } else if (item.kind === "tool_use") {
-                // response.function_call_arguments.done
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.function_call_arguments.done", {
-                      type: "response.function_call_arguments.done",
-                      item_id: item.itemId,
-                      output_index: item.outputIndex,
-                      arguments: item.args,
-                    }),
-                  ),
-                );
-
-                // response.output_item.done
-                safeEnqueue(
-                  encoder.encode(
-                    emit("response.output_item.done", {
-                      type: "response.output_item.done",
-                      output_index: item.outputIndex,
-                      item: {
-                        type: "function_call",
-                        id: item.itemId,
-                        call_id: item.callId,
-                        name: item.name,
-                        arguments: item.args,
-                        status: "completed",
-                      },
-                    }),
-                  ),
-                );
-              }
-              break;
-            }
-
-            case "message_delta": {
-              // Stop reason is captured by the accumulator — we use it
-              // in message_stop to build the final response.completed event.
-              break;
-            }
-
-            case "message_stop": {
-              // Build the final response.completed from the accumulator
-              const resp = accumulator.getResponse();
-
-              const finalOutput: Array<Record<string, unknown>> = [];
-              for (const block of resp.content) {
-                if (block.type === "text") {
-                  finalOutput.push({
-                    type: "message",
-                    id: `msg_${respId}_${finalOutput.length}`,
-                    role: "assistant",
-                    status: "completed",
-                    content: [
-                      {
-                        type: "output_text",
-                        text: block.text,
-                        annotations: [],
-                      },
-                    ],
-                  });
-                } else if (block.type === "tool_use") {
-                  finalOutput.push({
-                    type: "function_call",
-                    id: `fc_${block.id}`,
-                    call_id: block.id,
-                    name: block.name,
-                    arguments: JSON.stringify(block.input),
-                    status: "completed",
-                  });
+            switch (event) {
+              case "message_start": {
+                const message = parsed.message as
+                  | Record<string, unknown>
+                  | undefined;
+                if (message) {
+                  const rawId =
+                    typeof message.id === "string" ? message.id : "";
+                  respId = rawId.startsWith("resp_") ? rawId : `resp_${rawId}`;
+                  model =
+                    typeof message.model === "string" ? message.model : "";
+                  created = Math.floor(Date.now() / 1000);
                 }
+
+                // response.created
+                await safeEnqueue(
+                  encoder.encode(
+                    emit("response.created", {
+                      type: "response.created",
+                      response: {
+                        id: respId,
+                        object: "response",
+                        created_at: created,
+                        model,
+                        status: "in_progress",
+                        output: [],
+                        usage: null,
+                      },
+                    }),
+                  ),
+                );
+
+                // response.in_progress
+                await safeEnqueue(
+                  encoder.encode(
+                    emit("response.in_progress", {
+                      type: "response.in_progress",
+                      response: {
+                        id: respId,
+                        object: "response",
+                        created_at: created,
+                        model,
+                        status: "in_progress",
+                        output: [],
+                        usage: null,
+                      },
+                    }),
+                  ),
+                );
+                break;
               }
 
-              const finalStatus = mapStatusFromStopReason(resp.stopReason);
+              case "content_block_start": {
+                const index = parsed.index as number;
+                if (typeof index !== "number") break;
 
-              const ru = resp.usage ?? ZERO_USAGE;
-              const usageData: Record<string, unknown> = {
-                input_tokens: ru.inputTokens,
-                output_tokens: ru.outputTokens,
-                total_tokens: ru.inputTokens + ru.outputTokens,
-              };
-              if (ru.cacheReadInputTokens != null) {
-                usageData.prompt_tokens_details = {
-                  cached_tokens: ru.cacheReadInputTokens,
+                const block = parsed.content_block as
+                  | Record<string, unknown>
+                  | undefined;
+                if (!block || typeof block.type !== "string") break;
+
+                const currentOutputIndex = outputIndex++;
+
+                if (block.type === "text") {
+                  const itemId = `msg_${respId}_${currentOutputIndex}`;
+                  outputItems.set(index, {
+                    kind: "text",
+                    itemId,
+                    outputIndex: currentOutputIndex,
+                    text: "",
+                  });
+
+                  // response.output_item.added
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.output_item.added", {
+                        type: "response.output_item.added",
+                        output_index: currentOutputIndex,
+                        item: {
+                          type: "message",
+                          id: itemId,
+                          role: "assistant",
+                          status: "in_progress",
+                          content: [],
+                        },
+                      }),
+                    ),
+                  );
+
+                  // response.content_part.added
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.content_part.added", {
+                        type: "response.content_part.added",
+                        item_id: itemId,
+                        output_index: currentOutputIndex,
+                        content_index: 0,
+                        part: {
+                          type: "output_text",
+                          text: "",
+                          annotations: [],
+                        },
+                      }),
+                    ),
+                  );
+                } else if (block.type === "tool_use") {
+                  const callId = typeof block.id === "string" ? block.id : "";
+                  const name = typeof block.name === "string" ? block.name : "";
+                  const itemId = `fc_${callId}`;
+                  outputItems.set(index, {
+                    kind: "tool_use",
+                    itemId,
+                    outputIndex: currentOutputIndex,
+                    callId,
+                    name,
+                    args: "",
+                  });
+
+                  // response.output_item.added
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.output_item.added", {
+                        type: "response.output_item.added",
+                        output_index: currentOutputIndex,
+                        item: {
+                          type: "function_call",
+                          id: itemId,
+                          call_id: callId,
+                          name,
+                          arguments: "",
+                          status: "in_progress",
+                        },
+                      }),
+                    ),
+                  );
+                }
+                // thinking blocks: not represented in Responses API — skip
+                break;
+              }
+
+              case "content_block_delta": {
+                const index = parsed.index as number;
+                if (typeof index !== "number") break;
+
+                const delta = parsed.delta as
+                  | Record<string, unknown>
+                  | undefined;
+                if (!delta || typeof delta.type !== "string") break;
+
+                const item = outputItems.get(index);
+                if (!item) break;
+
+                if (
+                  delta.type === "text_delta" &&
+                  typeof delta.text === "string" &&
+                  item.kind === "text"
+                ) {
+                  item.text += delta.text;
+
+                  // response.output_text.delta
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.output_text.delta", {
+                        type: "response.output_text.delta",
+                        item_id: item.itemId,
+                        output_index: item.outputIndex,
+                        content_index: 0,
+                        delta: delta.text,
+                      }),
+                    ),
+                  );
+                } else if (
+                  delta.type === "input_json_delta" &&
+                  typeof delta.partial_json === "string" &&
+                  item.kind === "tool_use"
+                ) {
+                  item.args += delta.partial_json;
+
+                  // response.function_call_arguments.delta
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.function_call_arguments.delta", {
+                        type: "response.function_call_arguments.delta",
+                        item_id: item.itemId,
+                        output_index: item.outputIndex,
+                        delta: delta.partial_json,
+                      }),
+                    ),
+                  );
+                }
+                break;
+              }
+
+              case "content_block_stop": {
+                const index = parsed.index as number;
+                if (typeof index !== "number") break;
+
+                const item = outputItems.get(index);
+                if (!item) break;
+
+                if (item.kind === "text") {
+                  // response.output_text.done
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.output_text.done", {
+                        type: "response.output_text.done",
+                        item_id: item.itemId,
+                        output_index: item.outputIndex,
+                        content_index: 0,
+                        text: item.text,
+                      }),
+                    ),
+                  );
+
+                  // response.content_part.done
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.content_part.done", {
+                        type: "response.content_part.done",
+                        item_id: item.itemId,
+                        output_index: item.outputIndex,
+                        content_index: 0,
+                        part: {
+                          type: "output_text",
+                          text: item.text,
+                          annotations: [],
+                        },
+                      }),
+                    ),
+                  );
+
+                  // response.output_item.done
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.output_item.done", {
+                        type: "response.output_item.done",
+                        output_index: item.outputIndex,
+                        item: {
+                          type: "message",
+                          id: item.itemId,
+                          role: "assistant",
+                          status: "completed",
+                          content: [
+                            {
+                              type: "output_text",
+                              text: item.text,
+                              annotations: [],
+                            },
+                          ],
+                        },
+                      }),
+                    ),
+                  );
+                } else if (item.kind === "tool_use") {
+                  // response.function_call_arguments.done
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.function_call_arguments.done", {
+                        type: "response.function_call_arguments.done",
+                        item_id: item.itemId,
+                        output_index: item.outputIndex,
+                        arguments: item.args,
+                      }),
+                    ),
+                  );
+
+                  // response.output_item.done
+                  await safeEnqueue(
+                    encoder.encode(
+                      emit("response.output_item.done", {
+                        type: "response.output_item.done",
+                        output_index: item.outputIndex,
+                        item: {
+                          type: "function_call",
+                          id: item.itemId,
+                          call_id: item.callId,
+                          name: item.name,
+                          arguments: item.args,
+                          status: "completed",
+                        },
+                      }),
+                    ),
+                  );
+                }
+                break;
+              }
+
+              case "message_delta": {
+                // Stop reason is captured by the accumulator — we use it
+                // in message_stop to build the final response.completed event.
+                break;
+              }
+
+              case "message_stop": {
+                // Build the final response.completed from the accumulator
+                const resp = accumulator.getResponse();
+
+                const finalOutput: Array<Record<string, unknown>> = [];
+                for (const block of resp.content) {
+                  if (block.type === "text") {
+                    finalOutput.push({
+                      type: "message",
+                      id: `msg_${respId}_${finalOutput.length}`,
+                      role: "assistant",
+                      status: "completed",
+                      content: [
+                        {
+                          type: "output_text",
+                          text: block.text,
+                          annotations: [],
+                        },
+                      ],
+                    });
+                  } else if (block.type === "tool_use") {
+                    finalOutput.push({
+                      type: "function_call",
+                      id: `fc_${block.id}`,
+                      call_id: block.id,
+                      name: block.name,
+                      arguments: JSON.stringify(block.input),
+                      status: "completed",
+                    });
+                  }
+                }
+
+                const finalStatus = mapStatusFromStopReason(resp.stopReason);
+
+                const ru = resp.usage ?? ZERO_USAGE;
+                const inclusiveInputTokens = safeTokenSum(
+                  [
+                    ru.inputTokens,
+                    ru.cacheReadInputTokens,
+                    ru.cacheCreationInputTokens,
+                  ],
+                  "Anthropic usage token overflow",
+                );
+                const usageData: Record<string, unknown> = {
+                  input_tokens: inclusiveInputTokens,
+                  output_tokens: ru.outputTokens,
+                  total_tokens: safeTokenSum(
+                    [inclusiveInputTokens, ru.outputTokens],
+                    "Anthropic usage token overflow",
+                  ),
                 };
+                if (
+                  ru.cacheReadInputTokens != null ||
+                  ru.cacheCreationInputTokens != null
+                ) {
+                  usageData.input_tokens_details = {
+                    cached_tokens: ru.cacheReadInputTokens ?? 0,
+                    cache_write_tokens: ru.cacheCreationInputTokens ?? 0,
+                  };
+                }
+
+                await safeEnqueue(
+                  encoder.encode(
+                    emit("response.completed", {
+                      type: "response.completed",
+                      response: {
+                        id: respId,
+                        object: "response",
+                        created_at: created,
+                        model: resp.model,
+                        status: finalStatus,
+                        output: finalOutput,
+                        usage: usageData,
+                      },
+                    }),
+                  ),
+                );
+                terminalEmitted = true;
+                break;
               }
 
-              safeEnqueue(
-                encoder.encode(
-                  emit("response.completed", {
-                    type: "response.completed",
-                    response: {
-                      id: respId,
-                      object: "response",
-                      created_at: created,
-                      model: resp.model,
-                      status: finalStatus,
-                      output: finalOutput,
-                      usage: usageData,
-                    },
-                  }),
-                ),
-              );
-              break;
+              // "ping" and unknown events — skip
             }
-
-            // "ping" and unknown events — skip
+            if (terminalEmitted) break;
+          }
+          validator?.assertDone();
+        } catch (err) {
+          log.error("openai-responses stream translation error:", err);
+          if (opts.strict) {
+            try {
+              controller.error(err);
+            } catch {
+              // Already closed/cancelled.
+            }
+            return;
+          }
+          // Emit a response.failed event so clients don't hang waiting
+          try {
+            await safeEnqueue(
+              encoder.encode(
+                emit("response.failed", {
+                  type: "response.failed",
+                  response: {
+                    id: respId || "resp_error",
+                    object: "response",
+                    created_at: created,
+                    model,
+                    status: "failed",
+                    output: [],
+                    usage: null,
+                    error: {
+                      type: "server_error",
+                      message:
+                        err instanceof Error
+                          ? err.message
+                          : "upstream stream error",
+                    },
+                  },
+                }),
+              ),
+            );
+          } catch {
+            // Controller may already be closed
+          }
+        } finally {
+          opts.signal?.removeEventListener("abort", onAbort);
+          const reader = activeReader;
+          activeReader = undefined;
+          if (reader) cancelAndReleaseReader(reader);
+          if (!downstreamSettled) {
+            downstreamSettled = true;
+            try {
+              controller.close();
+            } catch {
+              // Already closed
+            }
           }
         }
-      } catch (err) {
-        log.error("openai-responses stream translation error:", err);
-        // Emit a response.failed event so clients don't hang waiting
-        try {
-          controller.enqueue(
-            encoder.encode(
-              emit("response.failed", {
-                type: "response.failed",
-                response: {
-                  id: respId || "resp_error",
-                  object: "response",
-                  created_at: created,
-                  model,
-                  status: "failed",
-                  output: [],
-                  usage: null,
-                  error: {
-                    type: "server_error",
-                    message:
-                      err instanceof Error
-                        ? err.message
-                        : "upstream stream error",
-                  },
-                },
-              }),
-            ),
-          );
-        } catch {
-          // Controller may already be closed
-        }
-      } finally {
-        try {
-          controller.close();
-        } catch {
-          // Already closed
-        }
-      }
+      };
+      queueMicrotask(
+        () =>
+          void pump().catch((error) => {
+            if (downstreamSettled) return;
+            downstreamSettled = true;
+            try {
+              controller.error(error);
+            } catch {
+              // Already closed/cancelled.
+            }
+          }),
+      );
+    },
+
+    pull() {
+      resumeDemand?.();
+      resumeDemand = undefined;
     },
 
     cancel() {
       // Client disconnected — cancel the upstream reader to stop wasting bandwidth
       cancelled = true;
-      try {
-        void anthropicResponse.body?.cancel();
-      } catch {
-        // Best-effort cancellation
-      }
+      downstreamSettled = true;
+      resumeDemand?.();
+      resumeDemand = undefined;
+      const reader = activeReader;
+      activeReader = undefined;
+      if (reader) cancelAndReleaseReader(reader);
+      else void anthropicResponse.body?.cancel().catch(() => {});
     },
   });
 

--- a/packages/gateway/src/stream/openai.ts
+++ b/packages/gateway/src/stream/openai.ts
@@ -23,7 +23,14 @@ import {
   type GatewayContentBlock,
   type GatewayResponse,
 } from "../translate/types";
-import { parseSSEStream, createStreamAccumulator } from "./anthropic";
+import {
+  DEFAULT_MAX_SSE_FRAMES,
+  AnthropicSSEValidator,
+  parseSSEStream,
+  createStreamAccumulator,
+  cancelAndReleaseReader,
+} from "./anthropic";
+import { safeTokenSum, validateOpenAIUsage } from "../usage-validation";
 
 // ---------------------------------------------------------------------------
 // Types for in-flight tool call tracking
@@ -76,6 +83,7 @@ function mapStopReason(reason: string): string {
  */
 export function translateAnthropicStreamToOpenAI(
   anthropicResponse: Response,
+  opts: { strict?: boolean; signal?: AbortSignal } = {},
 ): Response {
   const encoder = new TextEncoder();
   const accumulator = createStreamAccumulator();
@@ -91,6 +99,10 @@ export function translateAnthropicStreamToOpenAI(
   const toolCalls = new Map<number, InflightToolCall>();
   let nextToolCallIndex = 0;
   let cancelled = false;
+  let activeReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  let resumeDemand: (() => void) | undefined;
+  let terminalEmitted = false;
+  let downstreamSettled = false;
 
   function formatChunk(
     delta: Record<string, unknown>,
@@ -117,8 +129,40 @@ export function translateAnthropicStreamToOpenAI(
   }
 
   const stream = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      function safeEnqueue(chunk: Uint8Array): boolean {
+    start(controller) {
+      const onAbort = (): void => {
+        cancelled = true;
+        resumeDemand?.();
+        resumeDemand = undefined;
+        const reason = opts.signal?.reason;
+        if (activeReader) cancelAndReleaseReader(activeReader, reason);
+        else void anthropicResponse.body?.cancel(reason).catch(() => {});
+        if (!downstreamSettled) {
+          downstreamSettled = true;
+          try {
+            controller.error(reason);
+          } catch {
+            // Already closed/cancelled.
+          }
+        }
+      };
+      opts.signal?.addEventListener("abort", onAbort, { once: true });
+      if (opts.signal?.aborted) onAbort();
+      const waitForDemand = async (): Promise<void> => {
+        while (
+          !cancelled &&
+          !opts.signal?.aborted &&
+          (controller.desiredSize ?? 1) <= 0
+        ) {
+          await new Promise<void>((resolve) => {
+            resumeDemand = resolve;
+          });
+        }
+        opts.signal?.throwIfAborted();
+      };
+      async function safeEnqueue(chunk: Uint8Array): Promise<boolean> {
+        if (cancelled) return false;
+        await waitForDemand();
         if (cancelled) return false;
         try {
           controller.enqueue(chunk);
@@ -129,130 +173,97 @@ export function translateAnthropicStreamToOpenAI(
         }
       }
 
-      try {
-        if (!anthropicResponse.body) {
-          throw new Error("Anthropic response has no body");
-        }
-        const reader = anthropicResponse.body.getReader();
-
-        for await (const { event, data } of parseSSEStream(reader)) {
-          if (cancelled) break;
-
-          // Always feed the accumulator so we get a complete GatewayResponse
-          accumulator.processEvent(event, data);
-
-          let parsed: Record<string, unknown>;
-          try {
-            parsed = JSON.parse(data) as Record<string, unknown>;
-          } catch {
-            // Non-JSON event (ping, etc.) — skip
-            continue;
+      void (async () => {
+        try {
+          if (!anthropicResponse.body) {
+            throw new Error("Anthropic response has no body");
           }
+          const reader = anthropicResponse.body.getReader();
+          activeReader = reader;
+          const validator = opts.strict ? new AnthropicSSEValidator() : null;
 
-          switch (event) {
-            case "message_start": {
-              const message = parsed.message as
-                | Record<string, unknown>
-                | undefined;
-              if (message) {
-                const rawId = typeof message.id === "string" ? message.id : "";
-                baseId = rawId.startsWith("chatcmpl-")
-                  ? rawId
-                  : `chatcmpl-${rawId}`;
-                model = typeof message.model === "string" ? message.model : "";
-                created = Math.floor(Date.now() / 1000);
-              }
+          for await (const { event, data } of parseSSEStream(reader, {
+            signal: opts.signal,
+            requireEventTerminator: opts.strict,
+            fatalUtf8: opts.strict,
+            maxFrames: opts.strict ? DEFAULT_MAX_SSE_FRAMES : undefined,
+            maxEventBytes: opts.strict ? 4 * 1024 * 1024 : undefined,
+            maxTotalBytes: opts.strict ? 4 * 1024 * 1024 : undefined,
+          })) {
+            if (cancelled) break;
+            validator?.process(event, data);
 
-              // Emit the role chunk
-              if (!roleChunkEmitted) {
-                safeEnqueue(
-                  encoder.encode(formatChunk({ role: "assistant" }, null)),
-                );
-                roleChunkEmitted = true;
-              }
-              break;
+            // Always feed the accumulator so we get a complete GatewayResponse
+            accumulator.processEvent(event, data);
+
+            let parsed: Record<string, unknown>;
+            try {
+              parsed = JSON.parse(data) as Record<string, unknown>;
+            } catch {
+              // Non-JSON event (ping, etc.) — skip
+              continue;
             }
 
-            case "content_block_start": {
-              const index = parsed.index as number;
-              if (typeof index !== "number") break;
+            switch (event) {
+              case "message_start": {
+                const message = parsed.message as
+                  | Record<string, unknown>
+                  | undefined;
+                if (message) {
+                  const rawId =
+                    typeof message.id === "string" ? message.id : "";
+                  baseId = rawId.startsWith("chatcmpl-")
+                    ? rawId
+                    : `chatcmpl-${rawId}`;
+                  model =
+                    typeof message.model === "string" ? message.model : "";
+                  created = Math.floor(Date.now() / 1000);
+                }
 
-              const block = parsed.content_block as
-                | Record<string, unknown>
-                | undefined;
-              if (!block || typeof block.type !== "string") break;
-
-              if (block.type === "tool_use") {
-                // Register the tool call — emit the initial chunk with id+name
-                const toolCallIndex = nextToolCallIndex++;
-                const tc: InflightToolCall = {
-                  blockIndex: index,
-                  toolCallIndex,
-                  id: typeof block.id === "string" ? block.id : "",
-                  name: typeof block.name === "string" ? block.name : "",
-                  headerEmitted: false,
-                };
-                toolCalls.set(index, tc);
-
-                // Emit the tool call header chunk (id, type, function name)
-                safeEnqueue(
-                  encoder.encode(
-                    formatChunk(
-                      {
-                        tool_calls: [
-                          {
-                            index: tc.toolCallIndex,
-                            id: tc.id,
-                            type: "function",
-                            function: {
-                              name: tc.name,
-                              arguments: "",
-                            },
-                          },
-                        ],
-                      },
-                      null,
-                    ),
-                  ),
-                );
-                tc.headerEmitted = true;
+                // Emit the role chunk
+                if (!roleChunkEmitted) {
+                  await safeEnqueue(
+                    encoder.encode(formatChunk({ role: "assistant" }, null)),
+                  );
+                  roleChunkEmitted = true;
+                }
+                break;
               }
-              // text blocks: nothing to emit yet — wait for deltas
-              // thinking blocks: not represented in OpenAI format — skip
-              break;
-            }
 
-            case "content_block_delta": {
-              const index = parsed.index as number;
-              if (typeof index !== "number") break;
+              case "content_block_start": {
+                const index = parsed.index as number;
+                if (typeof index !== "number") break;
 
-              const delta = parsed.delta as Record<string, unknown> | undefined;
-              if (!delta || typeof delta.type !== "string") break;
+                const block = parsed.content_block as
+                  | Record<string, unknown>
+                  | undefined;
+                if (!block || typeof block.type !== "string") break;
 
-              if (
-                delta.type === "text_delta" &&
-                typeof delta.text === "string"
-              ) {
-                // Emit text content incrementally
-                safeEnqueue(
-                  encoder.encode(formatChunk({ content: delta.text }, null)),
-                );
-              } else if (
-                delta.type === "input_json_delta" &&
-                typeof delta.partial_json === "string"
-              ) {
-                // Stream tool call arguments incrementally
-                const tc = toolCalls.get(index);
-                if (tc) {
-                  safeEnqueue(
+                if (block.type === "tool_use") {
+                  // Register the tool call — emit the initial chunk with id+name
+                  const toolCallIndex = nextToolCallIndex++;
+                  const tc: InflightToolCall = {
+                    blockIndex: index,
+                    toolCallIndex,
+                    id: typeof block.id === "string" ? block.id : "",
+                    name: typeof block.name === "string" ? block.name : "",
+                    headerEmitted: false,
+                  };
+                  toolCalls.set(index, tc);
+
+                  // Emit the tool call header chunk (id, type, function name)
+                  await safeEnqueue(
                     encoder.encode(
                       formatChunk(
                         {
                           tool_calls: [
                             {
                               index: tc.toolCallIndex,
+                              id: tc.id,
+                              type: "function",
                               function: {
-                                arguments: delta.partial_json,
+                                name: tc.name,
+                                arguments: "",
                               },
                             },
                           ],
@@ -261,80 +272,176 @@ export function translateAnthropicStreamToOpenAI(
                       ),
                     ),
                   );
+                  tc.headerEmitted = true;
                 }
+                // text blocks: nothing to emit yet — wait for deltas
+                // thinking blocks: not represented in OpenAI format — skip
+                break;
               }
-              // thinking_delta, signature_delta: not in OpenAI format — skip
-              break;
-            }
 
-            case "content_block_stop": {
-              // No explicit emission needed for content_block_stop in OpenAI format.
-              // Text blocks are already fully streamed via deltas.
-              // Tool call arguments are already fully streamed via deltas.
-              break;
-            }
+              case "content_block_delta": {
+                const index = parsed.index as number;
+                if (typeof index !== "number") break;
 
-            case "message_delta": {
-              const delta = parsed.delta as Record<string, unknown> | undefined;
-              if (delta && typeof delta.stop_reason === "string") {
-                finishReason = mapStopReason(delta.stop_reason);
+                const delta = parsed.delta as
+                  | Record<string, unknown>
+                  | undefined;
+                if (!delta || typeof delta.type !== "string") break;
+
+                if (
+                  delta.type === "text_delta" &&
+                  typeof delta.text === "string"
+                ) {
+                  // Emit text content incrementally
+                  await safeEnqueue(
+                    encoder.encode(formatChunk({ content: delta.text }, null)),
+                  );
+                } else if (
+                  delta.type === "input_json_delta" &&
+                  typeof delta.partial_json === "string"
+                ) {
+                  // Stream tool call arguments incrementally
+                  const tc = toolCalls.get(index);
+                  if (tc) {
+                    await safeEnqueue(
+                      encoder.encode(
+                        formatChunk(
+                          {
+                            tool_calls: [
+                              {
+                                index: tc.toolCallIndex,
+                                function: {
+                                  arguments: delta.partial_json,
+                                },
+                              },
+                            ],
+                          },
+                          null,
+                        ),
+                      ),
+                    );
+                  }
+                }
+                // thinking_delta, signature_delta: not in OpenAI format — skip
+                break;
               }
-              break;
-            }
 
-            case "message_stop": {
-              // Build usage from accumulator
-              const resp = accumulator.getResponse();
-              const ru = resp.usage ?? ZERO_USAGE;
-              const usage: Record<string, unknown> = {
-                prompt_tokens: ru.inputTokens,
-                completion_tokens: ru.outputTokens,
-                total_tokens: ru.inputTokens + ru.outputTokens,
-              };
-              if (ru.cacheReadInputTokens != null) {
-                usage.prompt_tokens_details = {
-                  cached_tokens: ru.cacheReadInputTokens,
+              case "content_block_stop": {
+                // No explicit emission needed for content_block_stop in OpenAI format.
+                // Text blocks are already fully streamed via deltas.
+                // Tool call arguments are already fully streamed via deltas.
+                break;
+              }
+
+              case "message_delta": {
+                const delta = parsed.delta as
+                  | Record<string, unknown>
+                  | undefined;
+                if (delta && typeof delta.stop_reason === "string") {
+                  finishReason = mapStopReason(delta.stop_reason);
+                }
+                break;
+              }
+
+              case "message_stop": {
+                // Build usage from accumulator
+                const resp = accumulator.getResponse();
+                const ru = resp.usage ?? ZERO_USAGE;
+                const inclusiveInputTokens = safeTokenSum(
+                  [
+                    ru.inputTokens,
+                    ru.cacheReadInputTokens,
+                    ru.cacheCreationInputTokens,
+                  ],
+                  "Anthropic usage token overflow",
+                );
+                const usage: Record<string, unknown> = {
+                  prompt_tokens: inclusiveInputTokens,
+                  completion_tokens: ru.outputTokens,
+                  total_tokens: safeTokenSum(
+                    [inclusiveInputTokens, ru.outputTokens],
+                    "Anthropic usage token overflow",
+                  ),
                 };
+                if (
+                  ru.cacheReadInputTokens != null ||
+                  ru.cacheCreationInputTokens != null
+                ) {
+                  usage.prompt_tokens_details = {
+                    cached_tokens: ru.cacheReadInputTokens ?? 0,
+                    cache_write_tokens: ru.cacheCreationInputTokens ?? 0,
+                  };
+                }
+
+                // Emit final chunk with finish_reason and usage
+                await safeEnqueue(
+                  encoder.encode(
+                    formatChunk({}, finishReason || "stop", usage),
+                  ),
+                );
+
+                // Emit [DONE] sentinel
+                await safeEnqueue(encoder.encode("data: [DONE]\n\n"));
+                terminalEmitted = true;
+                break;
               }
 
-              // Emit final chunk with finish_reason and usage
-              safeEnqueue(
-                encoder.encode(formatChunk({}, finishReason || "stop", usage)),
-              );
-
-              // Emit [DONE] sentinel
-              safeEnqueue(encoder.encode("data: [DONE]\n\n"));
-              break;
+              // "ping" and unknown events — skip (already fed to accumulator)
             }
-
-            // "ping" and unknown events — skip (already fed to accumulator)
+            if (terminalEmitted) break;
+          }
+          validator?.assertDone();
+        } catch (err) {
+          if (opts.strict) {
+            log.error("openai stream translation validation error:", err);
+            try {
+              controller.error(err);
+            } catch {
+              // Already closed/cancelled.
+            }
+            return;
+          }
+          // If upstream errors, try to close gracefully with [DONE]
+          if (!terminalEmitted) {
+            try {
+              await safeEnqueue(encoder.encode("data: [DONE]\n\n"));
+            } catch {
+              // Controller may already be closed
+            }
+          }
+          log.error("openai stream translation error:", err);
+        } finally {
+          opts.signal?.removeEventListener("abort", onAbort);
+          const reader = activeReader;
+          activeReader = undefined;
+          if (reader) cancelAndReleaseReader(reader);
+          if (!downstreamSettled) {
+            downstreamSettled = true;
+            try {
+              controller.close();
+            } catch {
+              // Already closed
+            }
           }
         }
-      } catch (err) {
-        // If upstream errors, try to close gracefully with [DONE]
-        try {
-          safeEnqueue(encoder.encode("data: [DONE]\n\n"));
-        } catch {
-          // Controller may already be closed
-        }
-        log.error("openai stream translation error:", err);
-      } finally {
-        try {
-          controller.close();
-        } catch {
-          // Already closed
-        }
-      }
+      })();
+    },
+
+    pull() {
+      resumeDemand?.();
+      resumeDemand = undefined;
     },
 
     cancel() {
       // Client disconnected — cancel the upstream reader to stop wasting bandwidth
       cancelled = true;
-      try {
-        void anthropicResponse.body?.cancel();
-      } catch {
-        // Best-effort cancellation
-      }
+      downstreamSettled = true;
+      resumeDemand?.();
+      resumeDemand = undefined;
+      const reader = activeReader;
+      activeReader = undefined;
+      if (reader) cancelAndReleaseReader(reader);
+      else void anthropicResponse.body?.cancel().catch(() => {});
     },
   });
 
@@ -364,6 +471,16 @@ export function translateAnthropicStreamToOpenAI(
  */
 export async function accumulateOpenAISSEStream(
   upstreamResponse: Response,
+  opts: {
+    signal?: AbortSignal;
+    stopAtTerminal?: boolean;
+    strict?: boolean;
+    inactivityMs?: number;
+    maxFrames?: number;
+    onSemanticContent?: () => void;
+    consumeUntilDone?: boolean;
+    onValidatedEvent?: (event: string, data: string) => void | Promise<void>;
+  } = {},
 ): Promise<GatewayResponse> {
   let id = "";
   let model = "";
@@ -374,6 +491,7 @@ export async function accumulateOpenAISSEStream(
   // reasoning-only response is not mistaken for an empty completion (#1334) —
   // mirrors the non-streaming parseOpenAIResponse content→reasoning fallback.
   let reasoningContent = "";
+  let refusalContent = "";
   const toolCalls = new Map<
     number,
     { id: string; name: string; args: string }
@@ -382,89 +500,347 @@ export async function accumulateOpenAISSEStream(
   let outputTokens = 0;
   let cachedTokens: number | undefined;
   let cacheWriteTokens: number | undefined;
+  let terminalSeen = false;
+  let doneSeen = false;
+  let choiceIndex: number | undefined;
+  const toolCallIndexById = new Map<string, number>();
+  // Every choice is validated even though the gateway projects choices[0].
+  const validatedToolCalls = new Map<string, { id: string; name: string }>();
+  // Tool call IDs only need to be unique within one independent choice.
+  const validatedToolOwnerByChoiceAndId = new Map<string, string>();
+
+  const applyUsage = (parsed: Record<string, unknown>): void => {
+    const usage = parsed.usage as Record<string, unknown> | undefined;
+    if (!usage) return;
+    if (typeof usage.prompt_tokens === "number")
+      inputTokens = usage.prompt_tokens;
+    if (typeof usage.completion_tokens === "number")
+      outputTokens = usage.completion_tokens;
+    const details = usage.prompt_tokens_details as
+      | Record<string, number>
+      | undefined;
+    if (details?.cached_tokens !== undefined)
+      cachedTokens = details.cached_tokens;
+    if (details?.cache_write_tokens !== undefined)
+      cacheWriteTokens = details.cache_write_tokens;
+  };
+  const malformedUsage = (usage: unknown): boolean => {
+    try {
+      validateOpenAIUsage(usage, "malformed OpenAI stream event");
+      return false;
+    } catch {
+      return true;
+    }
+  };
+  const malformedChoice = (choice: unknown): boolean => {
+    if (!choice || typeof choice !== "object" || Array.isArray(choice)) {
+      return true;
+    }
+    const typed = choice as Record<string, unknown>;
+    if (
+      !typed.delta ||
+      typeof typed.delta !== "object" ||
+      Array.isArray(typed.delta) ||
+      (typed.finish_reason !== undefined &&
+        typed.finish_reason !== null &&
+        typeof typed.finish_reason !== "string")
+    ) {
+      return true;
+    }
+    if (
+      typed.index !== undefined &&
+      (!Number.isSafeInteger(typed.index) || (typed.index as number) < 0)
+    ) {
+      return true;
+    }
+    const delta = typed.delta as Record<string, unknown>;
+    if (delta.role !== undefined && typeof delta.role !== "string") {
+      return true;
+    }
+    for (const field of [
+      "content",
+      "reasoning",
+      "reasoning_content",
+      "refusal",
+    ] as const) {
+      if (
+        delta[field] !== undefined &&
+        delta[field] !== null &&
+        typeof delta[field] !== "string"
+      ) {
+        return true;
+      }
+    }
+    if (delta.tool_calls === undefined) return false;
+    if (!Array.isArray(delta.tool_calls)) return true;
+    return delta.tool_calls.some((call) => {
+      if (!call || typeof call !== "object" || Array.isArray(call)) return true;
+      const toolCall = call as Record<string, unknown>;
+      if (
+        !Number.isSafeInteger(toolCall.index) ||
+        (toolCall.index as number) < 0
+      ) {
+        return true;
+      }
+      if (toolCall.id !== undefined && typeof toolCall.id !== "string") {
+        return true;
+      }
+      if (toolCall.function === undefined) return false;
+      if (
+        !toolCall.function ||
+        typeof toolCall.function !== "object" ||
+        Array.isArray(toolCall.function)
+      ) {
+        return true;
+      }
+      const fn = toolCall.function as Record<string, unknown>;
+      return (
+        (fn.name !== undefined && typeof fn.name !== "string") ||
+        (fn.arguments !== undefined && typeof fn.arguments !== "string")
+      );
+    });
+  };
 
   if (!upstreamResponse.body) {
     throw new Error("Upstream response has no body");
   }
   const reader = upstreamResponse.body.getReader();
 
-  for await (const { data } of parseSSEStream(reader)) {
-    if (data === "[DONE]") break;
+  try {
+    for await (const { event, data } of parseSSEStream(reader, {
+      signal: opts.signal,
+      inactivityMs: opts.inactivityMs,
+      requireEventTerminator: opts.strict,
+      fatalUtf8: opts.strict,
+      maxFrames: opts.strict
+        ? (opts.maxFrames ?? DEFAULT_MAX_SSE_FRAMES)
+        : opts.maxFrames,
+      maxTotalBytes: opts.strict ? 4 * 1024 * 1024 : undefined,
+    })) {
+      if (data === "[DONE]") {
+        await opts.onValidatedEvent?.(event, data);
+        doneSeen = true;
+        break;
+      }
 
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(data) as Record<string, unknown>;
-    } catch {
-      continue;
-    }
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(data) as Record<string, unknown>;
+      } catch {
+        if (opts.strict) throw new Error("malformed OpenAI stream event");
+        continue;
+      }
 
-    if (typeof parsed.id === "string") id = parsed.id;
-    if (typeof parsed.model === "string") model = parsed.model;
+      const choices = parsed.choices;
+      if (
+        opts.strict &&
+        (!Array.isArray(choices) ||
+          choices.some(malformedChoice) ||
+          malformedUsage(parsed.usage))
+      ) {
+        throw new Error("malformed OpenAI stream event");
+      }
 
-    const choices = parsed.choices as
-      | Array<Record<string, unknown>>
-      | undefined;
-    const firstChoice = choices?.[0];
-    if (firstChoice) {
-      const delta = firstChoice.delta as Record<string, unknown> | undefined;
-      if (delta) {
-        if (typeof delta.content === "string") {
-          textContent += delta.content;
-        }
-        // Reasoning deltas: `reasoning` (OpenRouter/others) or `reasoning_content`
-        // (DeepSeek/Qwen). Accumulated separately and surfaced as a thinking block
-        // only when there is no visible text (#1334). No provider emits BOTH fields
-        // in one delta, so the else-if precedence here (reasoning first) is
-        // per-provider identical to parseOpenAIResponse (which prefers
-        // reasoning_content) — the order only diverges in the impossible both-set case.
-        if (typeof delta.reasoning === "string") {
-          reasoningContent += delta.reasoning;
-        } else if (typeof delta.reasoning_content === "string") {
-          reasoningContent += delta.reasoning_content;
-        }
-        const tcs = delta.tool_calls as
-          | Array<Record<string, unknown>>
-          | undefined;
-        if (tcs) {
-          for (const tc of tcs) {
-            const idx = tc.index as number;
-            const fn = tc.function as Record<string, unknown> | undefined;
-            const existing = toolCalls.get(idx);
-            if (!existing) {
-              toolCalls.set(idx, {
-                id: asString(tc.id),
-                name: asString(fn?.name),
-                args: asString(fn?.arguments),
-              });
-            } else {
-              if (fn?.arguments) existing.args += asString(fn.arguments);
+      if (
+        opts.strict &&
+        ((parsed.id !== undefined && typeof parsed.id !== "string") ||
+          (id && typeof parsed.id === "string" && parsed.id !== id) ||
+          (parsed.model !== undefined && typeof parsed.model !== "string") ||
+          (model && typeof parsed.model === "string" && parsed.model !== model))
+      ) {
+        throw new Error("malformed OpenAI stream event");
+      }
+      if (typeof parsed.id === "string") id = parsed.id;
+      if (typeof parsed.model === "string") model = parsed.model;
+
+      const normalizedChoices = parsed.choices as
+        | Array<Record<string, unknown>>
+        | undefined;
+      if (opts.strict && normalizedChoices) {
+        const frameChoiceIndices = new Set<number>();
+        for (
+          let position = 0;
+          position < normalizedChoices.length;
+          position++
+        ) {
+          const choice = normalizedChoices[position];
+          const currentChoiceIndex =
+            typeof choice.index === "number" ? choice.index : position;
+          if (frameChoiceIndices.has(currentChoiceIndex)) {
+            throw new Error("malformed OpenAI stream event");
+          }
+          frameChoiceIndices.add(currentChoiceIndex);
+          const delta = choice.delta as Record<string, unknown>;
+          const calls = delta.tool_calls as
+            | Array<Record<string, unknown>>
+            | undefined;
+          for (const call of calls ?? []) {
+            const toolIndex = call.index as number;
+            const slot = `${currentChoiceIndex}:${toolIndex}`;
+            const existing = validatedToolCalls.get(slot);
+            const fn = call.function as Record<string, unknown> | undefined;
+            const id = typeof call.id === "string" ? call.id : "";
+            const name = typeof fn?.name === "string" ? fn.name : "";
+            if (
+              (existing?.id && id && existing.id !== id) ||
+              (existing?.name && name && existing.name !== name)
+            ) {
+              throw new Error("malformed OpenAI stream event");
             }
+            const effectiveId = id || existing?.id || "";
+            const effectiveName = name || existing?.name || "";
+            if (effectiveId) {
+              const identity = `${currentChoiceIndex}:${effectiveId}`;
+              const owner = validatedToolOwnerByChoiceAndId.get(identity);
+              if (owner !== undefined && owner !== slot) {
+                throw new Error("malformed OpenAI stream event");
+              }
+              validatedToolOwnerByChoiceAndId.set(identity, slot);
+            }
+            validatedToolCalls.set(slot, {
+              id: effectiveId,
+              name: effectiveName,
+            });
           }
         }
       }
-      if (typeof firstChoice.finish_reason === "string") {
-        const fr = firstChoice.finish_reason;
-        if (fr === "stop") stopReason = "end_turn";
-        else if (fr === "length") stopReason = "max_tokens";
-        else if (fr === "tool_calls") stopReason = "tool_use";
+      const firstChoice = normalizedChoices?.[0];
+      if (opts.strict && terminalSeen && normalizedChoices?.length) {
+        throw new Error("malformed OpenAI stream event");
       }
-    }
+      if (firstChoice) {
+        if (opts.strict) {
+          const projectedChoiceIndex =
+            typeof firstChoice.index === "number" ? firstChoice.index : 0;
+          if (
+            choiceIndex !== undefined &&
+            choiceIndex !== projectedChoiceIndex
+          ) {
+            throw new Error("malformed OpenAI stream event");
+          }
+          choiceIndex = projectedChoiceIndex;
+        }
+        const delta = firstChoice.delta as Record<string, unknown> | undefined;
+        if (delta) {
+          if (typeof delta.content === "string") {
+            textContent += delta.content;
+          }
+          if (typeof delta.refusal === "string") {
+            refusalContent += delta.refusal;
+          }
+          // Reasoning deltas: `reasoning` (OpenRouter/others) or `reasoning_content`
+          // (DeepSeek/Qwen). Accumulated separately and surfaced as a thinking block
+          // only when there is no visible text (#1334). No provider emits BOTH fields
+          // in one delta, so the else-if precedence here (reasoning first) is
+          // per-provider identical to parseOpenAIResponse (which prefers
+          // reasoning_content) — the order only diverges in the impossible both-set case.
+          if (typeof delta.reasoning === "string") {
+            reasoningContent += delta.reasoning;
+          } else if (typeof delta.reasoning_content === "string") {
+            reasoningContent += delta.reasoning_content;
+          }
+          const tcs = delta.tool_calls as
+            | Array<Record<string, unknown>>
+            | undefined;
+          if (tcs) {
+            for (const tc of tcs) {
+              const idx = tc.index as number;
+              const fn = tc.function as Record<string, unknown> | undefined;
+              const fnName = fn?.name;
+              const fnArguments = fn?.arguments;
+              const existing = toolCalls.get(idx);
+              if (opts.strict && typeof tc.id === "string" && tc.id) {
+                const existingIndex = toolCallIndexById.get(tc.id);
+                if (existingIndex !== undefined && existingIndex !== idx) {
+                  throw new Error("malformed OpenAI stream event");
+                }
+                toolCallIndexById.set(tc.id, idx);
+              }
+              if (!existing) {
+                toolCalls.set(idx, {
+                  id: asString(tc.id),
+                  name: asString(fn?.name),
+                  args: asString(fn?.arguments),
+                });
+              } else {
+                if (
+                  opts.strict &&
+                  ((typeof tc.id === "string" &&
+                    existing.id &&
+                    tc.id !== existing.id) ||
+                    (typeof fnName === "string" &&
+                      existing.name &&
+                      fnName !== existing.name))
+                ) {
+                  throw new Error("malformed OpenAI stream event");
+                }
+                if (!existing.id && typeof tc.id === "string") {
+                  existing.id = tc.id;
+                }
+                if (!existing.name && typeof fnName === "string") {
+                  existing.name = fnName;
+                }
+                if (fnArguments) existing.args += asString(fnArguments);
+              }
+            }
+          }
+          if (
+            opts.onSemanticContent &&
+            ([
+              delta.content,
+              delta.reasoning,
+              delta.reasoning_content,
+              delta.refusal,
+            ].some((value) => typeof value === "string" && value.length > 0) ||
+              tcs?.some((tc) => {
+                const fn = tc.function as Record<string, unknown> | undefined;
+                return (
+                  (typeof tc.id === "string" && tc.id.length > 0) ||
+                  (typeof fn?.name === "string" && fn.name.length > 0) ||
+                  (typeof fn?.arguments === "string" && fn.arguments.length > 0)
+                );
+              }))
+          ) {
+            opts.onSemanticContent();
+          }
+        }
+        if (typeof firstChoice.finish_reason === "string") {
+          const fr = firstChoice.finish_reason;
+          if (fr === "stop") stopReason = "end_turn";
+          else if (fr === "length") stopReason = "max_tokens";
+          else if (fr === "tool_calls" || fr === "function_call")
+            stopReason = "tool_use";
+          else stopReason = fr;
+          if (opts.stopAtTerminal) terminalSeen = true;
+        }
+      }
 
-    // Usage is typically in the final chunk
-    const usage = parsed.usage as Record<string, unknown> | undefined;
-    if (usage) {
-      if (typeof usage.prompt_tokens === "number")
-        inputTokens = usage.prompt_tokens;
-      if (typeof usage.completion_tokens === "number")
-        outputTokens = usage.completion_tokens;
-      const details = usage.prompt_tokens_details as
-        | Record<string, number>
-        | undefined;
-      if (details?.cached_tokens !== undefined)
-        cachedTokens = details.cached_tokens;
-      if (details?.cache_write_tokens !== undefined)
-        cacheWriteTokens = details.cache_write_tokens;
+      // Usage is typically in the final chunk
+      applyUsage(parsed);
+      await opts.onValidatedEvent?.(event, data);
+      // Worker requests do not ask for stream_options.include_usage, so a
+      // non-null finish_reason is the last required chunk. Usage on this same
+      // frame is retained; optional later usage-only frames are not awaited.
+      if (terminalSeen && !opts.consumeUntilDone) break;
     }
+  } finally {
+    cancelAndReleaseReader(reader);
+  }
+
+  if (opts.stopAtTerminal && !terminalSeen) {
+    throw new Error("missing OpenAI finish_reason terminal");
+  }
+  if (opts.consumeUntilDone && !doneSeen) {
+    throw new Error("missing OpenAI [DONE] terminal");
+  }
+  if (opts.strict && Array.from(toolCalls.values()).some((tc) => !tc.id)) {
+    throw new Error("malformed OpenAI stream event");
+  }
+  if (
+    opts.strict &&
+    Array.from(validatedToolCalls.values()).some((call) => !call.id)
+  ) {
+    throw new Error("malformed OpenAI stream event");
   }
 
   const content: GatewayContentBlock[] = [];
@@ -476,6 +852,8 @@ export async function accumulateOpenAISSEStream(
   }
   if (textContent) {
     content.push({ type: "text", text: textContent });
+  } else if (refusalContent) {
+    content.push({ type: "text", text: refusalContent });
   }
   for (const [, tc] of Array.from(toolCalls.entries()).sort(
     ([a], [b]) => a - b,

--- a/packages/gateway/src/temporal-adapter.ts
+++ b/packages/gateway/src/temporal-adapter.ts
@@ -72,7 +72,7 @@ function hashBlocks(
         );
         break;
       case "tool_result":
-        h.update(`tool_result:${block.toolUseId}:`);
+        h.update(`tool_result:${block.toolUseId}:${block.toolName ?? ""}:`);
         hashBlocks(h, block.content);
         break;
       case "opaque": {
@@ -161,6 +161,7 @@ function contentBlockToPart(
         messageID,
         type: "tool",
         tool: "result",
+        ...(block.toolName ? { toolName: block.toolName } : undefined),
         callID: block.toolUseId,
         // Propagate the error flag so downstream consumers (structured
         // tool-call trace, gradient) can distinguish failed tool results.
@@ -320,7 +321,12 @@ export function resolveToolResults(messages: LoreMessageWithParts[]): void {
   // --- Pass 1: Index all tool_result parts by callID ---
   const resultsByCallID = new Map<
     string,
-    { output: string; blocks?: LoreContentBlock[]; isError: boolean }
+    {
+      output: string;
+      blocks?: LoreContentBlock[];
+      toolName?: string;
+      isError: boolean;
+    }
   >();
 
   for (const msg of messages) {
@@ -330,12 +336,14 @@ export function resolveToolResults(messages: LoreMessageWithParts[]): void {
           resultsByCallID.set(part.callID, {
             output: part.state.output,
             blocks: part.state.blocks,
+            toolName: part.toolName,
             isError: false,
           });
         } else if (part.state.status === "error") {
           resultsByCallID.set(part.callID, {
             output: part.state.error,
             blocks: part.state.blocks,
+            toolName: part.toolName,
             isError: true,
           });
         }
@@ -354,6 +362,7 @@ export function resolveToolResults(messages: LoreMessageWithParts[]): void {
       ) {
         const result = resultsByCallID.get(part.callID);
         if (result) {
+          if (result.toolName) part.toolName = result.toolName;
           part.state = result.isError
             ? {
                 status: "error",

--- a/packages/gateway/src/translate/anthropic.ts
+++ b/packages/gateway/src/translate/anthropic.ts
@@ -15,6 +15,11 @@ import type {
 import { forwardClientHeaders, ZERO_USAGE } from "./types";
 import { asString } from "@loreai/core";
 import { extractAuth, authHeaders } from "../auth";
+import {
+  normalizeAnthropicStopReason,
+  toAnthropicStopReason,
+} from "../anthropic-protocol";
+import { validateAnthropicUsage } from "../usage-validation";
 
 // ---------------------------------------------------------------------------
 // Anthropic API version — used in all outgoing requests
@@ -540,6 +545,7 @@ export function parseAnthropicResponseJSON(
   json: Record<string, unknown>,
 ): GatewayResponse {
   const content: GatewayContentBlock[] = [];
+  const toolIdentities = new Set<string>();
   const rawContent = json.content as Array<Record<string, unknown>> | undefined;
   if (rawContent) {
     for (const block of rawContent) {
@@ -556,14 +562,29 @@ export function parseAnthropicResponseJSON(
               : undefined),
           });
           break;
-        case "tool_use":
+        case "tool_use": {
+          const id = asString(block.id);
+          if (!id || toolIdentities.has(id)) {
+            throw new Error("malformed Anthropic response tool identity");
+          }
+          toolIdentities.add(id);
           content.push({
             type: "tool_use",
-            id: asString(block.id),
+            id,
             name: asString(block.name),
             input: block.input,
           });
           break;
+        }
+        case "server_tool_use": {
+          const id = asString(block.id);
+          if (!id || toolIdentities.has(id)) {
+            throw new Error("malformed Anthropic response tool identity");
+          }
+          toolIdentities.add(id);
+          content.push({ type: "opaque", raw: block });
+          break;
+        }
         default:
           // Preserve unknown response block types as opaque so no data is
           // silently lost (lossless-by-default for future modalities).
@@ -573,18 +594,28 @@ export function parseAnthropicResponseJSON(
     }
   }
 
-  const usage = json.usage as Record<string, number> | undefined;
+  const usage = validateAnthropicUsage(json.usage, {
+    message: "malformed Anthropic response usage",
+    requireInput: true,
+    requireOutput: true,
+  });
 
   return {
     id: asString(json.id),
     model: asString(json.model),
     content,
-    stopReason: String((json.stop_reason as string) ?? "end_turn"),
+    stopReason: normalizeAnthropicStopReason(
+      String((json.stop_reason as string) ?? "end_turn"),
+    ),
     usage: {
-      inputTokens: usage?.input_tokens ?? 0,
-      outputTokens: usage?.output_tokens ?? 0,
-      cacheReadInputTokens: usage?.cache_read_input_tokens,
-      cacheCreationInputTokens: usage?.cache_creation_input_tokens,
+      inputTokens: (usage?.input_tokens as number | undefined) ?? 0,
+      outputTokens: (usage?.output_tokens as number | undefined) ?? 0,
+      cacheReadInputTokens: usage?.cache_read_input_tokens as
+        | number
+        | undefined,
+      cacheCreationInputTokens: usage?.cache_creation_input_tokens as
+        | number
+        | undefined,
     },
   };
 }
@@ -617,7 +648,7 @@ export function buildAnthropicNonStreamResponse(
     role: "assistant",
     model: resp.model,
     content: resp.content.map(toAnthropicBlock),
-    stop_reason: resp.stopReason,
+    stop_reason: toAnthropicStopReason(resp.stopReason),
     stop_sequence: null,
     usage,
   };

--- a/packages/gateway/src/translate/bedrock-runtime.ts
+++ b/packages/gateway/src/translate/bedrock-runtime.ts
@@ -24,6 +24,63 @@
  * credential rotation and re-shaping it would break those guarantees.
  */
 
+import { promiseAgainstAbort, responseAgainstAbort } from "../abort-race";
+import { upstreamFetch } from "../fetch";
+import { createForegroundAbortScope, wrapBodyWithCleanup } from "../pipeline";
+import { cancelAndReleaseReader } from "../stream/anthropic";
+
+/** Bedrock Runtime InvokeModel accepts request payloads up to 25 MiB. */
+export const BEDROCK_RUNTIME_MAX_REQUEST_BYTES = 25 * 1024 * 1024;
+
+class BedrockRuntimeRequestTooLargeError extends Error {
+  constructor() {
+    super(
+      `Bedrock Runtime request exceeded ${BEDROCK_RUNTIME_MAX_REQUEST_BYTES} byte limit`,
+    );
+    this.name = "BedrockRuntimeRequestTooLargeError";
+  }
+}
+
+export async function readBedrockRuntimeRequestBody(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal,
+): Promise<Buffer> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let completed = false;
+  try {
+    while (true) {
+      const { done, value } = await promiseAgainstAbort(
+        () => reader.read(),
+        signal,
+      );
+      signal.throwIfAborted();
+      if (done) {
+        completed = true;
+        break;
+      }
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > BEDROCK_RUNTIME_MAX_REQUEST_BYTES) {
+        throw new BedrockRuntimeRequestTooLargeError();
+      }
+      chunks.push(value);
+    }
+    return Buffer.concat(chunks, total);
+  } finally {
+    if (completed) {
+      try {
+        reader.releaseLock();
+      } catch {
+        // Normal completion has no pending read in conforming runtimes.
+      }
+    } else {
+      cancelAndReleaseReader(reader, signal.reason);
+    }
+  }
+}
+
 export const BEDROCK_RUNTIME_VERBS = [
   "converse",
   "converse-stream",
@@ -57,23 +114,58 @@ export function bedrockRuntimeUrl(region: string): string {
   return `https://bedrock-runtime.${region}.amazonaws.com`;
 }
 
+const BEDROCK_STRIPPED_HEADERS = new Set([
+  "connection",
+  "cookie",
+  "cookie2",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+export function bedrockRuntimeHeaders(headers: Headers): Headers {
+  const connectionHeaders = new Set(
+    (headers.get("connection") ?? "")
+      .split(",")
+      .map((name) => name.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const upstream = new Headers();
+  headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    if (
+      BEDROCK_STRIPPED_HEADERS.has(normalized) ||
+      connectionHeaders.has(normalized) ||
+      normalized.startsWith("x-lore-")
+    ) {
+      return;
+    }
+    upstream.set(key, value);
+  });
+  return upstream;
+}
+
 /**
  * Forward an incoming Bedrock Runtime API request to the real
  * `bedrock-runtime.<region>.amazonaws.com` endpoint and return the upstream
  * response untouched. Body, status, and headers (including the AWS event
  * stream `Content-Type` for streaming verbs) are passed through verbatim.
  *
- * Headers forwarded: every header from the original request, minus `Host`
- * (Node's http module rewrites it for the new destination; carrying the
- * original `127.0.0.1:3207` value through would cause Bedrock to reject
- * with a TLS/SNI mismatch). `Authorization` (bearer token from
- * `AWS_BEARER_TOKEN_BEDROCK`) is host-agnostic and passes through unchanged.
- * SigV4-signed headers are NOT stripped — the upstream's 403 is a clearer
- * signal than a gateway-synthesized error.
+ * End-to-end AWS headers, including `Authorization` and signed `x-amz-*`
+ * fields, pass through. Hop-by-hop fields, connection-nominated headers,
+ * cookies, proxy credentials, and Lore's internal metadata do not cross the
+ * origin boundary.
  */
 export async function proxyBedrockRuntimeRequest(
   req: Request,
   region: string,
+  deps: { upstreamFetch?: typeof upstreamFetch } = {},
 ): Promise<Response> {
   const match = BEDROCK_RUNTIME_PATH_RE.exec(new URL(req.url).pathname);
   if (!match) {
@@ -91,32 +183,50 @@ export async function proxyBedrockRuntimeRequest(
   }
   const [, modelId, verb] = match;
 
-  const upstreamHeaders = new Headers();
-  req.headers.forEach((value, key) => {
-    if (key.toLowerCase() === "host") return;
-    upstreamHeaders.set(key, value);
-  });
+  const upstreamHeaders = bedrockRuntimeHeaders(req.headers);
 
   const destination = `${bedrockRuntimeUrl(region)}/model/${modelId}/${verb}`;
 
-  // Buffer the request body upfront. Converse / InvokeModel bodies are JSON
-  // payloads that arrive fully buffered (the wire-format response streams
-  // out independently), so draining the Web ReadableStream here is both
-  // correct and the simplest path for the upstream dispatcher — undici /
-  // node:http treat a Buffer body as a single Content-Length chunk, which
-  // sidesteps the `duplex: "half"` streaming-body contract entirely.
-  const body = req.body ? Buffer.from(await req.arrayBuffer()) : undefined;
+  const abortScope = createForegroundAbortScope(req.signal);
+  try {
+    const body = req.body
+      ? await readBedrockRuntimeRequestBody(req.body, abortScope.signal)
+      : undefined;
 
-  const { upstreamFetch } = await import("../fetch");
-  const upstream = await upstreamFetch(destination, {
-    method: req.method,
-    headers: upstreamHeaders,
-    body,
-  });
+    const upstream = await responseAgainstAbort(
+      () =>
+        (deps.upstreamFetch ?? upstreamFetch)(destination, {
+          method: req.method,
+          headers: upstreamHeaders,
+          body: body ? new Uint8Array(body) : undefined,
+          signal: abortScope.signal,
+        }),
+      abortScope.signal,
+    );
 
-  return new Response(upstream.body, {
-    status: upstream.status,
-    statusText: upstream.statusText,
-    headers: new Headers(upstream.headers),
-  });
+    return wrapBodyWithCleanup(
+      new Response(upstream.body, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: new Headers(upstream.headers),
+      }),
+      abortScope.dispose,
+      abortScope.signal,
+    );
+  } catch (error) {
+    abortScope.dispose();
+    if (error instanceof BedrockRuntimeRequestTooLargeError) {
+      return new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message: error.message,
+          },
+        }),
+        { status: 413, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw error;
+  }
 }

--- a/packages/gateway/src/translate/gemini.ts
+++ b/packages/gateway/src/translate/gemini.ts
@@ -10,9 +10,8 @@
  * compatibility layer at `/v1beta/openai/...`). Key differences:
  *   - roles are `user` / `model` (not `assistant`);
  *   - the system prompt lives in `systemInstruction` (a `{parts:[{text}]}`);
- *   - tool calls are `functionCall` parts; tool results are `functionResponse`
- *     parts. Gemini has NO per-call id — calls/results are paired by function
- *     NAME, so we synthesize the internal tool-use id from the name;
+ *   - tool calls are `functionCall` parts; modern Gemini responses may include
+ *     a per-call `id`. Legacy responses are paired by function NAME only;
  *   - tools are `[{functionDeclarations:[{name,description,parameters}]}]`;
  *   - generation params live under `generationConfig`;
  *   - auth is an API key via the `x-goog-api-key` header. Clients that use the
@@ -29,6 +28,7 @@ import type {
 } from "./types";
 import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
 import { asString } from "@loreai/core";
+import { safeTokenSum, validateGeminiUsageMetadata } from "../usage-validation";
 
 /** Default Gemini API version segment used when building upstream URLs. */
 const GEMINI_API_VERSION = "v1beta";
@@ -37,6 +37,99 @@ const GEMINI_API_VERSION = "v1beta";
 const DEFAULT_GEMINI_MAX_TOKENS = 8192;
 
 type GeminiPart = Record<string, unknown>;
+
+export interface GeminiFunctionCall {
+  id?: string;
+  name: string;
+  args?: Record<string, unknown>;
+}
+
+export function validateGeminiFunctionCallIdentity(
+  value: unknown,
+  identities: Set<string>,
+  diagnostic: string,
+): GeminiFunctionCall {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(diagnostic);
+  }
+  const call = value as Record<string, unknown>;
+  if (
+    typeof call.name !== "string" ||
+    call.name.length === 0 ||
+    (call.id !== undefined &&
+      (typeof call.id !== "string" || call.id.length === 0)) ||
+    (call.args !== undefined &&
+      (!call.args || typeof call.args !== "object" || Array.isArray(call.args)))
+  ) {
+    throw new Error(diagnostic);
+  }
+  const identity = call.id ?? call.name;
+  if (identities.has(identity)) throw new Error(diagnostic);
+  identities.add(identity);
+  return call as unknown as GeminiFunctionCall;
+}
+
+export function validateGeminiCandidateToolIdentities(
+  candidates: unknown[],
+  diagnostic: string,
+): void {
+  for (const candidate of candidates) {
+    // Tool identities are local to each independent candidate.
+    const identities = new Set<string>();
+    if (
+      !candidate ||
+      typeof candidate !== "object" ||
+      Array.isArray(candidate)
+    ) {
+      throw new Error(diagnostic);
+    }
+    const typedCandidate = candidate as Record<string, unknown>;
+    if (
+      (typedCandidate.index !== undefined &&
+        (!Number.isSafeInteger(typedCandidate.index) ||
+          (typedCandidate.index as number) < 0)) ||
+      (typedCandidate.finishReason !== undefined &&
+        typedCandidate.finishReason !== null &&
+        typeof typedCandidate.finishReason !== "string")
+    ) {
+      throw new Error(diagnostic);
+    }
+    const content = typedCandidate.content;
+    if (content === undefined) continue;
+    if (!content || typeof content !== "object" || Array.isArray(content)) {
+      throw new Error(diagnostic);
+    }
+    const parts = (content as Record<string, unknown>).parts;
+    const role = (content as Record<string, unknown>).role;
+    if (role !== undefined && typeof role !== "string") {
+      throw new Error(diagnostic);
+    }
+    if (parts === undefined) continue;
+    if (!Array.isArray(parts)) throw new Error(diagnostic);
+    for (const part of parts) {
+      if (!part || typeof part !== "object" || Array.isArray(part)) {
+        throw new Error(diagnostic);
+      }
+      const functionCall = (part as Record<string, unknown>).functionCall;
+      const text = (part as Record<string, unknown>).text;
+      const thought = (part as Record<string, unknown>).thought;
+      if (
+        (text !== undefined && typeof text !== "string") ||
+        (thought !== undefined && typeof thought !== "boolean") ||
+        (text !== undefined && functionCall !== undefined)
+      ) {
+        throw new Error(diagnostic);
+      }
+      if (functionCall !== undefined) {
+        validateGeminiFunctionCallIdentity(
+          functionCall,
+          identities,
+          diagnostic,
+        );
+      }
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Gemini generateContent request → GatewayRequest
@@ -65,17 +158,30 @@ function partToBlock(part: GeminiPart): GatewayContentBlock | null {
     return { type: "text", text: part.text };
   }
   if (part.functionCall && typeof part.functionCall === "object") {
-    const fc = part.functionCall as { name?: unknown; args?: unknown };
+    const fc = part.functionCall as {
+      id?: unknown;
+      name?: unknown;
+      args?: unknown;
+    };
     const name = asString(fc.name);
-    // Gemini has no per-call id; pair by NAME (see file header).
-    return { type: "tool_use", id: name, name, input: fc.args ?? {} };
+    return {
+      type: "tool_use",
+      id: asString(fc.id) || name,
+      name,
+      input: fc.args ?? {},
+    };
   }
   if (part.functionResponse && typeof part.functionResponse === "object") {
-    const fr = part.functionResponse as { name?: unknown; response?: unknown };
+    const fr = part.functionResponse as {
+      id?: unknown;
+      name?: unknown;
+      response?: unknown;
+    };
     const name = asString(fr.name);
     return {
       type: "tool_result",
-      toolUseId: name,
+      toolUseId: asString(fr.id) || name,
+      toolName: name,
       content: [{ type: "text", text: JSON.stringify(fr.response ?? {}) }],
     };
   }
@@ -188,7 +294,15 @@ function blockToGeminiParts(block: GatewayContentBlock): GeminiPart[] {
       // visible answer text.
       return block.thinking ? [{ text: block.thinking, thought: true }] : [];
     case "tool_use":
-      return [{ functionCall: { name: block.name, args: block.input ?? {} } }];
+      return [
+        {
+          functionCall: {
+            id: block.id,
+            name: block.name,
+            args: block.input ?? {},
+          },
+        },
+      ];
     case "tool_result": {
       const text = blocksToText(block.content);
       let response: unknown;
@@ -199,7 +313,15 @@ function blockToGeminiParts(block: GatewayContentBlock): GeminiPart[] {
       } catch {
         response = { output: text };
       }
-      return [{ functionResponse: { name: block.toolUseId, response } }];
+      return [
+        {
+          functionResponse: {
+            id: block.toolUseId,
+            name: block.toolName ?? block.toolUseId,
+            response,
+          },
+        },
+      ];
     }
     case "opaque":
       return [block.raw];
@@ -308,30 +430,45 @@ export function mapGeminiFinishReason(
  * INCLUDES thinking). Omitting it undercounts output for the gateway's
  * cost-aware routing and understates the client's total.
  */
-export function geminiUsageFromMetadata(
-  um: Record<string, unknown> | undefined,
-): GatewayUsage {
+export function geminiUsageFromMetadata(value: unknown): GatewayUsage {
+  const um = validateGeminiUsageMetadata(
+    value,
+    "malformed Gemini usage metadata",
+  );
   if (!um) return { ...ZERO_USAGE };
   const candidates =
     typeof um.candidatesTokenCount === "number" ? um.candidatesTokenCount : 0;
   const thoughts =
     typeof um.thoughtsTokenCount === "number" ? um.thoughtsTokenCount : 0;
+  const cached =
+    typeof um.cachedContentTokenCount === "number"
+      ? um.cachedContentTokenCount
+      : 0;
+  const toolPrompt =
+    typeof um.toolUsePromptTokenCount === "number"
+      ? um.toolUsePromptTokenCount
+      : 0;
   const usage: GatewayUsage = {
     inputTokens:
-      typeof um.promptTokenCount === "number" ? um.promptTokenCount : 0,
-    outputTokens: candidates + thoughts,
+      Math.max(
+        0,
+        (typeof um.promptTokenCount === "number" ? um.promptTokenCount : 0) -
+          cached,
+      ) + toolPrompt,
+    outputTokens: safeTokenSum(
+      [candidates, thoughts],
+      "malformed Gemini usage metadata",
+    ),
   };
   if (typeof um.cachedContentTokenCount === "number") {
-    usage.cacheReadInputTokens = um.cachedContentTokenCount;
+    usage.cacheReadInputTokens = cached;
   }
   return usage;
 }
 
 /** Parse Gemini `usageMetadata` into `GatewayUsage`. */
 function parseGeminiUsage(json: Record<string, unknown>): GatewayUsage {
-  return geminiUsageFromMetadata(
-    json.usageMetadata as Record<string, unknown> | undefined,
-  );
+  return geminiUsageFromMetadata(json.usageMetadata);
 }
 
 /**
@@ -342,6 +479,10 @@ export function parseGeminiResponseJSON(
   json: Record<string, unknown>,
 ): GatewayResponse {
   const candidates = Array.isArray(json.candidates) ? json.candidates : [];
+  validateGeminiCandidateToolIdentities(
+    candidates,
+    "malformed Gemini response tool identity",
+  );
   // LIMITATION: the internal model holds a single response, so when a client
   // requests `candidateCount > 1` only candidates[0] is surfaced. Multi-candidate
   // fan-out is a documented follow-up, not currently supported.
@@ -356,7 +497,9 @@ export function parseGeminiResponseJSON(
   for (const p of parts) {
     const block = partToBlock(p);
     if (!block) continue;
-    if (block.type === "tool_use") hasToolCall = true;
+    if (block.type === "tool_use") {
+      hasToolCall = true;
+    }
     blocks.push(block);
   }
 
@@ -407,13 +550,24 @@ export function buildGeminiResponseBody(
   resp: GatewayResponse,
 ): Record<string, unknown> {
   const usage = resp.usage ?? ZERO_USAGE;
+  const inclusiveInputTokens = safeTokenSum(
+    [
+      usage.inputTokens,
+      usage.cacheReadInputTokens,
+      usage.cacheCreationInputTokens,
+    ],
+    "Gemini response usage overflow",
+  );
   const parts: GeminiPart[] = [];
   for (const block of resp.content) parts.push(...blockToGeminiParts(block));
 
   const usageMetadata: Record<string, unknown> = {
-    promptTokenCount: usage.inputTokens,
+    promptTokenCount: inclusiveInputTokens,
     candidatesTokenCount: usage.outputTokens,
-    totalTokenCount: usage.inputTokens + usage.outputTokens,
+    totalTokenCount: safeTokenSum(
+      [inclusiveInputTokens, usage.outputTokens],
+      "Gemini response usage overflow",
+    ),
   };
   if (usage.cacheReadInputTokens != null) {
     usageMetadata.cachedContentTokenCount = usage.cacheReadInputTokens;

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -17,9 +17,40 @@ import type {
   GatewayRequest,
   GatewayResponse,
   GatewayTool,
+  GatewayUsage,
 } from "./types";
 import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
 import { extractAuth } from "../auth";
+import { safeTokenSum } from "../usage-validation";
+
+function responsesUsage(usage: GatewayUsage): Record<string, unknown> {
+  const inclusiveInputTokens = safeTokenSum(
+    [
+      usage.inputTokens,
+      usage.cacheReadInputTokens,
+      usage.cacheCreationInputTokens,
+    ],
+    "Responses usage overflow",
+  );
+  const result: Record<string, unknown> = {
+    input_tokens: inclusiveInputTokens,
+    output_tokens: usage.outputTokens,
+    total_tokens: safeTokenSum(
+      [inclusiveInputTokens, usage.outputTokens],
+      "Responses usage overflow",
+    ),
+  };
+  if (
+    usage.cacheReadInputTokens != null ||
+    usage.cacheCreationInputTokens != null
+  ) {
+    result.input_tokens_details = {
+      cached_tokens: usage.cacheReadInputTokens ?? 0,
+      cache_write_tokens: usage.cacheCreationInputTokens ?? 0,
+    };
+  }
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // OpenAI Responses API → GatewayRequest
@@ -720,18 +751,7 @@ function buildOpenAIResponsesNonStreamResponse(
     model: resp.model,
     status: mapStopReasonToStatus(resp.stopReason),
     output,
-    usage: {
-      input_tokens: usage.inputTokens,
-      output_tokens: usage.outputTokens,
-      total_tokens: usage.inputTokens + usage.outputTokens,
-      ...(usage.cacheReadInputTokens != null
-        ? {
-            prompt_tokens_details: {
-              cached_tokens: usage.cacheReadInputTokens,
-            },
-          }
-        : {}),
-    },
+    usage: responsesUsage(usage),
   };
 
   return new Response(JSON.stringify(response), {
@@ -975,18 +995,7 @@ function buildOpenAIResponsesStreamResponse(resp: GatewayResponse): Response {
               return null;
             })
             .filter(Boolean),
-          usage: {
-            input_tokens: usage.inputTokens,
-            output_tokens: usage.outputTokens,
-            total_tokens: usage.inputTokens + usage.outputTokens,
-            ...(usage.cacheReadInputTokens != null
-              ? {
-                  prompt_tokens_details: {
-                    cached_tokens: usage.cacheReadInputTokens,
-                  },
-                }
-              : {}),
-          },
+          usage: responsesUsage(usage),
         },
       });
 

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -10,11 +10,42 @@ import type {
   GatewayRequest,
   GatewayResponse,
   GatewayTool,
+  GatewayUsage,
 } from "./types";
 import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
 import type { AnthropicCacheOptions } from "./anthropic";
 import { asString } from "@loreai/core";
 import { extractAuth } from "../auth";
+import { safeTokenSum } from "../usage-validation";
+
+function openAIUsage(usage: GatewayUsage): Record<string, unknown> {
+  const inclusiveInputTokens = safeTokenSum(
+    [
+      usage.inputTokens,
+      usage.cacheReadInputTokens,
+      usage.cacheCreationInputTokens,
+    ],
+    "OpenAI response usage overflow",
+  );
+  const result: Record<string, unknown> = {
+    prompt_tokens: inclusiveInputTokens,
+    completion_tokens: usage.outputTokens,
+    total_tokens: safeTokenSum(
+      [inclusiveInputTokens, usage.outputTokens],
+      "OpenAI response usage overflow",
+    ),
+  };
+  if (
+    usage.cacheReadInputTokens != null ||
+    usage.cacheCreationInputTokens != null
+  ) {
+    result.prompt_tokens_details = {
+      cached_tokens: usage.cacheReadInputTokens ?? 0,
+      cache_write_tokens: usage.cacheCreationInputTokens ?? 0,
+    };
+  }
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // OpenAI → GatewayRequest
@@ -354,24 +385,7 @@ function buildOpenAINonStreamResponse(resp: GatewayResponse): Response {
         logprobs: null,
       },
     ],
-    usage: {
-      prompt_tokens: usage.inputTokens,
-      completion_tokens: usage.outputTokens,
-      total_tokens: usage.inputTokens + usage.outputTokens,
-      ...(usage.cacheReadInputTokens != null ||
-      usage.cacheCreationInputTokens != null
-        ? {
-            prompt_tokens_details: {
-              ...(usage.cacheReadInputTokens != null
-                ? { cached_tokens: usage.cacheReadInputTokens }
-                : {}),
-              ...(usage.cacheCreationInputTokens != null
-                ? { cache_creation_tokens: usage.cacheCreationInputTokens }
-                : {}),
-            },
-          }
-        : {}),
-    },
+    usage: openAIUsage(usage),
   };
 
   return new Response(JSON.stringify(response), {
@@ -414,24 +428,7 @@ function buildOpenAIStreamResponse(resp: GatewayResponse): Response {
       // Emitted unconditionally, not gated on include_usage — same as the
       // reference; clients that didn't opt in simply ignore the extra field.
       const ru = resp.usage ?? ZERO_USAGE;
-      const terminalUsage: Record<string, unknown> = {
-        prompt_tokens: ru.inputTokens,
-        completion_tokens: ru.outputTokens,
-        total_tokens: ru.inputTokens + ru.outputTokens,
-      };
-      if (
-        ru.cacheReadInputTokens != null ||
-        ru.cacheCreationInputTokens != null
-      ) {
-        const details: Record<string, number> = {};
-        if (ru.cacheReadInputTokens != null) {
-          details.cached_tokens = ru.cacheReadInputTokens;
-        }
-        if (ru.cacheCreationInputTokens != null) {
-          details.cache_creation_tokens = ru.cacheCreationInputTokens;
-        }
-        terminalUsage.prompt_tokens_details = details;
-      }
+      const terminalUsage = openAIUsage(ru);
 
       function emitChunk(
         delta: Record<string, unknown>,

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -41,6 +41,8 @@ export type GatewayToolResultBlock = {
   type: "tool_result";
   /** ID of the tool_use block this result corresponds to. */
   toolUseId: string;
+  /** Provider function name when identity and name are distinct (Gemini). */
+  toolName?: string;
   /**
    * Structured tool-result content. Anthropic `tool_result` content can be a
    * string or an array of blocks (text, image, etc.). We always normalize to
@@ -204,6 +206,8 @@ export type GatewayProtocol =
 
 /** Normalized request after ingress translation from either protocol. */
 export type GatewayRequest = {
+  /** Caller disconnect/cancellation propagated from the ingress Request. */
+  signal?: AbortSignal;
   /** Which protocol the request arrived as — determines egress translation. */
   protocol: GatewayProtocol;
   /** Model identifier (e.g. `claude-sonnet-4-20250514`, `gpt-4o`). */
@@ -313,16 +317,12 @@ export const ZERO_USAGE: GatewayUsage = Object.freeze({
  * check misses them and `JSON.parse`-ing the SSE body throws
  * (`Unexpected token 'e', "event: res"...` — LOREAI-GATEWAY-38 / -1P).
  *
- * Only `data:`/`event:` are sniffed (not `id:`/`retry:`/`:` comments): those two
- * are the only prefixes a completion stream opens with, and the narrower set
- * avoids false-positives on plaintext error bodies (e.g. a body starting with
- * `retry: later`). The caller feeds a detected SSE body to a stream accumulator,
- * which tolerates any subsequent field.
+ * Recognizes every legal field/comment that may precede the first data event.
  */
 export function looksLikeSSE(contentType: string, body: string): boolean {
   if (contentType.includes("text/event-stream")) return true;
   const head = body.replace(/^\uFEFF/, "").trimStart();
-  return /^(?:data|event):/.test(head);
+  return /^(?:(?:data|event|id|retry):|:)/.test(head);
 }
 
 /** Accumulated response from the upstream provider. */

--- a/packages/gateway/src/usage-validation.ts
+++ b/packages/gateway/src/usage-validation.ts
@@ -1,0 +1,324 @@
+/** Runtime validation for provider-reported token usage. */
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function invalid(message: string): never {
+  throw new Error(message);
+}
+
+function tokenCount(
+  value: unknown,
+  message: string,
+  allowNull = false,
+): number | undefined {
+  if (value === undefined || (allowNull && value === null)) return undefined;
+  if (!Number.isSafeInteger(value) || (value as number) < 0) invalid(message);
+  return value as number;
+}
+
+/** Add validated token counts without allowing a safe-integer overflow. */
+export function safeTokenSum(
+  values: Array<number | undefined>,
+  message: string,
+): number {
+  let total = 0;
+  for (const value of values) {
+    if (value === undefined) continue;
+    if (value > Number.MAX_SAFE_INTEGER - total) invalid(message);
+    total += value;
+  }
+  return total;
+}
+
+function optionalDetails(
+  value: unknown,
+  message: string,
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) invalid(message);
+  return value;
+}
+
+function validateSubset(
+  components: Array<number | undefined>,
+  total: number | undefined,
+  message: string,
+): number {
+  const sum = safeTokenSum(components, message);
+  if (sum > 0 && total === undefined) invalid(message);
+  if (total !== undefined && sum > total) invalid(message);
+  return sum;
+}
+
+export function validateAnthropicUsage(
+  value: unknown,
+  options: {
+    message: string;
+    required?: boolean;
+    requireInput?: boolean;
+    requireOutput?: boolean;
+    allowNullCounts?: boolean;
+  },
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) {
+    if (options.required) invalid(options.message);
+    return undefined;
+  }
+  if (!isRecord(value)) invalid(options.message);
+
+  const input = tokenCount(
+    value.input_tokens,
+    options.message,
+    options.allowNullCounts,
+  );
+  const output = tokenCount(value.output_tokens, options.message);
+  const cacheRead = tokenCount(
+    value.cache_read_input_tokens,
+    options.message,
+    true,
+  );
+  const cacheCreation = tokenCount(
+    value.cache_creation_input_tokens,
+    options.message,
+    true,
+  );
+  if (options.requireInput && input === undefined) invalid(options.message);
+  if (options.requireOutput && output === undefined) invalid(options.message);
+  safeTokenSum([input, output, cacheRead, cacheCreation], options.message);
+
+  const cacheDetails = optionalDetails(value.cache_creation, options.message);
+  if (cacheDetails) {
+    const fiveMinute = tokenCount(
+      cacheDetails.ephemeral_5m_input_tokens,
+      options.message,
+    );
+    const oneHour = tokenCount(
+      cacheDetails.ephemeral_1h_input_tokens,
+      options.message,
+    );
+    validateSubset([fiveMinute, oneHour], cacheCreation, options.message);
+  }
+
+  const outputDetails = optionalDetails(
+    value.output_tokens_details,
+    options.message,
+  );
+  if (outputDetails) {
+    const thinking = tokenCount(outputDetails.thinking_tokens, options.message);
+    validateSubset([thinking], output, options.message);
+  }
+
+  const serverToolUse = optionalDetails(value.server_tool_use, options.message);
+  if (serverToolUse) {
+    const webSearch = tokenCount(
+      serverToolUse.web_search_requests,
+      options.message,
+    );
+    const webFetch = tokenCount(
+      serverToolUse.web_fetch_requests,
+      options.message,
+    );
+    safeTokenSum([webSearch, webFetch], options.message);
+  }
+
+  return value;
+}
+
+const OPENAI_COMPLETION_DETAIL_FIELDS = [
+  "reasoning_tokens",
+  "audio_tokens",
+  "accepted_prediction_tokens",
+  "rejected_prediction_tokens",
+] as const;
+
+function validateOpenAIDetails(
+  value: unknown,
+  total: number | undefined,
+  fields: readonly string[],
+  message: string,
+): Record<string, unknown> | undefined {
+  const details = optionalDetails(value, message);
+  if (!details) return undefined;
+  const components = fields.map((field) => tokenCount(details[field], message));
+  validateSubset(components, total, message);
+  return details;
+}
+
+export function validateOpenAIUsage(
+  value: unknown,
+  message: string,
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) invalid(message);
+
+  const prompt = tokenCount(value.prompt_tokens, message);
+  const completion = tokenCount(value.completion_tokens, message);
+  const total = tokenCount(value.total_tokens, message);
+  if (
+    total !== undefined &&
+    (prompt === undefined || completion === undefined)
+  ) {
+    invalid(message);
+  }
+  const componentTotal = safeTokenSum([prompt, completion], message);
+  // Cache counts are subsets of prompt_tokens; reasoning/audio/prediction
+  // counts are subsets of completion_tokens. They must not be added again.
+  if (total !== undefined && componentTotal !== total) invalid(message);
+
+  const promptDetails = validateOpenAIDetails(
+    value.prompt_tokens_details,
+    prompt,
+    ["cached_tokens", "cache_write_tokens"],
+    message,
+  );
+  if (promptDetails) {
+    const cached = tokenCount(promptDetails.cached_tokens, message);
+    const cacheWrite = tokenCount(promptDetails.cache_write_tokens, message);
+    validateSubset([cached, cacheWrite], prompt, message);
+  }
+  validateOpenAIDetails(
+    value.completion_tokens_details,
+    completion,
+    OPENAI_COMPLETION_DETAIL_FIELDS,
+    message,
+  );
+
+  return value;
+}
+
+function validateResponsesInputDetails(
+  value: unknown,
+  input: number | undefined,
+  message: string,
+): Record<string, unknown> | undefined {
+  const details = optionalDetails(value, message);
+  if (!details) return undefined;
+  const cached = tokenCount(details.cached_tokens, message);
+  const cacheWrite = tokenCount(details.cache_write_tokens, message);
+  validateSubset([cached, cacheWrite], input, message);
+  return details;
+}
+
+export function validateResponsesUsage(
+  value: unknown,
+  message: string,
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) invalid(message);
+
+  const input = tokenCount(value.input_tokens, message);
+  const output = tokenCount(value.output_tokens, message);
+  const total = tokenCount(value.total_tokens, message);
+  if (total !== undefined && (input === undefined || output === undefined)) {
+    invalid(message);
+  }
+  const componentTotal = safeTokenSum([input, output], message);
+  // Responses uses the same inclusive parent-count semantics as Chat:
+  // cache details belong to input_tokens and reasoning details to output_tokens.
+  if (total !== undefined && componentTotal !== total) invalid(message);
+
+  validateResponsesInputDetails(value.input_tokens_details, input, message);
+  validateResponsesInputDetails(value.prompt_tokens_details, input, message);
+  validateOpenAIDetails(
+    value.output_tokens_details,
+    output,
+    OPENAI_COMPLETION_DETAIL_FIELDS,
+    message,
+  );
+
+  return value;
+}
+
+const GEMINI_COUNT_FIELDS = [
+  "promptTokenCount",
+  "candidatesTokenCount",
+  "thoughtsTokenCount",
+  "cachedContentTokenCount",
+  "toolUsePromptTokenCount",
+  "totalTokenCount",
+] as const;
+
+function validateGeminiModalityDetails(
+  value: unknown,
+  total: number | undefined,
+  message: string,
+): void {
+  if (value === undefined || value === null) return;
+  if (!Array.isArray(value)) invalid(message);
+  const components: number[] = [];
+  for (const detail of value) {
+    if (!isRecord(detail)) invalid(message);
+    const count = tokenCount(detail.tokenCount, message);
+    if (count !== undefined) components.push(count);
+  }
+  validateSubset(components, total, message);
+}
+
+export function validateGeminiUsageMetadata(
+  value: unknown,
+  message: string,
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!isRecord(value)) invalid(message);
+
+  const counts = Object.fromEntries(
+    GEMINI_COUNT_FIELDS.map((field) => [
+      field,
+      tokenCount(value[field], message),
+    ]),
+  ) as Record<(typeof GEMINI_COUNT_FIELDS)[number], number | undefined>;
+
+  // Gemini reports cached tokens as a subset of promptTokenCount and modality
+  // details as decompositions of their parent counts, so neither is added here.
+  // thoughtsTokenCount and toolUsePromptTokenCount are separate billable
+  // components of totalTokenCount.
+  const componentTotal = safeTokenSum(
+    [
+      counts.promptTokenCount,
+      counts.candidatesTokenCount,
+      counts.thoughtsTokenCount,
+      counts.toolUsePromptTokenCount,
+    ],
+    message,
+  );
+  if (
+    counts.totalTokenCount !== undefined &&
+    (counts.promptTokenCount === undefined ||
+      counts.candidatesTokenCount === undefined ||
+      componentTotal !== counts.totalTokenCount)
+  ) {
+    invalid(message);
+  }
+  if (
+    counts.cachedContentTokenCount !== undefined &&
+    (counts.promptTokenCount === undefined ||
+      counts.cachedContentTokenCount > counts.promptTokenCount)
+  ) {
+    invalid(message);
+  }
+
+  validateGeminiModalityDetails(
+    value.cacheTokensDetails,
+    counts.cachedContentTokenCount,
+    message,
+  );
+  validateGeminiModalityDetails(
+    value.candidatesTokensDetails,
+    counts.candidatesTokenCount,
+    message,
+  );
+  validateGeminiModalityDetails(
+    value.promptTokensDetails,
+    counts.promptTokenCount,
+    message,
+  );
+  validateGeminiModalityDetails(
+    value.toolUsePromptTokensDetails,
+    counts.toolUsePromptTokenCount,
+    message,
+  );
+
+  return value;
+}

--- a/packages/gateway/src/vertex-auth.ts
+++ b/packages/gateway/src/vertex-auth.ts
@@ -28,6 +28,32 @@ let cachedProject: string | null = null;
 // credentials (CI has none). `null` restores real ADC behavior.
 let testTokenProvider: (() => Promise<string>) | null = null;
 
+async function withAbort<T>(
+  start: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) return start();
+  signal.throwIfAborted();
+  const promise = start();
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = (): void => signal.removeEventListener("abort", onAbort);
+    const settle = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      operation();
+    };
+    const onAbort = (): void => settle(() => reject(signal.reason));
+    signal.addEventListener("abort", onAbort, { once: true });
+    void promise.then(
+      (value) => settle(() => resolve(value)),
+      (error) => settle(() => reject(error)),
+    );
+    if (signal.aborted) onAbort();
+  });
+}
+
 /** @internal test-only: inject (or clear with null) a fake access-token source. */
 export function _setTestVertexTokenProvider(
   fn: (() => Promise<string>) | null,
@@ -47,12 +73,15 @@ function getAuth(): GoogleAuth {
  * unavailable (the request path surfaces it rather than sending an unauthorized
  * call upstream).
  */
-export async function getVertexAccessToken(): Promise<string> {
-  if (testTokenProvider) return testTokenProvider();
+export async function getVertexAccessToken(
+  signal?: AbortSignal,
+): Promise<string> {
+  if (testTokenProvider) return withAbort(testTokenProvider, signal);
   let token: string | null | undefined;
   try {
-    token = await getAuth().getAccessToken();
+    token = await withAbort(() => getAuth().getAccessToken(), signal);
   } catch (err) {
+    if (signal?.aborted) throw signal.reason;
     // Log the raw ADC failure to stderr so the operator can debug it, but do
     // NOT embed it in the thrown message: this Error can propagate to the
     // client (the conversation path surfaces it), and the raw ADC error may
@@ -84,6 +113,7 @@ export async function getVertexAccessToken(): Promise<string> {
  */
 export async function resolveVertexProject(
   configured: string,
+  signal?: AbortSignal,
 ): Promise<string> {
   // Cache the configured project too: the conversation path resolves it with
   // config.vertexProject on the first turn, so a later warmer call (which has
@@ -101,10 +131,12 @@ export async function resolveVertexProject(
   // and recovers automatically once ADC provides a project).
   if (cachedProject) return cachedProject;
   try {
-    const derived = (await getAuth().getProjectId()) ?? "";
+    const derived =
+      (await withAbort(() => getAuth().getProjectId(), signal)) ?? "";
     if (derived) cachedProject = derived;
     return derived;
   } catch {
+    if (signal?.aborted) throw signal.reason;
     return "";
   }
 }

--- a/packages/gateway/src/worker-health.ts
+++ b/packages/gateway/src/worker-health.ts
@@ -381,6 +381,7 @@ function modelKey(
  *  - "length"           — OpenAI output-budget truncation
  *  - "max_tokens"       — Anthropic output-budget truncation (same as length)
  *  - "content_filter"   — prompt-specific moderation, not a model trait
+ *  - "refusal"          — Anthropic filtering (defense if not normalized)
  *  - "tool_calls" /
  *    "tool_use"         — the model emitted tool calls, not text (expected)
  *
@@ -394,6 +395,7 @@ export function isCapabilityEmpty(finishReason: string | undefined): boolean {
     "length",
     "max_tokens",
     "content_filter",
+    "refusal",
     "tool_calls",
     "tool_use",
   ].includes(finishReason);

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -668,17 +668,16 @@ function lineageKey(family: string): string {
  *
  * This is the only robust discriminator: a ChatGPT-backend session reports the
  * same `providerID` ("openai") and `protocol` ("openai-responses") as a real
- * `api.openai.com` API-key session (config.ts PROVIDER_ROUTES) — only the host
- * differs.
+ * `api.openai.com` API-key session. The `/backend-api` path is preserved by
+ * compatible proxies, unlike the host.
  */
 function isChatGPTBackend(url: string | undefined): boolean {
   if (!url) return false;
   try {
     const u = new URL(url);
-    return u.hostname === "chatgpt.com" || u.pathname.includes("/backend-api");
+    return /(?:^|\/)backend-api(?:\/|$)/.test(u.pathname);
   } catch {
-    // Scheme-less or malformed URL — fall back to a substring check.
-    return url.includes("chatgpt.com") || url.includes("/backend-api");
+    return false;
   }
 }
 

--- a/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
+++ b/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../src/recall", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/recall")>();
+  return { ...actual, executeRecall: vi.fn() };
+});
+
+import { loadConfig } from "../src/config";
+import {
+  buildStreamingResponse,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+import { executeRecall } from "../src/recall";
+import type { GatewayRequest, SessionState } from "../src/translate/types";
+
+const mockedRecall = vi.mocked(executeRecall);
+
+function event(type: string, data: Record<string, unknown>): string {
+  return `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+}
+
+function recallOnlyResponse(): Response {
+  return new Response(
+    event("message_start", {
+      message: {
+        id: "msg_recall",
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }) +
+      event("content_block_start", {
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "tool_recall",
+          name: "recall",
+          input: {},
+        },
+      }) +
+      event("content_block_delta", {
+        index: 0,
+        delta: {
+          type: "input_json_delta",
+          partial_json: '{"query":"architecture"}',
+        },
+      }) +
+      event("content_block_stop", { index: 0 }) +
+      event("message_delta", {
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      }) +
+      event("message_stop", {}),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function request(signal?: AbortSignal): GatewayRequest {
+  return {
+    protocol: "anthropic",
+    model: "claude-test",
+    system: "test",
+    messages: [{ role: "user", content: [{ type: "text", text: "question" }] }],
+    tools: [{ name: "recall", description: "recall", inputSchema: {} }],
+    stream: true,
+    maxTokens: 32,
+    metadata: {},
+    rawHeaders: {
+      "x-api-key": "test-key",
+      "x-lore-provider": "anthropic",
+      "x-lore-upstream-url": "https://api.anthropic.com",
+    },
+    signal,
+  };
+}
+
+function sessionState(): SessionState {
+  return {
+    sessionID: `recall-abort-${crypto.randomUUID()}`,
+    projectPath: "/tmp/recall-abort",
+    fingerprint: "fingerprint",
+    lastRequestTime: Date.now(),
+    lastUserTurnTime: Date.now(),
+    messageCount: 1,
+    turnsSinceCuration: 0,
+    consecutiveTextOnlyTurns: 0,
+    upstreamByProvider: new Map(),
+    recallStore: new Map(),
+    cacheAnalytics: {
+      lastRequestBody: null,
+      turns: [],
+    },
+  } as unknown as SessionState;
+}
+
+function hostileContinuation(keepAlive = false): {
+  response: Response;
+  readStarted: Promise<void>;
+  cancelled: () => boolean;
+} {
+  const readStarted = Promise.withResolvers<void>();
+  let cancelled = false;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            event("message_start", {
+              message: {
+                id: "msg_continuation",
+                type: "message",
+                role: "assistant",
+                model: "claude-test",
+                content: [],
+                stop_reason: null,
+                stop_sequence: null,
+                usage: { input_tokens: 1, output_tokens: 0 },
+              },
+            }),
+          ),
+        );
+      },
+      pull(controller) {
+        readStarted.resolve();
+        if (keepAlive) {
+          return new Promise<void>((resolve) => {
+            setTimeout(() => {
+              try {
+                controller.enqueue(new TextEncoder().encode(event("ping", {})));
+              } catch {
+                // The foreground deadline may close the stream first.
+              }
+              resolve();
+            }, 60_000);
+          });
+        }
+        return new Promise(() => {});
+      },
+      cancel() {
+        cancelled = true;
+        return new Promise<void>(() => {});
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+  return {
+    response,
+    readStarted: readStarted.promise,
+    cancelled: () => cancelled,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  setUpstreamInterceptor(undefined);
+  mockedRecall.mockReset();
+});
+
+describe("Anthropic recall continuation abort", () => {
+  test.each(["caller", "deadline"] as const)(
+    "%s abort settles a hostile nonterminal follow-up",
+    async (mode) => {
+      if (mode === "deadline") vi.useFakeTimers();
+      mockedRecall.mockResolvedValue({
+        result: "recall results",
+        input: { query: "architecture" },
+      });
+      const continuation = hostileContinuation(mode === "deadline");
+      setUpstreamInterceptor(async () => continuation.response);
+      const caller = new AbortController();
+      const req = request(caller.signal);
+      const state = sessionState();
+      const downstream = buildStreamingResponse(
+        recallOnlyResponse(),
+        () => {},
+        {
+          clientMessages: req.messages,
+          modifiedReq: req,
+          config: loadConfig(),
+          sessionState: state,
+          cacheOptions: { cacheConversation: false },
+          clientSpeaksAnthropic: true,
+        },
+        undefined,
+        state.sessionID,
+        undefined,
+        caller.signal,
+      );
+      const pending = downstream.text();
+      await continuation.readStarted;
+      if (mode === "caller") {
+        caller.abort(new DOMException("caller aborted", "AbortError"));
+        await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      } else {
+        const outcome = pending.then(
+          () => null,
+          (error: unknown) => error,
+        );
+        await vi.advanceTimersByTimeAsync(300_000);
+        await expect(outcome).resolves.toMatchObject({ name: "TimeoutError" });
+      }
+      expect(continuation.cancelled()).toBe(true);
+      expect(continuation.response.body?.locked).toBe(false);
+    },
+  );
+});

--- a/packages/gateway/test/anthropic-response-parse.test.ts
+++ b/packages/gateway/test/anthropic-response-parse.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { parseAnthropicResponseJSON } from "../src/translate/anthropic";
+
+describe("parseAnthropicResponseJSON usage validation", () => {
+  test.each([
+    { input_tokens: -1, output_tokens: 1 },
+    { input_tokens: 1.5, output_tokens: 1 },
+    { input_tokens: Number.MAX_SAFE_INTEGER + 1, output_tokens: 1 },
+    {
+      input_tokens: Number.MAX_SAFE_INTEGER,
+      output_tokens: 1,
+    },
+  ])("rejects malformed or overflowing usage", (usage) => {
+    expect(() => parseAnthropicResponseJSON({ content: [], usage })).toThrow(
+      "malformed Anthropic response usage",
+    );
+  });
+
+  test("accepts validated usage", () => {
+    expect(
+      parseAnthropicResponseJSON({
+        content: [],
+        usage: { input_tokens: 2, output_tokens: 3 },
+      }).usage,
+    ).toMatchObject({ inputTokens: 2, outputTokens: 3 });
+  });
+});

--- a/packages/gateway/test/bedrock-runtime.test.ts
+++ b/packages/gateway/test/bedrock-runtime.test.ts
@@ -6,12 +6,14 @@
  * body) by intercepting the upstream via undici's `MockAgent` injected
  * through the `setUpstreamDispatcherForTest` seam in `fetch.ts`.
  */
-import { describe, test, expect, afterEach } from "vitest";
+import { describe, test, expect, afterEach, vi } from "vitest";
 import { existsSync, unlinkSync } from "node:fs";
 import { MockAgent } from "undici";
 import {
   BEDROCK_RUNTIME_PATH_RE,
+  BEDROCK_RUNTIME_MAX_REQUEST_BYTES,
   BEDROCK_RUNTIME_VERBS,
+  bedrockRuntimeHeaders,
   bedrockRuntimeUrl,
   proxyBedrockRuntimeRequest,
 } from "../src/translate/bedrock-runtime";
@@ -43,6 +45,38 @@ describe("bedrockRuntimeUrl", () => {
     // final upstream path stays `/model/<id>/<verb>` (verified by the e2e
     // test below).
     expect(u.pathname).toBe("/");
+  });
+});
+
+describe("bedrockRuntimeHeaders", () => {
+  test("keeps AWS auth while stripping cross-origin and hop-by-hop fields", () => {
+    const headers = bedrockRuntimeHeaders(
+      new Headers({
+        authorization: "Bearer bedrock-token",
+        connection: "keep-alive, x-connection-secret",
+        cookie: "session=secret",
+        "proxy-authorization": "Basic proxy-secret",
+        "transfer-encoding": "chunked",
+        "x-amz-content-sha256": "signed-payload",
+        "x-connection-secret": "remove-me",
+        "x-lore-project": "/private/project",
+        "x-lore-session": "private-session",
+      }),
+    );
+
+    expect(headers.get("authorization")).toBe("Bearer bedrock-token");
+    expect(headers.get("x-amz-content-sha256")).toBe("signed-payload");
+    for (const name of [
+      "connection",
+      "cookie",
+      "proxy-authorization",
+      "transfer-encoding",
+      "x-connection-secret",
+      "x-lore-project",
+      "x-lore-session",
+    ]) {
+      expect(headers.has(name), name).toBe(false);
+    }
   });
 });
 
@@ -154,6 +188,267 @@ describe("proxyBedrockRuntimeRequest — handler logic", () => {
     };
     expect(body.error.type).toBe("invalid_request_error");
     expect(body.error.message).toMatch(/path does not match/i);
+  });
+
+  test.each([
+    ["exact limit", BEDROCK_RUNTIME_MAX_REQUEST_BYTES, 200],
+    ["limit plus one", BEDROCK_RUNTIME_MAX_REQUEST_BYTES + 1, 413],
+  ] as const)(
+    "bounds request upload at the %s",
+    async (_name, size, status) => {
+      let fetchCalls = 0;
+      let uploaded: Uint8Array | undefined;
+      let sourceCancelled = false;
+      const bytes = new Uint8Array(size);
+      bytes[0] = 0x11;
+      bytes[size - 1] = 0xee;
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(bytes);
+          if (size <= BEDROCK_RUNTIME_MAX_REQUEST_BYTES) controller.close();
+        },
+        cancel() {
+          sourceCancelled = true;
+        },
+      });
+      const request = new Request("http://gateway/v1/model/test/converse", {
+        method: "POST",
+        body: source,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+      const response = await proxyBedrockRuntimeRequest(request, "us-east-1", {
+        upstreamFetch: async (_url, init) => {
+          fetchCalls++;
+          uploaded = init?.body as Uint8Array;
+          return new Response("ok");
+        },
+      });
+      expect(response.status).toBe(status);
+      if (status === 200) {
+        expect(fetchCalls).toBe(1);
+        expect(uploaded?.byteLength).toBe(size);
+        expect(uploaded?.[0]).toBe(0x11);
+        expect(uploaded?.[size - 1]).toBe(0xee);
+        await response.body?.cancel();
+        expect(sourceCancelled).toBe(false);
+      } else {
+        expect(fetchCalls).toBe(0);
+        expect(sourceCancelled).toBe(true);
+      }
+      expect(source.locked).toBe(false);
+    },
+  );
+
+  test.each(["caller", "deadline"] as const)(
+    "%s abort settles a stalled request upload and releases hostile input",
+    async (mode) => {
+      if (mode === "deadline") vi.useFakeTimers();
+      const caller = new AbortController();
+      let rejectPull!: (error: unknown) => void;
+      let markPull!: () => void;
+      const pulling = new Promise<void>((resolve) => (markPull = resolve));
+      let sourceCancelled = false;
+      const source = new ReadableStream<Uint8Array>({
+        pull() {
+          return new Promise<void>((_resolve, reject) => {
+            rejectPull = reject;
+            markPull();
+          });
+        },
+        cancel() {
+          sourceCancelled = true;
+          return new Promise<void>(() => {});
+        },
+      });
+      const request = new Request("http://gateway/v1/model/test/converse", {
+        method: "POST",
+        body: source,
+        signal: mode === "caller" ? caller.signal : undefined,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+      let fetchCalls = 0;
+      const pending = proxyBedrockRuntimeRequest(request, "us-east-1", {
+        upstreamFetch: async () => {
+          fetchCalls++;
+          return new Response("should not happen");
+        },
+      });
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: mode === "caller" ? "AbortError" : "TimeoutError",
+      });
+      await pulling;
+      if (mode === "caller") {
+        caller.abort(new DOMException("client disconnected", "AbortError"));
+      } else {
+        await vi.advanceTimersByTimeAsync(300_000);
+      }
+      await rejected;
+      rejectPull(new Error("late upload rejection"));
+      await Promise.resolve();
+      expect(fetchCalls).toBe(0);
+      expect(sourceCancelled).toBe(true);
+      expect(source.locked).toBe(false);
+      if (mode === "deadline") vi.useRealTimers();
+    },
+  );
+
+  test.each(["caller", "deadline"] as const)(
+    "%s abort settles a signal-ignoring upstream fetch",
+    async (mode) => {
+      if (mode === "deadline") vi.useFakeTimers();
+      const caller = new AbortController();
+      let upstreamSignal: AbortSignal | undefined;
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => (markStarted = resolve));
+      const pending = proxyBedrockRuntimeRequest(
+        new Request("http://gateway/v1/model/test/converse", {
+          method: "POST",
+          body: "{}",
+          signal: mode === "caller" ? caller.signal : undefined,
+        }),
+        "us-east-1",
+        {
+          upstreamFetch: async (_url, init) => {
+            upstreamSignal = init?.signal ?? undefined;
+            markStarted();
+            return new Promise(() => {});
+          },
+        },
+      );
+      await started;
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: mode === "caller" ? "AbortError" : "TimeoutError",
+      });
+      if (mode === "caller") {
+        caller.abort(new DOMException("client disconnected", "AbortError"));
+      } else {
+        await vi.advanceTimersByTimeAsync(300_000);
+      }
+      await rejected;
+      expect(upstreamSignal?.aborted).toBe(true);
+      if (mode === "deadline") vi.useRealTimers();
+    },
+  );
+
+  test.each(["caller", "deadline"] as const)(
+    "%s abort preserves metadata and cancels a hostile upstream body",
+    async (mode) => {
+      if (mode === "deadline") vi.useFakeTimers();
+      const caller = new AbortController();
+      let cancelled = false;
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("partial"));
+          },
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled = true;
+            return new Promise<void>(() => {});
+          },
+        }),
+        {
+          status: 207,
+          statusText: "Multi-Status",
+          headers: { "x-bedrock": "preserved" },
+        },
+      );
+      const response = await proxyBedrockRuntimeRequest(
+        new Request("http://gateway/v1/model/test/converse-stream", {
+          method: "POST",
+          body: "{}",
+          signal: mode === "caller" ? caller.signal : undefined,
+        }),
+        "us-east-1",
+        { upstreamFetch: async () => upstream },
+      );
+      expect(response.status).toBe(207);
+      expect(response.statusText).toBe("Multi-Status");
+      expect(response.headers.get("x-bedrock")).toBe("preserved");
+      const body = response.text();
+      const rejected = expect(body).rejects.toMatchObject({
+        name: mode === "caller" ? "AbortError" : "TimeoutError",
+      });
+      await Promise.resolve();
+      if (mode === "caller") {
+        caller.abort(new DOMException("client disconnected", "AbortError"));
+      } else {
+        await vi.advanceTimersByTimeAsync(300_000);
+      }
+      await rejected;
+      expect(cancelled).toBe(true);
+      expect(upstream.body?.locked).toBe(false);
+      if (mode === "deadline") vi.useRealTimers();
+    },
+  );
+
+  test("normal body completion disposes the foreground deadline", async () => {
+    vi.useFakeTimers();
+    let upstreamSignal: AbortSignal | undefined;
+    const caller = new AbortController();
+    const request = new Request("http://gateway/v1/model/test/converse", {
+      method: "POST",
+      body: "{}",
+      signal: caller.signal,
+    });
+    const remove = vi.spyOn(request.signal, "removeEventListener");
+    try {
+      const response = await proxyBedrockRuntimeRequest(request, "us-east-1", {
+        upstreamFetch: async (_url, init) => {
+          upstreamSignal = init?.signal ?? undefined;
+          return new Response("complete", {
+            status: 201,
+            headers: { "x-bedrock": "complete" },
+          });
+        },
+      });
+      expect(response.status).toBe(201);
+      expect(response.headers.get("x-bedrock")).toBe("complete");
+      await expect(response.text()).resolves.toBe("complete");
+      await vi.advanceTimersByTimeAsync(300_000);
+      expect(upstreamSignal?.aborted).toBe(false);
+      expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("downstream cancellation promptly cancels the hostile body and disposes the deadline", async () => {
+    vi.useFakeTimers();
+    let cancelled = false;
+    let upstreamSignal: AbortSignal | undefined;
+    try {
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            cancelled = true;
+            return new Promise<void>(() => {});
+          },
+        }),
+      );
+      const response = await proxyBedrockRuntimeRequest(
+        new Request("http://gateway/v1/model/test/converse-stream", {
+          method: "POST",
+          body: "{}",
+        }),
+        "us-east-1",
+        {
+          upstreamFetch: async (_url, init) => {
+            upstreamSignal = init?.signal ?? undefined;
+            return upstream;
+          },
+        },
+      );
+      await expect(response.body?.cancel()).resolves.toBeUndefined();
+      expect(cancelled).toBe(true);
+      expect(upstream.body?.locked).toBe(false);
+      await vi.advanceTimersByTimeAsync(300_000);
+      expect(upstreamSignal?.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/gateway/test/cache-stability.e2e.test.ts
+++ b/packages/gateway/test/cache-stability.e2e.test.ts
@@ -1955,7 +1955,7 @@ describe("cache stability (e2e)", () => {
       if (prevIdleTimeout === undefined) delete process.env.LORE_IDLE_TIMEOUT;
       else process.env.LORE_IDLE_TIMEOUT = prevIdleTimeout;
     }
-  });
+  }, 600_000);
 
   // A full, signed billing-header sentinel — the exact shape BILLING_RESIGN_RE
   // matches. Quoting this verbatim in conversation content (e.g. while editing

--- a/packages/gateway/test/cli-bundle-smoke.test.ts
+++ b/packages/gateway/test/cli-bundle-smoke.test.ts
@@ -17,6 +17,11 @@ import { once } from "node:events";
 import { createServer, type Server } from "node:http";
 
 const BUNDLE = resolve(process.cwd(), "packages/gateway/dist/bin.cjs");
+// The full suite can saturate CPU with large cache-stability fixtures. Give the
+// real bundled subprocess enough wall time to start instead of reporting a
+// synthetic `code === null` timeout under load.
+const BUNDLE_TIMEOUT_MS = 30_000;
+const TEST_TIMEOUT_MS = 45_000;
 
 async function runBundle(
   args: string[],
@@ -35,7 +40,7 @@ async function runBundle(
         LORE_NO_UPDATE_CHECK: "1",
         ...env,
       },
-      timeout: 10_000,
+      timeout: BUNDLE_TIMEOUT_MS,
     });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
@@ -95,37 +100,49 @@ describe("Phase 1 — bundled CLI reaches the typed commands", () => {
     else process.env.LORE_NO_UPDATE_CHECK = origNoUpdateCheck;
   });
 
-  test("`lore version` through the bundle returns the build version", async () => {
-    const { stdout, code } = await runBundle(["version"]);
-    expect(code).toBe(0);
-    // The version is a semver string from build-injected VERSION.
-    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
-  }, 15_000);
+  test(
+    "`lore version` through the bundle returns the build version",
+    async () => {
+      const { stdout, code } = await runBundle(["version"]);
+      expect(code).toBe(0);
+      // The version is a semver string from build-injected VERSION.
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-  test("`lore help --json` through the bundle returns the typed payload", async () => {
-    const { stdout, code } = await runBundle(["help", "--json"]);
-    expect(code).toBe(0);
-    const payload = JSON.parse(stdout.trim());
-    expect(payload.schemaVersion).toBe(1);
-    expect(payload.name).toBe("lore");
-  }, 15_000);
+  test(
+    "`lore help --json` through the bundle returns the typed payload",
+    async () => {
+      const { stdout, code } = await runBundle(["help", "--json"]);
+      expect(code).toBe(0);
+      const payload = JSON.parse(stdout.trim());
+      expect(payload.schemaVersion).toBe(1);
+      expect(payload.name).toBe("lore");
+    },
+    TEST_TIMEOUT_MS,
+  );
 
-  test("`lore whoami` through the bundle returns the typed AuthError envelope when not logged in", async () => {
-    // Force the bundle to see no persisted session. The smoke test only
-    // verifies that the npm binary reaches the typed envelope shape, not
-    // the underlying supabase state.
-    const { stderr, code } = await runBundle(["whoami"], {
-      HOME: "/tmp/lore-bundle-smoke",
-      USERPROFILE: "/tmp/lore-bundle-smoke",
-      LORE_DATA_DIR: "/tmp/lore-bundle-smoke",
-    });
-    // When no session exists, the typed adapter throws AuthError(10)
-    // and the buildOutputCommand wrapper renders the human format with
-    // a `Try: lore login` recovery command.
-    expect(stderr).toContain("Not logged in");
-    expect(stderr).toContain("Try: lore login");
-    expect(code).toBe(10);
-  }, 15_000);
+  test(
+    "`lore whoami` through the bundle returns the typed AuthError envelope when not logged in",
+    async () => {
+      // Force the bundle to see no persisted session. The smoke test only
+      // verifies that the npm binary reaches the typed envelope shape, not
+      // the underlying supabase state.
+      const { stderr, code } = await runBundle(["whoami"], {
+        HOME: "/tmp/lore-bundle-smoke",
+        USERPROFILE: "/tmp/lore-bundle-smoke",
+        LORE_DATA_DIR: "/tmp/lore-bundle-smoke",
+      });
+      // When no session exists, the typed adapter throws AuthError(10)
+      // and the buildOutputCommand wrapper renders the human format with
+      // a `Try: lore login` recovery command.
+      expect(stderr).toContain("Not logged in");
+      expect(stderr).toContain("Try: lore login");
+      expect(code).toBe(10);
+    },
+    TEST_TIMEOUT_MS,
+  );
 
   test.each([
     [[], "Please provide a search query."],
@@ -150,7 +167,7 @@ describe("Phase 1 — bundled CLI reaches the typed commands", () => {
         message,
       });
     },
-    15_000,
+    TEST_TIMEOUT_MS,
   );
 
   test.each([["--json"], ["--json=true"]])(
@@ -173,7 +190,7 @@ describe("Phase 1 — bundled CLI reaches the typed commands", () => {
         await stopRecallServer(server);
       }
     },
-    15_000,
+    TEST_TIMEOUT_MS,
   );
 
   test("`lore recall --json` preserves successful remote JSON output", async () => {

--- a/packages/gateway/test/codex-worker-cache-accounting.test.ts
+++ b/packages/gateway/test/codex-worker-cache-accounting.test.ts
@@ -75,6 +75,7 @@ describe("parseResponsesWorkerResponse cache accounting", () => {
       output_text: null as unknown as string,
       output: [
         {
+          id: "msg-fallback",
           type: "message",
           content: [{ type: "output_text", text: "fallback via item walk" }],
         },

--- a/packages/gateway/test/compact-endpoint.test.ts
+++ b/packages/gateway/test/compact-endpoint.test.ts
@@ -7,7 +7,12 @@
 import { describe, it, expect, afterEach } from "vitest";
 import type { Harness } from "./helpers/harness";
 import { createHarness } from "./helpers/harness";
-import { shouldCancelCompactionFromBudget } from "../src/pipeline";
+import {
+  generateCompactionSummary,
+  handleCompactEndpoint,
+  shouldCancelCompactionFromBudget,
+} from "../src/pipeline";
+import { loadConfig } from "../src/config";
 
 async function postCompact(baseURL: string, body: string): Promise<Response> {
   return fetch(`${baseURL}/v1/compact`, {
@@ -34,6 +39,24 @@ describe("POST /v1/compact", () => {
     expect(body.message).toBe("Invalid JSON body");
   });
 
+  it("rejects missing authentication without reading an indefinite body", async () => {
+    const source = new ReadableStream<Uint8Array>({
+      type: "bytes",
+      pull() {
+        return new Promise(() => {});
+      },
+    });
+    const req = new Request("http://gateway.test/v1/compact", {
+      method: "POST",
+      body: source,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    const response = await handleCompactEndpoint(req, loadConfig());
+    expect(response.status).toBe(401);
+    expect(req.bodyUsed).toBe(false);
+    await response.body?.cancel();
+  });
+
   it("returns 400 when project_path is missing", async () => {
     harness = await createHarness({ fixtures: [] });
     const resp = await postCompact(harness.baseURL, JSON.stringify({}));
@@ -54,6 +77,19 @@ describe("POST /v1/compact", () => {
     expect(body.error).toBe("session_not_found");
     expect(body.message).toContain("No active session found");
   });
+});
+
+it("compaction summary generation rejects an already-aborted foreground signal", async () => {
+  const controller = new AbortController();
+  controller.abort(new DOMException("client disconnected", "AbortError"));
+  await expect(
+    generateCompactionSummary({
+      projectPath: process.cwd(),
+      sessionID: "aborted-compaction",
+      config: loadConfig(),
+      signal: controller.signal,
+    }),
+  ).rejects.toMatchObject({ name: "AbortError" });
 });
 
 /**

--- a/packages/gateway/test/early-flush-stream.test.ts
+++ b/packages/gateway/test/early-flush-stream.test.ts
@@ -125,7 +125,7 @@ describe("earlyFlushStreamingResponse", () => {
     expect(match?.[1]).toContain("upstream 429");
   });
 
-  test("the pipeline runs once inside the stream start", async () => {
+  test("the pipeline runs once when downstream starts reading", async () => {
     const run = vi.fn(async () =>
       innerStream(["event: response.created\n\n"], 0),
     );
@@ -133,5 +133,99 @@ describe("earlyFlushStreamingResponse", () => {
 
     await drain(resp);
     expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not drain the inner stream while downstream is stalled", async () => {
+    let pulls = 0;
+    const chunks = Array.from({ length: 100 }, () =>
+      new TextEncoder().encode("x".repeat(1024)),
+    );
+    const inner = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls++;
+          const chunk = chunks.shift();
+          if (chunk) controller.enqueue(chunk);
+          else controller.close();
+        },
+      }),
+      { headers: SSE },
+    );
+    const response = earlyFlushStreamingResponse(
+      async () => inner,
+      "gpt-5.6-terra",
+    );
+    const reader = response.body?.getReader();
+
+    expect(new TextDecoder().decode((await reader?.read())?.value)).toBe(
+      KEEPALIVE,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(pulls).toBeLessThanOrEqual(2);
+    expect(chunks.length).toBeGreaterThan(0);
+    await reader?.cancel();
+    expect(inner.body?.locked).toBe(false);
+  });
+
+  test("downstream cancellation aborts unresolved pre-response work", async () => {
+    let operationSignal: AbortSignal | undefined;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => (markStarted = resolve));
+    let upstreamCalls = 0;
+    const response = earlyFlushStreamingResponse(async (signal) => {
+      operationSignal = signal;
+      markStarted();
+      await new Promise(() => {});
+      upstreamCalls++;
+      return innerStream(["event: response.completed\n\n"], 0);
+    }, "gpt-5.6-terra");
+    const reader = response.body?.getReader();
+
+    expect(new TextDecoder().decode((await reader?.read())?.value)).toBe(
+      KEEPALIVE,
+    );
+    await started;
+    await reader?.cancel(new DOMException("client gone", "AbortError"));
+    reader?.releaseLock();
+    expect(operationSignal?.aborted).toBe(true);
+    expect(upstreamCalls).toBe(0);
+    expect(response.body?.locked).toBe(false);
+  });
+
+  test("caller abort settles a valid nonterminal inner event with a hostile tail", async () => {
+    let cancelled = false;
+    const inner = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'event: response.created\ndata: {"type":"response.created","response":{"id":"stalled","status":"in_progress"}}\n\n',
+            ),
+          );
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+      { headers: SSE },
+    );
+    const abort = new AbortController();
+    const response = earlyFlushStreamingResponse(
+      async () => inner,
+      "gpt-5.6-terra",
+      abort.signal,
+    );
+    const pending = drain(response);
+    await new Promise((resolve) => setImmediate(resolve));
+    abort.abort(new DOMException("caller aborted", "AbortError"));
+    const output = await pending;
+    expect(output).toContain("event: response.created");
+    expect(output).toContain("event: response.failed");
+    expect(cancelled).toBe(true);
+    expect(inner.body?.locked).toBe(false);
   });
 });

--- a/packages/gateway/test/fetch.test.ts
+++ b/packages/gateway/test/fetch.test.ts
@@ -1,5 +1,29 @@
 import { describe, test, expect, vi, afterEach } from "vitest";
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { EventEmitter } from "node:events";
+
+class FakeIncomingMessage extends EventEmitter {
+  paused = 0;
+  resumed = 0;
+  destroyed = false;
+  complete = false;
+  readableEnded = false;
+
+  pause(): this {
+    this.paused++;
+    return this;
+  }
+
+  resume(): this {
+    this.resumed++;
+    return this;
+  }
+
+  destroy(): this {
+    this.destroyed = true;
+    return this;
+  }
+}
 
 /**
  * upstreamFetch chooses its transport by runtime:
@@ -97,7 +121,8 @@ describe("upstreamFetch runtime split", () => {
       expect(res.status).toBe(200);
 
       // Read the body incrementally via the standard ReadableStream API
-      const reader = res.body!.getReader();
+      if (!res.body) throw new Error("streaming response has no body");
+      const reader = res.body.getReader();
       const chunks: string[] = [];
       const decoder = new TextDecoder();
       for (;;) {
@@ -112,6 +137,79 @@ describe("upstreamFetch runtime split", () => {
       server.close();
     }
   });
+
+  test("Bun bridge pauses at its byte high-water mark and resumes only on pull", async () => {
+    (globalThis as { Bun?: unknown }).Bun = { version: "1.3.14" };
+    vi.resetModules();
+    vi.doMock("undici", () => ({ fetch: vi.fn(), Agent: class {} }));
+    const { nodeReadableToWebStream } = await import("../src/fetch");
+    const source = new FakeIncomingMessage();
+    const body = nodeReadableToWebStream(source as unknown as IncomingMessage);
+
+    // Two 40 KiB chunks exceed the bridge's 64 KiB byte queue. The source is
+    // paused exactly once rather than continuing to buffer arbitrarily.
+    source.emit("data", Buffer.alloc(40 * 1024, 1));
+    source.emit("data", Buffer.alloc(40 * 1024, 2));
+    expect(source.paused).toBe(1);
+    expect(source.resumed).toBe(0);
+
+    const reader = body.getReader();
+    await expect(reader.read()).resolves.toMatchObject({ done: false });
+    await vi.waitFor(() => expect(source.resumed).toBe(1));
+
+    source.readableEnded = true;
+    source.complete = true;
+    source.emit("end");
+    await expect(reader.read()).resolves.toMatchObject({ done: false });
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(source.eventNames()).toEqual([]);
+  });
+
+  test("Bun bridge cancellation destroys the source and removes listeners", async () => {
+    (globalThis as { Bun?: unknown }).Bun = { version: "1.3.14" };
+    vi.resetModules();
+    vi.doMock("undici", () => ({ fetch: vi.fn(), Agent: class {} }));
+    const { nodeReadableToWebStream } = await import("../src/fetch");
+    const source = new FakeIncomingMessage();
+    const reader = nodeReadableToWebStream(
+      source as unknown as IncomingMessage,
+    ).getReader();
+
+    await reader.cancel(new Error("consumer stopped"));
+
+    expect(source.destroyed).toBe(true);
+    expect(source.eventNames()).toEqual([]);
+  });
+
+  test.each(["error", "close"] as const)(
+    "Bun bridge %s cleanup removes every source listener",
+    async (event) => {
+      (globalThis as { Bun?: unknown }).Bun = { version: "1.3.14" };
+      vi.resetModules();
+      vi.doMock("undici", () => ({ fetch: vi.fn(), Agent: class {} }));
+      const { nodeReadableToWebStream } = await import("../src/fetch");
+      const source = new FakeIncomingMessage();
+      const reader = nodeReadableToWebStream(
+        source as unknown as IncomingMessage,
+      ).getReader();
+      const pending = reader.read();
+
+      if (event === "error") {
+        source.emit("error", new Error("socket reset"));
+      } else {
+        source.emit("close");
+      }
+
+      await expect(pending).rejects.toThrow(
+        event === "error" ? "socket reset" : "closed before end",
+      );
+      expect(source.eventNames()).toEqual([]);
+      if (event === "error") expect(source.destroyed).toBe(true);
+    },
+  );
 
   test("Bun: abort destroys a request waiting for response headers", async () => {
     let requestStartedResolve: (() => void) | undefined;

--- a/packages/gateway/test/foreground-body-limit.test.ts
+++ b/packages/gateway/test/foreground-body-limit.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "vitest";
+import {
+  accumulateNonStreamResponse,
+  readForegroundBody,
+} from "../src/pipeline";
+
+function chunkedResponse(chunks: number, chunkBytes: number): Response {
+  const chunk = new Uint8Array(chunkBytes).fill(120);
+  let sent = 0;
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sent++ < chunks) controller.enqueue(chunk);
+        else controller.close();
+      },
+    }),
+  );
+}
+
+describe("foreground response body limits", () => {
+  test.each([
+    [
+      "anthropic",
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stalled","type":"message","role":"assistant","model":"test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+    ],
+    [
+      "openai",
+      'data: {"id":"chatcmpl_stalled","model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+    ],
+    [
+      "openai-responses",
+      'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_stalled","model":"gpt-test","status":"in_progress"}}\n\n',
+    ],
+    [
+      "gemini",
+      'data: {"responseId":"gemini-stalled","modelVersion":"gemini-test","candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"partial"}]}}]}\n\n',
+    ],
+  ] as const)(
+    "aborts a stalled buffered %s body after a valid nonterminal event",
+    async (protocol, wire) => {
+      let cancelled = false;
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(wire));
+          },
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled = true;
+            return new Promise<void>(() => {});
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+      const abort = new AbortController();
+      const pending = accumulateNonStreamResponse(
+        response,
+        protocol,
+        false,
+        abort.signal,
+      );
+      await new Promise((resolve) => setImmediate(resolve));
+      abort.abort(new DOMException("caller aborted", "AbortError"));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(cancelled).toBe(true);
+      expect(response.body?.locked).toBe(false);
+    },
+  );
+
+  test("accepts the exact 4 MiB boundary", async () => {
+    const body = await readForegroundBody(chunkedResponse(1024, 4096), false);
+    expect(Buffer.byteLength(body)).toBe(4 * 1024 * 1024);
+  });
+
+  test("rejects the first byte beyond the 4 MiB boundary", async () => {
+    const response = chunkedResponse(1024, 4096);
+    const original = response.body;
+    if (!original) throw new Error("test response has no body");
+    const reader = original.getReader();
+    let appended = false;
+    const boundedPlusOne = new Response(
+      new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          const { done, value } = await reader.read();
+          if (!done) controller.enqueue(value);
+          else if (!appended) {
+            appended = true;
+            controller.enqueue(new Uint8Array([120]));
+          } else controller.close();
+        },
+      }),
+    );
+    await expect(readForegroundBody(boundedPlusOne, false)).rejects.toThrow(
+      "foreground response exceeded 4194304 byte limit",
+    );
+  });
+
+  test("rejects invalid and split-invalid JSON UTF-8", async () => {
+    for (const chunks of [
+      [new Uint8Array([0xff])],
+      [new Uint8Array([0xe2]), new Uint8Array([0x28, 0xa1])],
+    ]) {
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+      );
+      await expect(readForegroundBody(response, false)).rejects.toThrow(
+        "malformed upstream response UTF-8",
+      );
+    }
+  });
+
+  test("caps diagnostic bodies instead of retaining the remainder", async () => {
+    const body = await readForegroundBody(chunkedResponse(17, 4096), true);
+    expect(Buffer.byteLength(body)).toBe(64 * 1024);
+  });
+
+  test("returns at the exact diagnostic cap without probing a stalled tail", async () => {
+    let pulls = 0;
+    let truncated = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(64 * 1024).fill(120));
+        },
+        pull() {
+          pulls++;
+          return new Promise(() => {});
+        },
+      }),
+    );
+    const body = await readForegroundBody(response, true, () => {
+      truncated = true;
+    });
+    expect(Buffer.byteLength(body)).toBe(64 * 1024);
+    expect(truncated).toBe(true);
+    expect(pulls).toBeLessThanOrEqual(1);
+    expect(response.body?.locked).toBe(false);
+  });
+
+  test("replacement-decodes malformed and boundary-split diagnostic UTF-8", async () => {
+    expect(
+      await readForegroundBody(new Response(new Uint8Array([0xff])), true),
+    ).toBe("�");
+    const bytes = new Uint8Array(64 * 1024 + 2).fill(120);
+    bytes.set(new TextEncoder().encode("€"), 64 * 1024 - 1);
+    const text = await readForegroundBody(new Response(bytes), true);
+    expect(text.endsWith("�")).toBe(true);
+  });
+
+  test("buffered Codex accepts sparse events without output_index", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+    const response = new Response(
+      event("response.output_item.added", {
+        item: { type: "message", id: "msg-sparse" },
+      }) +
+        event("response.output_text.delta", {
+          item_id: "msg-sparse",
+          delta: "sparse",
+        }) +
+        event("response.completed", {
+          response: { status: "completed" },
+        }),
+    );
+    const result = await accumulateNonStreamResponse(
+      response,
+      "openai-responses",
+      true,
+    );
+    expect(result.content).toEqual([{ type: "text", text: "sparse" }]);
+  });
+
+  test("buffered OpenAI retains usage-only frames after finish_reason", async () => {
+    const response = new Response(
+      'data: {"choices":[{"index":0,"delta":{"content":"done"},"finish_reason":null}]}\n\n' +
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n' +
+        'data: {"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":2,"total_tokens":9}}\n\n' +
+        "data: [DONE]\n\n",
+    );
+    const result = await accumulateNonStreamResponse(response, "openai");
+    expect(result.usage).toMatchObject({ inputTokens: 7, outputTokens: 2 });
+  });
+});

--- a/packages/gateway/test/foreground-routes-abort.test.ts
+++ b/packages/gateway/test/foreground-routes-abort.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { loadConfig } from "../src/config";
+import {
+  passthroughResponsesCompact,
+  resetPipelineState,
+} from "../src/pipeline";
+import { handleModelsPassthrough } from "../src/server";
+import { upstreamFetch } from "../src/fetch";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+const mockedFetch = vi.mocked(upstreamFetch);
+const config = loadConfig();
+
+function fetchUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function modelsRequest(signal?: AbortSignal): Request {
+  return new Request("http://gateway.test/v1/models", { signal });
+}
+
+const ROUTES = [
+  {
+    name: "POST /v1/responses/compact fallback",
+    target: "/v1/responses/compact",
+    invoke: (signal?: AbortSignal) =>
+      passthroughResponsesCompact(
+        JSON.stringify({ model: "gpt-test", input: [] }),
+        { authorization: "Bearer test-key" },
+        config,
+        signal,
+      ),
+  },
+  {
+    name: "GET /v1/models",
+    target: "/v1/models",
+    invoke: (signal?: AbortSignal) =>
+      handleModelsPassthrough(modelsRequest(signal), config),
+  },
+] as const;
+
+afterEach(async () => {
+  vi.useRealTimers();
+  mockedFetch.mockReset();
+  await resetPipelineState({ fast: true });
+});
+
+describe("foreground passthrough route aborts", () => {
+  test.each(ROUTES)(
+    "caller abort settles $name when fetch ignores signal",
+    async ({ invoke, target }) => {
+      mockedFetch.mockImplementation((url) =>
+        fetchUrl(url).endsWith(target)
+          ? new Promise(() => {})
+          : Promise.resolve(new Response("{}")),
+      );
+      const caller = new AbortController();
+      const pending = invoke(caller.signal);
+      await Promise.resolve();
+      caller.abort(new DOMException("caller aborted", "AbortError"));
+      const response = await pending;
+      expect(response.status).toBe(502);
+      const init = mockedFetch.mock.calls.find(([url]) =>
+        fetchUrl(url).endsWith(target),
+      )?.[1];
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      expect(init?.signal?.aborted).toBe(true);
+    },
+  );
+
+  test.each(ROUTES)(
+    "300s deadline settles $name when fetch ignores signal",
+    async ({ invoke, target }) => {
+      vi.useFakeTimers();
+      mockedFetch.mockImplementation((url) =>
+        fetchUrl(url).endsWith(target)
+          ? new Promise(() => {})
+          : Promise.resolve(new Response("{}")),
+      );
+      const pending = invoke();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(300_000);
+      const response = await pending;
+      expect(response.status).toBe(502);
+      expect(
+        mockedFetch.mock.calls.find(([url]) =>
+          fetchUrl(url).endsWith(target),
+        )?.[1]?.signal?.aborted,
+      ).toBe(true);
+    },
+  );
+
+  test.each(ROUTES)(
+    "preserves $name response metadata and aborts a hostile body",
+    async ({ invoke, target }) => {
+      let cancelled = false;
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("partial"));
+          },
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled = true;
+            return new Promise<void>(() => {});
+          },
+        }),
+        {
+          status: 207,
+          statusText: "Multi-Status",
+          headers: { "x-upstream": "kept" },
+        },
+      );
+      mockedFetch.mockImplementation((url) =>
+        fetchUrl(url).endsWith(target)
+          ? Promise.resolve(upstream)
+          : Promise.resolve(new Response("{}")),
+      );
+      const caller = new AbortController();
+      const response = await invoke(caller.signal);
+      expect(response.status).toBe(207);
+      expect(response.statusText).toBe("Multi-Status");
+      expect(response.headers.get("x-upstream")).toBe("kept");
+      const pending = response.text();
+      await new Promise((resolve) => setImmediate(resolve));
+      caller.abort(new DOMException("caller aborted", "AbortError"));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(cancelled).toBe(true);
+      expect(upstream.body?.locked).toBe(false);
+    },
+  );
+});

--- a/packages/gateway/test/gemini-ingress.e2e.test.ts
+++ b/packages/gateway/test/gemini-ingress.e2e.test.ts
@@ -41,6 +41,29 @@ function geminiUpstreamResponse(): Response {
   );
 }
 
+function geminiUpstreamStreamResponse(): Response {
+  return new Response(
+    `data: ${JSON.stringify({
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: "ok" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+      modelVersion: "gemini-2.5-pro",
+    })}\n\n`,
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
 async function sendGemini(
   harness: Harness,
   path: string,
@@ -58,7 +81,11 @@ async function sendGemini(
     return makeReal();
   });
   mockFetch.mockReset();
-  mockFetch.mockResolvedValue(geminiUpstreamResponse());
+  mockFetch.mockResolvedValue(
+    path.includes(":streamGenerateContent")
+      ? geminiUpstreamStreamResponse()
+      : geminiUpstreamResponse(),
+  );
 
   const res = await fetch(`${harness.baseURL}${path}`, {
     method: "POST",

--- a/packages/gateway/test/gemini-stream.test.ts
+++ b/packages/gateway/test/gemini-stream.test.ts
@@ -27,6 +27,373 @@ async function readGeminiSSEFrame(
 // ---------------------------------------------------------------------------
 
 describe("accumulateGeminiSSEStream", () => {
+  test("strict mode rejects ambiguous repeated same-name calls without IDs", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    { functionCall: { name: "lookup", args: { a: 1 } } },
+                    { functionCall: { name: "lookup", args: { a: 2 } } },
+                  ],
+                },
+                finishReason: "STOP",
+              },
+            ],
+          },
+        ]),
+        { strict: true, stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
+  });
+
+  test("strict mode preserves independent same-name calls with distinct IDs", async () => {
+    const response = await accumulateGeminiSSEStream(
+      sse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: {
+                      id: "call-a",
+                      name: "lookup",
+                      args: { a: 1 },
+                    },
+                  },
+                  {
+                    functionCall: {
+                      id: "call-b",
+                      name: "lookup",
+                      args: { a: 2 },
+                    },
+                  },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+      { strict: true, stopAtTerminal: true },
+    );
+
+    expect(response.content).toEqual([
+      { type: "tool_use", id: "call-a", name: "lookup", input: { a: 1 } },
+      { type: "tool_use", id: "call-b", name: "lookup", input: { a: 2 } },
+    ]);
+  });
+  test("strict mode permits the same tool identity in independent candidates", async () => {
+    const response = await accumulateGeminiSSEStream(
+      sse([
+        {
+          candidates: [
+            {
+              index: 0,
+              content: {
+                parts: [
+                  { functionCall: { id: "shared", name: "lookup", args: {} } },
+                ],
+              },
+              finishReason: "STOP",
+            },
+            {
+              index: 1,
+              content: {
+                parts: [
+                  { functionCall: { id: "shared", name: "lookup", args: {} } },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+      { strict: true, stopAtTerminal: true },
+    );
+    expect(response.content).toEqual([
+      { type: "tool_use", id: "shared", name: "lookup", input: {} },
+    ]);
+  });
+  test("stops at finishReason without waiting for transport EOF", async () => {
+    let cancelled = false;
+    const terminal = {
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: "done" }] },
+          finishReason: "STOP",
+        },
+      ],
+    };
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(`data: ${JSON.stringify(terminal)}\n\n`),
+          );
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise(() => {});
+        },
+      }),
+    );
+
+    const resp = await accumulateGeminiSSEStream(response, {
+      stopAtTerminal: true,
+      strict: true,
+    });
+
+    expect(resp.content).toEqual([{ type: "text", text: "done" }]);
+    expect(cancelled).toBe(true);
+    expect(response.body?.locked).toBe(false);
+  });
+
+  test("takes cumulative usage from the finishReason frame and cancels transport tail", async () => {
+    let cancelled = false;
+    const terminal = {
+      candidates: [
+        {
+          content: { parts: [{ text: "done" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: { promptTokenCount: 7, candidatesTokenCount: 2 },
+    };
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(`data: ${JSON.stringify(terminal)}\n\n`),
+          );
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    const result = await accumulateGeminiSSEStream(response, {
+      strict: true,
+      stopAtTerminal: true,
+    });
+    expect(result.usage).toMatchObject({ inputTokens: 7, outputTokens: 2 });
+    expect(cancelled).toBe(true);
+  });
+
+  test("does not stop on FINISH_REASON_UNSPECIFIED", async () => {
+    const res = sse([
+      {
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: "Hel" }] },
+            finishReason: "FINISH_REASON_UNSPECIFIED",
+          },
+        ],
+      },
+      {
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: "lo" }] },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    ]);
+
+    const resp = await accumulateGeminiSSEStream(res, {
+      stopAtTerminal: true,
+      strict: true,
+    });
+
+    expect(resp.content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  test("rejects EOF before finishReason in strict worker mode", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([{ candidates: [{ content: { parts: [{ text: "partial" }] } }] }]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("missing Gemini finishReason terminal");
+  });
+
+  test("rejects an unterminated terminal frame in strict worker mode", async () => {
+    const terminal = {
+      candidates: [{ content: { parts: [] }, finishReason: "STOP" }],
+    };
+    await expect(
+      accumulateGeminiSSEStream(
+        new Response(`data: ${JSON.stringify(terminal)}`),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("unterminated SSE event at EOF");
+  });
+
+  test("rejects malformed JSON before a valid terminal", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        new Response(
+          `data: {not-json}\n\ndata: ${JSON.stringify({
+            candidates: [{ content: { parts: [] }, finishReason: "STOP" }],
+          })}\n\n`,
+        ),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
+  });
+
+  test("rejects malformed consumed part fields in strict worker mode", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([
+          {
+            candidates: [
+              { content: { parts: [{ text: 42 }] }, finishReason: "STOP" },
+            ],
+          },
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
+  });
+
+  test("rejects contradictory parts and malformed usage", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    {
+                      text: "visible",
+                      functionCall: { name: "tool", args: 7 },
+                    },
+                  ],
+                },
+                finishReason: "STOP",
+              },
+            ],
+            usageMetadata: { promptTokenCount: -1 },
+          },
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
+  });
+
+  test.each([
+    [
+      "candidates plus thoughts overflow",
+      {
+        promptTokenCount: 1,
+        candidatesTokenCount: Number.MAX_SAFE_INTEGER,
+        thoughtsTokenCount: 1,
+      },
+    ],
+    [
+      "cache exceeds prompt subset",
+      { promptTokenCount: 1, cachedContentTokenCount: 2 },
+    ],
+    [
+      "malformed modality details",
+      { promptTokenCount: 1, promptTokensDetails: [null] },
+    ],
+  ])("rejects %s", async (_case, usageMetadata) => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([
+          {
+            candidates: [
+              { content: { parts: [{ text: "x" }] }, finishReason: "STOP" },
+            ],
+            usageMetadata,
+          },
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
+  });
+
+  test("validates every candidate while preserving first-candidate extraction", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([
+          {
+            candidates: [
+              { content: { parts: [{ text: "first" }] }, finishReason: "STOP" },
+              { content: { parts: [null] }, index: 1 },
+            ],
+          },
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
+
+    const result = await accumulateGeminiSSEStream(
+      sse([
+        {
+          candidates: [
+            { content: { parts: [{ text: "first" }] }, finishReason: "STOP" },
+            { content: { parts: [{ text: "ignored" }] }, index: 1 },
+          ],
+        },
+      ]),
+      { stopAtTerminal: true, strict: true },
+    );
+    expect(result.content).toEqual([{ type: "text", text: "first" }]);
+  });
+
+  test("accepts nullable optional usage detail arrays", async () => {
+    const result = await accumulateGeminiSSEStream(
+      sse([
+        {
+          candidates: [
+            { content: { parts: [{ text: "ok" }] }, finishReason: "STOP" },
+          ],
+          usageMetadata: {
+            promptTokenCount: 1,
+            candidatesTokenCount: 1,
+            promptTokensDetails: null,
+            candidatesTokensDetails: null,
+          },
+        },
+      ]),
+      { stopAtTerminal: true, strict: true },
+    );
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  test("preserves a prompt-level native block reason", async () => {
+    const result = await accumulateGeminiSSEStream(
+      sse([{ promptFeedback: { blockReason: "SAFETY" } }]),
+      { stopAtTerminal: true, strict: true },
+    );
+
+    expect(result.content).toEqual([]);
+    expect(result.stopReason).toBe("SAFETY");
+  });
+
+  test("preserves a candidate-level native safety reason", async () => {
+    const result = await accumulateGeminiSSEStream(
+      sse([
+        { candidates: [{ content: { parts: [] }, finishReason: "SAFETY" }] },
+      ]),
+      { stopAtTerminal: true, strict: true },
+    );
+
+    expect(result.content).toEqual([]);
+    expect(result.stopReason).toBe("SAFETY");
+  });
+
   test("concatenates text deltas across frames + final usage/finishReason", async () => {
     const res = sse([
       {
@@ -132,6 +499,99 @@ describe("accumulateGeminiSSEStream", () => {
     ]);
     const resp = await accumulateGeminiSSEStream(res);
     expect(resp.usage).toEqual({ inputTokens: 10, outputTokens: 42 });
+  });
+
+  test("rejects totalTokenCount contradictory to prompt, candidates, thoughts, and tool tokens", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([
+          {
+            candidates: [
+              {
+                content: { role: "model", parts: [{ text: "done" }] },
+                finishReason: "STOP",
+              },
+            ],
+            usageMetadata: {
+              promptTokenCount: 2,
+              candidatesTokenCount: 3,
+              thoughtsTokenCount: 4,
+              toolUsePromptTokenCount: 5,
+              cachedContentTokenCount: 1,
+              totalTokenCount: 15,
+            },
+          },
+        ]),
+        { strict: true, stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
+  });
+
+  test("accepts exact Gemini totals without double-counting cached prompt tokens", async () => {
+    const result = await accumulateGeminiSSEStream(
+      sse([
+        {
+          candidates: [
+            {
+              content: { role: "model", parts: [{ text: "done" }] },
+              finishReason: "STOP",
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 100,
+            cachedContentTokenCount: 80,
+            candidatesTokenCount: 20,
+            thoughtsTokenCount: 10,
+            toolUsePromptTokenCount: 5,
+            totalTokenCount: 135,
+          },
+        },
+      ]),
+      { strict: true, stopAtTerminal: true },
+    );
+    expect(result.usage).toMatchObject({
+      inputTokens: 25,
+      cacheReadInputTokens: 80,
+      outputTokens: 30,
+    });
+  });
+
+  test("counts no-cache Gemini tool-use prompt tokens exactly once", async () => {
+    const result = await accumulateGeminiSSEStream(
+      sse([
+        {
+          candidates: [
+            { content: { parts: [{ text: "done" }] }, finishReason: "STOP" },
+          ],
+          usageMetadata: {
+            promptTokenCount: 100,
+            candidatesTokenCount: 20,
+            toolUsePromptTokenCount: 5,
+            totalTokenCount: 125,
+          },
+        },
+      ]),
+      { strict: true, stopAtTerminal: true },
+    );
+    expect(result.usage).toMatchObject({
+      inputTokens: 105,
+      outputTokens: 20,
+    });
+    expect(result.usage?.cacheReadInputTokens).toBeUndefined();
+  });
+
+  test("rejects totalTokenCount when a required parent count is absent", async () => {
+    await expect(
+      accumulateGeminiSSEStream(
+        sse([
+          {
+            candidates: [{ content: { parts: [] }, finishReason: "STOP" }],
+            usageMetadata: { promptTokenCount: 2, totalTokenCount: 2 },
+          },
+        ]),
+        { strict: true, stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Gemini stream event");
   });
 
   test("SAFETY finishReason preserved verbatim", async () => {

--- a/packages/gateway/test/gemini-translate.test.ts
+++ b/packages/gateway/test/gemini-translate.test.ts
@@ -8,6 +8,7 @@ import {
   buildGeminiResponse,
 } from "../src/translate/gemini";
 import type { GatewayRequest, GatewayResponse } from "../src/translate/types";
+import { validateGeminiUsageMetadata } from "../src/usage-validation";
 
 // ---------------------------------------------------------------------------
 // parseGeminiRequest (Gemini generateContent body → GatewayRequest)
@@ -230,11 +231,15 @@ describe("buildGeminiUpstreamRequest", () => {
       { role: "user", parts: [{ text: "hi" }] },
       {
         role: "model",
-        parts: [{ functionCall: { name: "f", args: { a: 1 } } }],
+        parts: [{ functionCall: { id: "f", name: "f", args: { a: 1 } } }],
       },
       {
         role: "user",
-        parts: [{ functionResponse: { name: "f", response: { ok: true } } }],
+        parts: [
+          {
+            functionResponse: { id: "f", name: "f", response: { ok: true } },
+          },
+        ],
       },
     ]);
     expect(b.tools).toEqual([
@@ -269,6 +274,89 @@ describe("buildGeminiUpstreamRequest", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseGeminiResponseJSON", () => {
+  test("rejects ambiguous repeated same-name function calls without IDs", () => {
+    expect(() =>
+      parseGeminiResponseJSON({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { functionCall: { name: "lookup", args: { a: 1 } } },
+                { functionCall: { name: "lookup", args: { a: 2 } } },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toThrow("malformed Gemini response tool identity");
+  });
+  test("preserves same-name function calls with distinct provider IDs", () => {
+    const response = parseGeminiResponseJSON({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { functionCall: { id: "one", name: "lookup", args: { a: 1 } } },
+              { functionCall: { id: "two", name: "lookup", args: { a: 2 } } },
+            ],
+          },
+        },
+      ],
+    });
+    expect(response.content).toEqual([
+      { type: "tool_use", id: "one", name: "lookup", input: { a: 1 } },
+      { type: "tool_use", id: "two", name: "lookup", input: { a: 2 } },
+    ]);
+  });
+
+  test("permits the same tool identity in independent candidates", () => {
+    const response = parseGeminiResponseJSON({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { functionCall: { id: "shared", name: "lookup", args: {} } },
+            ],
+          },
+        },
+        {
+          content: {
+            parts: [
+              { functionCall: { id: "shared", name: "lookup", args: {} } },
+            ],
+          },
+        },
+      ],
+    });
+    expect(response.content).toEqual([
+      { type: "tool_use", id: "shared", name: "lookup", input: {} },
+    ]);
+  });
+
+  test("validates tool identity in candidate one even though candidate zero is projected", () => {
+    expect(() =>
+      parseGeminiResponseJSON({
+        candidates: [
+          { content: { parts: [{ text: "projected" }] } },
+          { content: { parts: [{ functionCall: { id: "", name: "bad" } }] } },
+        ],
+      }),
+    ).toThrow("malformed Gemini response tool identity");
+  });
+  test.each([
+    { index: -1, content: { parts: [{ text: "bad" }] } },
+    { finishReason: 7, content: { parts: [{ text: "bad" }] } },
+    { content: { parts: [{ text: 42 }] } },
+  ])("rejects malformed non-projected Gemini candidate %#", (candidate) => {
+    expect(() =>
+      parseGeminiResponseJSON({
+        candidates: [
+          { content: { parts: [{ text: "projected" }] } },
+          candidate,
+        ],
+      }),
+    ).toThrow("malformed Gemini response tool identity");
+  });
   test("maps candidate text parts + usageMetadata", () => {
     const resp = parseGeminiResponseJSON({
       candidates: [
@@ -289,7 +377,7 @@ describe("parseGeminiResponseJSON", () => {
     expect(resp.stopReason).toBe("end_turn");
     expect(resp.model).toBe("gemini-2.5-pro");
     expect(resp.usage).toEqual({
-      inputTokens: 10,
+      inputTokens: 6,
       outputTokens: 3,
       cacheReadInputTokens: 4,
     });
@@ -389,6 +477,58 @@ describe("parseGeminiResponseJSON", () => {
   });
 });
 
+test("Gemini request round-trip preserves distinct function ID and name", () => {
+  const parsed = parseGeminiRequest(
+    {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            { functionCall: { id: "call-1", name: "lookup", args: { q: 1 } } },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            {
+              functionResponse: {
+                id: "call-1",
+                name: "lookup",
+                response: { ok: true },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {},
+    "gemini-test",
+    false,
+  );
+  const rebuilt = buildGeminiUpstreamRequest(parsed, "https://example.test")
+    .body as { contents: Array<{ parts: unknown[] }> };
+  expect(rebuilt.contents).toEqual([
+    {
+      role: "model",
+      parts: [
+        { functionCall: { id: "call-1", name: "lookup", args: { q: 1 } } },
+      ],
+    },
+    {
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            id: "call-1",
+            name: "lookup",
+            response: { ok: true },
+          },
+        },
+      ],
+    },
+  ]);
+});
+
 // ---------------------------------------------------------------------------
 // Egress: thinking + preserved finishReason round-trip
 // ---------------------------------------------------------------------------
@@ -450,7 +590,7 @@ describe("buildGeminiResponse", () => {
           role: "model",
           parts: [
             { text: "hello" },
-            { functionCall: { name: "f", args: { a: 1 } } },
+            { functionCall: { id: "f", name: "f", args: { a: 1 } } },
           ],
         },
         finishReason: "STOP",
@@ -458,9 +598,9 @@ describe("buildGeminiResponse", () => {
       },
     ]);
     expect(b.usageMetadata).toEqual({
-      promptTokenCount: 5,
+      promptTokenCount: 6,
       candidatesTokenCount: 2,
-      totalTokenCount: 7,
+      totalTokenCount: 8,
       cachedContentTokenCount: 1,
     });
     expect(b.modelVersion).toBe("gemini-2.5-pro");
@@ -474,6 +614,30 @@ describe("buildGeminiResponse", () => {
     const text = await sseRes.text();
     expect(text.startsWith("data: ")).toBe(true);
     expect(text.endsWith("\n\n")).toBe(true);
+  });
+
+  test("includes disjoint cache creation in Gemini's inclusive parent count", () => {
+    const body = buildGeminiResponseBody({
+      ...resp,
+      usage: {
+        inputTokens: 10,
+        cacheReadInputTokens: 90,
+        cacheCreationInputTokens: 20,
+        outputTokens: 1,
+      },
+    });
+    expect(body.usageMetadata).toEqual({
+      promptTokenCount: 120,
+      candidatesTokenCount: 1,
+      totalTokenCount: 121,
+      cachedContentTokenCount: 90,
+    });
+    expect(() =>
+      validateGeminiUsageMetadata(
+        body.usageMetadata,
+        "invalid translated usage",
+      ),
+    ).not.toThrow();
   });
 });
 

--- a/packages/gateway/test/harness.test.ts
+++ b/packages/gateway/test/harness.test.ts
@@ -1,6 +1,42 @@
 import { afterEach, describe, expect, test } from "vitest";
+import { existsSync, unlinkSync } from "node:fs";
 import type { Harness } from "./helpers/harness";
 import { createHarness } from "./helpers/harness";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  STANDARD_TOOLS,
+  makeConversationFixtures,
+} from "./helpers/fixtures";
+
+function isUnavailableBind(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 4 && current; depth++) {
+    if (typeof current === "object") {
+      const record = current as { code?: unknown; cause?: unknown };
+      if (record.code === "EADDRINUSE" || record.code === "EACCES") return true;
+      current = record.cause;
+      continue;
+    }
+    break;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /EADDRINUSE|EACCES|port\b.*\bin use|permission denied/i.test(message);
+}
+
+async function cleanupFailedHarnessAttempt(dbPath?: string): Promise<void> {
+  const { close } = await import("@loreai/core");
+  const { resetPipelineState, setUpstreamInterceptor } =
+    await import("../src/pipeline");
+  close();
+  await resetPipelineState();
+  setUpstreamInterceptor(undefined);
+  if (!dbPath) return;
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const file = `${dbPath}${suffix}`;
+    if (existsSync(file)) unlinkSync(file);
+  }
+}
 
 describe("gateway test harness", () => {
   let harness: Harness | undefined;
@@ -22,5 +58,44 @@ describe("gateway test harness", () => {
     const port = Number(new URL(harness.baseURL).port);
     expect(port).toBeGreaterThan(0);
     expect(port).not.toBe(1);
+  });
+
+  test("chat works when the OS selects a WHATWG fetch-blocked port", async () => {
+    const forbiddenPorts = [6667, 6666, 6668, 6669, 6697, 6566, 6000, 5060];
+    const userMessage = "Test the loopback harness transport.";
+    const fixtures = makeConversationFixtures([
+      { userMessage, assistantText: "Loopback transport works." },
+    ]);
+    const unavailable: number[] = [];
+    for (const candidate of forbiddenPorts) {
+      try {
+        harness = await createHarness({
+          configOverrides: { port: candidate },
+          fixtures,
+        });
+        break;
+      } catch (error) {
+        const failedDbPath = process.env.LORE_DB_PATH;
+        await cleanupFailedHarnessAttempt(failedDbPath);
+        if (!isUnavailableBind(error)) throw error;
+        unavailable.push(candidate);
+      }
+    }
+    if (!harness) {
+      throw new Error(
+        `could not bind any WHATWG forbidden port: ${unavailable.join(", ")}`,
+      );
+    }
+
+    const response = await harness.chat({
+      model: DEFAULT_MODEL,
+      max_tokens: 128,
+      stream: false,
+      system: DEFAULT_SYSTEM,
+      messages: [{ role: "user", content: userMessage }],
+      tools: STANDARD_TOOLS,
+    });
+
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -5,6 +5,10 @@
  * temporary DB, wires in a replay interceptor from a fixture array, and
  * provides helper methods for sending requests and asserting DB state.
  *
+ * Harnesses are serial-only within a process: they intentionally replace
+ * process-wide DB and pipeline singletons. Concurrent create/teardown is not a
+ * supported architecture; use separate Vitest workers for parallel isolation.
+ *
  * Usage:
  *   const harness = await createHarness({ fixtures });
  *   const resp = await harness.chat(body);
@@ -12,6 +16,8 @@
  */
 import { unlinkSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
+import { request as httpRequest } from "node:http";
+import { Readable } from "node:stream";
 import type { FixtureEntry } from "../../src/recorder";
 import type { SimulatedCacheTurn } from "./simulated-cache";
 
@@ -206,20 +212,55 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
     apiKey = "test-key",
     extraHeaders?: Record<string, string>,
   ): Promise<Response> {
-    return fetch(`${baseURL}/v1/messages`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-        // Provide a confident project binding by default so the synthetic
-        // project-resolution probe is never triggered in harness-based tests.
-        // Tests that intentionally test path-less sessions can override this
-        // via extraHeaders (set to empty string to suppress).
-        "x-lore-project": projectPath,
-        ...extraHeaders,
-      },
-      body: JSON.stringify(requestBody),
+    const body = JSON.stringify(requestBody);
+    const headers = {
+      "content-type": "application/json",
+      "content-length": String(Buffer.byteLength(body)),
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      // Provide a confident project binding by default so the synthetic
+      // project-resolution probe is never triggered in harness-based tests.
+      // Tests that intentionally test path-less sessions can override this
+      // via extraHeaders (set to empty string to suppress).
+      "x-lore-project": projectPath,
+      ...extraHeaders,
+    };
+    // WHATWG fetch rejects a browser-defined list of "bad ports". Port 0 can
+    // legitimately assign one of those ports to the local test server, making
+    // an otherwise valid harness request fail nondeterministically. Use Node's
+    // HTTP transport for this loopback-only helper while retaining a web
+    // Response and streaming body for callers.
+    return new Promise<Response>((resolve, reject) => {
+      const request = httpRequest(
+        {
+          hostname: "127.0.0.1",
+          port: server.port,
+          path: "/v1/messages",
+          method: "POST",
+          headers,
+        },
+        (incoming) => {
+          const responseHeaders = new Headers();
+          for (let i = 0; i < incoming.rawHeaders.length; i += 2) {
+            responseHeaders.append(
+              incoming.rawHeaders[i],
+              incoming.rawHeaders[i + 1],
+            );
+          }
+          resolve(
+            new Response(
+              Readable.toWeb(incoming) as unknown as ReadableStream<Uint8Array>,
+              {
+                status: incoming.statusCode ?? 500,
+                statusText: incoming.statusMessage,
+                headers: responseHeaders,
+              },
+            ),
+          );
+        },
+      );
+      request.once("error", reject);
+      request.end(body);
     });
   }
 

--- a/packages/gateway/test/http-body.test.ts
+++ b/packages/gateway/test/http-body.test.ts
@@ -5,7 +5,8 @@
  * bodies by default (ChatGPT auth), and the gateway must decode them on ingress
  * and re-encode them on the way upstream.
  */
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
+import { randomBytes } from "node:crypto";
 import {
   brotliCompressSync,
   deflateRawSync,
@@ -24,6 +25,8 @@ import {
   isSupportedEncoding,
   mayReencodeUpstream,
   normalizeRequestEncoding,
+  MAX_HTTP_REQUEST_COMPRESSED_BYTES,
+  MAX_HTTP_REQUEST_DECOMPRESSED_BYTES,
 } from "../src/http-body";
 
 const SAMPLE = JSON.stringify({
@@ -129,6 +132,125 @@ describe("decodeRequestBody", () => {
       /Unsupported/,
     );
   });
+
+  test.each([
+    ["exact cap", MAX_HTTP_REQUEST_COMPRESSED_BYTES, true],
+    ["cap plus one", MAX_HTTP_REQUEST_COMPRESSED_BYTES + 1, false],
+  ] as const)(
+    "bounds identity request bytes at the %s",
+    async (_name, size, ok) => {
+      let cancelled = false;
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(size).fill(0x61));
+          if (ok) controller.close();
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      const req = new Request("http://gateway.local/v1/messages", {
+        method: "POST",
+        body: source,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+      if (ok) {
+        const decoded = await decodeRequestBody(req);
+        expect(Buffer.byteLength(decoded)).toBe(size);
+        expect(cancelled).toBe(false);
+      } else {
+        await expect(decodeRequestBody(req)).rejects.toThrow(
+          `exceeded ${MAX_HTTP_REQUEST_COMPRESSED_BYTES} byte limit`,
+        );
+        expect(cancelled).toBe(true);
+      }
+      expect(source.locked).toBe(false);
+    },
+  );
+
+  test.each(["gzip", "br", "zstd"])(
+    "rejects a %s decompression bomb at the output cap",
+    async (encoding) => {
+      const expanded = Buffer.alloc(
+        MAX_HTTP_REQUEST_DECOMPRESSED_BYTES + 1,
+        0x61,
+      );
+      const compressed = ENCODERS[encoding](expanded.toString("utf8"));
+      expect(compressed.byteLength).toBeLessThan(
+        MAX_HTTP_REQUEST_COMPRESSED_BYTES,
+      );
+      await expect(
+        decodeRequestBody(reqWith(compressed, encoding)),
+      ).rejects.toThrow(
+        `exceeded ${MAX_HTTP_REQUEST_DECOMPRESSED_BYTES} byte limit`,
+      );
+    },
+  );
+
+  test("abort preempts asynchronous decompression", async () => {
+    const compressed = gzipSync(randomBytes(8 * 1024 * 1024));
+    const controller = new AbortController();
+    const pending = decodeRequestBody(
+      reqWith(compressed, "gzip"),
+      controller.signal,
+    );
+    setImmediate(() =>
+      controller.abort(new DOMException("client disconnected", "AbortError")),
+    );
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  test.each(["caller", "deadline"] as const)(
+    "%s abort cancels and unlocks a never-ending chunked upload",
+    async (mode) => {
+      if (mode === "deadline") vi.useFakeTimers();
+      const controller = new AbortController();
+      let cancelled = false;
+      let markPull!: () => void;
+      const pulling = new Promise<void>((resolve) => (markPull = resolve));
+      const source = new ReadableStream<Uint8Array>({
+        pull() {
+          markPull();
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      });
+      const req = new Request("http://gateway.local/v1/messages", {
+        method: "POST",
+        body: source,
+        signal: controller.signal,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" });
+      const deadline =
+        mode === "deadline"
+          ? setTimeout(
+              () =>
+                controller.abort(
+                  new DOMException("request deadline", "TimeoutError"),
+                ),
+              300_000,
+            )
+          : undefined;
+      const pending = decodeRequestBody(req);
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: mode === "caller" ? "AbortError" : "TimeoutError",
+      });
+      await pulling;
+      if (mode === "caller") {
+        controller.abort(new DOMException("client disconnected", "AbortError"));
+      } else {
+        await vi.advanceTimersByTimeAsync(300_000);
+      }
+      await rejected;
+      if (deadline) clearTimeout(deadline);
+      expect(cancelled).toBe(true);
+      expect(source.locked).toBe(false);
+      if (mode === "deadline") vi.useRealTimers();
+    },
+  );
 });
 
 describe("encodeUpstreamBody", () => {

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -6,6 +6,13 @@ import { fetchArgUrl } from "./helpers/fetch-url";
 // globalThis.fetch (upstreamFetch is the gateway's own upstream path and does
 // not go through globalThis.fetch, so mocking it is the reliable seam).
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+vi.mock("@sentry/bun", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@sentry/bun")>();
+  return {
+    ...actual,
+    captureException: vi.fn(actual.captureException),
+  };
+});
 vi.mock("../src/worker-health", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/worker-health")>();
   return {
@@ -20,13 +27,16 @@ vi.mock("../src/worker-health", async (importOriginal) => {
 
 import {
   backoffMs,
+  parseRetryAfter,
   abortableSleep,
   readWorkerResponseText,
+  describeEmptyWorkerResponse,
   createGatewayLLMClient,
   getLastWorkerError,
   maxRetriesFor,
   normalizeOpenAIUsage,
   resolveWorkerProtocol,
+  resolveTarget,
   AUTH_ERROR_CODES,
   isTemperatureUnsupportedModel,
   isAnthropicClaudeModel,
@@ -56,10 +66,14 @@ import {
 import {
   markWorkerIncapable,
   markFreeModelsDataBlocked,
+  getWorkerHealth,
+  isWorkerIncapable,
   _resetForTest as _resetWorkerHealthForTest,
 } from "../src/worker-health";
 import { captureSessionHeaders, captureBillingPrefix } from "../src/cch";
 import { _setTestVertexTokenProvider } from "../src/vertex-auth";
+import * as Sentry from "@sentry/bun";
+import { log } from "@loreai/core";
 
 // Claude Code billing-header system prompt — marks a session as an OAuth
 // billing session so worker calls replay its sniffed anthropic-beta header.
@@ -101,6 +115,33 @@ describe("backoffMs — with Retry-After", () => {
     expect(backoffMs(0, 60_000)).toBe(32_000);
     expect(backoffMs(2, 300_000)).toBe(32_000);
   });
+
+  test("rejects negative and non-finite Retry-After values", () => {
+    for (const value of ["-1", "Infinity", "-Infinity"]) {
+      expect(
+        parseRetryAfter(
+          new Response(null, { headers: { "retry-after": value } }),
+        ),
+      ).toBeNull();
+    }
+    expect(backoffMs(0, -1)).toBe(0);
+    expect(backoffMs(0, Number.POSITIVE_INFINITY)).toBeGreaterThanOrEqual(500);
+  });
+
+  test("rejects unsafe multiplied values and caps finite server hints", () => {
+    expect(
+      parseRetryAfter(
+        new Response(null, {
+          headers: { "retry-after": String(Number.MAX_SAFE_INTEGER) },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseRetryAfter(
+        new Response(null, { headers: { "retry-after": "1000000" } }),
+      ),
+    ).toBe(32_000);
+  });
 });
 
 describe("abortableSleep", () => {
@@ -119,6 +160,14 @@ describe("abortableSleep", () => {
 });
 
 describe("readWorkerResponseText", () => {
+  test("keeps diagnostic error bodies capped at 64 KiB", async () => {
+    const text = await readWorkerResponseText(
+      new Response("x".repeat(70 * 1024), { status: 500 }),
+    );
+
+    expect(Buffer.byteLength(text)).toBe(64 * 1024);
+  });
+
   test("cancels a stalled worker error body on abort", async () => {
     const controller = new AbortController();
     let cancelled = false;
@@ -140,6 +189,51 @@ describe("readWorkerResponseText", () => {
     await expect(pending).rejects.toMatchObject({ name: "AbortError" });
     expect(cancelled).toBe(true);
   });
+
+  test("replacement-decodes malformed diagnostic UTF-8", async () => {
+    for (const chunks of [
+      [new Uint8Array([0xff])],
+      [new Uint8Array([0xe2]), new Uint8Array([0x28, 0xa1])],
+    ]) {
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+      );
+      expect(await readWorkerResponseText(response)).toContain("�");
+    }
+  });
+
+  test("replacement-decodes a multibyte code point split by the 64 KiB cap", async () => {
+    const prefix = new TextEncoder().encode("x".repeat(64 * 1024 - 1));
+    const euro = new TextEncoder().encode("€");
+    const text = await readWorkerResponseText(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(prefix);
+            controller.enqueue(euro);
+            controller.close();
+          },
+        }),
+      ),
+    );
+    expect(text.endsWith("�")).toBe(true);
+  });
+});
+
+test("empty worker diagnostics never include response values", () => {
+  const sentinel = "must-not-leak-empty-secret";
+  const diagnostic = describeEmptyWorkerResponse({
+    metadata: { token: sentinel },
+    choices: [{ message: { content: "" }, finish_reason: sentinel }],
+  });
+
+  expect(diagnostic).not.toContain(sentinel);
+  expect(diagnostic).toContain("finish_reason=unknown");
 });
 
 // ---------------------------------------------------------------------------
@@ -316,6 +410,52 @@ describe("AUTH_ERROR_CODES", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveWorkerProtocol", () => {
+  test("target resolution never maps OpenAI-family protocols to Anthropic", () => {
+    const upstreams = {
+      anthropic: "https://api.anthropic.com",
+      openai: "https://api.openai.com",
+    };
+    for (const protocol of ["openai", "openai-responses"] as const) {
+      expect(
+        resolveTarget(upstreams, protocol, undefined, "openai"),
+      ).toMatchObject({
+        url: "https://api.openai.com",
+        protocol,
+      });
+      expect(
+        resolveTarget(
+          { ...upstreams, openai: "" },
+          protocol,
+          undefined,
+          "openai",
+        ),
+      ).toMatchObject({ routeUnavailable: true, url: "" });
+      expect(
+        resolveTarget(
+          upstreams,
+          protocol,
+          "https://api.anthropic.com",
+          "openai",
+          "openai",
+        ),
+      ).toMatchObject({ routeUnavailable: true, url: "" });
+    }
+    expect(
+      resolveTarget(
+        upstreams,
+        "anthropic",
+        "https://api.openai.com",
+        "anthropic",
+        "anthropic",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+    expect(
+      resolveTarget(upstreams, "anthropic", undefined, "openai"),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+    expect(
+      resolveTarget(upstreams, "openai", undefined, "anthropic"),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+  });
   // Priority 1: explicit protocol from UpstreamSnapshot wins
   test("explicit 'anthropic' wins over route table", () => {
     expect(resolveWorkerProtocol("openai", "anthropic")).toBe("anthropic");
@@ -793,6 +933,10 @@ describe("createGatewayLLMClient.prompt", () => {
             output_index: 0,
             delta: "reply",
           }) +
+          event("response.output_item.done", {
+            output_index: 0,
+            item: { type: "message", id: "msg_worker", role: "assistant" },
+          }) +
           event("response.completed", {
             response: {
               id: "resp_worker",
@@ -816,6 +960,7 @@ describe("createGatewayLLMClient.prompt", () => {
       workerID: "lore-distill",
       // Session upstream override (chatgpt backend) + responses protocol hint.
       upstreamUrl: "https://chatgpt.com/backend-api",
+      upstreamProviderID: "openai-codex",
       protocol: "openai-responses",
     });
 
@@ -839,6 +984,641 @@ describe("createGatewayLLMClient.prompt", () => {
     expect(distillationCost?.cost).toBeGreaterThan(0);
   });
 
+  test("OpenAI worker ignores an unproven ChatGPT backend URL", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "direct OpenAI reply" } }],
+          model: "gpt-4o-mini",
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sessionID, providerID) =>
+        providerID === "openai"
+          ? { scheme: "api-key", value: "openai-key" }
+          : null,
+      { providerID: "openai", modelID: "gpt-4o-mini" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      sessionID: "sess-cross-provider-chatgpt",
+      workerID: "lore-distill",
+      model: { providerID: "openai", modelID: "gpt-4o-mini" },
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      protocol: "openai-responses",
+    });
+
+    expect(text).toBe("direct OpenAI reply");
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://api.openai.com/v1/chat/completions",
+    );
+  });
+
+  test("ChatGPT worker preserves a valid Responses stream larger than 64 KiB", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+    const deltas = Array.from({ length: 900 }, () => "x".repeat(80));
+    const output = deltas.join("");
+    const wire =
+      event("response.created", {
+        response: { id: "resp_large", model: "gpt-5.6-sol" },
+      }) +
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { type: "message", id: "msg_large", role: "assistant" },
+      }) +
+      deltas
+        .map((delta) =>
+          event("response.output_text.delta", { output_index: 0, delta }),
+        )
+        .join("") +
+      event("response.output_item.done", {
+        output_index: 0,
+        item: { type: "message", id: "msg_large", role: "assistant" },
+      }) +
+      event("response.completed", {
+        response: {
+          id: "resp_large",
+          model: "gpt-5.6-sol",
+          status: "completed",
+          usage: { input_tokens: 12, output_tokens: 16_000 },
+        },
+      });
+    const bytes = new TextEncoder().encode(wire);
+    let offset = 0;
+    captureSessionHeaders("sess-chatgpt-large-worker", {
+      "chatgpt-account-id": "acct-large-worker",
+      originator: "opencode",
+    });
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (offset >= bytes.byteLength) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(bytes.subarray(offset, offset + 257));
+            offset += 257;
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sessionID, providerID) =>
+        providerID === "openai"
+          ? { scheme: "bearer", value: "jwt-token" }
+          : null,
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      sessionID: "sess-chatgpt-large-worker",
+      workerID: "lore-distill",
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      upstreamProviderID: "openai",
+      protocol: "openai-responses",
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "https://chatgpt.com/backend-api/codex/responses",
+    );
+    const headers = mockFetch.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers["chatgpt-account-id"]).toBe("acct-large-worker");
+    expect(text).toBe(output);
+  });
+
+  test("sniffs a mislabeled SSE stream with a leading comment one byte at a time", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+    const bytes = new TextEncoder().encode(
+      ": upstream heartbeat\n\n" +
+        event("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_comment", role: "assistant" },
+        }) +
+        event("response.output_text.delta", {
+          output_index: 0,
+          delta: "comment-safe",
+        }) +
+        event("response.output_item.done", {
+          output_index: 0,
+          item: { type: "message", id: "msg_comment", role: "assistant" },
+        }) +
+        event("response.completed", {
+          response: { status: "completed" },
+        }),
+    );
+    let offset = 0;
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (offset === bytes.byteLength) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(bytes.subarray(offset, ++offset));
+          },
+        }),
+        { headers: { "content-type": "application/octet-stream" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "jwt-token" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      sessionID: "sess-chatgpt-comment-sniff",
+      workerID: "lore-distill",
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      upstreamProviderID: "openai",
+      protocol: "openai-responses",
+    });
+
+    expect(text).toBe("comment-safe");
+  });
+
+  test("ChatGPT worker stops and cancels after a valid terminal event", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+    const wire =
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { type: "message", id: "msg_terminal", role: "assistant" },
+      }) +
+      event("response.output_text.delta", {
+        output_index: 0,
+        delta: "finished",
+      }) +
+      event("response.output_item.done", {
+        output_index: 0,
+        item: { type: "message", id: "msg_terminal", role: "assistant" },
+      }) +
+      event("response.completed", {
+        response: { status: "completed" },
+      });
+    let cancelled = false;
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(wire + "x".repeat(4 * 1024 * 1024)),
+            );
+          },
+          cancel() {
+            cancelled = true;
+            return new Promise(() => {});
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "jwt-token" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+
+    let timeoutID: ReturnType<typeof setTimeout> | undefined = undefined;
+    const timeout = new Promise<"timeout">((resolve) => {
+      timeoutID = setTimeout(() => resolve("timeout"), 1000);
+    });
+    const result = await Promise.race([
+      client.prompt("system", "user", {
+        sessionID: "sess-chatgpt-terminal",
+        workerID: "lore-distill",
+        upstreamUrl: "https://chatgpt.com/backend-api",
+        upstreamProviderID: "openai",
+        protocol: "openai-responses",
+      }),
+      timeout,
+    ]);
+    if (timeoutID) clearTimeout(timeoutID);
+
+    expect(result).toBe("finished");
+    expect(cancelled).toBe(true);
+  });
+
+  test("aborting a stalled ChatGPT worker read cancels the source", async () => {
+    const controller = new AbortController();
+    let cancelled = false;
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled = true;
+            return new Promise(() => {});
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "jwt-token" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+    const pending = client.prompt("system", "user", {
+      sessionID: "sess-chatgpt-abort",
+      workerID: "lore-distill",
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      upstreamProviderID: "openai",
+      protocol: "openai-responses",
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(cancelled).toBe(true);
+  });
+
+  test("oversized ChatGPT worker stream fails explicitly without partial output", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+    mockFetch.mockResolvedValue(
+      new Response(
+        event("response.output_item.added", {
+          output_index: 0,
+          item: { type: "message", id: "msg_oversized", role: "assistant" },
+        }) +
+          event("response.output_text.delta", {
+            output_index: 0,
+            delta: "x".repeat(4 * 1024 * 1024),
+          }) +
+          event("response.completed", {
+            response: { status: "completed" },
+          }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "jwt-token" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-chatgpt-oversized",
+      workerID: "lore-distill",
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      upstreamProviderID: "openai",
+      protocol: "openai-responses",
+    });
+
+    expect(result).toBeNull();
+    expect(recordWorkerFailure).toHaveBeenCalledWith(
+      "sess-chatgpt-oversized",
+      "lore-distill",
+      "upstream-error",
+    );
+    expect(recordEmptyWorkerResponse).not.toHaveBeenCalled();
+    expect(getLastWorkerError()).toContain(
+      "worker response exceeded 4194304 byte limit",
+    );
+  });
+
+  test("strict worker SSE rejects the finite frame ceiling before protocol parsing", async () => {
+    // One comment frame makes body sniffing select SSE; 100,000 following blank
+    // frames cross the shared foreground/worker ceiling using only ~200 KiB.
+    // This reproduces the millions-of-delimiters shape without allocating
+    // millions of frames in the regression itself.
+    const wire = ": heartbeat\n\n" + "\n\n".repeat(100_000);
+    mockFetch.mockResolvedValue(
+      new Response(wire, {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-worker-frame-limit",
+      workerID: "lore-distill",
+      upstreamProviderID: "openai",
+      protocol: "openai-responses",
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(getLastWorkerError()).toContain(
+      "SSE stream exceeded 100000 frame limit",
+    );
+  });
+
+  test("oversized first JSON chunk fails before body decoding", async () => {
+    const oversized = new TextEncoder().encode(
+      `{"value":"${"x".repeat(4 * 1024 * 1024)}"}`,
+    );
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(oversized);
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "jwt-token" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-chatgpt-oversized-json",
+      workerID: "lore-distill",
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      upstreamProviderID: "openai",
+      protocol: "openai-responses",
+    });
+
+    expect(result).toBeNull();
+    expect(getLastWorkerError()).toContain(
+      "worker response exceeded 4194304 byte limit",
+    );
+  });
+
+  test("malformed JSON diagnostics do not expose response content", async () => {
+    const sentinel = "must-not-leak-worker-secret";
+    mockFetch.mockResolvedValue(
+      new Response(`{"token":"${sentinel}"`, {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-4o-mini" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-malformed-json",
+      workerID: "lore-distill",
+      upstreamProviderID: "openai",
+      protocol: "openai",
+    });
+
+    expect(result).toBeNull();
+    expect(getLastWorkerError()).toContain("malformed JSON body");
+    expect(getLastWorkerError()).not.toContain(sentinel);
+  });
+
+  test("non-object JSON response roots are upstream errors", async () => {
+    mockFetch.mockResolvedValue(
+      new Response("[]", {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-4o-mini" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-array-json-root",
+      workerID: "lore-distill",
+      upstreamProviderID: "openai",
+      protocol: "openai",
+    });
+
+    expect(result).toBeNull();
+    expect(recordWorkerFailure).toHaveBeenCalledWith(
+      "sess-array-json-root",
+      "lore-distill",
+      "upstream-error",
+    );
+    expect(recordEmptyWorkerResponse).not.toHaveBeenCalled();
+    expect(getLastWorkerError()).toContain(
+      "worker JSON response root must be an object",
+    );
+  });
+
+  test.each(["failed", "cancelled", "in_progress"])(
+    "non-streaming Responses status %s is an upstream error",
+    async (status) => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ status, output_text: "partial" }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "api-key", value: "test-key" }),
+        { providerID: "openai", modelID: "gpt-5.6-sol" },
+      );
+
+      const result = await client.prompt("system", "user", {
+        sessionID: `sess-json-status-${status}`,
+        workerID: "lore-distill",
+        upstreamProviderID: "openai",
+        protocol: "openai-responses",
+      });
+
+      expect(result).toBeNull();
+      expect(recordWorkerFailure).toHaveBeenCalledWith(
+        `sess-json-status-${status}`,
+        "lore-distill",
+        "upstream-error",
+      );
+      expect(recordEmptyWorkerResponse).not.toHaveBeenCalled();
+      expect(getLastWorkerError()).toContain(
+        "non-success Responses response status",
+      );
+    },
+  );
+
+  test("openai-responses applies reasoning headroom above a 256-token request", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({ status: "completed", output_text: "reasoned" }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+    await expect(
+      client.prompt("system", "user", {
+        sessionID: "sess-responses-headroom",
+        workerID: "lore-distill",
+        upstreamProviderID: "openai",
+        protocol: "openai-responses",
+        maxTokens: 256,
+        reasoningEffort: "high",
+      }),
+    ).resolves.toBe("reasoned");
+    const body = JSON.parse(mockFetch.mock.calls[0]?.[1]?.body as string) as {
+      max_output_tokens: number;
+      reasoning?: { effort?: string };
+    };
+    expect(body.max_output_tokens).toBeGreaterThan(256);
+    expect(body.reasoning).toEqual({ effort: "high" });
+  });
+
+  test("retries an empty incomplete Responses body truncated at max_output_tokens", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: "incomplete",
+            incomplete_details: { reason: "max_output_tokens" },
+            output: [],
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ status: "completed", output_text: "retried" }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+    await expect(
+      client.prompt("system", "user", {
+        sessionID: "sess-responses-incomplete",
+        workerID: "lore-distill",
+        upstreamProviderID: "openai",
+        protocol: "openai-responses",
+        maxTokens: 256,
+      }),
+    ).resolves.toBe("retried");
+    const budgets = mockFetch.mock.calls.map((call) => {
+      const body = JSON.parse(call[1]?.body as string) as {
+        max_output_tokens: number;
+      };
+      return body.max_output_tokens;
+    });
+    expect(budgets).toHaveLength(2);
+    expect(budgets[1]).toBeGreaterThan(budgets[0]);
+  });
+
+  test("does not length-retry a non-budget incomplete Responses reason", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "incomplete",
+          incomplete_details: { reason: "content_filter" },
+          output: [],
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+    await expect(
+      client.prompt("system", "user", {
+        sessionID: "sess-responses-incomplete-filter",
+        workerID: "lore-distill",
+        upstreamProviderID: "openai",
+        protocol: "openai-responses",
+        maxTokens: 256,
+      }),
+    ).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("caller abort settles when the injected worker fetch never resolves", async () => {
+    let markStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    mockFetch.mockImplementation(() => {
+      markStarted?.();
+      return new Promise(() => {});
+    });
+    const controller = new AbortController();
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-4o-mini" },
+    );
+    const pending = client.prompt("system", "user", {
+      sessionID: "sess-hostile-fetch",
+      workerID: "lore-distill",
+      upstreamProviderID: "openai",
+      protocol: "openai",
+      signal: controller.signal,
+    });
+    await started;
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("public openai-responses workers retain strict output lifecycle validation", async () => {
+    const stream =
+      `event: response.output_item.done\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: {
+          type: "message",
+          id: "msg_public_done_only",
+          content: [{ type: "output_text", text: "must not escape" }],
+        },
+      })}\n\n` +
+      `event: response.completed\ndata: ${JSON.stringify({
+        response: { status: "completed" },
+      })}\n\n`;
+    mockFetch.mockResolvedValue(
+      new Response(stream, {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "test-key" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-public-responses-strict",
+      workerID: "lore-distill",
+      upstreamProviderID: "openai",
+      protocol: "openai-responses",
+    });
+
+    expect(result).toBeNull();
+    expect(recordWorkerFailure).toHaveBeenCalledWith(
+      "sess-public-responses-strict",
+      "lore-distill",
+      "upstream-error",
+    );
+    expect(recordEmptyWorkerResponse).not.toHaveBeenCalled();
+    expect(getLastWorkerError()).toContain("malformed Responses stream event");
+  });
+
   test.each([
     [
       "failed terminal",
@@ -850,14 +1630,45 @@ describe("createGatewayLLMClient.prompt", () => {
     [
       "malformed event",
       "event: response.output_text.delta\ndata: {not-json}\n\n",
-      "malformed response.output_text.delta event",
+      "malformed Responses stream event",
+    ],
+    [
+      "malformed provided output index",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: "0",
+        item: { type: "message", id: "msg_bad_output_index" },
+      })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "malformed provided content index",
+      `event: response.output_text.delta\ndata: ${JSON.stringify({
+        item_id: "msg_bad_content_index",
+        content_index: "0",
+        delta: "partial",
+      })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "malformed provided incomplete reason",
+      `event: response.incomplete\ndata: ${JSON.stringify({
+        response: {
+          status: "incomplete",
+          incomplete_details: { reason: 1 },
+        },
+      })}\n\n`,
+      "malformed Responses terminal event",
     ],
     [
       "missing terminal",
-      `event: response.output_text.delta\ndata: ${JSON.stringify({
+      `event: response.output_item.added\ndata: ${JSON.stringify({
         output_index: 0,
-        delta: "partial",
-      })}\n\n`,
+        item: { type: "message", id: "msg_partial", role: "assistant" },
+      })}\n\n` +
+        `event: response.output_text.delta\ndata: ${JSON.stringify({
+          output_index: 0,
+          delta: "partial",
+        })}\n\n`,
       "missing terminal response status",
     ],
     [
@@ -865,14 +1676,231 @@ describe("createGatewayLLMClient.prompt", () => {
       `event: response.completed\ndata: ${JSON.stringify({
         response: { status: "failed" },
       })}\n\n`,
-      "terminal response status=failed",
+      "Responses terminal reported failure",
     ],
     [
       "cancelled status",
       `event: response.completed\ndata: ${JSON.stringify({
         response: { status: "cancelled" },
       })}\n\n`,
-      "terminal response status=cancelled",
+      "Responses terminal reported failure",
+    ],
+    [
+      "nonterminal completed status",
+      `event: response.completed\ndata: ${JSON.stringify({
+        response: { status: "in_progress" },
+      })}\n\n`,
+      "Responses terminal event/status mismatch",
+    ],
+    [
+      "nonterminal response.done status",
+      `event: response.done\ndata: ${JSON.stringify({
+        response: { status: "in_progress" },
+      })}\n\n`,
+      "Responses terminal event/status mismatch",
+    ],
+    [
+      "contradictory incomplete status",
+      `event: response.incomplete\ndata: ${JSON.stringify({
+        response: { status: "completed" },
+      })}\n\n`,
+      "Responses terminal event/status mismatch",
+    ],
+    [
+      "out-of-order delta",
+      `event: response.output_text.delta\ndata: ${JSON.stringify({
+        output_index: 0,
+        delta: "partial",
+      })}\n\n` +
+        `event: response.completed\ndata: ${JSON.stringify({
+          response: { status: "completed" },
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "duplicate added item",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_first" },
+      })}\n\n` +
+        `event: response.output_item.added\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_duplicate" },
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "added item without type",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { id: "msg_missing_type" },
+      })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "done item type mismatch",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_mismatch" },
+      })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "function_call", id: "fc_mismatch" },
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "terminal without response object",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_no_response" },
+      })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_no_response" },
+        })}\n\n` +
+        "event: response.completed\ndata: {}\n\n",
+      "malformed Responses terminal event",
+    ],
+    [
+      "done item ID mismatch",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_added" },
+      })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_different" },
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "payload type mismatch",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { type: "message", id: "msg_type_mismatch" },
+      })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "delta item ID mismatch",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_expected" },
+      })}\n\n` +
+        `event: response.output_text.delta\ndata: ${JSON.stringify({
+          output_index: 0,
+          item_id: "msg_other",
+          delta: "cross-wired",
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "response ID mismatch",
+      `event: response.created\ndata: ${JSON.stringify({
+        response: { id: "resp_created" },
+      })}\n\n` +
+        `event: response.output_item.added\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_response_mismatch" },
+        })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_response_mismatch" },
+        })}\n\n` +
+        `event: response.completed\ndata: ${JSON.stringify({
+          response: { id: "resp_terminal", status: "completed" },
+        })}\n\n`,
+      "malformed Responses terminal event",
+    ],
+    [
+      "delta after item done",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_already_done" },
+      })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_already_done" },
+        })}\n\n` +
+        `event: response.output_text.delta\ndata: ${JSON.stringify({
+          output_index: 0,
+          delta: "late",
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "regressing sequence number",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        sequence_number: 2,
+        output_index: 0,
+        item: { type: "message", id: "msg_sequence" },
+      })}\n\n` +
+        `event: response.output_text.delta\ndata: ${JSON.stringify({
+          sequence_number: 1,
+          output_index: 0,
+          delta: "late sequence",
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "content part after item done",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_content_done" },
+      })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_content_done" },
+        })}\n\n` +
+        `event: response.content_part.added\ndata: ${JSON.stringify({
+          output_index: 0,
+          item_id: "msg_content_done",
+          content_index: 0,
+          part: { type: "output_text", text: "late" },
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "completed response.created status",
+      `event: response.created\ndata: ${JSON.stringify({
+        response: { id: "resp_bad_created", status: "completed" },
+      })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "changing content index",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_content_index" },
+      })}\n\n` +
+        `event: response.output_text.delta\ndata: ${JSON.stringify({
+          output_index: 0,
+          content_index: 0,
+          delta: "text",
+        })}\n\n` +
+        `event: response.output_text.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          content_index: 1,
+          text: "text",
+        })}\n\n`,
+      "malformed Responses stream event",
+    ],
+    [
+      "unterminated terminal frame",
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        output_index: 0,
+        item: { type: "message", id: "msg_unterminated" },
+      })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          output_index: 0,
+          item: { type: "message", id: "msg_unterminated" },
+        })}\n\n` +
+        `event: response.completed\ndata: ${JSON.stringify({
+          response: { status: "completed" },
+        })}`,
+      "unterminated SSE event at EOF",
     ],
   ])(
     "openai-codex worker classifies %s SSE as upstream-error, never model incapability",
@@ -908,9 +1936,51 @@ describe("createGatewayLLMClient.prompt", () => {
     },
   );
 
-  test.each(["response.done", "response.incomplete"])(
-    "openai-codex worker accepts %s with CRLF framing",
-    async (terminalEvent) => {
+  test.each([
+    [
+      "terminal status",
+      (sentinel: string) =>
+        `event: response.completed\ndata: ${JSON.stringify({
+          response: { status: sentinel },
+        })}\n\n`,
+    ],
+    [
+      "event name",
+      (sentinel: string) => `event: ${sentinel}\ndata: {not-json}\n\n`,
+    ],
+  ])("does not expose an untrusted Responses %s", async (_case, streamFor) => {
+    const sentinel = "must-not-leak-provider-secret";
+    mockFetch.mockResolvedValue(
+      new Response(streamFor(sentinel), {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "jwt-token" }),
+      { providerID: "openai-codex", modelID: "gpt-5.1-codex-mini" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      sessionID: "sess-codex-secret-safe",
+      workerID: "lore-distill",
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      protocol: "openai-responses",
+    });
+
+    expect(text).toBeNull();
+    expect(getLastWorkerError()).not.toContain(sentinel);
+  });
+
+  test.each([
+    ["response.done", "completed"],
+    ["response.done", undefined],
+    ["response.incomplete", "incomplete"],
+    ["response.completed", "incomplete"],
+    ["response.completed", undefined],
+  ])(
+    "openai-codex worker accepts %s with status %s and CRLF framing",
+    async (terminalEvent, terminalStatus) => {
       const event = (type: string, data: Record<string, unknown>) =>
         `event: ${type}\r\ndata: ${JSON.stringify(data)}\r\n\r\n`;
       mockFetch.mockResolvedValue(
@@ -923,13 +1993,16 @@ describe("createGatewayLLMClient.prompt", () => {
               output_index: 0,
               delta: "codex CRLF reply",
             }) +
-            event(terminalEvent, {
-              response: {
-                status:
-                  terminalEvent === "response.incomplete"
-                    ? "incomplete"
-                    : "completed",
+            event("response.output_item.done", {
+              output_index: 0,
+              item: {
+                type: "message",
+                id: "msg_worker",
+                role: "assistant",
               },
+            }) +
+            event(terminalEvent, {
+              response: { status: terminalStatus },
             }),
           { headers: { "content-type": "text/event-stream" } },
         ),
@@ -1079,11 +2152,136 @@ describe("createGatewayLLMClient.prompt", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [url, init] = mockFetch.mock.calls[0];
       expect(url).toContain(":rawPredict");
-      expect((init!.headers as Record<string, string>).Authorization).toBe(
-        "Bearer test-vertex-token",
-      );
+      const headers = init?.headers as Record<string, string> | undefined;
+      expect(headers?.Authorization).toBe("Bearer test-vertex-token");
     } finally {
       _setTestVertexTokenProvider(null);
+    }
+  });
+
+  test("caller abort covers stalled initial Vertex token minting", async () => {
+    _setTestVertexTokenProvider(() => new Promise(() => {}));
+    const controller = new AbortController();
+    try {
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => null,
+        { providerID: "vertex", modelID: "claude-opus-4-8" },
+        { vertexProject: "test-vertex-project" },
+      );
+      const pending = client.prompt("system", "user", {
+        protocol: "vertex",
+        upstreamProviderID: "vertex",
+        upstreamUrl: "https://aiplatform.googleapis.com",
+        signal: controller.signal,
+      });
+      controller.abort(new DOMException("cancelled", "AbortError"));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      _setTestVertexTokenProvider(null);
+    }
+  });
+
+  test("overall deadline covers stalled initial Vertex token minting", async () => {
+    vi.useFakeTimers();
+    _setTestVertexTokenProvider(() => new Promise(() => {}));
+    try {
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => null,
+        { providerID: "vertex", modelID: "claude-opus-4-8" },
+        { vertexProject: "test-vertex-project" },
+      );
+      const pending = client.prompt("system", "user", {
+        protocol: "vertex",
+        upstreamProviderID: "vertex",
+        upstreamUrl: "https://aiplatform.googleapis.com",
+      });
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      await vi.advanceTimersByTimeAsync(300_000);
+      await rejected;
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      _setTestVertexTokenProvider(null);
+      vi.useRealTimers();
+    }
+  });
+
+  test("caller abort covers a stalled Vertex retry rebuild", async () => {
+    let tokenCalls = 0;
+    _setTestVertexTokenProvider(() => {
+      tokenCalls++;
+      return tokenCalls === 1
+        ? Promise.resolve("first-token")
+        : new Promise(() => {});
+    });
+    mockFetch.mockResolvedValue(
+      new Response('{"error":{"message":"temperature is unsupported"}}', {
+        status: 400,
+      }),
+    );
+    const controller = new AbortController();
+    try {
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => null,
+        { providerID: "vertex", modelID: "claude-opus-4-8" },
+        { vertexProject: "test-vertex-project" },
+      );
+      const pending = client.prompt("system", "user", {
+        protocol: "vertex",
+        upstreamProviderID: "vertex",
+        upstreamUrl: "https://aiplatform.googleapis.com",
+        temperature: 0.5,
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(tokenCalls).toBe(2));
+      controller.abort(new DOMException("cancelled", "AbortError"));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    } finally {
+      _setTestVertexTokenProvider(null);
+    }
+  });
+
+  test("overall deadline surfaces during a stalled Vertex retry rebuild", async () => {
+    vi.useFakeTimers();
+    let tokenCalls = 0;
+    _setTestVertexTokenProvider(() => {
+      tokenCalls++;
+      return tokenCalls === 1
+        ? Promise.resolve("first-token")
+        : new Promise(() => {});
+    });
+    mockFetch.mockResolvedValue(
+      new Response('{"error":{"message":"temperature is unsupported"}}', {
+        status: 400,
+      }),
+    );
+    try {
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => null,
+        { providerID: "vertex", modelID: "claude-opus-4-8" },
+        { vertexProject: "test-vertex-project" },
+      );
+      const pending = client.prompt("system", "user", {
+        protocol: "vertex",
+        upstreamProviderID: "vertex",
+        upstreamUrl: "https://aiplatform.googleapis.com",
+        temperature: 0.5,
+      });
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      await vi.advanceTimersByTimeAsync(300_000);
+      await rejected;
+      expect(tokenCalls).toBe(2);
+    } finally {
+      _setTestVertexTokenProvider(null);
+      vi.useRealTimers();
     }
   });
 
@@ -1118,6 +2316,22 @@ describe("createGatewayLLMClient.prompt", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  test("rejects an Anthropic API key on the OpenAI Responses protocol", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-secret" }),
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+    await expect(
+      client.prompt("system", "user", {
+        workerID: "lore-distill",
+        upstreamProviderID: "openai",
+        protocol: "openai-responses",
+      }),
+    ).resolves.toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   test("returns null on a 401 auth error (no credential change)", async () => {
     mockFetch.mockResolvedValue(
       new Response(JSON.stringify({ error: { message: "unauthorized" } }), {
@@ -1137,6 +2351,416 @@ describe("createGatewayLLMClient.prompt", () => {
 
     expect(text).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("worker provider body validation", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const upstreams = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    _resetWorkerHealthForTest();
+    vi.mocked(recordWorkerFailure).mockClear();
+    vi.mocked(recordEmptyWorkerResponse).mockClear();
+    vi.mocked(markWorkerIncapable).mockClear();
+  });
+
+  afterEach(() => {
+    mockFetch.mockReset();
+    clearAllCosts();
+    _resetWorkerHealthForTest();
+  });
+
+  const cases: Array<{
+    name: string;
+    providerID: string;
+    modelID: string;
+    protocol: "anthropic" | "openai" | "openai-responses" | "gemini";
+    upstreamUrl: string;
+    contentType?: string;
+    body: string;
+  }> = [
+    {
+      name: "Anthropic SSE negative usage",
+      providerID: "anthropic",
+      modelID: "claude-test",
+      protocol: "anthropic" as const,
+      upstreamUrl: "https://api.anthropic.com",
+      contentType: "text/event-stream",
+      body:
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":-1,"output_tokens":0}}}\n\n' +
+        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":0}}\n\n' +
+        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    },
+    {
+      name: "Anthropic negative usage",
+      providerID: "anthropic",
+      modelID: "claude-test",
+      protocol: "anthropic" as const,
+      upstreamUrl: "https://api.anthropic.com",
+      body: JSON.stringify({
+        content: [{ type: "text", text: "must not escape" }],
+        model: "claude-test",
+        stop_reason: "end_turn",
+        usage: { input_tokens: -1, output_tokens: 1 },
+      }),
+    },
+    {
+      name: "Anthropic Infinity-equivalent usage",
+      providerID: "anthropic",
+      modelID: "claude-test",
+      protocol: "anthropic" as const,
+      upstreamUrl: "https://api.anthropic.com",
+      body: '{"content":[{"type":"text","text":"must not escape"}],"stop_reason":"end_turn","usage":{"input_tokens":1e309,"output_tokens":1}}',
+    },
+    {
+      name: "Anthropic malformed later block",
+      providerID: "anthropic",
+      modelID: "claude-test",
+      protocol: "anthropic" as const,
+      upstreamUrl: "https://api.anthropic.com",
+      body: JSON.stringify({
+        content: [{ type: "text", text: "must not escape" }, null],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    },
+    {
+      name: "OpenAI SSE cache sum overflow without prompt_tokens",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai" as const,
+      upstreamUrl: "https://api.openai.com",
+      contentType: "text/event-stream",
+      body: `data: ${JSON.stringify({
+        choices: [
+          {
+            delta: { content: "must not escape" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          completion_tokens: 1,
+          prompt_tokens_details: {
+            cached_tokens: Number.MAX_SAFE_INTEGER,
+            cache_write_tokens: 1,
+          },
+        },
+      })}\n\n`,
+    },
+    {
+      name: "OpenAI cache sum overflow without prompt_tokens",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai" as const,
+      upstreamUrl: "https://api.openai.com",
+      body: JSON.stringify({
+        choices: [
+          { message: { content: "must not escape" }, finish_reason: "stop" },
+        ],
+        usage: {
+          completion_tokens: 1,
+          prompt_tokens_details: {
+            cached_tokens: Number.MAX_SAFE_INTEGER,
+            cache_write_tokens: 1,
+          },
+        },
+      }),
+    },
+    {
+      name: "OpenAI unsafe usage",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai" as const,
+      upstreamUrl: "https://api.openai.com",
+      body: JSON.stringify({
+        choices: [{ message: { content: "must not escape" } }],
+        usage: { prompt_tokens: Number.MAX_SAFE_INTEGER + 1 },
+      }),
+    },
+    {
+      name: "OpenAI malformed later choice",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai" as const,
+      upstreamUrl: "https://api.openai.com",
+      body: JSON.stringify({
+        choices: [{ message: { content: "must not escape" } }, null],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    },
+    {
+      name: "Responses SSE unsafe usage sum",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai-responses" as const,
+      upstreamUrl: "https://api.openai.com",
+      contentType: "text/event-stream",
+      body:
+        `event: response.output_item.added\ndata: ${JSON.stringify({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { type: "message", id: "msg_usage", role: "assistant" },
+        })}\n\n` +
+        `event: response.output_text.delta\ndata: ${JSON.stringify({
+          type: "response.output_text.delta",
+          output_index: 0,
+          delta: "must not escape",
+        })}\n\n` +
+        `event: response.output_item.done\ndata: ${JSON.stringify({
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { type: "message", id: "msg_usage", role: "assistant" },
+        })}\n\n` +
+        `event: response.completed\ndata: ${JSON.stringify({
+          type: "response.completed",
+          response: {
+            status: "completed",
+            usage: { input_tokens: Number.MAX_SAFE_INTEGER, output_tokens: 1 },
+          },
+        })}\n\n`,
+    },
+    {
+      name: "Responses unsafe usage",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai-responses" as const,
+      upstreamUrl: "https://api.openai.com",
+      body: JSON.stringify({
+        status: "completed",
+        output_text: "must not escape",
+        usage: { input_tokens: Number.MAX_SAFE_INTEGER, output_tokens: 1 },
+      }),
+    },
+    {
+      name: "Responses malformed details",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai-responses" as const,
+      upstreamUrl: "https://api.openai.com",
+      body: JSON.stringify({
+        status: "completed",
+        output_text: "must not escape",
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          input_tokens_details: [],
+        },
+      }),
+    },
+    {
+      name: "Responses malformed later output item",
+      providerID: "openai",
+      modelID: "gpt-test",
+      protocol: "openai-responses" as const,
+      upstreamUrl: "https://api.openai.com",
+      body: JSON.stringify({
+        status: "completed",
+        output_text: "must not escape",
+        output: [
+          { type: "message", content: [{ type: "output_text", text: "ok" }] },
+          null,
+        ],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+    },
+    {
+      name: "Gemini SSE candidates plus thoughts overflow",
+      providerID: "google",
+      modelID: "gemini-test",
+      protocol: "gemini" as const,
+      upstreamUrl: "https://generativelanguage.googleapis.com",
+      contentType: "text/event-stream",
+      body: `data: ${JSON.stringify({
+        candidates: [
+          {
+            content: { parts: [{ text: "must not escape" }] },
+            finishReason: "STOP",
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: Number.MAX_SAFE_INTEGER,
+          thoughtsTokenCount: 1,
+        },
+      })}\n\n`,
+    },
+    {
+      name: "Gemini candidates plus thoughts overflow",
+      providerID: "google",
+      modelID: "gemini-test",
+      protocol: "gemini" as const,
+      upstreamUrl: "https://generativelanguage.googleapis.com",
+      body: JSON.stringify({
+        candidates: [{ content: { parts: [{ text: "must not escape" }] } }],
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: Number.MAX_SAFE_INTEGER,
+          thoughtsTokenCount: 1,
+        },
+      }),
+    },
+    {
+      name: "Gemini malformed usage container",
+      providerID: "google",
+      modelID: "gemini-test",
+      protocol: "gemini" as const,
+      upstreamUrl: "https://generativelanguage.googleapis.com",
+      body: JSON.stringify({
+        candidates: [{ content: { parts: [{ text: "must not escape" }] } }],
+        usageMetadata: [],
+      }),
+    },
+    {
+      name: "Gemini malformed candidates container",
+      providerID: "google",
+      modelID: "gemini-test",
+      protocol: "gemini" as const,
+      upstreamUrl: "https://generativelanguage.googleapis.com",
+      body: JSON.stringify({
+        candidates: { content: { parts: [{ text: "must not escape" }] } },
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+      }),
+    },
+    {
+      name: "Gemini malformed later candidate",
+      providerID: "google",
+      modelID: "gemini-test",
+      protocol: "gemini" as const,
+      upstreamUrl: "https://generativelanguage.googleapis.com",
+      body: JSON.stringify({
+        candidates: [
+          { content: { parts: [{ text: "must not escape" }] } },
+          null,
+        ],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1 },
+      }),
+    },
+  ];
+
+  test.each(cases)(
+    "$name is upstream-error with no cost or incapability mutation",
+    async ({
+      name,
+      providerID,
+      modelID,
+      protocol,
+      upstreamUrl,
+      contentType,
+      body,
+    }) => {
+      const sessionID = `sess-malformed-${name.replaceAll(/\W+/g, "-")}`;
+      mockFetch.mockResolvedValue(
+        new Response(body, {
+          headers: { "content-type": contentType ?? "application/json" },
+        }),
+      );
+      const client = createGatewayLLMClient(
+        upstreams,
+        () => ({
+          scheme: "api-key",
+          value: providerID === "anthropic" ? "sk-ant-test" : "test-key",
+        }),
+        { providerID, modelID },
+      );
+
+      const result = await client.prompt("system", "user", {
+        sessionID,
+        workerID: "lore-distill",
+        upstreamProviderID: providerID,
+        upstreamUrl,
+        protocol,
+      });
+
+      expect(result).toBeNull();
+      expect(recordWorkerFailure).toHaveBeenCalledWith(
+        sessionID,
+        "lore-distill",
+        "upstream-error",
+      );
+      expect(recordEmptyWorkerResponse).not.toHaveBeenCalled();
+      expect(markWorkerIncapable).not.toHaveBeenCalled();
+      expect(isWorkerIncapable(providerID, modelID, "lore-distill")).toBe(
+        false,
+      );
+      expect(getSessionCosts(sessionID)).toBeNull();
+      expect(getWorkerHealth()).toContainEqual(
+        expect.objectContaining({
+          sessionID,
+          failureCount: 1,
+          reasons: ["upstream-error"],
+        }),
+      );
+    },
+  );
+
+  test("three valid empty Anthropic refusals never mark the real worker path incapable", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+    const wire =
+      event("message_start", {
+        message: {
+          id: "msg_refusal",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-test",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 0 },
+        },
+      }) +
+      event("message_delta", {
+        delta: { stop_reason: "refusal", stop_sequence: null },
+        usage: { output_tokens: 0 },
+      }) +
+      event("message_stop", {});
+    mockFetch.mockImplementation(
+      async () =>
+        new Response(wire, {
+          headers: { "content-type": "text/event-stream" },
+        }),
+    );
+    const client = createGatewayLLMClient(
+      upstreams,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+    const opts = {
+      sessionID: "sess-three-refusals",
+      workerID: "lore-distill" as const,
+      protocol: "anthropic" as const,
+      upstreamProviderID: "anthropic",
+      upstreamUrl: "https://api.anthropic.com",
+    };
+
+    for (let i = 0; i < 3; i++) {
+      await expect(client.prompt("system", "user", opts)).resolves.toBeNull();
+    }
+
+    expect(recordEmptyWorkerResponse).toHaveBeenCalledTimes(3);
+    expect(recordEmptyWorkerResponse).toHaveBeenCalledWith(
+      "anthropic",
+      "claude-test",
+      "content_filter",
+      "lore-distill",
+    );
+    expect(markWorkerIncapable).not.toHaveBeenCalled();
+    expect(isWorkerIncapable("anthropic", "claude-test", "lore-distill")).toBe(
+      false,
+    );
+    expect(getWorkerHealth()).toContainEqual(
+      expect.objectContaining({
+        sessionID: "sess-three-refusals",
+        failureCount: 3,
+        reasons: ["no-response"],
+      }),
+    );
   });
 });
 
@@ -1636,6 +3260,33 @@ describe("cross-provider collusion guard", () => {
       "sess-xprov-2",
       "lore-distill",
       expect.stringMatching(/cross-provider|no-auth/),
+    );
+  });
+
+  test("never sends a route-less provider credential to an unproven override", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "route-less-provider"
+          ? { scheme: "api-key", value: "EXFILTRATED_PROVIDER_SECRET" }
+          : null,
+      { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+    );
+
+    const result = await client.prompt("system", "user", {
+      sessionID: "sess-unproven-route-less",
+      workerID: "lore-distill",
+      model: { providerID: "route-less-provider", modelID: "custom-model" },
+      upstreamUrl: "https://attacker.invalid/provider",
+      protocol: "anthropic",
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      "sess-unproven-route-less",
+      "lore-distill",
+      "cross-provider",
     );
   });
 
@@ -3160,6 +4811,7 @@ describe("worker empty-response retry on budget truncation (finish_reason: lengt
       "",
       "data: [DONE]",
       "",
+      "",
     ].join("\n");
     return new Response(body, {
       status: 200,
@@ -3773,6 +5425,62 @@ describe("worker 400 model-not-supported: fall back to a same-provider backup", 
     expect(mockMarkPaused).not.toHaveBeenCalled();
   });
 
+  test("gpt-5.6 Responses fallback rebuilds the route for Chat Completions", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(UNSUPPORTED_400, {
+          status: 400,
+          statusText: "Bad Request",
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(OK_200, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.githubcopilot.com",
+        openai: "https://api.githubcopilot.com",
+      },
+      () => ({ scheme: "bearer", value: "gho_test" }),
+      { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+    );
+
+    const text = await client.prompt("system", "user", {
+      workerID: "lore-import",
+      sessionID: "sess-route-fallback",
+      protocol: "openai",
+      upstreamProviderID: "github-copilot",
+      upstreamUrl: "https://api.githubcopilot.com",
+      maxTokens: 256,
+      reasoningEffort: "high",
+    });
+
+    expect(text).toBe("worked on the backup");
+    expect(fetchArgUrl(mockFetch.mock.calls[0]?.[0])).toContain("/responses");
+    expect(fetchArgUrl(mockFetch.mock.calls[1]?.[0])).toContain(
+      "/chat/completions",
+    );
+    const firstBody = JSON.parse(
+      mockFetch.mock.calls[0]?.[1]?.body as string,
+    ) as Record<string, unknown>;
+    const secondBody = JSON.parse(
+      mockFetch.mock.calls[1]?.[1]?.body as string,
+    ) as Record<string, unknown>;
+    expect(firstBody.model).toBe("gpt-5.6-luna");
+    expect(firstBody.input).toBeDefined();
+    expect(firstBody.messages).toBeUndefined();
+    expect(firstBody.max_output_tokens).toEqual(expect.any(Number));
+    expect(firstBody.max_output_tokens as number).toBeGreaterThan(256);
+    expect(secondBody.model).toBe("gpt-5-mini");
+    expect(secondBody.messages).toBeDefined();
+    expect(secondBody.input).toBeUndefined();
+    expect(secondBody.max_completion_tokens).toEqual(expect.any(Number));
+    expect(secondBody.max_completion_tokens as number).toBeGreaterThan(256);
+  });
+
   test("a provider with NO backup list surfaces the 400 (no swap, one call)", async () => {
     mockFetch.mockResolvedValue(
       new Response(
@@ -3917,4 +5625,601 @@ describe("worker 400 model-not-supported: fall back to a same-provider backup", 
       else process.env.LORE_MAX_RETRIES = prev;
     }
   });
+});
+
+describe("worker transport lifecycle remediation", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const originalRetries = process.env.LORE_MAX_RETRIES;
+  const UPSTREAMS = {
+    anthropic: "https://api.anthropic.com",
+    openai: "https://api.openai.com",
+  };
+  const success = () =>
+    new Response(
+      JSON.stringify({
+        content: [{ type: "text", text: "recovered" }],
+        model: "claude-test",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+  const client = () =>
+    createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+  beforeEach(() => {
+    process.env.LORE_MAX_RETRIES = "1";
+    mockFetch.mockReset();
+    vi.mocked(recordWorkerFailure).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    mockFetch.mockReset();
+    if (originalRetries === undefined) delete process.env.LORE_MAX_RETRIES;
+    else process.env.LORE_MAX_RETRIES = originalRetries;
+  });
+
+  test("retries a post-header reader failure and succeeds without intermediate health failure", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull() {
+              return Promise.reject(new Error("provider reset secret"));
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(success());
+
+    const pending = client().prompt("system", "user", {
+      sessionID: "sess-reader-retry",
+      workerID: "lore-distill",
+    });
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(pending).resolves.toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(recordWorkerFailure).not.toHaveBeenCalled();
+  });
+
+  test("does not retry a non-SSE JSON reset after partial body bytes", async () => {
+    let delivered = false;
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (!delivered) {
+              delivered = true;
+              controller.enqueue(
+                new TextEncoder().encode(
+                  '{"content":[{"type":"text","text":"partial',
+                ),
+              );
+              return;
+            }
+            return Promise.reject(new Error("JSON body reset secret"));
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await expect(
+      client().prompt("system", "user", {
+        sessionID: "sess-json-partial-reset",
+        workerID: "lore-distill",
+      }),
+    ).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(recordWorkerFailure).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries body inactivity, never awaits cancel, and succeeds on the second response", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    let cancelled = false;
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull() {
+              return new Promise(() => {});
+            },
+            cancel() {
+              cancelled = true;
+              return new Promise(() => {});
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      )
+      .mockResolvedValueOnce(success());
+
+    const pending = client().prompt("system", "user", {
+      sessionID: "sess-inactivity-retry",
+      workerID: "lore-distill",
+    });
+    await vi.advanceTimersByTimeAsync(120_500);
+
+    await expect(pending).resolves.toBe("recovered");
+    expect(cancelled).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(recordWorkerFailure).not.toHaveBeenCalled();
+  });
+
+  test("retries a reset after bookkeeping metadata but before semantic content", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const metadata =
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n';
+    let delivered = false;
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (!delivered) {
+                delivered = true;
+                controller.enqueue(new TextEncoder().encode(metadata));
+                return;
+              }
+              return Promise.reject(new Error("reset after metadata"));
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      )
+      .mockResolvedValueOnce(success());
+
+    const pending = client().prompt("system", "user", {
+      sessionID: "sess-metadata-reset",
+      workerID: "lore-distill",
+    });
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(pending).resolves.toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry a reset after partial semantic content", async () => {
+    const partial =
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n';
+    let delivered = false;
+    mockFetch.mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (!delivered) {
+              delivered = true;
+              controller.enqueue(new TextEncoder().encode(partial));
+              return;
+            }
+            return Promise.reject(new Error("reset after partial text"));
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+
+    await expect(
+      client().prompt("system", "user", {
+        sessionID: "sess-semantic-reset",
+        workerID: "lore-distill",
+      }),
+    ).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(recordWorkerFailure).toHaveBeenCalledTimes(1);
+  });
+
+  const streamModes = [
+    {
+      name: "Anthropic",
+      providerID: "anthropic",
+      protocol: "anthropic",
+      upstreamUrl: "https://api.anthropic.com",
+      metadata:
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+      semantic:
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n',
+      success: {
+        content: [{ type: "text", text: "recovered" }],
+        model: "claude-test",
+      },
+    },
+    {
+      name: "OpenAI Chat",
+      providerID: "openai",
+      protocol: "openai",
+      upstreamUrl: "https://api.openai.com",
+      metadata: 'data: {"choices":[{"delta":{"role":"assistant"}}]}\n\n',
+      semantic:
+        'data: {"choices":[{"delta":{"role":"assistant","content":"partial"}}]}\n\n',
+      success: {
+        choices: [{ message: { content: "recovered" }, finish_reason: "stop" }],
+      },
+    },
+    {
+      name: "public Responses",
+      providerID: "openai",
+      protocol: "openai-responses",
+      upstreamUrl: "https://api.openai.com",
+      metadata:
+        'event: response.created\ndata: {"type":"response.created","response":{"id":"r","model":"gpt-test","status":"in_progress"}}\n\n',
+      semantic:
+        'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg"}}\n\n' +
+        'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"partial"}\n\n',
+      success: {
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg-recovered-public",
+            content: [{ type: "output_text", text: "recovered" }],
+          },
+        ],
+      },
+    },
+    {
+      name: "Codex Responses",
+      providerID: "openai-codex",
+      protocol: "openai-responses",
+      upstreamUrl: "https://chatgpt.com/backend-api",
+      metadata:
+        'event: response.created\ndata: {"type":"response.created","response":{"id":"r","model":"gpt-test","status":"in_progress"}}\n\n',
+      semantic:
+        'event: response.output_item.added\ndata: {"type":"response.output_item.added","item":{"type":"message","id":"msg"}}\n\n' +
+        'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","item_id":"msg","delta":"partial"}\n\n',
+      success: {
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: "msg-recovered-codex",
+            content: [{ type: "output_text", text: "recovered" }],
+          },
+        ],
+      },
+    },
+    {
+      name: "Gemini",
+      providerID: "google",
+      protocol: "gemini",
+      upstreamUrl: "https://generativelanguage.googleapis.com",
+      metadata: 'data: {"responseId":"r","modelVersion":"gemini-test"}\n\n',
+      semantic:
+        'data: {"candidates":[{"content":{"role":"model","parts":[{"text":"partial"}]}}]}\n\n',
+      success: {
+        candidates: [
+          {
+            content: { role: "model", parts: [{ text: "recovered" }] },
+            finishReason: "STOP",
+          },
+        ],
+      },
+    },
+  ] as const;
+
+  const resettingStream = (wire: string): Response => {
+    let delivered = false;
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (!delivered) {
+            delivered = true;
+            controller.enqueue(new TextEncoder().encode(wire));
+            return;
+          }
+          return Promise.reject(new Error("provider reset"));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+  };
+
+  test.each(streamModes)("$name retries metadata-only resets", async (mode) => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mockFetch
+      .mockResolvedValueOnce(resettingStream(mode.metadata))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mode.success), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const modeClient = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({
+        scheme: "api-key",
+        value: mode.providerID === "anthropic" ? "sk-ant-test" : "sk-test",
+      }),
+      { providerID: mode.providerID, modelID: `${mode.providerID}-test` },
+    );
+    const pending = modeClient.prompt("system", "user", {
+      protocol: mode.protocol,
+      upstreamProviderID: mode.providerID,
+      upstreamUrl: mode.upstreamUrl,
+      sessionID: `metadata-${mode.providerID}`,
+      workerID: "lore-distill",
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(pending).resolves.toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test.each(streamModes)(
+    "$name does not retry after semantic stream content",
+    async (mode) => {
+      mockFetch.mockResolvedValue(resettingStream(mode.semantic));
+      const modeClient = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({
+          scheme: "api-key",
+          value: mode.providerID === "anthropic" ? "sk-ant-test" : "sk-test",
+        }),
+        { providerID: mode.providerID, modelID: `${mode.providerID}-test` },
+      );
+      await expect(
+        modeClient.prompt("system", "user", {
+          protocol: mode.protocol,
+          upstreamProviderID: mode.providerID,
+          upstreamUrl: mode.upstreamUrl,
+          sessionID: `semantic-${mode.providerID}`,
+          workerID: "lore-distill",
+        }),
+      ).resolves.toBeNull();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(["id: stream-1\n\n", "retry: 1000\n\n"])(
+    "sniffs SSE with a leading %s field on a mislabeled response",
+    async (prefix) => {
+      const wire =
+        prefix +
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"sniffed"}}\n\n' +
+        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n' +
+        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n' +
+        'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+      mockFetch.mockResolvedValue(new Response(wire));
+      await expect(
+        client().prompt("system", "user", {
+          sessionID: "sess-sse-field-prefix",
+          workerID: "lore-distill",
+        }),
+      ).resolves.toBe("sniffed");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("cancels a transient HTTP body before retry without awaiting cancel", async () => {
+    vi.useFakeTimers();
+    let cancelled = false;
+    let call = 0;
+    mockFetch.mockImplementation(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              cancelled = true;
+              return new Promise(() => {});
+            },
+          }),
+          { status: 500, headers: { "retry-after": "0" } },
+        );
+      }
+      expect(cancelled).toBe(true);
+      return success();
+    });
+
+    const pending = client().prompt("system", "user", {
+      sessionID: "sess-transient-cancel",
+      workerID: "lore-distill",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(pending).resolves.toBe("recovered");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("one 300-second deadline covers fetch, retry delay, and every attempt", async () => {
+    vi.useFakeTimers();
+    let cancelled = false;
+    mockFetch.mockImplementation(
+      async () =>
+        new Promise<Response>((resolve) => {
+          setTimeout(
+            () =>
+              resolve(
+                new Response(
+                  new ReadableStream<Uint8Array>({
+                    cancel() {
+                      cancelled = true;
+                    },
+                  }),
+                  { status: 500, headers: { "retry-after": "32" } },
+                ),
+              ),
+            299_000,
+          );
+        }),
+    );
+
+    const pending = client().prompt("system", "user", {
+      sessionID: "sess-overall-deadline",
+      workerID: "lore-distill",
+    });
+    const rejected = expect(pending).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    await vi.advanceTimersByTimeAsync(299_000);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(cancelled).toBe(true);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await rejected;
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("the deadline settles a fetch implementation that ignores AbortSignal", async () => {
+    vi.useFakeTimers();
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    const pending = client().prompt("system", "user", {
+      sessionID: "sess-hostile-deadline",
+      workerID: "lore-distill",
+    });
+    const rejected = expect(pending).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    await vi.advanceTimersByTimeAsync(300_000);
+    await rejected;
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects an oversized serialized worker request before fetch", async () => {
+    // Raw source stays within the derived worst-case preflight cap, but JSON
+    // expands every NUL to `\u0000`, crossing the 4 MiB serialized wire cap.
+    const worstCaseSourceBytes = Math.floor((4 * 1024 * 1024) / 6);
+    const result = await client().prompt(
+      "",
+      "\u0000".repeat(worstCaseSourceBytes),
+      {
+        sessionID: "sess-request-cap",
+        workerID: "lore-distill",
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(getLastWorkerError()).toBe(
+      "worker request exceeded 4194304 byte limit",
+    );
+  });
+
+  test("rejects source prompts above the derived JSON expansion cap before serialization", async () => {
+    const sourceLimit = Math.floor((4 * 1024 * 1024) / 6);
+    const result = await client().prompt("", "x".repeat(sourceLimit + 1), {
+      sessionID: "sess-prompt-source-cap",
+      workerID: "lore-distill",
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(getLastWorkerError()).toBe(
+      `worker prompt exceeded ${sourceLimit} byte limit`,
+    );
+  });
+});
+
+describe("worker diagnostic redaction", () => {
+  const mockFetch = vi.mocked(upstreamFetch);
+  const originalRetries = process.env.LORE_MAX_RETRIES;
+  const capturedLogs: string[] = [];
+  const silentSink = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    captureException: () => {},
+  };
+
+  beforeEach(() => {
+    process.env.LORE_MAX_RETRIES = "1";
+    capturedLogs.length = 0;
+    mockFetch.mockReset();
+    vi.mocked(Sentry.captureException).mockClear();
+    log.registerSink({
+      info: (message) => capturedLogs.push(message),
+      warn: (message) => capturedLogs.push(message),
+      error: (message) => capturedLogs.push(message),
+      captureException: (error) =>
+        capturedLogs.push(
+          error instanceof Error ? error.message : String(error),
+        ),
+    });
+  });
+
+  afterEach(() => {
+    log.registerSink(silentSink);
+    mockFetch.mockReset();
+    if (originalRetries === undefined) delete process.env.LORE_MAX_RETRIES;
+    else process.env.LORE_MAX_RETRIES = originalRetries;
+  });
+
+  test.each([400, 401, 429, 500])(
+    "HTTP %i exposes neither provider body nor URL credentials/path/query in diagnostics",
+    async (status) => {
+      const bodySentinel = `BODY_SECRET_${status}\nFORGED_LOG_LINE_${status}`;
+      const urlSentinels = [
+        "URL_USER_SECRET",
+        "URL_PASSWORD_SECRET",
+        "private-worker-path",
+        "QUERY_SECRET",
+      ];
+      const upstreamUrl =
+        "https://URL_USER_SECRET:URL_PASSWORD_SECRET@example.com/" +
+        "private-worker-path?token=QUERY_SECRET";
+      mockFetch.mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify({ error: { code: status, message: bodySentinel } }),
+            { status, headers: { "retry-after": "0" } },
+          ),
+      );
+      const client = createGatewayLLMClient(
+        {
+          anthropic: "https://api.anthropic.com",
+          openai: "https://api.openai.com",
+        },
+        () => ({ scheme: "api-key", value: "sk-ant-test" }),
+        { providerID: "anthropic", modelID: "claude-test" },
+      );
+
+      await expect(
+        client.prompt("system", "user", {
+          sessionID: `sess-redaction-${status}`,
+          workerID: "lore-distill",
+          upstreamUrl,
+          upstreamProviderID: "anthropic",
+          protocol: "anthropic",
+        }),
+      ).resolves.toBeNull();
+
+      const logDump = capturedLogs.join("\n");
+      const sentryDump = vi
+        .mocked(Sentry.captureException)
+        .mock.calls.map(([error, context]) =>
+          [error instanceof Error ? error.message : String(error), context]
+            .map((value) =>
+              typeof value === "string" ? value : JSON.stringify(value),
+            )
+            .join(" "),
+        )
+        .join("\n");
+      const lastError = getLastWorkerError() ?? "";
+
+      for (const dump of [logDump, sentryDump, lastError]) {
+        expect(dump).not.toContain(bodySentinel);
+        expect(dump).not.toContain("FORGED_LOG_LINE");
+        for (const sentinel of urlSentinels) {
+          expect(dump).not.toContain(sentinel);
+        }
+      }
+      expect(logDump).toContain("https://example.com");
+    },
+  );
 });

--- a/packages/gateway/test/openai-cache-write-accounting.test.ts
+++ b/packages/gateway/test/openai-cache-write-accounting.test.ts
@@ -49,6 +49,128 @@ function responsesSSE(
 // ---------------------------------------------------------------------------
 
 describe("non-stream Chat Completions cache-write accounting", () => {
+  test("foreground parser rejects duplicate effective tool identities", () => {
+    expect(() =>
+      accumulateOpenAINonStreamJSON({
+        choices: [
+          {
+            message: {
+              tool_calls: [
+                { id: "shared", function: { name: "a", arguments: "{}" } },
+                { id: "shared", function: { name: "b", arguments: "{}" } },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toThrow("malformed OpenAI response tool identity");
+  });
+  test("foreground parser validates tool identities in choice 1", () => {
+    expect(() =>
+      accumulateOpenAINonStreamJSON({
+        choices: [
+          { message: { content: "supported" } },
+          {
+            message: {
+              tool_calls: [
+                { id: "", function: { name: "bad", arguments: "{}" } },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toThrow("malformed OpenAI response tool identity");
+  });
+  test("foreground parser validates all choices while projecting choice zero", () => {
+    const response = accumulateOpenAINonStreamJSON({
+      choices: [
+        {
+          index: 0,
+          message: {
+            content: "projected",
+            tool_calls: [
+              {
+                id: "choice-zero",
+                function: { name: "zero", arguments: "{}" },
+              },
+            ],
+          },
+        },
+        {
+          index: 1,
+          message: {
+            content: "ignored",
+            tool_calls: [
+              { id: "choice-one", function: { name: "one", arguments: "{}" } },
+            ],
+          },
+        },
+      ],
+    });
+    expect(response.content).toEqual([
+      { type: "text", text: "projected" },
+      { type: "tool_use", id: "choice-zero", name: "zero", input: {} },
+    ]);
+  });
+  test("foreground parser permits the same tool identity in independent choices", () => {
+    const response = accumulateOpenAINonStreamJSON({
+      choices: [
+        {
+          index: 0,
+          message: {
+            tool_calls: [
+              { id: "shared", function: { name: "zero", arguments: "{}" } },
+            ],
+          },
+        },
+        {
+          index: 1,
+          message: {
+            tool_calls: [
+              { id: "shared", function: { name: "one", arguments: "{}" } },
+            ],
+          },
+        },
+      ],
+    });
+    expect(response.content).toEqual([
+      { type: "tool_use", id: "shared", name: "zero", input: {} },
+    ]);
+  });
+  test("foreground parser rejects duplicate logical choice indices before tool validation", () => {
+    expect(() =>
+      accumulateOpenAINonStreamJSON({
+        choices: [
+          { index: 4, message: { content: "first" } },
+          { index: 4, message: { tool_calls: "malformed" } },
+        ],
+      }),
+    ).toThrow("malformed OpenAI response choice");
+  });
+  test("foreground parser fallback indices cannot collide with explicit indices", () => {
+    expect(() =>
+      accumulateOpenAINonStreamJSON({
+        choices: [
+          { index: 1, message: { content: "first" } },
+          { message: { content: "second" } },
+        ],
+      }),
+    ).toThrow("malformed OpenAI response choice");
+  });
+  test.each([
+    [{ index: -1, message: { content: "bad" } }],
+    [{ finish_reason: 7, message: { content: "bad" } }],
+    [{ message: { content: 42 } }],
+  ])(
+    "foreground parser rejects malformed non-projected choice %#",
+    (choice) => {
+      expect(() =>
+        accumulateOpenAINonStreamJSON({
+          choices: [{ message: { content: "projected" } }, choice],
+        }),
+      ).toThrow("malformed OpenAI response choice");
+    },
+  );
   test("maps prompt_tokens_details.cache_write_tokens to cacheCreationInputTokens", () => {
     const resp = accumulateOpenAINonStreamJSON({
       id: "c1",
@@ -89,6 +211,43 @@ describe("non-stream Chat Completions cache-write accounting", () => {
 // ---------------------------------------------------------------------------
 
 describe("non-stream Responses API cache-write accounting", () => {
+  test("foreground parser rejects missing and duplicate effective tool identities", () => {
+    expect(() =>
+      accumulateResponsesNonStreamJSON({
+        output: [
+          {
+            type: "function_call",
+            call_id: "",
+            id: "",
+            name: "missing",
+            arguments: "{}",
+          },
+        ],
+      }),
+    ).toThrow("malformed Responses response item identity");
+  });
+  test("foreground parser rejects duplicate item IDs with distinct call IDs", () => {
+    expect(() =>
+      accumulateResponsesNonStreamJSON({
+        output: [
+          {
+            type: "function_call",
+            id: "item-shared",
+            call_id: "call-a",
+            name: "a",
+            arguments: "{}",
+          },
+          {
+            type: "function_call",
+            id: "item-shared",
+            call_id: "call-b",
+            name: "b",
+            arguments: "{}",
+          },
+        ],
+      }),
+    ).toThrow("malformed Responses response item identity");
+  });
   test("reads cache_write_tokens from input_tokens_details", () => {
     const resp = accumulateResponsesNonStreamJSON({
       id: "resp_1",
@@ -97,6 +256,7 @@ describe("non-stream Responses API cache-write accounting", () => {
       output: [
         {
           type: "message",
+          id: "msg-cache-write",
           content: [{ type: "output_text", text: "hi" }],
         },
       ],

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -4042,6 +4042,84 @@ describe("streamResponsesRecallAware", () => {
     ).resolves.toBe("cancelled");
   });
 
+  test("foreground timeout settles a non-settling follow-up setup", async () => {
+    const followUpStarted = Promise.withResolvers<void>();
+    const foreground = new AbortController();
+    let callbackSignal: AbortSignal | undefined;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_timeout_followup", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_timeout_followup"),
+      ]),
+      {
+        signal: foreground.signal,
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async ({ signal }) => {
+          callbackSignal = signal;
+          followUpStarted.resolve();
+          return new Promise<never>(() => {});
+        },
+      },
+    );
+    const pending = drain(client);
+    await followUpStarted.promise;
+    foreground.abort(new DOMException("foreground timed out", "TimeoutError"));
+    await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(callbackSignal?.aborted).toBe(true);
+  });
+
+  test("foreground abort cancels and unlocks a hostile continuation reader", async () => {
+    const foreground = new AbortController();
+    const continuationStarted = Promise.withResolvers<void>();
+    let cancelled = false;
+    const continuation = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              created("resp_hostile_continuation", "gpt-5.6-terra"),
+            ),
+          );
+        },
+        pull() {
+          continuationStarted.resolve();
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_hostile_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "architecture" }),
+        completed("resp_hostile_principal"),
+      ]),
+      {
+        signal: foreground.signal,
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("architecture"),
+          resultText: "results",
+        }),
+        runFollowUp: async () => ({ reader: continuation.body!.getReader() }),
+      },
+    );
+    const pending = drain(client);
+    await continuationStarted.promise;
+    foreground.abort(new DOMException("caller aborted", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(cancelled).toBe(true);
+    expect(continuation.body?.locked).toBe(false);
+  });
+
   test("rejects a chained recall whose arguments never complete", async () => {
     const malformed = streamFrom([
       created("resp_malformed", "gpt-5.6-terra"),

--- a/packages/gateway/test/openai-responses-stream.test.ts
+++ b/packages/gateway/test/openai-responses-stream.test.ts
@@ -8,12 +8,14 @@
  *  - Stop reason mapping from status
  *  - Mixed text + function_call output
  */
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import {
   accumulateResponsesSSEStream,
   streamResponsesPassthrough,
+  translateAnthropicStreamToResponses,
 } from "../src/stream/openai-responses";
 import type { GatewayResponse } from "../src/translate/types";
+import { validateResponsesUsage } from "../src/usage-validation";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -563,6 +565,1731 @@ describe("accumulateResponsesSSEStream", () => {
     expect(result.stopReason).toBe("max_tokens");
     expect(result.usage?.outputTokens).toBe(100);
   });
+
+  test.each([
+    ["max_output_tokens", "max_tokens"],
+    ["content_filter", "content_filter"],
+  ])(
+    "strict empty incomplete response maps %s without requiring output items",
+    async (reason, stopReason) => {
+      const response = buildSSEResponse([
+        {
+          event: "response.incomplete",
+          data: {
+            type: "response.incomplete",
+            response: {
+              id: "resp_empty_incomplete",
+              status: "incomplete",
+              incomplete_details: { reason },
+            },
+          },
+        },
+      ]);
+
+      const result = await accumulateResponsesSSEStream(response, {
+        validation: "public",
+        stopAtTerminal: true,
+      });
+
+      expect(result.content).toEqual([]);
+      expect(result.stopReason).toBe(stopReason);
+    },
+  );
+
+  test.each([
+    ["negative tokens", { input_tokens: -1, output_tokens: 0 }],
+    [
+      "cache overflow without input_tokens",
+      {
+        output_tokens: 0,
+        input_tokens_details: {
+          cached_tokens: Number.MAX_SAFE_INTEGER,
+          cache_write_tokens: 1,
+        },
+      },
+    ],
+    [
+      "malformed detail container",
+      { input_tokens: 1, output_tokens: 0, input_tokens_details: [] },
+    ],
+    [
+      "output detail overflow",
+      {
+        input_tokens: 1,
+        output_tokens: Number.MAX_SAFE_INTEGER,
+        output_tokens_details: {
+          reasoning_tokens: Number.MAX_SAFE_INTEGER,
+          audio_tokens: 1,
+        },
+      },
+    ],
+  ])("strict validation rejects %s", async (_case, usage) => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.completed",
+            data: { response: { status: "completed", usage } },
+          },
+        ]),
+        { validation: "public", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses usage");
+  });
+
+  test("strict validation accepts nullable optional usage details", async () => {
+    const result = await accumulateResponsesSSEStream(
+      buildSSEResponse([
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              status: "completed",
+              output: [],
+              usage: {
+                input_tokens: 1,
+                output_tokens: 1,
+                input_tokens_details: null,
+                output_tokens_details: null,
+              },
+            },
+          },
+        },
+      ]),
+      { validation: "public", stopAtTerminal: true },
+    );
+    expect(result.usage).toMatchObject({ inputTokens: 1, outputTokens: 1 });
+  });
+
+  test("strict validation rejects contradictory Responses total_tokens", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.completed",
+            data: {
+              response: {
+                status: "completed",
+                usage: {
+                  input_tokens: 2,
+                  output_tokens: 3,
+                  total_tokens: 6,
+                },
+              },
+            },
+          },
+        ]),
+        { validation: "public", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses usage");
+  });
+
+  test("strict validation rejects totals with absent parent components", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.completed",
+            data: {
+              response: {
+                status: "completed",
+                usage: { input_tokens: 2, total_tokens: 2 },
+              },
+            },
+          },
+        ]),
+        { validation: "public", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses usage");
+  });
+
+  test.each([
+    [
+      "done-only item",
+      [
+        {
+          event: "response.output_item.done",
+          data: {
+            output_index: 0,
+            item: {
+              type: "message",
+              id: "msg_done_only",
+              content: [{ type: "output_text", text: "done" }],
+            },
+          },
+        },
+        {
+          event: "response.completed",
+          data: { response: { status: "completed" } },
+        },
+      ],
+      "malformed Responses stream event",
+    ],
+    [
+      "added item without done",
+      [
+        {
+          event: "response.output_item.added",
+          data: {
+            output_index: 0,
+            item: { type: "message", id: "msg_not_done" },
+          },
+        },
+        {
+          event: "response.completed",
+          data: { response: { status: "completed" } },
+        },
+      ],
+      "malformed Responses terminal event",
+    ],
+    [
+      "response.done without status",
+      [
+        {
+          event: "response.done",
+          data: { response: {} },
+        },
+      ],
+      "missing Responses compatibility terminal status",
+    ],
+    [
+      "response.completed without status",
+      [
+        {
+          event: "response.completed",
+          data: { response: {} },
+        },
+      ],
+      "missing Responses compatibility terminal status",
+    ],
+    [
+      "response.completed with empty status",
+      [
+        {
+          event: "response.completed",
+          data: { response: { status: "" } },
+        },
+      ],
+      "missing Responses compatibility terminal status",
+    ],
+    [
+      "response.incomplete without status",
+      [
+        {
+          event: "response.incomplete",
+          data: { response: {} },
+        },
+      ],
+      "missing Responses compatibility terminal status",
+    ],
+    [
+      "response.completed with incomplete status",
+      [
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              status: "incomplete",
+              incomplete_details: { reason: "max_output_tokens" },
+            },
+          },
+        },
+      ],
+      "Responses terminal event/status mismatch",
+    ],
+    [
+      "unknown incomplete reason",
+      [
+        {
+          event: "response.incomplete",
+          data: {
+            response: {
+              status: "incomplete",
+              incomplete_details: { reason: "provider_specific" },
+            },
+          },
+        },
+      ],
+      "malformed Responses terminal event",
+    ],
+  ] as const)(
+    "public validation still rejects %s",
+    async (_case, events, diagnostic) => {
+      await expect(
+        accumulateResponsesSSEStream(buildSSEResponse([...events]), {
+          validation: "public",
+          stopAtTerminal: true,
+        }),
+      ).rejects.toThrow(diagnostic);
+    },
+  );
+
+  test("public validation accepts null incomplete_details", async () => {
+    const result = await accumulateResponsesSSEStream(
+      buildSSEResponse([
+        {
+          event: "response.incomplete",
+          data: {
+            response: {
+              status: "incomplete",
+              incomplete_details: null,
+            },
+          },
+        },
+      ]),
+      { validation: "public", stopAtTerminal: true },
+    );
+
+    expect(result.stopReason).toBe("max_tokens");
+  });
+
+  test.each([
+    ["string details", "invalid"],
+    ["numeric details", 1],
+    ["array details", []],
+    ["boolean details", true],
+    ["non-string reason", { reason: 1 }],
+  ])("public validation rejects %s", async (_case, incompleteDetails) => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.incomplete",
+            data: {
+              response: {
+                status: "incomplete",
+                incomplete_details: incompleteDetails,
+              },
+            },
+          },
+        ]),
+        { validation: "public", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses terminal event");
+  });
+
+  test("public validation rejects duplicate item IDs across output indices", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: {
+              output_index: 0,
+              item: { type: "message", id: "msg_duplicate_global" },
+            },
+          },
+          {
+            event: "response.output_item.added",
+            data: {
+              output_index: 1,
+              item: { type: "message", id: "msg_duplicate_global" },
+            },
+          },
+        ]),
+        { validation: "public", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses stream event");
+  });
+
+  test("public validation rejects duplicate effective function call IDs", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: {
+              output_index: 0,
+              item: {
+                type: "function_call",
+                id: "fc_first",
+                call_id: "call_duplicate",
+                name: "first",
+                arguments: "",
+              },
+            },
+          },
+          {
+            event: "response.output_item.added",
+            data: {
+              output_index: 1,
+              item: {
+                type: "function_call",
+                id: "fc_second",
+                call_id: "call_duplicate",
+                name: "second",
+                arguments: "",
+              },
+            },
+          },
+        ]),
+        { validation: "public", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses stream event");
+  });
+
+  test("Codex rejects duplicate effective call IDs across distinct items", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: {
+              item: {
+                type: "function_call",
+                id: "fc_codex_first",
+                call_id: "",
+                name: "",
+                arguments: "",
+              },
+            },
+          },
+          {
+            event: "response.output_item.added",
+            data: {
+              item: {
+                type: "function_call",
+                id: "fc_codex_second",
+                call_id: "",
+                name: "",
+                arguments: "",
+              },
+            },
+          },
+          {
+            event: "response.output_item.done",
+            data: {
+              item: {
+                type: "function_call",
+                id: "fc_codex_first",
+                call_id: "call_codex_shared",
+                name: "first",
+                arguments: "{}",
+              },
+            },
+          },
+          {
+            event: "response.output_item.done",
+            data: {
+              item: {
+                type: "function_call",
+                id: "fc_codex_second",
+                call_id: "call_codex_shared",
+                name: "second",
+                arguments: "{}",
+              },
+            },
+          },
+        ]),
+        { validation: "codex", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses stream event");
+  });
+
+  test("Codex rejects fallback item-id/call-id collisions and missing effective IDs", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: {
+              item: {
+                type: "function_call",
+                id: "effective-shared",
+                call_id: "",
+                name: "fallback",
+                arguments: "",
+              },
+            },
+          },
+          {
+            event: "response.output_item.added",
+            data: {
+              item: {
+                type: "function_call",
+                id: "other-item",
+                call_id: "effective-shared",
+                name: "collision",
+                arguments: "",
+              },
+            },
+          },
+        ]),
+        { validation: "codex", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses stream event");
+
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: {
+              item: {
+                type: "function_call",
+                call_id: "",
+                name: "missing",
+                arguments: "",
+              },
+            },
+          },
+          {
+            event: "response.completed",
+            data: { response: { status: "completed" } },
+          },
+        ]),
+        { validation: "codex", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses stream event");
+  });
+
+  test("Codex permits repeated same-item call identity deltas", async () => {
+    const result = await accumulateResponsesSSEStream(
+      buildSSEResponse([
+        {
+          event: "response.output_item.added",
+          data: {
+            item: {
+              type: "function_call",
+              id: "fc-repeat",
+              call_id: "call-repeat",
+              name: "lookup",
+              arguments: "",
+            },
+          },
+        },
+        {
+          event: "response.function_call_arguments.delta",
+          data: { item_id: "fc-repeat", delta: '{"a":' },
+        },
+        {
+          event: "response.function_call_arguments.delta",
+          data: { item_id: "fc-repeat", delta: "1}" },
+        },
+        {
+          event: "response.function_call_arguments.done",
+          data: { item_id: "fc-repeat", arguments: '{"a":1}' },
+        },
+        {
+          event: "response.completed",
+          data: { response: { status: "completed" } },
+        },
+      ]),
+      { validation: "codex", stopAtTerminal: true },
+    );
+    expect(result.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call-repeat",
+        name: "lookup",
+        input: { a: 1 },
+      },
+    ]);
+  });
+
+  for (const validation of ["public", "codex"] as const) {
+    test.each([
+      ["delta after arguments.done", "response.function_call_arguments.delta"],
+      ["duplicate arguments.done", "response.function_call_arguments.done"],
+    ])(`${validation} rejects %s`, async (_case, lateEvent) => {
+      const itemId = `fc-args-terminal-${validation}`;
+      const item = {
+        type: "function_call",
+        id: itemId,
+        call_id: `call-args-terminal-${validation}`,
+        name: "lookup",
+        arguments: "",
+      };
+      await expect(
+        accumulateResponsesSSEStream(
+          buildSSEResponse([
+            {
+              event: "response.output_item.added",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item,
+              },
+            },
+            {
+              event: "response.function_call_arguments.done",
+              data: {
+                ...(validation === "public"
+                  ? { output_index: 0 }
+                  : { item_id: itemId }),
+                arguments: "{}",
+              },
+            },
+            {
+              event: lateEvent,
+              data: {
+                ...(validation === "public"
+                  ? { output_index: 0 }
+                  : { item_id: itemId }),
+                ...(lateEvent.endsWith(".delta")
+                  ? { delta: "late" }
+                  : { arguments: "{}" }),
+              },
+            },
+          ]),
+          { validation, stopAtTerminal: true },
+        ),
+      ).rejects.toThrow("malformed Responses stream event");
+    });
+
+    test.each([
+      ["text", "output_text", "response.output_text.delta"],
+      ["refusal", "refusal", "response.refusal.delta"],
+    ])(
+      `${validation} rejects %s deltas after content_part.done`,
+      async (_case, partType, lateEvent) => {
+        const itemId = `msg-part-terminal-${validation}-${partType}`;
+        const reference =
+          validation === "public"
+            ? { output_index: 0, item_id: itemId, content_index: 0 }
+            : { item_id: itemId, content_index: 0 };
+        const part =
+          partType === "output_text"
+            ? { type: partType, text: "done" }
+            : { type: partType, refusal: "done" };
+        const addedPart =
+          partType === "output_text"
+            ? { type: partType, text: "" }
+            : { type: partType, refusal: "" };
+        await expect(
+          accumulateResponsesSSEStream(
+            buildSSEResponse([
+              {
+                event: "response.output_item.added",
+                data: {
+                  ...(validation === "public" ? { output_index: 0 } : {}),
+                  item: { type: "message", id: itemId },
+                },
+              },
+              {
+                event: "response.content_part.added",
+                data: { ...reference, part: addedPart },
+              },
+              {
+                event: "response.content_part.done",
+                data: { ...reference, part },
+              },
+              {
+                event: lateEvent,
+                data: { ...reference, delta: "late" },
+              },
+            ]),
+            { validation, stopAtTerminal: true },
+          ),
+        ).rejects.toThrow("malformed Responses stream event");
+      },
+    );
+  }
+
+  test.each(["public", "codex"] as const)(
+    "%s rejects an EVIL final response.output snapshot",
+    async (validation) => {
+      const itemId = `msg-final-snapshot-${validation}`;
+      await expect(
+        accumulateResponsesSSEStream(
+          buildSSEResponse([
+            {
+              event: "response.output_item.added",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item: { type: "message", id: itemId },
+              },
+            },
+            {
+              event: "response.output_item.done",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item: {
+                  type: "message",
+                  id: itemId,
+                  content: [{ type: "output_text", text: "good" }],
+                },
+              },
+            },
+            {
+              event: "response.completed",
+              data: {
+                response: {
+                  status: "completed",
+                  output: [
+                    {
+                      type: "message",
+                      id: itemId,
+                      content: [{ type: "output_text", text: "EVIL" }],
+                    },
+                  ],
+                },
+              },
+            },
+          ]),
+          { validation, stopAtTerminal: true },
+        ),
+      ).rejects.toThrow("malformed Responses terminal event");
+    },
+  );
+
+  test.each(["public", "codex"] as const)(
+    "%s requires a present terminal output snapshot to be a one-to-one complete mapping",
+    async (validation) => {
+      const itemId = `snapshot-complete-${validation}`;
+      const prefix = [
+        {
+          event: "response.output_item.added",
+          data: {
+            ...(validation === "public" ? { output_index: 0 } : {}),
+            item: { type: "message", id: itemId },
+          },
+        },
+        {
+          event: "response.output_item.done",
+          data: {
+            ...(validation === "public" ? { output_index: 0 } : {}),
+            item: { type: "message", id: itemId, content: [] },
+          },
+        },
+      ];
+      for (const output of [
+        [],
+        [{ type: "message", id: "", content: [] }],
+        [{ type: "item_reference", id: "unknown-item" }],
+        [
+          { type: "item_reference", id: itemId },
+          { type: "item_reference", id: itemId },
+        ],
+      ]) {
+        await expect(
+          accumulateResponsesSSEStream(
+            buildSSEResponse([
+              ...prefix,
+              {
+                event: "response.completed",
+                data: { response: { status: "completed", output } },
+              },
+            ]),
+            { validation, stopAtTerminal: true },
+          ),
+        ).rejects.toThrow("malformed Responses terminal event");
+      }
+
+      const omitted = accumulateResponsesSSEStream(
+        buildSSEResponse([
+          ...prefix,
+          {
+            event: "response.completed",
+            data: { response: { status: "completed" } },
+          },
+        ]),
+        { validation, stopAtTerminal: true },
+      );
+      if (validation === "public") {
+        await expect(omitted).rejects.toThrow(
+          "malformed Responses terminal event",
+        );
+      } else {
+        await expect(omitted).resolves.toBeDefined();
+      }
+    },
+  );
+
+  for (const validation of ["public", "codex"] as const) {
+    test(`${validation} rejects wrapper snapshots contradicting terminal arguments`, async () => {
+      const itemId = `fc-snapshot-${validation}`;
+      const reference =
+        validation === "public" ? { output_index: 0 } : { item_id: itemId };
+      await expect(
+        accumulateResponsesSSEStream(
+          buildSSEResponse([
+            {
+              event: "response.output_item.added",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item: {
+                  type: "function_call",
+                  id: itemId,
+                  call_id: `call-${validation}`,
+                  name: "lookup",
+                  arguments: "",
+                },
+              },
+            },
+            {
+              event: "response.function_call_arguments.done",
+              data: { ...reference, arguments: '{"x":1}' },
+            },
+            {
+              event: "response.output_item.done",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item: {
+                  type: "function_call",
+                  id: itemId,
+                  call_id: `call-${validation}`,
+                  name: "lookup",
+                  arguments: '{"x":2}',
+                },
+              },
+            },
+          ]),
+          { validation, stopAtTerminal: true },
+        ),
+      ).rejects.toThrow("malformed Responses stream event");
+    });
+
+    test(`${validation} accepts matching terminal wrapper snapshots`, async () => {
+      const itemId = `msg-matching-${validation}`;
+      const reference =
+        validation === "public"
+          ? { output_index: 0, item_id: itemId, content_index: 0 }
+          : { item_id: itemId, content_index: 0 };
+      const result = await accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: {
+              ...(validation === "public" ? { output_index: 0 } : {}),
+              item: { type: "message", id: itemId },
+            },
+          },
+          {
+            event: "response.output_text.done",
+            data: { ...reference, text: "same" },
+          },
+          {
+            event: "response.content_part.added",
+            data: {
+              ...reference,
+              part: { type: "output_text", text: "" },
+            },
+          },
+          {
+            event: "response.content_part.done",
+            data: {
+              ...reference,
+              part: { type: "output_text", text: "same" },
+            },
+          },
+          {
+            event: "response.output_item.done",
+            data: {
+              ...(validation === "public" ? { output_index: 0 } : {}),
+              item: {
+                type: "message",
+                id: itemId,
+                content: [{ type: "output_text", text: "same" }],
+              },
+            },
+          },
+          {
+            event: "response.completed",
+            data: {
+              response: {
+                status: "completed",
+                output: [
+                  {
+                    type: "message",
+                    id: itemId,
+                    content: [{ type: "output_text", text: "same" }],
+                  },
+                ],
+              },
+            },
+          },
+        ]),
+        { validation, stopAtTerminal: true },
+      );
+      expect(result.content).toEqual([{ type: "text", text: "same" }]);
+    });
+
+    test(`${validation} rejects content and item snapshots contradicting output_text.done`, async () => {
+      const itemId = `msg-contradicting-${validation}`;
+      const reference =
+        validation === "public"
+          ? { output_index: 0, item_id: itemId, content_index: 0 }
+          : { item_id: itemId, content_index: 0 };
+      await expect(
+        accumulateResponsesSSEStream(
+          buildSSEResponse([
+            {
+              event: "response.output_item.added",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item: { type: "message", id: itemId },
+              },
+            },
+            {
+              event: "response.content_part.added",
+              data: {
+                ...reference,
+                part: { type: "output_text", text: "" },
+              },
+            },
+            {
+              event: "response.output_text.done",
+              data: { ...reference, text: "one" },
+            },
+            {
+              event: "response.content_part.done",
+              data: {
+                ...reference,
+                part: { type: "output_text", text: "two" },
+              },
+            },
+            {
+              event: "response.output_item.done",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item: {
+                  type: "message",
+                  id: itemId,
+                  content: [{ type: "output_text", text: "three" }],
+                },
+              },
+            },
+          ]),
+          { validation, stopAtTerminal: true },
+        ),
+      ).rejects.toThrow("malformed Responses stream event");
+    });
+  }
+
+  test.each(["public", "codex"] as const)(
+    "%s validation handles high-cardinality indexed identities",
+    async (validation) => {
+      const count = 2_000;
+      const events: Array<{
+        event: string;
+        data: Record<string, unknown>;
+      }> = Array.from({ length: count }, (_, outputIndex) => ({
+        event: "response.output_item.added",
+        data: {
+          ...(validation === "public" ? { output_index: outputIndex } : {}),
+          item: { type: "message", id: `msg_${validation}_${outputIndex}` },
+        },
+      }));
+      if (validation === "public") {
+        events.push(
+          ...Array.from({ length: count }, (_, outputIndex) => ({
+            event: "response.output_item.done",
+            data: {
+              output_index: outputIndex,
+              item: {
+                type: "message",
+                id: `msg_${validation}_${outputIndex}`,
+                content: [],
+              },
+            },
+          })),
+        );
+      }
+      events.push({
+        event: "response.completed",
+        data: {
+          response: {
+            status: "completed",
+            ...(validation === "public"
+              ? {
+                  output: Array.from({ length: count }, (_, outputIndex) => ({
+                    type: "item_reference",
+                    id: `msg_${validation}_${outputIndex}`,
+                  })),
+                }
+              : {}),
+          },
+        },
+      });
+
+      const result = await accumulateResponsesSSEStream(
+        buildSSEResponse(events),
+        { validation, stopAtTerminal: true, maxFrames: events.length },
+      );
+      expect(result.rawOutputItems).toHaveLength(count);
+    },
+  );
+
+  test.each(["public", "codex"] as const)(
+    "%s rejects MAX_SAFE_INTEGER sparse output and content indices",
+    async (validation) => {
+      const indexed =
+        validation === "public"
+          ? { output_index: Number.MAX_SAFE_INTEGER }
+          : { output_index: Number.MAX_SAFE_INTEGER };
+      await expect(
+        accumulateResponsesSSEStream(
+          buildSSEResponse([
+            {
+              event: "response.output_item.added",
+              data: { ...indexed, item: { type: "message", id: "too-large" } },
+            },
+          ]),
+          { validation, stopAtTerminal: true, maxFrames: 4 },
+        ),
+      ).rejects.toThrow("malformed Responses stream event");
+
+      await expect(
+        accumulateResponsesSSEStream(
+          buildSSEResponse([
+            {
+              event: "response.output_item.added",
+              data: {
+                ...(validation === "public" ? { output_index: 0 } : {}),
+                item: { type: "message", id: "content-too-large" },
+              },
+            },
+            {
+              event: "response.output_text.delta",
+              data: {
+                ...(validation === "public"
+                  ? { output_index: 0 }
+                  : { item_id: "content-too-large" }),
+                content_index: Number.MAX_SAFE_INTEGER,
+                delta: "x",
+              },
+            },
+          ]),
+          { validation, stopAtTerminal: true, maxFrames: 4 },
+        ),
+      ).rejects.toThrow("malformed Responses stream event");
+    },
+  );
+
+  test.each(["public", "codex"] as const)(
+    "%s accepts the sparse-index boundary and rejects the first value beyond it",
+    async (validation) => {
+      const itemId = `boundary-${validation}`;
+      const events = [
+        {
+          event: "response.output_item.added",
+          data: { output_index: 3, item: { type: "message", id: itemId } },
+        },
+        {
+          event: "response.output_item.done",
+          data: {
+            output_index: 3,
+            item: { type: "message", id: itemId, content: [] },
+          },
+        },
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              status: "completed",
+              ...(validation === "public"
+                ? { output: [{ type: "item_reference", id: itemId }] }
+                : {}),
+            },
+          },
+        },
+      ];
+      await expect(
+        accumulateResponsesSSEStream(buildSSEResponse(events), {
+          validation,
+          stopAtTerminal: true,
+          maxFrames: 4,
+        }),
+      ).resolves.toBeDefined();
+      events[0] = {
+        event: "response.output_item.added",
+        data: { output_index: 4, item: { type: "message", id: itemId } },
+      };
+      await expect(
+        accumulateResponsesSSEStream(buildSSEResponse(events), {
+          validation,
+          stopAtTerminal: true,
+          maxFrames: 4,
+        }),
+      ).rejects.toThrow("malformed Responses stream event");
+    },
+  );
+
+  test.each(["public", "codex"] as const)(
+    "%s bounds sparse content indices by the frame ceiling",
+    async (validation) => {
+      const itemId = `content-boundary-${validation}`;
+      const makeEvents = (contentIndex: number) => [
+        {
+          event: "response.output_item.added",
+          data: { output_index: 0, item: { type: "message", id: itemId } },
+        },
+        {
+          event: "response.output_text.done",
+          data: {
+            output_index: 0,
+            item_id: itemId,
+            content_index: contentIndex,
+            text: "ok",
+          },
+        },
+        {
+          event: "response.output_item.done",
+          data: {
+            output_index: 0,
+            item: {
+              type: "message",
+              id: itemId,
+              content: [{ type: "output_text", text: "ok" }],
+            },
+          },
+        },
+        {
+          event: "response.completed",
+          data: {
+            response: {
+              status: "completed",
+              ...(validation === "public"
+                ? { output: [{ type: "item_reference", id: itemId }] }
+                : {}),
+            },
+          },
+        },
+      ];
+      await expect(
+        accumulateResponsesSSEStream(buildSSEResponse(makeEvents(3)), {
+          validation,
+          stopAtTerminal: true,
+          maxFrames: 4,
+        }),
+      ).resolves.toBeDefined();
+      await expect(
+        accumulateResponsesSSEStream(buildSSEResponse(makeEvents(4)), {
+          validation,
+          stopAtTerminal: true,
+          maxFrames: 4,
+        }),
+      ).rejects.toThrow("malformed Responses stream event");
+    },
+  );
+
+  test("Codex sparse sole-active inference stays indexed at high cardinality", async () => {
+    const count = 2_000;
+    const events: Array<{
+      event: string;
+      data: Record<string, unknown>;
+    }> = [];
+    for (let index = 0; index < count; index++) {
+      const itemId = `msg-sparse-${index}`;
+      events.push(
+        {
+          event: "response.output_item.added",
+          data: { item: { type: "message", id: itemId } },
+        },
+        {
+          event: "response.output_text.delta",
+          data: { delta: "x" },
+        },
+        {
+          event: "response.output_item.done",
+          data: {
+            item: {
+              type: "message",
+              id: itemId,
+              content: [{ type: "output_text", text: "x" }],
+            },
+          },
+        },
+      );
+    }
+    events.push({
+      event: "response.completed",
+      data: { response: { status: "completed" } },
+    });
+    const entries = vi.spyOn(Map.prototype, "entries");
+    try {
+      const result = await accumulateResponsesSSEStream(
+        buildSSEResponse(events),
+        { validation: "codex", stopAtTerminal: true },
+      );
+      expect(result.rawOutputItems).toHaveLength(count);
+      // Finalization enumerates rawItems once. Sparse inference must not scan
+      // the growing item registry for each omitted-index delta/done event.
+      expect(entries).toHaveBeenCalledTimes(1);
+    } finally {
+      entries.mockRestore();
+    }
+  });
+
+  const contentTerminalCases = [
+    {
+      name: "text delta after output_text.done",
+      terminalEvent: "response.output_text.done",
+      terminalData: { text: "done" },
+      lateEvent: "response.output_text.delta",
+      lateData: { delta: "late" },
+    },
+    {
+      name: "refusal delta after refusal.done",
+      terminalEvent: "response.refusal.done",
+      terminalData: { refusal: "done" },
+      lateEvent: "response.refusal.delta",
+      lateData: { delta: "late" },
+    },
+    {
+      name: "duplicate output_text.done",
+      terminalEvent: "response.output_text.done",
+      terminalData: { text: "done" },
+      lateEvent: "response.output_text.done",
+      lateData: { text: "done again" },
+    },
+    {
+      name: "duplicate refusal.done",
+      terminalEvent: "response.refusal.done",
+      terminalData: { refusal: "done" },
+      lateEvent: "response.refusal.done",
+      lateData: { refusal: "done again" },
+    },
+    {
+      name: "text after refusal.done",
+      terminalEvent: "response.refusal.done",
+      terminalData: { refusal: "done" },
+      lateEvent: "response.output_text.done",
+      lateData: { text: "late text" },
+    },
+    {
+      name: "refusal after output_text.done",
+      terminalEvent: "response.output_text.done",
+      terminalData: { text: "done" },
+      lateEvent: "response.refusal.done",
+      lateData: { refusal: "late refusal" },
+    },
+  ] as const;
+
+  for (const validation of ["public", "codex"] as const) {
+    test.each(contentTerminalCases)(
+      `${validation} validation rejects $name`,
+      async ({ terminalEvent, terminalData, lateEvent, lateData }) => {
+        const itemId = `msg_content_terminal_${validation}`;
+        const contentReference =
+          validation === "public"
+            ? { output_index: 0, content_index: 0 }
+            : { item_id: itemId };
+        await expect(
+          accumulateResponsesSSEStream(
+            buildSSEResponse([
+              {
+                event: "response.output_item.added",
+                data: {
+                  ...(validation === "public" ? { output_index: 0 } : {}),
+                  item: { type: "message", id: itemId },
+                },
+              },
+              {
+                event: terminalEvent,
+                data: { ...contentReference, ...terminalData },
+              },
+              {
+                event: lateEvent,
+                data: { ...contentReference, ...lateData },
+              },
+            ]),
+            { validation, stopAtTerminal: true },
+          ),
+        ).rejects.toThrow("malformed Responses stream event");
+      },
+    );
+
+    test(`${validation} validation permits content_part.done after output_text.done`, async () => {
+      const itemId = `msg_content_part_done_${validation}`;
+      const contentReference =
+        validation === "public"
+          ? { output_index: 0, content_index: 0, item_id: itemId }
+          : { item_id: itemId };
+      const result = await accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: {
+              ...(validation === "public" ? { output_index: 0 } : {}),
+              item: { type: "message", id: itemId },
+            },
+          },
+          {
+            event: "response.content_part.added",
+            data: {
+              ...contentReference,
+              part: { type: "output_text", text: "" },
+            },
+          },
+          {
+            event: "response.output_text.done",
+            data: { ...contentReference, text: "complete" },
+          },
+          {
+            event: "response.content_part.done",
+            data: {
+              ...contentReference,
+              part: { type: "output_text", text: "complete" },
+            },
+          },
+          {
+            event: "response.output_item.done",
+            data: {
+              ...(validation === "public" ? { output_index: 0 } : {}),
+              item: {
+                type: "message",
+                id: itemId,
+                content: [{ type: "output_text", text: "complete" }],
+              },
+            },
+          },
+          {
+            event: "response.completed",
+            data: {
+              response: {
+                status: "completed",
+                ...(validation === "public"
+                  ? { output: [{ type: "item_reference", id: itemId }] }
+                  : {}),
+              },
+            },
+          },
+        ]),
+        { validation, stopAtTerminal: true },
+      );
+
+      expect(result.content).toEqual([{ type: "text", text: "complete" }]);
+    });
+  }
+
+  test("Codex applies an omitted late content index to the terminal part", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: { item: { type: "message", id: "msg_sparse_terminal" } },
+          },
+          {
+            event: "response.output_text.done",
+            data: {
+              item_id: "msg_sparse_terminal",
+              content_index: 7,
+              text: "done",
+            },
+          },
+          {
+            event: "response.output_text.delta",
+            data: { item_id: "msg_sparse_terminal", delta: "late" },
+          },
+        ]),
+        { validation: "codex", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses stream event");
+  });
+
+  test("Codex reconciles sparse function-call fields from output_item.done", async () => {
+    const result = await accumulateResponsesSSEStream(
+      buildSSEResponse([
+        {
+          event: "response.output_item.added",
+          data: {
+            item: {
+              type: "function_call",
+              id: "fc_sparse_final",
+              call_id: "",
+              name: "",
+              arguments: "",
+            },
+          },
+        },
+        {
+          event: "response.function_call_arguments.delta",
+          data: {
+            item_id: "fc_sparse_final",
+            delta: '{"partial":',
+          },
+        },
+        {
+          event: "response.output_item.done",
+          data: {
+            item: {
+              type: "function_call",
+              id: "fc_sparse_final",
+              call_id: "call_final",
+              name: "lookup",
+              arguments: '{"final":true}',
+            },
+          },
+        },
+        {
+          event: "response.completed",
+          data: { response: { status: "completed" } },
+        },
+      ]),
+      { validation: "codex", stopAtTerminal: true },
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call_final",
+        name: "lookup",
+        input: { final: true },
+      },
+    ]);
+  });
+
+  test("Codex binds an omitted added function-call ID from output_item.done", async () => {
+    const result = await accumulateResponsesSSEStream(
+      buildSSEResponse([
+        {
+          event: "response.output_item.added",
+          data: {
+            item: {
+              type: "function_call",
+              call_id: "",
+              name: "",
+              arguments: "",
+            },
+          },
+        },
+        {
+          event: "response.output_item.done",
+          data: {
+            item: {
+              type: "function_call",
+              id: "fc_bound_final",
+              name: "bound_lookup",
+              arguments: "{}",
+            },
+          },
+        },
+        {
+          event: "response.completed",
+          data: { response: { status: "completed" } },
+        },
+      ]),
+      { validation: "codex", stopAtTerminal: true },
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "tool_use",
+        id: "fc_bound_final",
+        name: "bound_lookup",
+        input: {},
+      },
+    ]);
+  });
+
+  test("Codex accepts a done-only function call", async () => {
+    const result = await accumulateResponsesSSEStream(
+      buildSSEResponse([
+        {
+          event: "response.output_item.done",
+          data: {
+            item: {
+              type: "function_call",
+              id: "fc_done_only",
+              call_id: "call_done_only",
+              name: "done_only",
+              arguments: '{"value":1}',
+            },
+          },
+        },
+        {
+          event: "response.completed",
+          data: { response: { status: "completed" } },
+        },
+      ]),
+      { validation: "codex", stopAtTerminal: true },
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call_done_only",
+        name: "done_only",
+        input: { value: 1 },
+      },
+    ]);
+  });
+
+  test.each([
+    ["item ID", { id: "fc_conflicting_final" }],
+    ["call ID", { call_id: "call_conflicting_final" }],
+    ["name", { name: "conflicting_final_name" }],
+  ])(
+    "Codex rejects a conflicting final function-call %s",
+    async (_case, final) => {
+      await expect(
+        accumulateResponsesSSEStream(
+          buildSSEResponse([
+            {
+              event: "response.output_item.added",
+              data: {
+                item: {
+                  type: "function_call",
+                  id: "fc_original",
+                  call_id: "call_original",
+                  name: "original_name",
+                  arguments: "",
+                },
+              },
+            },
+            {
+              event: "response.output_item.done",
+              data: {
+                item: {
+                  type: "function_call",
+                  id: "fc_original",
+                  call_id: "call_original",
+                  name: "original_name",
+                  arguments: "{}",
+                  ...final,
+                },
+              },
+            },
+          ]),
+          { validation: "codex", stopAtTerminal: true },
+        ),
+      ).rejects.toThrow("malformed Responses stream event");
+    },
+  );
+
+  test("Codex rejects contradictory output_index and item_id aliases", async () => {
+    await expect(
+      accumulateResponsesSSEStream(
+        buildSSEResponse([
+          {
+            event: "response.output_item.added",
+            data: { item: { type: "message", id: "msg_alias_zero" } },
+          },
+          {
+            event: "response.output_item.added",
+            data: { item: { type: "message", id: "msg_alias_one" } },
+          },
+          {
+            event: "response.output_text.delta",
+            data: {
+              output_index: 0,
+              item_id: "msg_alias_one",
+              delta: "cross-wired",
+            },
+          },
+        ]),
+        { validation: "codex", stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed Responses stream event");
+  });
+
+  test("Codex validation infers omitted output/content indices and permits an added item without done", async () => {
+    const response = buildSSEResponse([
+      {
+        event: "response.output_item.added",
+        data: {
+          item: { type: "message", id: "msg_minimal", role: "assistant" },
+        },
+      },
+      {
+        event: "response.output_text.delta",
+        data: { item_id: "msg_minimal", delta: "minimal " },
+      },
+      {
+        event: "response.output_text.delta",
+        data: { item_id: "msg_minimal", delta: "Codex" },
+      },
+      {
+        event: "response.done",
+        data: { response: {} },
+      },
+    ]);
+
+    const result = await accumulateResponsesSSEStream(response, {
+      validation: "codex",
+      stopAtTerminal: true,
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "minimal Codex" }]);
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  test("Codex validation infers an item from item_id when lifecycle events are omitted", async () => {
+    const response = buildSSEResponse([
+      {
+        event: "response.output_text.delta",
+        data: { item_id: "msg_implicit", delta: "implicit item" },
+      },
+      {
+        event: "response.completed",
+        data: { response: { status: "completed" } },
+      },
+    ]);
+
+    const result = await accumulateResponsesSSEStream(response, {
+      validation: "codex",
+      stopAtTerminal: true,
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "implicit item" }]);
+  });
+
+  test("Codex validation accepts a done-only message item and extracts its content", async () => {
+    const response = buildSSEResponse([
+      {
+        event: "response.output_item.done",
+        data: {
+          item: {
+            type: "message",
+            id: "msg_done_only",
+            content: [{ type: "output_text", text: "done-only text" }],
+          },
+        },
+      },
+      {
+        event: "response.completed",
+        data: { response: { status: "completed" } },
+      },
+    ]);
+
+    const result = await accumulateResponsesSSEStream(response, {
+      validation: "codex",
+      stopAtTerminal: true,
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: "done-only text" }]);
+  });
+
+  test("Codex validation accepts provider-specific incomplete reasons", async () => {
+    const response = buildSSEResponse([
+      {
+        event: "response.incomplete",
+        data: {
+          response: {
+            status: "incomplete",
+            incomplete_details: { reason: "provider_specific" },
+          },
+        },
+      },
+    ]);
+
+    const result = await accumulateResponsesSSEStream(response, {
+      validation: "codex",
+      stopAtTerminal: true,
+    });
+
+    expect(result.stopReason).toBe("max_tokens");
+  });
+
+  test.each([
+    [
+      "malformed output index",
+      [
+        {
+          event: "response.output_item.added",
+          data: {
+            output_index: "0",
+            item: { type: "message", id: "msg_bad_output" },
+          },
+        },
+      ],
+      "malformed Responses stream event",
+    ],
+    [
+      "malformed content index",
+      [
+        {
+          event: "response.output_text.delta",
+          data: {
+            item_id: "msg_bad_content",
+            content_index: "0",
+            delta: "text",
+          },
+        },
+      ],
+      "malformed Responses stream event",
+    ],
+    [
+      "non-string incomplete reason",
+      [
+        {
+          event: "response.incomplete",
+          data: {
+            response: {
+              status: "incomplete",
+              incomplete_details: { reason: 1 },
+            },
+          },
+        },
+      ],
+      "malformed Responses terminal event",
+    ],
+    [
+      "contradictory response.done status",
+      [
+        {
+          event: "response.done",
+          data: { response: { status: "in_progress" } },
+        },
+      ],
+      "Responses terminal event/status mismatch",
+    ],
+  ] as const)(
+    "Codex validation rejects %s when provided",
+    async (_case, events, diagnostic) => {
+      await expect(
+        accumulateResponsesSSEStream(buildSSEResponse([...events]), {
+          validation: "codex",
+          stopAtTerminal: true,
+        }),
+      ).rejects.toThrow(diagnostic);
+    },
+  );
+});
+
+test("Anthropic translator emits inclusive Responses cache usage", async () => {
+  const event = (type: string, data: Record<string, unknown>) =>
+    `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+  const upstream = new Response(
+    event("message_start", {
+      message: {
+        id: "msg_usage",
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          cache_read_input_tokens: 90,
+          cache_creation_input_tokens: 20,
+          output_tokens: 0,
+        },
+      },
+    }) +
+      event("message_delta", {
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      }) +
+      event("message_stop", {}),
+  );
+  const output = await translateAnthropicStreamToResponses(upstream, {
+    strict: true,
+  }).text();
+  const completedLine = output
+    .split("\n")
+    .find(
+      (line) =>
+        line.startsWith("data: {") && line.includes("response.completed"),
+    );
+  const completed = JSON.parse(completedLine?.slice(6) ?? "null") as {
+    response: { usage: Record<string, unknown> };
+  };
+  expect(completed.response.usage).toEqual({
+    input_tokens: 120,
+    output_tokens: 1,
+    total_tokens: 121,
+    input_tokens_details: { cached_tokens: 90, cache_write_tokens: 20 },
+  });
+  expect(() =>
+    validateResponsesUsage(
+      completed.response.usage,
+      "invalid translated usage",
+    ),
+  ).not.toThrow();
 });
 
 // ---------------------------------------------------------------------------
@@ -602,7 +2329,8 @@ function controllableSSE(): {
 
 /** Read the client-facing SSE stream fully into a decoded string. */
 async function drainToString(resp: Response): Promise<string> {
-  const reader = resp.body!.getReader();
+  if (!resp.body) throw new Error("test response has no body");
+  const reader = resp.body.getReader();
   const decoder = new TextDecoder();
   let out = "";
   for (;;) {
@@ -614,6 +2342,330 @@ async function drainToString(resp: Response): Promise<string> {
 }
 
 describe("streamResponsesPassthrough", () => {
+  test("drains a pre-buffered stream after a delayed first read", async () => {
+    const downstream = streamResponsesPassthrough(
+      buildSSEResponse([
+        {
+          event: "response.created",
+          data: {
+            type: "response.created",
+            response: { id: "delayed", status: "in_progress" },
+          },
+        },
+        {
+          event: "response.completed",
+          data: {
+            type: "response.completed",
+            response: { id: "delayed", status: "completed", output: [] },
+          },
+        },
+      ]),
+      () => {},
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    const output = await downstream.text();
+    expect(output).toContain("response.created");
+    expect(output).toContain("response.completed");
+  });
+
+  test("an already-aborted external signal errors downstream and cancels upstream", async () => {
+    let sourceCancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          sourceCancelled = true;
+        },
+      }),
+    );
+    const abort = new AbortController();
+    abort.abort(new DOMException("deadline", "TimeoutError"));
+    const removeAbortListener = vi.spyOn(abort.signal, "removeEventListener");
+    const downstream = streamResponsesPassthrough(
+      upstream,
+      () => {},
+      undefined,
+      "public",
+      abort.signal,
+    );
+    await expect(downstream.text()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(sourceCancelled).toBe(true);
+    expect(removeAbortListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+  });
+
+  test("external abort wakes a demand waiter and errors the reader", async () => {
+    let sourceCancelled = false;
+    const abort = new AbortController();
+    const removeAbortListener = vi.spyOn(abort.signal, "removeEventListener");
+    const event = (type: string, response: Record<string, unknown>) =>
+      `event: ${type}\ndata: ${JSON.stringify({ type, response })}\n\n`;
+    const wrapped = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              event("response.created", {
+                id: "waiting",
+                status: "in_progress",
+              }) +
+                event("response.completed", {
+                  id: "waiting",
+                  status: "completed",
+                  output: [],
+                }),
+            ),
+          );
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          sourceCancelled = true;
+        },
+      }),
+    );
+    const downstream = streamResponsesPassthrough(
+      wrapped,
+      () => {},
+      undefined,
+      "public",
+      abort.signal,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    abort.abort(new DOMException("deadline", "TimeoutError"));
+    await expect(downstream.text()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(sourceCancelled).toBe(true);
+    expect(removeAbortListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+  });
+
+  test("downstream cancel before reader acquisition is silent and cancels the source", async () => {
+    let sourceCancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          sourceCancelled = true;
+        },
+      }),
+    );
+    const downstream = streamResponsesPassthrough(upstream, () => {});
+    await downstream.body?.cancel();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(sourceCancelled).toBe(true);
+  });
+
+  test("downstream cancel does not await a hostile upstream cancel", async () => {
+    let sourceCancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'event: response.created\ndata: {"type":"response.created","response":{"id":"hostile","status":"in_progress"}}\n\n',
+            ),
+          );
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          sourceCancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const downstreamBody = streamResponsesPassthrough(upstream, () => {}).body;
+    if (!downstreamBody) throw new Error("test stream has no body");
+    const reader = downstreamBody.getReader();
+    await reader.read();
+    const outcome = await Promise.race([
+      reader.cancel().then(() => "cancelled"),
+      new Promise<string>((resolve) => setImmediate(() => resolve("hung"))),
+    ]);
+    expect(outcome).toBe("cancelled");
+    expect(sourceCancelled).toBe(true);
+    expect(upstream.body?.locked).toBe(false);
+  });
+
+  test("does not emit a second terminal when onComplete throws", async () => {
+    const output = await streamResponsesPassthrough(
+      buildSSEResponse([
+        {
+          event: "response.completed",
+          data: {
+            type: "response.completed",
+            response: { status: "completed", output: [] },
+          },
+        },
+      ]),
+      () => {
+        throw new Error("accounting failed");
+      },
+      undefined,
+      "public",
+    ).text();
+    expect(output.match(/event: response\.completed/g)).toHaveLength(1);
+    expect(output).not.toContain("event: response.failed");
+  });
+
+  test("does not forward malformed JSON", async () => {
+    const output = await streamResponsesPassthrough(
+      new Response("event: response.created\ndata: {bad}\n\n"),
+      () => {},
+      undefined,
+      "public",
+    ).text();
+    expect(output).not.toContain("{bad}");
+    expect(output).toContain("event: response.failed");
+  });
+
+  test("rejects duplicate call_id before forwarding the conflicting event", async () => {
+    const first = {
+      type: "function_call",
+      id: "item-one",
+      call_id: "duplicate-call",
+      name: "one",
+      arguments: "{}",
+    };
+    const second = { ...first, id: "item-two", name: "two" };
+    const upstream = buildSSEResponse([
+      {
+        event: "response.output_item.added",
+        data: { output_index: 0, item: first },
+      },
+      {
+        event: "response.output_item.added",
+        data: { output_index: 1, item: second },
+      },
+    ]);
+    const output = await streamResponsesPassthrough(
+      upstream,
+      () => {},
+      undefined,
+      "public",
+    ).text();
+    expect(output).toContain("item-one");
+    expect(output).not.toContain("item-two");
+    expect(output).toContain("response.failed");
+  });
+
+  test("threads Codex sparse validation instead of public lifecycle rules", async () => {
+    const events = [
+      {
+        event: "response.output_item.added",
+        data: { item: { type: "message", id: "codex-sparse" } },
+      },
+      {
+        event: "response.output_text.delta",
+        data: { item_id: "codex-sparse", delta: "ok" },
+      },
+      {
+        event: "response.completed",
+        data: { response: { status: "completed" } },
+      },
+    ];
+    const codex = await streamResponsesPassthrough(
+      buildSSEResponse(events),
+      () => {},
+      undefined,
+      "codex",
+    ).text();
+    expect(codex).toContain('"delta":"ok"');
+    expect(codex).not.toContain("response.failed");
+
+    const publicOutput = await streamResponsesPassthrough(
+      buildSSEResponse(events),
+      () => {},
+      undefined,
+      "public",
+    ).text();
+    expect(publicOutput).not.toContain('"delta":"ok"');
+    expect(publicOutput).toContain("response.failed");
+  });
+
+  test("validates and forwards a provider failure terminal", async () => {
+    const output = await streamResponsesPassthrough(
+      buildSSEResponse([
+        {
+          event: "response.failed",
+          data: {
+            type: "response.failed",
+            response: {
+              status: "failed",
+              error: { type: "server_error", message: "provider failed" },
+            },
+          },
+        },
+      ]),
+      () => {},
+      undefined,
+      "public",
+    ).text();
+    expect(output.match(/event: response\.failed/g)).toHaveLength(1);
+    expect(output).toContain("provider failed");
+  });
+
+  test("counts comment-only wire bytes toward the aggregate cap", async () => {
+    const output = await streamResponsesPassthrough(
+      new Response(`: ${"x".repeat(4 * 1024 * 1024)}\n\n`),
+      () => {},
+      undefined,
+      "public",
+    ).text();
+    expect(output).toContain("exceeded aggregate byte limit");
+  });
+
+  test("fails the stream when aggregate retained event data exceeds its cap", async () => {
+    const payload = JSON.stringify({ padding: "x".repeat(1024 * 1024) });
+    const frame = `event: response.unknown\ndata: ${payload}\n\n`;
+    const upstream = new Response(frame.repeat(5), {
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const output = await streamResponsesPassthrough(upstream, () => {}).text();
+
+    expect(output).toContain("event: response.failed");
+    expect(output).toContain("exceeded aggregate byte limit");
+  });
+
+  test("stops pulling upstream while a downstream consumer is not reading", async () => {
+    let pulls = 0;
+    let cancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls++;
+          controller.enqueue(
+            new TextEncoder().encode(
+              `event: response.in_progress\ndata: ${JSON.stringify({
+                type: "response.in_progress",
+                response: { id: "r", status: "in_progress" },
+              })}\n\n`,
+            ),
+          );
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+    );
+    const downstream = streamResponsesPassthrough(upstream, () => {});
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(pulls).toBeLessThan(10);
+    await downstream.body?.cancel();
+    expect(cancelled).toBe(true);
+  });
   test("forwards events to the client BEFORE the upstream completes (true streaming)", async () => {
     const upstream = controllableSSE();
     let completed: GatewayResponse | null = null;
@@ -621,7 +2673,8 @@ describe("streamResponsesPassthrough", () => {
     const clientResp = streamResponsesPassthrough(upstream.response, (r) => {
       completed = r;
     });
-    const reader = clientResp.body!.getReader();
+    if (!clientResp.body) throw new Error("test response has no body");
+    const reader = clientResp.body.getReader();
     const decoder = new TextDecoder();
 
     // Push the opening events; the terminal event is deliberately withheld.
@@ -669,6 +2722,7 @@ describe("streamResponsesPassthrough", () => {
         id: "resp_live",
         model: "gpt-5.6-sol",
         status: "completed",
+        output: [],
         usage: { input_tokens: 12, output_tokens: 3 },
       },
     });
@@ -709,6 +2763,7 @@ describe("streamResponsesPassthrough", () => {
         id: "resp_r",
         model: "gpt-5.6-sol",
         status: "completed",
+        output: [],
         usage: { input_tokens: 5, output_tokens: 1 },
       },
     });
@@ -750,6 +2805,7 @@ describe("streamResponsesPassthrough", () => {
                 id: "resp_u",
                 model: "m",
                 status: "completed",
+                output: [],
                 usage: { input_tokens: 1, output_tokens: 1 },
               },
             })}\n\n`,
@@ -822,7 +2878,8 @@ describe("streamResponsesPassthrough", () => {
     });
 
     const clientResp = streamResponsesPassthrough(upstreamResp, () => {});
-    const reader = clientResp.body!.getReader();
+    if (!clientResp.body) throw new Error("test response has no body");
+    const reader = clientResp.body.getReader();
     await reader.read(); // pull the first event through
     await reader.cancel(); // client disconnects
 

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -1101,7 +1101,7 @@ describe("buildOpenAIResponsesResponse", () => {
     expect(text).toContain('"name":"search"');
   });
 
-  test("non-streaming: emits prompt_tokens_details.cached_tokens when present", async () => {
+  test("non-streaming: emits input_tokens_details.cached_tokens when present", async () => {
     const resp: GatewayResponse = {
       ...baseResponse,
       usage: {
@@ -1114,17 +1114,17 @@ describe("buildOpenAIResponsesResponse", () => {
     const response = buildOpenAIResponsesResponse(resp, false);
     const body = (await response.json()) as Record<string, unknown>;
     const usage = body.usage as Record<string, unknown>;
-    expect(usage.input_tokens).toBe(100);
+    expect(usage.input_tokens).toBe(180);
     expect(usage.output_tokens).toBe(20);
-    const details = usage.prompt_tokens_details as Record<string, number>;
+    const details = usage.input_tokens_details as Record<string, number>;
     expect(details.cached_tokens).toBe(80);
   });
 
-  test("non-streaming: omits prompt_tokens_details when no cached tokens", async () => {
+  test("non-streaming: omits input_tokens_details when no cached tokens", async () => {
     const response = buildOpenAIResponsesResponse(baseResponse, false);
     const body = (await response.json()) as Record<string, unknown>;
     const usage = body.usage as Record<string, unknown>;
-    expect(usage.prompt_tokens_details).toBeUndefined();
+    expect(usage.input_tokens_details).toBeUndefined();
   });
 
   test("streaming: emits cached_tokens in response.completed usage", async () => {
@@ -1164,7 +1164,7 @@ describe("buildOpenAIResponse (Chat Completions) — cached_tokens", () => {
     const response = buildOpenAIResponse(resp, false);
     const body = (await response.json()) as Record<string, unknown>;
     const usage = body.usage as Record<string, unknown>;
-    expect(usage.prompt_tokens).toBe(100);
+    expect(usage.prompt_tokens).toBe(180);
     expect(usage.completion_tokens).toBe(20);
     const details = usage.prompt_tokens_details as Record<string, number>;
     expect(details.cached_tokens).toBe(80);

--- a/packages/gateway/test/openai-stream-usage.test.ts
+++ b/packages/gateway/test/openai-stream-usage.test.ts
@@ -53,7 +53,7 @@ async function readSseChunks(response: Response): Promise<unknown[]> {
 // ---------------------------------------------------------------------------
 
 describe("buildOpenAIResponse (Chat Completions) — non-stream usage (#1475)", () => {
-  test("emits cache_creation_tokens when cacheCreationInputTokens is set", async () => {
+  test("emits cache_write_tokens when cacheCreationInputTokens is set", async () => {
     const resp = baseResp({
       usage: {
         inputTokens: 100,
@@ -66,10 +66,11 @@ describe("buildOpenAIResponse (Chat Completions) — non-stream usage (#1475)", 
     const body = (await response.json()) as Record<string, unknown>;
     const usage = body.usage as Record<string, unknown>;
     const details = usage.prompt_tokens_details as Record<string, number>;
-    expect(details.cache_creation_tokens).toBe(50);
+    expect(details.cache_write_tokens).toBe(50);
+    expect(usage.prompt_tokens).toBe(150);
   });
 
-  test("emits both cached_tokens and cache_creation_tokens together", async () => {
+  test("emits both cached_tokens and cache_write_tokens together", async () => {
     const resp = baseResp({
       usage: {
         inputTokens: 100,
@@ -84,7 +85,8 @@ describe("buildOpenAIResponse (Chat Completions) — non-stream usage (#1475)", 
     const usage = body.usage as Record<string, unknown>;
     const details = usage.prompt_tokens_details as Record<string, number>;
     expect(details.cached_tokens).toBe(80);
-    expect(details.cache_creation_tokens).toBe(20);
+    expect(details.cache_write_tokens).toBe(20);
+    expect(usage.prompt_tokens).toBe(200);
   });
 
   test("omits prompt_tokens_details when neither cache field is set", async () => {
@@ -110,7 +112,7 @@ describe("buildOpenAIResponse (Chat Completions) — non-stream usage (#1475)", 
     const response = buildOpenAIResponse(resp, false);
     const body = (await response.json()) as Record<string, unknown>;
     const usage = body.usage as Record<string, unknown>;
-    expect(usage.prompt_tokens).toBe(100);
+    expect(usage.prompt_tokens).toBe(180);
     expect(usage.completion_tokens).toBe(20);
     const details = usage.prompt_tokens_details as Record<string, number>;
     expect(details.cached_tokens).toBe(80);
@@ -129,7 +131,7 @@ describe("buildOpenAIResponse (Chat Completions) — non-stream usage (#1475)", 
     const response = buildOpenAIResponse(resp, false);
     const body = (await response.json()) as Record<string, unknown>;
     const usage = body.usage as Record<string, unknown>;
-    expect(usage.total_tokens).toBe(120);
+    expect(usage.total_tokens).toBe(220);
   });
 });
 
@@ -178,7 +180,7 @@ describe("buildOpenAIResponse (Chat Completions) — stream usage (#1475)", () =
     expect(details.cached_tokens).toBe(80);
   });
 
-  test("stream terminal usage includes cache_creation_tokens when cacheCreationInputTokens is set", async () => {
+  test("stream terminal usage includes cache_write_tokens when cacheCreationInputTokens is set", async () => {
     const resp = baseResp({
       usage: {
         inputTokens: 100,
@@ -192,7 +194,8 @@ describe("buildOpenAIResponse (Chat Completions) — stream usage (#1475)", () =
     const penultimate = chunks[chunks.length - 2] as Record<string, unknown>;
     const usage = penultimate.usage as Record<string, unknown>;
     const details = usage.prompt_tokens_details as Record<string, number>;
-    expect(details.cache_creation_tokens).toBe(50);
+    expect(details.cache_write_tokens).toBe(50);
+    expect(usage.prompt_tokens).toBe(150);
   });
 
   test("stream terminal usage includes both cache fields together", async () => {
@@ -211,7 +214,8 @@ describe("buildOpenAIResponse (Chat Completions) — stream usage (#1475)", () =
     const usage = penultimate.usage as Record<string, unknown>;
     const details = usage.prompt_tokens_details as Record<string, number>;
     expect(details.cached_tokens).toBe(80);
-    expect(details.cache_creation_tokens).toBe(20);
+    expect(details.cache_write_tokens).toBe(20);
+    expect(usage.prompt_tokens).toBe(200);
   });
 
   test("stream emits usage chunk even when resp.usage is undefined (ZERO_USAGE fallback)", async () => {

--- a/packages/gateway/test/pipeline-streaming.test.ts
+++ b/packages/gateway/test/pipeline-streaming.test.ts
@@ -7,10 +7,24 @@
  * SSE, forwards it to the client, and accumulates in parallel for
  * postResponse storage.
  */
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import type { Harness } from "./helpers/harness";
 import { createHarness } from "./helpers/harness";
 import type { FixtureEntry } from "../src/recorder";
+import {
+  buildStreamingResponse,
+  abortAwareDelay,
+  completeBudgetThrottleDelay,
+  createForegroundAbortScope,
+  handleRequest,
+  mergeRecallUsage,
+  setUpstreamInterceptor,
+  validatedMetaStream,
+} from "../src/pipeline";
+import { loadConfig } from "../src/config";
+import { translateAnthropicStreamToOpenAI } from "../src/stream/openai";
+import { translateAnthropicStreamToResponses } from "../src/stream/openai-responses";
+import { translateAnthropicStreamToGemini } from "../src/stream/gemini";
 import {
   makeConversationFixtures,
   STANDARD_TOOLS,
@@ -29,6 +43,187 @@ function makeStreamBody(userMessage: string): Record<string, unknown> {
   };
 }
 
+function makeMetaStreamBody(userMessage: string): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 32,
+    stream: true,
+    messages: [{ role: "user", content: userMessage }],
+  };
+}
+
+function validAnthropicSSE(text = "meta ok"): Response {
+  const event = (type: string, data: Record<string, unknown>) =>
+    `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+  return new Response(
+    event("message_start", {
+      message: {
+        id: "msg_meta",
+        type: "message",
+        role: "assistant",
+        model: DEFAULT_MODEL,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }) +
+      event("content_block_start", {
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }) +
+      event("content_block_delta", {
+        index: 0,
+        delta: { type: "text_delta", text },
+      }) +
+      event("content_block_stop", { index: 0 }) +
+      event("message_delta", {
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      }) +
+      event("message_stop", {}),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+describe("non-stream recall usage aggregation", () => {
+  it("rejects per-field and cross-component safe-integer overflow", () => {
+    expect(() =>
+      mergeRecallUsage(
+        { inputTokens: Number.MAX_SAFE_INTEGER, outputTokens: 0 },
+        { inputTokens: 1, outputTokens: 0 },
+      ),
+    ).toThrow("recall usage token overflow");
+    expect(() =>
+      mergeRecallUsage(
+        { inputTokens: Number.MAX_SAFE_INTEGER, outputTokens: 0 },
+        { inputTokens: 0, outputTokens: 1 },
+      ),
+    ).toThrow("recall usage token overflow");
+  });
+});
+
+describe("budget throttle cancellation", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("caller abort clears a long delay and removes its listener", async () => {
+    vi.useFakeTimers();
+    const caller = new AbortController();
+    const remove = vi.spyOn(caller.signal, "removeEventListener");
+    let recorded = 0;
+    const pending = completeBudgetThrottleDelay(
+      600_000,
+      caller.signal,
+      () => recorded++,
+    );
+    expect(vi.getTimerCount()).toBe(1);
+    caller.abort(new DOMException("client disconnected", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(recorded).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+
+  it("the foreground deadline includes throttle delay and prevents later work", async () => {
+    vi.useFakeTimers();
+    const foreground = createForegroundAbortScope();
+    let recorded = 0;
+    let upstreamStarted = false;
+    const pending = (async () => {
+      await completeBudgetThrottleDelay(
+        600_000,
+        foreground.signal,
+        () => recorded++,
+      );
+      upstreamStarted = true;
+    })();
+    const rejected = expect(pending).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    await vi.advanceTimersByTimeAsync(300_000);
+    await rejected;
+    expect(recorded).toBe(0);
+    expect(upstreamStarted).toBe(false);
+    foreground.dispose();
+  });
+
+  it("records throttle completion before allowing upstream work", async () => {
+    vi.useFakeTimers();
+    const order: string[] = [];
+    const pending = (async () => {
+      await completeBudgetThrottleDelay(5_000, undefined, () =>
+        order.push("record"),
+      );
+      order.push("upstream");
+    })();
+    expect(order).toEqual([]);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await pending;
+    expect(order).toEqual(["record", "upstream"]);
+  });
+
+  it("zero delay does not leave timers or listeners", async () => {
+    vi.useFakeTimers();
+    const signal = new AbortController().signal;
+    await abortAwareDelay(0, signal);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+const STALLED_META_CASES = [
+  {
+    protocol: "anthropic",
+    model: DEFAULT_MODEL,
+    provider: "anthropic",
+    upstream: "https://api.anthropic.com",
+    wire: 'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stalled","type":"message","role":"assistant","model":"test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+  },
+  {
+    protocol: "openai",
+    model: "gpt-test",
+    provider: "groq",
+    upstream: "https://api.groq.com/openai/v1",
+    wire: 'data: {"id":"chatcmpl_stalled","model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+  },
+  {
+    protocol: "openai-responses",
+    model: "gpt-test",
+    provider: "openai",
+    upstream: "https://api.openai.com",
+    wire: 'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_stalled","model":"gpt-test","status":"in_progress"}}\n\n',
+  },
+  {
+    protocol: "gemini",
+    model: "gemini-test",
+    provider: "google",
+    upstream: "https://generativelanguage.googleapis.com",
+    wire: 'data: {"responseId":"gemini-stalled","modelVersion":"gemini-test","candidates":[{"index":0,"content":{"role":"model","parts":[{"text":"partial"}]}}]}\n\n',
+  },
+] as const;
+
+function stalledMetaUpstream(wire: string): {
+  response: Response;
+  cancelled: () => boolean;
+} {
+  let cancelled = false;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(wire));
+      },
+      pull() {
+        return new Promise(() => {});
+      },
+      cancel() {
+        cancelled = true;
+        return new Promise<void>(() => {});
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+  return { response, cancelled: () => cancelled };
+}
+
 async function readSSE(resp: Response): Promise<string> {
   return resp.text();
 }
@@ -37,6 +232,736 @@ describe("Pipeline — streaming responses", () => {
   let harness: Harness;
 
   afterEach(() => harness?.teardown());
+
+  it("does not deadlock when an OpenAI translator drops Anthropic lifecycle frames", async () => {
+    const anthropic = buildStreamingResponse(
+      validAnthropicSSE("translated"),
+      () => {},
+    );
+    const translated = translateAnthropicStreamToOpenAI(anthropic);
+    await new Promise((resolve) => setImmediate(resolve));
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const body = await Promise.race([
+        translated.text(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("translated stream deadlocked")),
+            1_000,
+          );
+        }),
+      ]);
+      expect(body).toContain("translated");
+      expect(body.match(/data: \[DONE\]/g)).toHaveLength(1);
+      expect(body.match(/"finish_reason":"stop"/g)).toHaveLength(1);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  });
+
+  it.each([
+    ["OpenAI", translateAnthropicStreamToOpenAI],
+    ["Responses", translateAnthropicStreamToResponses],
+    ["Gemini", translateAnthropicStreamToGemini],
+  ] as const)(
+    "aborts Anthropic->%s translation before downstream demand",
+    async (_name, translate) => {
+      const firstEvent = (
+        await validAnthropicSSE("never reached").text()
+      ).split(/(?=event: )/)[0];
+      let cancelled = 0;
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(firstEvent));
+          },
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled++;
+            return new Promise<void>(() => {});
+          },
+        }),
+      );
+      const abort = new AbortController();
+      const downstream = translate(upstream, {
+        strict: true,
+        signal: abort.signal,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      abort.abort(new DOMException("caller aborted", "AbortError"));
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await expect(
+          Promise.race([
+            downstream.text(),
+            new Promise<never>((_resolve, reject) => {
+              timer = setTimeout(
+                () => reject(new Error("translator abort deadlocked")),
+                1_000,
+              );
+            }),
+          ]),
+        ).rejects.toMatchObject({ name: "AbortError" });
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+      expect(cancelled).toBe(1);
+      expect(upstream.body?.locked).toBe(false);
+    },
+  );
+
+  it("aborts the Anthropic conversation streamer before downstream demand", async () => {
+    const firstEvent = (await validAnthropicSSE("never reached").text()).split(
+      /(?=event: )/,
+    )[0];
+    let cancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(firstEvent));
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const abort = new AbortController();
+    const downstream = buildStreamingResponse(
+      upstream,
+      () => {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      abort.signal,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    abort.abort(new DOMException("caller aborted", "AbortError"));
+    await expect(downstream.text()).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(cancelled).toBe(true);
+    expect(upstream.body?.locked).toBe(false);
+  });
+
+  it("wakes Anthropic conversation demand when its inactivity deadline fires", async () => {
+    vi.useFakeTimers();
+    const firstEvent = (await validAnthropicSSE("never reached").text()).split(
+      /(?=event: )/,
+    )[0];
+    let cancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(firstEvent));
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    try {
+      const downstream = buildStreamingResponse(upstream, () => {});
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(120_000);
+      await expect(downstream.text()).rejects.toThrow(
+        "SSE stream inactivity deadline exceeded",
+      );
+      expect(cancelled).toBe(true);
+      expect(upstream.body?.locked).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drains pre-buffered build and meta streams after delayed first reads", async () => {
+    const builtUpstream = validAnthropicSSE("built delayed");
+    const metaUpstream = validAnthropicSSE("meta delayed");
+    const built = buildStreamingResponse(builtUpstream, () => {});
+    const meta = validatedMetaStream(metaUpstream, "anthropic", false);
+    await new Promise((resolve) => setImmediate(resolve));
+    await expect(built.text()).resolves.toContain("built delayed");
+    await expect(meta.text()).resolves.toContain("meta delayed");
+    expect(builtUpstream.body?.locked).toBe(false);
+    expect(metaUpstream.body?.locked).toBe(false);
+  });
+
+  it("closes Anthropic build/meta streams at message_stop with an open tail", async () => {
+    const wire = await validAnthropicSSE("terminal").text();
+    const makeOpenTail = () => {
+      let cancelled = 0;
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(wire));
+          },
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled++;
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+      return { response, cancelled: () => cancelled };
+    };
+    const builtUpstream = makeOpenTail();
+    let completed = 0;
+    const built = buildStreamingResponse(builtUpstream.response, () => {
+      completed++;
+    });
+    const metaUpstream = makeOpenTail();
+    const meta = validatedMetaStream(metaUpstream.response, "anthropic", false);
+
+    await expect(built.text()).resolves.toContain("event: message_stop");
+    await expect(meta.text()).resolves.toContain("event: message_stop");
+    expect(completed).toBe(1);
+    expect(builtUpstream.cancelled()).toBe(1);
+    expect(metaUpstream.cancelled()).toBe(1);
+    expect(builtUpstream.response.body?.locked).toBe(false);
+    expect(metaUpstream.response.body?.locked).toBe(false);
+  });
+
+  it("pauses a filled build queue and resumes it when reads begin", async () => {
+    let pulls = 0;
+    const body = await validAnthropicSSE("resume").text();
+    const chunks = body
+      .split(/(?=event: )/)
+      .filter(Boolean)
+      .map((chunk) => new TextEncoder().encode(chunk));
+    let index = 0;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls++;
+          if (index < chunks.length) controller.enqueue(chunks[index++]);
+          else controller.close();
+        },
+      }),
+    );
+    const downstream = buildStreamingResponse(upstream, () => {});
+    await new Promise((resolve) => setImmediate(resolve));
+    const pullsBeforeRead = pulls;
+    expect(pullsBeforeRead).toBeLessThan(chunks.length + 1);
+    const text = await downstream.text();
+    expect(text).toContain("resume");
+    expect(pulls).toBeGreaterThan(pullsBeforeRead);
+  });
+
+  it("distinguishes external meta abort from silent downstream cancellation", async () => {
+    let cancelledBeforeAcquire = false;
+    const beforeAcquire = validatedMetaStream(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            cancelledBeforeAcquire = true;
+          },
+        }),
+      ),
+      "anthropic",
+      false,
+    );
+    await beforeAcquire.body?.cancel();
+    expect(cancelledBeforeAcquire).toBe(true);
+
+    let externallyCancelled = false;
+    const abort = new AbortController();
+    abort.abort(new DOMException("deadline", "TimeoutError"));
+    const removeAbortListener = vi.spyOn(abort.signal, "removeEventListener");
+    const externallyAborted = validatedMetaStream(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            externallyCancelled = true;
+          },
+        }),
+      ),
+      "anthropic",
+      false,
+      abort.signal,
+    );
+    await expect(externallyAborted.text()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(externallyCancelled).toBe(true);
+    expect(removeAbortListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    );
+  });
+
+  it("meta downstream cancel does not await a hostile upstream cancel", async () => {
+    let sourceCancelled = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'event: message_start\ndata: {"type":"message_start","message":{"id":"hostile","type":"message","role":"assistant","model":"test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+            ),
+          );
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          sourceCancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const downstreamBody = validatedMetaStream(
+      upstream,
+      "anthropic",
+      false,
+    ).body;
+    if (!downstreamBody) throw new Error("test stream has no body");
+    const reader = downstreamBody.getReader();
+    await reader.read();
+    const outcome = await Promise.race([
+      reader.cancel().then(() => "cancelled"),
+      new Promise<string>((resolve) => setImmediate(() => resolve("hung"))),
+    ]);
+    expect(outcome).toBe("cancelled");
+    expect(sourceCancelled).toBe(true);
+    expect(upstream.body?.locked).toBe(false);
+  });
+
+  it("external meta abort wakes a filled demand waiter", async () => {
+    let sourceCancelled = false;
+    const full = await validAnthropicSSE("waiting").text();
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(full));
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          sourceCancelled = true;
+        },
+      }),
+    );
+    const abort = new AbortController();
+    const downstream = validatedMetaStream(
+      upstream,
+      "anthropic",
+      false,
+      abort.signal,
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    abort.abort(new DOMException("deadline", "TimeoutError"));
+    await expect(downstream.text()).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(sourceCancelled).toBe(true);
+  });
+
+  it("foreground meta settles when its injected upstream ignores abort", async () => {
+    const controller = new AbortController();
+    setUpstreamInterceptor(async () => new Promise(() => {}));
+    try {
+      const pending = handleRequest(
+        {
+          protocol: "anthropic",
+          model: DEFAULT_MODEL,
+          system: "title this",
+          messages: [
+            { role: "user", content: [{ type: "text", text: "title" }] },
+          ],
+          tools: [],
+          stream: true,
+          maxTokens: 32,
+          metadata: {},
+          rawHeaders: { "x-lore-agent": "title" },
+          signal: controller.signal,
+        },
+        loadConfig(),
+      );
+      await Promise.resolve();
+      controller.abort(new DOMException("client disconnected", "AbortError"));
+      const response = await pending;
+      expect(response.status).toBe(502);
+      await expect(response.text()).resolves.toContain("client disconnected");
+    } finally {
+      setUpstreamInterceptor(undefined);
+    }
+  });
+
+  it("foreground deadline settles when its injected upstream never resolves", async () => {
+    vi.useFakeTimers();
+    setUpstreamInterceptor(async () => new Promise(() => {}));
+    try {
+      const pending = handleRequest(
+        {
+          protocol: "anthropic",
+          model: DEFAULT_MODEL,
+          system: "title this",
+          messages: [
+            { role: "user", content: [{ type: "text", text: "title" }] },
+          ],
+          tools: [],
+          stream: true,
+          maxTokens: 32,
+          metadata: {},
+          rawHeaders: { "x-lore-agent": "title" },
+        },
+        loadConfig(),
+      );
+      await vi.advanceTimersByTimeAsync(300_000);
+      const response = await pending;
+      expect(response.status).toBe(502);
+      await expect(response.text()).resolves.toContain("timed out");
+    } finally {
+      setUpstreamInterceptor(undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(STALLED_META_CASES)(
+    "caller abort settles a stalled $protocol meta body",
+    async ({ protocol, model, provider, upstream, wire }) => {
+      const source = stalledMetaUpstream(wire);
+      const caller = new AbortController();
+      setUpstreamInterceptor(async () => source.response);
+      try {
+        let responseTimer: ReturnType<typeof setTimeout> | undefined;
+        const downstream = await Promise.race([
+          handleRequest(
+            {
+              protocol,
+              model,
+              system: "title this",
+              messages: [
+                { role: "user", content: [{ type: "text", text: "title" }] },
+              ],
+              tools: [],
+              stream: true,
+              maxTokens: 32,
+              metadata: {},
+              rawHeaders: {
+                "x-api-key": "test-key",
+                authorization: "Bearer test-key",
+                "x-lore-agent": "title",
+                "x-lore-provider": provider,
+                "x-lore-upstream-url": upstream,
+              },
+              signal: caller.signal,
+            },
+            loadConfig(),
+          ),
+          new Promise<never>((_resolve, reject) => {
+            responseTimer = setTimeout(
+              () => reject(new Error("meta response was not returned")),
+              1_000,
+            );
+          }),
+        ]).finally(() => {
+          if (responseTimer) clearTimeout(responseTimer);
+        });
+        await new Promise((resolve) => setImmediate(resolve));
+        caller.abort(new DOMException("caller aborted", "AbortError"));
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(source.cancelled()).toBe(true);
+        expect(source.response.body?.locked).toBe(false);
+        await expect(
+          Promise.race([
+            downstream.text(),
+            new Promise<never>((_resolve, reject) => {
+              responseTimer = setTimeout(
+                () => reject(new Error("meta body abort deadlocked")),
+                1_000,
+              );
+            }),
+          ]).finally(() => {
+            if (responseTimer) clearTimeout(responseTimer);
+          }),
+        ).rejects.toMatchObject({ name: "AbortError" });
+      } finally {
+        setUpstreamInterceptor(undefined);
+      }
+    },
+  );
+
+  it.each(STALLED_META_CASES)(
+    "foreground deadline settles a stalled $protocol meta body",
+    async ({ protocol, model, provider, upstream, wire }) => {
+      vi.useFakeTimers();
+      const source = stalledMetaUpstream(wire);
+      setUpstreamInterceptor(async () => source.response);
+      try {
+        const downstream = await handleRequest(
+          {
+            protocol,
+            model,
+            system: "title this",
+            messages: [
+              { role: "user", content: [{ type: "text", text: "title" }] },
+            ],
+            tools: [],
+            stream: true,
+            maxTokens: 32,
+            metadata: {},
+            rawHeaders: {
+              "x-api-key": "test-key",
+              authorization: "Bearer test-key",
+              "x-lore-agent": "title",
+              "x-lore-provider": provider,
+              "x-lore-upstream-url": upstream,
+            },
+          },
+          loadConfig(),
+        );
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(300_000);
+        await expect(downstream.text()).rejects.toMatchObject({
+          name: "TimeoutError",
+        });
+        expect(source.cancelled()).toBe(true);
+        expect(source.response.body?.locked).toBe(false);
+      } finally {
+        setUpstreamInterceptor(undefined);
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("preserves non-OK meta responses for every client protocol", async () => {
+    harness = await createHarness({ fixtures: [] });
+    const cases = [
+      {
+        path: "/v1/messages",
+        status: 429,
+        body: {
+          model: DEFAULT_MODEL,
+          max_tokens: 32,
+          stream: true,
+          messages: [{ role: "user", content: "title" }],
+        },
+      },
+      {
+        path: "/v1/chat/completions",
+        status: 401,
+        body: {
+          model: "gpt-test",
+          max_tokens: 32,
+          stream: true,
+          messages: [{ role: "user", content: "title" }],
+        },
+      },
+      {
+        path: "/v1/responses",
+        status: 400,
+        body: {
+          model: "gpt-test",
+          max_output_tokens: 32,
+          stream: true,
+          input: "title",
+        },
+      },
+      {
+        path: "/v1beta/models/gemini-test:streamGenerateContent",
+        status: 429,
+        body: {
+          contents: [{ role: "user", parts: [{ text: "title" }] }],
+          generationConfig: { maxOutputTokens: 32 },
+        },
+      },
+    ];
+    let nextStatus = 500;
+    setUpstreamInterceptor(
+      async () =>
+        new Response(JSON.stringify({ error: { message: "provider error" } }), {
+          status: nextStatus,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "17",
+            "set-cookie": "upstream-secret=must-not-leak",
+            "x-ratelimit-reset-requests": "23ms",
+          },
+        }),
+    );
+
+    for (const testCase of cases) {
+      nextStatus = testCase.status;
+      const response = await fetch(`${harness.baseURL}${testCase.path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-key",
+          "x-lore-agent": "title",
+        },
+        body: JSON.stringify(testCase.body),
+      });
+      expect(response.status).toBe(testCase.status);
+      expect(response.headers.get("retry-after")).toBe("17");
+      expect(response.headers.get("set-cookie")).toBeNull();
+      expect(response.headers.get("x-ratelimit-reset-requests")).toBe("23ms");
+      expect(await response.json()).toEqual({
+        error: { message: "provider error" },
+      });
+    }
+  });
+
+  it.each(["openai-responses", "gemini"] as const)(
+    "strictly translates an open-tail Anthropic meta stream to %s",
+    async (protocol) => {
+      const wire = await validAnthropicSSE("cross protocol").text();
+      const chunks = wire
+        .split(/(?=event: )/)
+        .filter(Boolean)
+        .map((chunk) => new TextEncoder().encode(chunk));
+      let nextChunk = 0;
+      let pulls = 0;
+      let cancelled = 0;
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pulls++;
+            if (nextChunk < chunks.length) {
+              controller.enqueue(chunks[nextChunk++]);
+              return;
+            }
+            return new Promise(() => {});
+          },
+          cancel() {
+            cancelled++;
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+      setUpstreamInterceptor(async () => upstream);
+      try {
+        const response = await handleRequest(
+          {
+            protocol,
+            model: DEFAULT_MODEL,
+            system: "title this",
+            messages: [
+              { role: "user", content: [{ type: "text", text: "title" }] },
+            ],
+            tools: [],
+            stream: true,
+            maxTokens: 32,
+            metadata: {},
+            rawHeaders: {
+              "x-api-key": "test-key",
+              "x-lore-agent": "title",
+              "x-lore-provider": "anthropic",
+              "x-lore-upstream-url": "https://api.anthropic.com",
+            },
+          },
+          loadConfig(),
+        );
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(pulls).toBeLessThan(chunks.length);
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const output = await Promise.race([
+          response.text(),
+          new Promise<never>((_resolve, reject) => {
+            timer = setTimeout(
+              () => reject(new Error("translation deadlocked")),
+              1_000,
+            );
+          }),
+        ]).finally(() => {
+          if (timer) clearTimeout(timer);
+        });
+        expect(output).toContain("cross protocol");
+        if (protocol === "openai-responses") {
+          expect(output.match(/event: response\.completed/g)).toHaveLength(1);
+          expect(output).not.toContain("event: response.failed");
+        } else {
+          expect(output.match(/^data: /gm)).toHaveLength(1);
+          expect(output.match(/"finishReason":"STOP"/g)).toHaveLength(1);
+        }
+        expect(cancelled).toBe(1);
+        expect(upstream.body?.locked).toBe(false);
+      } finally {
+        setUpstreamInterceptor(undefined);
+      }
+    },
+  );
+
+  it.each(["openai-responses", "gemini"] as const)(
+    "rejects malformed Anthropic meta sources before translating to %s",
+    async (protocol) => {
+      const cases: Array<{ name: string; bytes: Uint8Array }> = [
+        {
+          name: "lifecycle",
+          bytes: new TextEncoder().encode(
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+          ),
+        },
+        { name: "utf8", bytes: new Uint8Array([0xff]) },
+        {
+          name: "oversize",
+          bytes: new TextEncoder().encode(
+            `event: ping\ndata: ${"x".repeat(4 * 1024 * 1024)}\n\n`,
+          ),
+        },
+      ];
+      for (const malformed of cases) {
+        let cancelled = false;
+        const upstream = new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(malformed.bytes);
+            },
+            pull() {
+              return new Promise(() => {});
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+        setUpstreamInterceptor(async () => upstream);
+        const response = await handleRequest(
+          {
+            protocol,
+            model: DEFAULT_MODEL,
+            system: "title this",
+            messages: [
+              { role: "user", content: [{ type: "text", text: "title" }] },
+            ],
+            tools: [],
+            stream: true,
+            maxTokens: 32,
+            metadata: {},
+            rawHeaders: {
+              "x-api-key": "test-key",
+              "x-lore-agent": "title",
+              "x-lore-provider": "anthropic",
+              "x-lore-upstream-url": "https://api.anthropic.com",
+            },
+          },
+          loadConfig(),
+        );
+        await expect(
+          response.text(),
+          `${protocol} ${malformed.name}`,
+        ).rejects.toThrow();
+        expect(cancelled, `${protocol} ${malformed.name}`).toBe(true);
+        expect(upstream.body?.locked).toBe(false);
+      }
+      setUpstreamInterceptor(undefined);
+    },
+  );
 
   it("streams an Anthropic SSE response containing the assistant text", async () => {
     harness = await createHarness({
@@ -113,5 +1038,281 @@ describe("Pipeline — streaming responses", () => {
     expect(sse).toContain('"name":"bash"');
     expect(sse).toContain("ls -la");
     expect(sse).toContain("event: message_stop");
+  });
+
+  it.each([
+    [
+      "malformed lifecycle",
+      new Response(
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"bad"}}\n\n',
+      ),
+    ],
+    [
+      "malformed UTF-8",
+      new Response(
+        new Uint8Array([
+          0x65, 0x76, 0x65, 0x6e, 0x74, 0x3a, 0x20, 0x70, 0x69, 0x6e, 0x67,
+          0x0a, 0x64, 0x61, 0x74, 0x61, 0x3a, 0x20, 0xff, 0x0a, 0x0a,
+        ]),
+      ),
+    ],
+  ])(
+    "rejects %s through the native foreground stream",
+    async (_case, upstream) => {
+      harness = await createHarness({
+        fixtures: makeConversationFixtures([
+          { userMessage: "invalid stream", assistantText: "unused" },
+        ]),
+      });
+      setUpstreamInterceptor(async () => upstream);
+      const body = await harness.chat(makeStreamBody("invalid stream")).then(
+        (response) => response.text().catch(() => ""),
+        () => "",
+      );
+      expect(body).not.toContain('"text":"bad"');
+    },
+  );
+
+  it("bounds comment-only native foreground streams", async () => {
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: "oversized stream", assistantText: "unused" },
+      ]),
+    });
+    const chunk = new TextEncoder().encode(`: ${"x".repeat(64 * 1024)}\n\n`);
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              for (let index = 0; index < 65; index++) {
+                controller.enqueue(chunk);
+              }
+              controller.close();
+            },
+          }),
+        ),
+    );
+    const body = await harness.chat(makeStreamBody("oversized stream")).then(
+      (response) => response.text().catch(() => ""),
+      () => "",
+    );
+    expect(body).not.toContain("x".repeat(64 * 1024));
+
+    const dataChunk = new TextEncoder().encode("x".repeat(64 * 1024));
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode("event: ping\ndata: "),
+              );
+              for (let index = 0; index < 65; index++) {
+                controller.enqueue(dataChunk);
+              }
+              controller.close();
+            },
+          }),
+        ),
+    );
+    const dataBody = await harness
+      .chat(makeStreamBody("oversized data stream"))
+      .then(
+        (response) => response.text().catch(() => ""),
+        () => "",
+      );
+    expect(dataBody).not.toContain("x".repeat(64 * 1024));
+  });
+
+  it("validates and forwards a same-wire Anthropic meta stream", async () => {
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: "meta valid", assistantText: "unused" },
+      ]),
+    });
+    setUpstreamInterceptor(async () => validAnthropicSSE());
+    const response = await harness.chat(makeMetaStreamBody("meta valid"));
+    const body = await response.text();
+    expect(body).toContain("meta ok");
+    expect(body).toContain("event: message_stop");
+  });
+
+  it.each([
+    {
+      name: "OpenAI Chat",
+      path: "/v1/chat/completions",
+      request: {
+        model: "gpt-4o",
+        stream: true,
+        messages: [{ role: "user", content: "meta" }],
+      },
+      upstream:
+        'data: {"choices":[{"index":0,"delta":{"content":"openai meta"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+      expected: "openai meta",
+    },
+    {
+      name: "Responses public",
+      path: "/v1/responses",
+      request: { model: "gpt-4o", stream: true, input: "meta" },
+      upstream:
+        'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","output":[]}}\n\n',
+      expected: "response.completed",
+    },
+    {
+      name: "Gemini",
+      path: "/v1beta/models/gemini-test:streamGenerateContent?alt=sse",
+      request: { contents: [{ role: "user", parts: [{ text: "meta" }] }] },
+      upstream:
+        'data: {"candidates":[{"content":{"parts":[{"text":"gemini meta"}]},"finishReason":"STOP"}]}\n\n',
+      expected: "gemini meta",
+    },
+  ])(
+    "validates a same-wire $name meta stream",
+    async ({ path, request, upstream, expected }) => {
+      harness = await createHarness({
+        fixtures: makeConversationFixtures([
+          { userMessage: "meta protocols", assistantText: "unused" },
+        ]),
+      });
+      setUpstreamInterceptor(
+        async () =>
+          new Response(upstream, {
+            headers: { "content-type": "text/event-stream" },
+          }),
+      );
+      const response = await fetch(`${harness.baseURL}${path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test",
+        },
+        body: JSON.stringify(request),
+      });
+      expect(await response.text()).toContain(expected);
+    },
+  );
+
+  it("rejects malformed and oversized same-wire meta streams", async () => {
+    harness = await createHarness({
+      fixtures: makeConversationFixtures([
+        { userMessage: "meta invalid", assistantText: "unused" },
+      ]),
+    });
+    setUpstreamInterceptor(
+      async () =>
+        new Response('event: message_stop\ndata: {"type":"message_stop"}\n\n'),
+    );
+    const malformedBody = await harness
+      .chat(makeMetaStreamBody("meta invalid"))
+      .then(
+        (response) => response.text().catch(() => ""),
+        () => "",
+      );
+    expect(malformedBody).not.toContain("message_stop");
+
+    const comment = new TextEncoder().encode(`: ${"x".repeat(64 * 1024)}\n\n`);
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              for (let index = 0; index < 65; index++) {
+                controller.enqueue(comment);
+              }
+              controller.close();
+            },
+          }),
+        ),
+    );
+    const oversizedBody = await harness
+      .chat(makeMetaStreamBody("meta invalid again"))
+      .then(
+        (response) => response.text().catch(() => ""),
+        () => "",
+      );
+    expect(oversizedBody).not.toContain("x".repeat(64 * 1024));
+  });
+
+  it("cancels a stalled same-wire meta upstream when the client aborts", async () => {
+    let cancelled = false;
+    const opening = validAnthropicSSE("partial");
+    const openingText = await opening.text();
+    const messageStart = openingText.slice(
+      0,
+      openingText.indexOf("event: content_block_start"),
+    );
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(messageStart));
+        },
+        pull() {
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const response = validatedMetaStream(upstream, "anthropic", false);
+    const reader = response.body?.getReader();
+    await reader?.read();
+    await reader?.cancel();
+    for (let attempt = 0; attempt < 10 && !cancelled; attempt++) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    expect(cancelled).toBe(true);
+  });
+
+  it("applies downstream backpressure and cancellation on the native path", async () => {
+    let pulls = 0;
+    let cancelled = false;
+    const encoder = new TextEncoder();
+    let openingSent = false;
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls++;
+          if (!openingSent) {
+            openingSent = true;
+            controller.enqueue(
+              encoder.encode(
+                `event: message_start\ndata: ${JSON.stringify({
+                  type: "message_start",
+                  message: {
+                    id: "msg_slow",
+                    type: "message",
+                    role: "assistant",
+                    model: DEFAULT_MODEL,
+                    content: [],
+                    stop_reason: null,
+                    stop_sequence: null,
+                    usage: { input_tokens: 1, output_tokens: 0 },
+                  },
+                })}\n\n`,
+              ),
+            );
+            return;
+          }
+          controller.enqueue(
+            encoder.encode('event: ping\ndata: {"type":"ping"}\n\n'),
+          );
+        },
+        cancel() {
+          cancelled = true;
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const response = buildStreamingResponse(upstream, () => {});
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(pulls).toBeLessThan(100);
+    await response.body?.cancel();
+    for (let attempt = 0; attempt < 10 && !cancelled; attempt++) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    expect(cancelled).toBe(true);
   });
 });

--- a/packages/gateway/test/recall-codex-stream.test.ts
+++ b/packages/gateway/test/recall-codex-stream.test.ts
@@ -264,6 +264,115 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     // The recall tool_use must NOT leak to the client.
     expect(bodyText).not.toContain('"name":"recall"');
     expect(bodyText).not.toContain('"name": "recall"');
+
+    const requestWithoutTools = async (
+      path: "/v1/codex/responses" | "/v1/responses",
+      upstream: Response,
+    ): Promise<string> => {
+      setUpstreamInterceptor(async () => upstream);
+      const response = await fetch(`${baseURL}${path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer test-token",
+          "x-lore-agent": "coder",
+          "x-lore-project": projectDir,
+        },
+        body: JSON.stringify({
+          model: "gpt-5.5",
+          stream: true,
+          input: "plain",
+        }),
+      });
+      return response.text();
+    };
+    const sparse = new Response(
+      sseEvent("response.output_item.added", {
+        item: { type: "message", id: "msg_sparse_real" },
+      }) +
+        sseEvent("response.output_text.done", {
+          item_id: "msg_sparse_real",
+          text: "sparse real caller",
+        }) +
+        sseEvent("response.output_item.done", {
+          item: {
+            type: "message",
+            id: "msg_sparse_real",
+            content: [{ type: "output_text", text: "sparse real caller" }],
+          },
+        }) +
+        sseEvent("response.completed", {
+          response: {
+            status: "completed",
+            output: [{ type: "item_reference", id: "msg_sparse_real" }],
+          },
+        }),
+    );
+    const sparseCodex = await requestWithoutTools(
+      "/v1/codex/responses",
+      sparse,
+    );
+    expect(sparseCodex).toContain("sparse real caller");
+    expect(sparseCodex).not.toContain("server_error");
+
+    const sparsePublic = await requestWithoutTools(
+      "/v1/responses",
+      new Response(
+        sseEvent("response.output_item.added", {
+          item: { type: "message", id: "public-mismatch" },
+        }),
+      ),
+    );
+    expect(sparsePublic).not.toContain("public-mismatch");
+    expect(sparsePublic).toContain("response.failed");
+
+    const malformed = await requestWithoutTools(
+      "/v1/codex/responses",
+      new Response("event: response.created\ndata: {bad}\n\n"),
+    );
+    expect(malformed).not.toContain("{bad}");
+    expect(malformed).toContain("response.failed");
+
+    const duplicate = await requestWithoutTools(
+      "/v1/codex/responses",
+      new Response(
+        sseEvent("response.output_item.added", {
+          item: {
+            type: "function_call",
+            id: "one",
+            call_id: "duplicate",
+            name: "one",
+            arguments: "{}",
+          },
+        }) +
+          sseEvent("response.output_item.added", {
+            item: {
+              type: "function_call",
+              id: "two",
+              call_id: "duplicate",
+              name: "two",
+              arguments: "{}",
+            },
+          }),
+      ),
+    );
+    expect(duplicate).toContain('"id":"one"');
+    expect(duplicate).not.toContain('"id":"two"');
+    expect(duplicate).toContain("response.failed");
+
+    const failure = await requestWithoutTools(
+      "/v1/codex/responses",
+      new Response(
+        sseEvent("response.failed", {
+          response: {
+            status: "failed",
+            error: { type: "server_error", message: "provider terminal" },
+          },
+        }),
+      ),
+    );
+    expect(failure.match(/event: response\.failed/g)).toHaveLength(1);
+    expect(failure).toContain("provider terminal");
   });
 
   test("non-codex openai-responses also streams the follow-up", async () => {

--- a/packages/gateway/test/recall.test.ts
+++ b/packages/gateway/test/recall.test.ts
@@ -11,6 +11,7 @@
 import { describe, test, expect, vi } from "vitest";
 import {
   LORE_COMMIT_REMINDER,
+  accumulateOpenAINonStreamJSON,
   loreMessagesToGateway,
   responsesProvenanceContent,
   responsesProvenanceByMessageId,
@@ -46,6 +47,7 @@ import {
   addRecallStoreEntry,
   MAX_RECALL_STORE_ENTRIES,
   MAX_RECALL_STORE_BYTES,
+  executeRecall,
 } from "../src/recall";
 import {
   buildOpenAIResponsesUpstreamRequest,
@@ -190,6 +192,62 @@ describe("RECALL_GATEWAY_TOOL", () => {
     // person/service reference against memory before filesystem exploration.
     expect(RECALL_GATEWAY_TOOL.description).toContain(
       "before searching the filesystem",
+    );
+  });
+});
+
+describe("executeRecall malformed input", () => {
+  test.each([
+    null,
+    [],
+    "query",
+    { query: null },
+    { query: "ok", scope: "invalid" },
+    { query: "ok", limit: 0 },
+    { query: "ok", limit: 1.5 },
+  ])("returns the safe failure result for %#", async (input) => {
+    const result = await executeRecall(
+      {
+        type: "tool_use",
+        id: "recall-malformed",
+        name: RECALL_TOOL_NAME,
+        input,
+      },
+      process.cwd(),
+      "malformed-input",
+    );
+    expect(result.result).toBe(
+      "Recall search failed. The memory system encountered an error.",
+    );
+    expect(result.input).toEqual({ query: "", scope: "all", id: undefined });
+  });
+
+  test('OpenAI arguments "null" reaches the same safe failure path', async () => {
+    const parsed = accumulateOpenAINonStreamJSON({
+      choices: [
+        {
+          index: 0,
+          finish_reason: "tool_calls",
+          message: {
+            tool_calls: [
+              {
+                id: "call-null",
+                function: { name: RECALL_TOOL_NAME, arguments: "null" },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const block = parsed.content[0];
+    if (block?.type !== "tool_use") throw new Error("missing recall tool use");
+    const result = await executeRecall(
+      block,
+      process.cwd(),
+      "openai-null-input",
+    );
+    expect(result.result).toBe(
+      "Recall search failed. The memory system encountered an error.",
     );
   });
 });
@@ -773,6 +831,9 @@ describe("buildRecallFollowUpRequest", () => {
     expect((resultBlock as { toolUseId: string }).toolUseId).toBe(
       recallBlock.id,
     );
+    expect((resultBlock as { toolName?: string }).toolName).toBe(
+      RECALL_TOOL_NAME,
+    );
 
     // Tools list keeps recall — the continuation is recall-aware and
     // can handle further recall calls (multi-turn recall).
@@ -781,6 +842,27 @@ describe("buildRecallFollowUpRequest", () => {
       "Read",
       "recall",
     ]);
+  });
+
+  test("keeps distinct provider id/name on a generated follow-up result", () => {
+    const call: GatewayToolUseBlock = {
+      type: "tool_use",
+      id: "call-1",
+      name: "lookup",
+      input: { query: "x" },
+    };
+    const followUp = buildRecallFollowUpRequest(
+      makeRequest(),
+      makeResponse([call], "tool_use"),
+      '{"value":1}',
+      call,
+      false,
+    );
+    expect(followUp.messages.at(-1)?.content[0]).toMatchObject({
+      type: "tool_result",
+      toolUseId: "call-1",
+      toolName: "lookup",
+    });
   });
 
   test("preserves other request properties", () => {
@@ -1140,6 +1222,73 @@ describe("runRecallFollowUpStreaming", () => {
     expect(forwardedSignal).toBe(controller.signal);
   });
 
+  test("settles on abort when follow-up setup ignores its signal", async () => {
+    const controller = new AbortController();
+    const ctx: RecallFollowUpCtx = {
+      forward: () => new Promise(() => {}),
+      parseJSON: () => {
+        throw new Error("should not be called");
+      },
+    };
+    const pending = runRecallFollowUpStreaming(
+      ctx,
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+      controller.signal,
+    );
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  test.each(["abort", "timeout"] as const)(
+    "%s cancels both branches of a pending SSE content probe without awaiting hostile cancellation",
+    async (mode) => {
+      if (mode === "timeout") vi.useFakeTimers();
+      const caller = new AbortController();
+      let sourceCancelled = false;
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            sourceCancelled = true;
+            return new Promise<void>(() => {});
+          },
+        }),
+      );
+      const pending = runRecallFollowUpStreaming(
+        {
+          forward: async () => ({
+            response,
+            effectiveProtocol: "openai-responses",
+          }),
+          parseJSON: () => Promise.reject(new Error("should not be called")),
+        },
+        makeRequest(),
+        resp,
+        "recall results",
+        recallBlock,
+        mode === "abort" ? caller.signal : undefined,
+      );
+      await Promise.resolve();
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: mode === "abort" ? "AbortError" : "TimeoutError",
+      });
+      if (mode === "abort") {
+        caller.abort(new DOMException("client disconnected", "AbortError"));
+      } else {
+        await vi.advanceTimersByTimeAsync(10_000);
+      }
+      await rejected;
+      await Promise.resolve();
+      expect(sourceCancelled).toBe(true);
+      if (mode === "timeout") vi.useRealTimers();
+    },
+  );
+
   test("cancellation interrupts a stalled non-OK response body", async () => {
     const controller = new AbortController();
     let bodyCancelled = false;
@@ -1424,6 +1573,56 @@ describe("runRecallFollowUpJSON", () => {
       ),
     ).rejects.toThrow("recall follow-up expected JSON but got SSE");
   });
+
+  test("abort settles when JSON follow-up setup ignores its signal", async () => {
+    const controller = new AbortController();
+    const pending = runRecallFollowUpJSON(
+      {
+        forward: () => new Promise(() => {}),
+        parseJSON: () => Promise.reject(new Error("should not be called")),
+      },
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+      controller.signal,
+    );
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  test("abort settles and cancels the body when JSON parsing ignores its signal", async () => {
+    const controller = new AbortController();
+    let bodyCancelled = false;
+    let markParsing!: () => void;
+    const parsing = new Promise<void>((resolve) => (markParsing = resolve));
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          bodyCancelled = true;
+        },
+      }),
+      { headers: { "content-type": "application/json" } },
+    );
+    const pending = runRecallFollowUpJSON(
+      {
+        forward: async () => ({ response, effectiveProtocol: "anthropic" }),
+        parseJSON: () => {
+          markParsing();
+          return new Promise(() => {});
+        },
+      },
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+      controller.signal,
+    );
+    await parsing;
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(bodyCancelled).toBe(true);
+  });
 });
 
 describe("runRecallFollowUpStreamAccumulated", () => {
@@ -1562,6 +1761,43 @@ describe("runRecallFollowUpStreamAccumulated", () => {
     ).rejects.toThrow("requires ctx.parseSSE");
     // Must fail fast before forwarding — never send an unaccumulatable request.
     expect(forwardCalled).toBe(false);
+  });
+
+  test("abort settles and cancels the body when SSE accumulation ignores its signal", async () => {
+    const controller = new AbortController();
+    let bodyCancelled = false;
+    let markParsing!: () => void;
+    const parsing = new Promise<void>((resolve) => (markParsing = resolve));
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(streamController) {
+          streamController.enqueue(new TextEncoder().encode("data: test\n\n"));
+        },
+        cancel() {
+          bodyCancelled = true;
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const pending = runRecallFollowUpStreamAccumulated(
+      {
+        forward: async () => ({ response, effectiveProtocol: "openai" }),
+        parseJSON: () => Promise.reject(new Error("should not be called")),
+        parseSSE: () => {
+          markParsing();
+          return new Promise(() => {});
+        },
+      },
+      makeRequest(),
+      resp,
+      "recall results",
+      recallBlock,
+      controller.signal,
+    );
+    await parsing;
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(bodyCancelled).toBe(true);
   });
 });
 

--- a/packages/gateway/test/server-node-bridge.test.ts
+++ b/packages/gateway/test/server-node-bridge.test.ts
@@ -1,0 +1,377 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, test, vi } from "vitest";
+import { handleForegroundBodyRoute, handleNodeRequest } from "../src/server";
+import { decodeRequestBody } from "../src/http-body";
+
+class FakeRequest extends EventEmitter {
+  method = "GET";
+  url = "/test";
+  headers: Record<string, string> = {};
+  complete = false;
+  socket = new EventEmitter();
+}
+
+class FakeResponse extends EventEmitter {
+  writableEnded = false;
+  writableFinished = false;
+  destroyed = false;
+  headersSent = false;
+  status = 0;
+  chunks: Uint8Array[] = [];
+  writeResults: boolean[] = [];
+  autoCloseOnEnd = true;
+
+  writeHead(status: number): this {
+    this.status = status;
+    this.headersSent = true;
+    return this;
+  }
+
+  write(chunk: Uint8Array): boolean {
+    this.chunks.push(chunk);
+    return this.writeResults.shift() ?? true;
+  }
+
+  end(chunk?: string): this {
+    if (chunk) this.chunks.push(new TextEncoder().encode(chunk));
+    this.writableEnded = true;
+    if (this.autoCloseOnEnd) {
+      this.writableFinished = true;
+      this.emit("finish");
+      this.emit("close");
+    }
+    return this;
+  }
+
+  destroy(): this {
+    this.destroyed = true;
+    this.emit("close");
+    return this;
+  }
+}
+
+function asRequest(req: FakeRequest): IncomingMessage {
+  return req as unknown as IncomingMessage;
+}
+
+function asResponse(res: FakeResponse): ServerResponse {
+  return res as unknown as ServerResponse;
+}
+
+function expectListenersCleaned(req: FakeRequest, res: FakeResponse): void {
+  expect(req.listenerCount("aborted")).toBe(0);
+  expect(req.listenerCount("close")).toBe(0);
+  expect(req.listenerCount("error")).toBe(0);
+  expect(res.listenerCount("close")).toBe(0);
+  expect(res.listenerCount("error")).toBe(0);
+  expect(res.listenerCount("drain")).toBe(0);
+  expect(res.listenerCount("finish")).toBe(0);
+  expect(req.socket.listenerCount("close")).toBe(0);
+  expect(req.socket.listenerCount("error")).toBe(0);
+}
+
+describe("node:http ingress lifecycle branches", () => {
+  test.each(["aborted", "incomplete-close", "request-error"] as const)(
+    "%s aborts pending handler work and removes listeners",
+    async (branch) => {
+      const req = new FakeRequest();
+      const res = new FakeResponse();
+      let requestSignal: AbortSignal | undefined;
+      let markStarted!: () => void;
+      const started = new Promise<void>((resolve) => (markStarted = resolve));
+      const handling = handleNodeRequest(
+        asRequest(req),
+        asResponse(res),
+        (request) => {
+          requestSignal = request.signal;
+          markStarted();
+          return new Promise(() => {});
+        },
+        "127.0.0.1",
+        3207,
+      );
+      await started;
+      if (branch === "aborted") req.emit("aborted");
+      else if (branch === "incomplete-close") req.emit("close");
+      else req.emit("error", new Error("request failed"));
+      await handling;
+      expect(requestSignal?.aborted).toBe(true);
+      expectListenersCleaned(req, res);
+    },
+  );
+
+  test("a normal-complete request close does not abort", async () => {
+    const req = new FakeRequest();
+    const res = new FakeResponse();
+    let requestSignal: AbortSignal | undefined;
+    await handleNodeRequest(
+      asRequest(req),
+      asResponse(res),
+      (request) => {
+        requestSignal = request.signal;
+        req.complete = true;
+        req.emit("close");
+        return new Response("ok");
+      },
+      "127.0.0.1",
+      3207,
+    );
+    expect(requestSignal?.aborted).toBe(false);
+    expect(res.writableEnded).toBe(true);
+    expectListenersCleaned(req, res);
+  });
+
+  test("a premature ServerResponse close aborts and cancels the response reader", async () => {
+    const req = new FakeRequest();
+    req.complete = true;
+    const res = new FakeResponse();
+    let requestSignal: AbortSignal | undefined;
+    let sourceCancelled = false;
+    let markReading!: () => void;
+    const reading = new Promise<void>((resolve) => (markReading = resolve));
+    const source = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("partial"));
+        },
+        pull() {
+          markReading();
+          return new Promise(() => {});
+        },
+        cancel() {
+          sourceCancelled = true;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const handling = handleNodeRequest(
+      asRequest(req),
+      asResponse(res),
+      (request) => {
+        requestSignal = request.signal;
+        return source;
+      },
+      "127.0.0.1",
+      3207,
+    );
+    await reading;
+    while (res.chunks.length === 0) await Promise.resolve();
+    res.emit("close");
+    await handling;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(sourceCancelled).toBe(true);
+    expect(source.body?.locked).toBe(false);
+    expectListenersCleaned(req, res);
+  });
+
+  test("an independently emitted ServerResponse error aborts and cancels exactly once", async () => {
+    const req = new FakeRequest();
+    req.complete = true;
+    const res = new FakeResponse();
+    let requestSignal: AbortSignal | undefined;
+    let cancelCount = 0;
+    let markReading!: () => void;
+    const reading = new Promise<void>((resolve) => (markReading = resolve));
+    const source = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("partial"));
+        },
+        pull() {
+          markReading();
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelCount++;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const handling = handleNodeRequest(
+      asRequest(req),
+      asResponse(res),
+      (request) => {
+        requestSignal = request.signal;
+        return source;
+      },
+      "127.0.0.1",
+      3207,
+    );
+    await reading;
+    while (res.chunks.length === 0) await Promise.resolve();
+    expect(() => res.emit("error", new Error("response failed"))).not.toThrow();
+    await handling;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(cancelCount).toBe(1);
+    expect(source.body?.locked).toBe(false);
+    expect(res.destroyed).toBe(true);
+    expect(Buffer.concat(res.chunks).toString("utf8")).toBe("partial");
+    expectListenersCleaned(req, res);
+  });
+
+  test("a late response error after end but before finish remains owned and adds no JSON suffix", async () => {
+    const req = new FakeRequest();
+    req.complete = true;
+    const res = new FakeResponse();
+    res.autoCloseOnEnd = false;
+    let requestSignal: AbortSignal | undefined;
+    const handling = handleNodeRequest(
+      asRequest(req),
+      asResponse(res),
+      (request) => {
+        requestSignal = request.signal;
+        return new Response("one-chunk");
+      },
+      "127.0.0.1",
+      3207,
+    );
+    while (!res.writableEnded) await Promise.resolve();
+    const chunksBeforeError = res.chunks.map((chunk) => Buffer.from(chunk));
+    expect(() =>
+      res.emit("error", new Error("late write failure")),
+    ).not.toThrow();
+    await handling;
+    expect(requestSignal?.aborted).toBe(true);
+    expect(res.destroyed).toBe(true);
+    expect(res.chunks).toEqual(chunksBeforeError);
+    expect(Buffer.concat(res.chunks).toString("utf8")).toBe("one-chunk");
+    expectListenersCleaned(req, res);
+  });
+
+  test("response backpressure pauses Web body reads until drain", async () => {
+    const req = new FakeRequest();
+    req.complete = true;
+    const res = new FakeResponse();
+    res.writeResults.push(false, true);
+    let pulls = 0;
+    const chunks = [
+      new TextEncoder().encode("one"),
+      new TextEncoder().encode("two"),
+    ];
+    const source = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls++;
+          const chunk = chunks.shift();
+          if (chunk) controller.enqueue(chunk);
+          else controller.close();
+        },
+      }),
+    );
+    const handling = handleNodeRequest(
+      asRequest(req),
+      asResponse(res),
+      () => source,
+      "127.0.0.1",
+      3207,
+    );
+    while (res.listenerCount("drain") === 0) await Promise.resolve();
+    const pullsWhilePaused = pulls;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(pulls).toBe(pullsWhilePaused);
+    expect(res.chunks).toHaveLength(1);
+    res.emit("drain");
+    await handling;
+    expect(res.chunks).toHaveLength(2);
+    expect(res.writableEnded).toBe(true);
+    expectListenersCleaned(req, res);
+  });
+
+  test("disconnect while waiting for drain cancels without reading more", async () => {
+    const req = new FakeRequest();
+    req.complete = true;
+    const res = new FakeResponse();
+    res.writeResults.push(false);
+    let cancelCount = 0;
+    let pulls = 0;
+    const source = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls++;
+          if (pulls === 1) {
+            controller.enqueue(new TextEncoder().encode("one"));
+          }
+          return new Promise(() => {});
+        },
+        cancel() {
+          cancelCount++;
+          return new Promise<void>(() => {});
+        },
+      }),
+    );
+    const handling = handleNodeRequest(
+      asRequest(req),
+      asResponse(res),
+      () => source,
+      "127.0.0.1",
+      3207,
+    );
+    while (res.listenerCount("drain") === 0) await Promise.resolve();
+    const pullsWhilePaused = pulls;
+    res.emit("close");
+    await handling;
+    expect(pulls).toBe(pullsWhilePaused);
+    expect(cancelCount).toBe(1);
+    expect(source.body?.locked).toBe(false);
+    expectListenersCleaned(req, res);
+  });
+
+  test("normal response close after end does not abort", async () => {
+    const req = new FakeRequest();
+    req.complete = true;
+    const res = new FakeResponse();
+    let requestSignal: AbortSignal | undefined;
+    await handleNodeRequest(
+      asRequest(req),
+      asResponse(res),
+      (request) => {
+        requestSignal = request.signal;
+        return new Response("complete");
+      },
+      "127.0.0.1",
+      3207,
+    );
+    expect(res.writableEnded).toBe(true);
+    expect(requestSignal?.aborted).toBe(false);
+    expectListenersCleaned(req, res);
+  });
+});
+
+test("the application foreground deadline starts before request body decoding", async () => {
+  vi.useFakeTimers();
+  let cancelled = false;
+  let markPull!: () => void;
+  const pulling = new Promise<void>((resolve) => (markPull = resolve));
+  const source = new ReadableStream<Uint8Array>({
+    pull() {
+      markPull();
+      return new Promise(() => {});
+    },
+    cancel() {
+      cancelled = true;
+      return new Promise<void>(() => {});
+    },
+  });
+  const req = new Request("http://gateway.test/v1/messages", {
+    method: "POST",
+    body: source,
+    duplex: "half",
+  } as RequestInit & { duplex: "half" });
+  try {
+    const pending = handleForegroundBodyRoute(req, async (scoped) => {
+      await decodeRequestBody(scoped);
+      return new Response("should not complete");
+    });
+    const rejected = expect(pending).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    await pulling;
+    await vi.advanceTimersByTimeAsync(300_000);
+    await rejected;
+    expect(cancelled).toBe(true);
+    expect(source.locked).toBe(false);
+  } finally {
+    vi.useRealTimers();
+  }
+});

--- a/packages/gateway/test/server.test.ts
+++ b/packages/gateway/test/server.test.ts
@@ -13,10 +13,12 @@
  */
 import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import { connect } from "node:net";
-import { zstdCompressSync } from "node:zlib";
+import { createServer as createHttpServer } from "node:http";
+import { brotliCompressSync, gzipSync, zstdCompressSync } from "node:zlib";
 import { startServer } from "../src/server";
 import { loadConfig } from "../src/config";
 import type { GatewayConfig } from "../src/config";
+import { MAX_HTTP_REQUEST_DECOMPRESSED_BYTES } from "../src/http-body";
 
 type ServerHandle = Awaited<ReturnType<typeof startServer>>;
 
@@ -45,6 +47,92 @@ afterAll(() => {
 });
 
 describe("server routing", () => {
+  test("destroying a client socket aborts a pending upstream fetch", async () => {
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => (markStarted = resolve));
+    let markClosed!: () => void;
+    const closed = new Promise<void>((resolve) => (markClosed = resolve));
+    const upstream = createHttpServer((req) => {
+      markStarted();
+      req.once("close", markClosed);
+    });
+    await new Promise<void>((resolve) =>
+      upstream.listen(0, "127.0.0.1", resolve),
+    );
+    const address = upstream.address();
+    if (!address || typeof address === "string") throw new Error("no address");
+    const gateway = await startServer(
+      makeConfig({ upstreamAnthropic: `http://127.0.0.1:${address.port}` }),
+    );
+    const socket = connect(gateway.port, "127.0.0.1", () => {
+      socket.write(
+        `GET /v1/models HTTP/1.1\r\nHost: 127.0.0.1:${gateway.port}\r\n\r\n`,
+      );
+    });
+    try {
+      await started;
+      socket.destroy();
+      await Promise.race([
+        closed,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("upstream fetch stayed open")),
+            2000,
+          ),
+        ),
+      ]);
+    } finally {
+      socket.destroy();
+      gateway.stop();
+      upstream.closeAllConnections();
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
+  test("destroying a client socket cancels an open upstream response body", async () => {
+    let markClosed!: () => void;
+    const closed = new Promise<void>((resolve) => (markClosed = resolve));
+    const upstream = createHttpServer((_req, res) => {
+      res.once("close", markClosed);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"partial":');
+    });
+    await new Promise<void>((resolve) =>
+      upstream.listen(0, "127.0.0.1", resolve),
+    );
+    const address = upstream.address();
+    if (!address || typeof address === "string") throw new Error("no address");
+    const gateway = await startServer(
+      makeConfig({ upstreamAnthropic: `http://127.0.0.1:${address.port}` }),
+    );
+    const socket = connect(gateway.port, "127.0.0.1", () => {
+      socket.write(
+        `GET /v1/models HTTP/1.1\r\nHost: 127.0.0.1:${gateway.port}\r\n\r\n`,
+      );
+    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        socket.once("data", () => resolve());
+        socket.once("error", reject);
+      });
+      socket.destroy();
+      await Promise.race([
+        closed,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("upstream body stayed open")),
+            2000,
+          ),
+        ),
+      ]);
+    } finally {
+      socket.destroy();
+      gateway.stop();
+      upstream.closeAllConnections();
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
   test("OPTIONS preflight returns 204 with permissive CORS headers", async () => {
     const res = await fetch(`${baseURL}/v1/messages`, { method: "OPTIONS" });
     expect(res.status).toBe(204);
@@ -123,6 +211,52 @@ describe("server routing", () => {
     const body = (await res.json()) as { error: { type: string } };
     expect(body.error.type).toBe("api_error");
   });
+
+  test("POST /v1/responses/compact rejects invalid JSON on the exact route", async () => {
+    const res = await fetch(`${baseURL}/v1/responses/compact`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{ not json",
+    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "invalid_request",
+      message: "Invalid JSON body",
+    });
+  });
+
+  test.each([
+    ["/v1/messages", "gzip"],
+    ["/v1/chat/completions", "br"],
+    ["/v1/responses", "zstd"],
+    ["/v1beta/models/gemini-test:generateContent", "gzip"],
+    ["/v1/compact", "br"],
+    ["/v1/responses/compact", "zstd"],
+  ] as const)(
+    "POST %s rejects a %s decompression bomb",
+    async (path, encoding) => {
+      const expanded = Buffer.alloc(
+        MAX_HTTP_REQUEST_DECOMPRESSED_BYTES + 1,
+        0x61,
+      );
+      const compressed =
+        encoding === "gzip"
+          ? gzipSync(expanded)
+          : encoding === "br"
+            ? brotliCompressSync(expanded)
+            : zstdCompressSync(expanded);
+      const res = await fetch(`${baseURL}${path}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-encoding": encoding,
+          "x-api-key": "test-key",
+        },
+        body: compressed,
+      });
+      expect(res.status).toBe(400);
+    },
+  );
 
   test("rejects a raw WebSocket upgrade with 426 at the socket level", async () => {
     // node:http dispatches Upgrade requests via a separate 'upgrade' event,

--- a/packages/gateway/test/stream-anthropic.test.ts
+++ b/packages/gateway/test/stream-anthropic.test.ts
@@ -40,6 +40,36 @@ function readerFromChunks(
   return stream.getReader();
 }
 
+function readerFromBytes(
+  chunks: Uint8Array[],
+): ReadableStreamDefaultReader<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  }).getReader();
+}
+
+test("strict SSE decoding rejects malformed UTF-8, including split sequences", async () => {
+  for (const chunks of [
+    [new Uint8Array([0x64, 0x61, 0x74, 0x61, 0x3a, 0x20, 0xff, 0x0a, 0x0a])],
+    [
+      new Uint8Array([0x64, 0x61, 0x74, 0x61, 0x3a, 0x20, 0xe2]),
+      new Uint8Array([0x28, 0xa1, 0x0a, 0x0a]),
+    ],
+  ]) {
+    const consume = async () => {
+      for await (const _event of parseSSEStream(readerFromBytes(chunks), {
+        fatalUtf8: true,
+      })) {
+        // consume
+      }
+    };
+    await expect(consume()).rejects.toThrow("malformed SSE UTF-8");
+  }
+});
+
 async function collect(
   reader: ReadableStreamDefaultReader<Uint8Array>,
 ): Promise<{ event: string; data: string }[]> {
@@ -76,6 +106,66 @@ describe("formatSSEEvent", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseSSEStream", () => {
+  test("supports lone-CR separators and split UTF-8 code points", async () => {
+    const encoded = new TextEncoder().encode("\uFEFFdata: café\r\r");
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          const split = encoded.indexOf(0xc3) + 1;
+          controller.enqueue(encoded.subarray(0, split));
+          controller.enqueue(encoded.subarray(split));
+          controller.close();
+        },
+      }),
+    );
+    if (!response.body) throw new Error("test response has no body");
+    const events = [];
+    for await (const event of parseSSEStream(response.body.getReader(), {
+      fatalUtf8: true,
+    })) {
+      events.push(event);
+    }
+    expect(events).toEqual([{ event: "message", data: "café" }]);
+  });
+  test("bounds aggregate bytes across many individually-small frames", async () => {
+    const response = new Response("data: 1\n\ndata: 2\n\ndata: 3\n\n");
+    const body = response.body;
+    if (!body) throw new Error("test response has no body");
+    await expect(async () => {
+      for await (const _event of parseSSEStream(body.getReader(), {
+        maxTotalBytes: 16,
+      })) {
+        // consume
+      }
+    }).rejects.toThrow("SSE stream exceeded aggregate byte limit");
+  });
+  test("does not remeasure the whole remaining buffer for each frame", async () => {
+    const frameCount = 2_000;
+    const wire = Array.from(
+      { length: frameCount },
+      (_, index) => `data: ${index}\r\n\r\n`,
+    ).join("");
+    const response = new Response(wire);
+    if (!response.body) throw new Error("test response has no body");
+    const reader = response.body.getReader();
+    const byteLength = vi.spyOn(Buffer, "byteLength");
+    try {
+      let seen = 0;
+      for await (const event of parseSSEStream(reader)) {
+        expect(event.data).toBe(String(seen));
+        seen++;
+      }
+      expect(seen).toBe(frameCount);
+      const measuredStrings = byteLength.mock.calls
+        .map(([value]) => value)
+        .filter((value): value is string => typeof value === "string");
+      expect(
+        Math.max(...measuredStrings.map((value) => value.length)),
+      ).toBeLessThan(32);
+    } finally {
+      byteLength.mockRestore();
+    }
+  });
   test("parses named events, multi-data lines, comments, and the default event", async () => {
     const sse =
       'event: message_start\ndata: {"a":1}\n\n' +
@@ -96,6 +186,18 @@ describe("parseSSEStream", () => {
       readerFromChunks(["event: message_start\nda", 'ta: {"x":1}\n\n']),
     );
     expect(events).toEqual([{ event: "message_start", data: '{"x":1}' }]);
+  });
+
+  test("bounds a byte-fragmented unterminated event without prefix rescans", async () => {
+    const wire = `data: ${"x".repeat(64 * 1024)}`;
+    const reader = readerFromChunks(Array.from(wire));
+    await expect(async () => {
+      for await (const _event of parseSSEStream(reader, {
+        maxEventBytes: 32 * 1024,
+      })) {
+        // No complete event should be yielded.
+      }
+    }).rejects.toThrow("SSE event exceeded 32768 byte limit");
   });
 
   test.each([1, 2, 3])(
@@ -145,6 +247,105 @@ describe("parseSSEStream", () => {
     );
   });
 
+  test("accepts exact event/comment byte boundaries and rejects the first extra byte", async () => {
+    const consume = async (wire: string, maxEventBytes: number) => {
+      const events = [];
+      for await (const event of parseSSEStream(readerFromChunks([wire]), {
+        maxEventBytes,
+      })) {
+        events.push(event);
+      }
+      return events;
+    };
+    await expect(consume("data: x\n\n", 7)).resolves.toHaveLength(1);
+    await expect(consume("data: x\n\n", 6)).rejects.toThrow(
+      "SSE event exceeded 6 byte limit",
+    );
+    await expect(consume(": abc\n\n", 5)).resolves.toHaveLength(0);
+    await expect(consume(": abc\n\n", 4)).rejects.toThrow(
+      "SSE event exceeded 4 byte limit",
+    );
+  });
+
+  test("accepts exact aggregate/frame boundaries and rejects first illegal byte/frame", async () => {
+    const consume = async (
+      wire: string,
+      opts: Parameters<typeof parseSSEStream>[1],
+    ) => {
+      for await (const _event of parseSSEStream(
+        readerFromChunks([wire]),
+        opts,
+      )) {
+        // consume
+      }
+    };
+    await expect(
+      consume("data: x\n\n", { maxTotalBytes: 9, maxFrames: 1 }),
+    ).resolves.toBeUndefined();
+    await expect(consume("data: x\n\n", { maxTotalBytes: 8 })).rejects.toThrow(
+      "SSE stream exceeded aggregate byte limit",
+    );
+    await expect(
+      consume("data: x\n\ndata: y\n\n", { maxFrames: 1 }),
+    ).rejects.toThrow("SSE stream exceeded 1 frame limit");
+  });
+
+  test("excludes one split UTF-8 BOM from event and aggregate byte limits", async () => {
+    const bom = [
+      new Uint8Array([0xef]),
+      new Uint8Array([0xbb]),
+      new Uint8Array([0xbf]),
+    ];
+    const wire = new TextEncoder().encode("data: x\n\n");
+    const consume = async (payload: Uint8Array, maxEventBytes: number) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array());
+          for (const chunk of bom) controller.enqueue(chunk);
+          controller.enqueue(payload);
+          controller.close();
+        },
+      });
+      const events = [];
+      for await (const event of parseSSEStream(stream.getReader(), {
+        maxEventBytes,
+        maxTotalBytes: payload.byteLength,
+        fatalUtf8: true,
+      })) {
+        events.push(event);
+      }
+      return events;
+    };
+    await expect(consume(wire, 7)).resolves.toEqual([
+      { event: "message", data: "x" },
+    ]);
+    await expect(
+      consume(new TextEncoder().encode("data: xx\n\n"), 7),
+    ).rejects.toThrow("SSE event exceeded 7 byte limit");
+  });
+
+  test("applies the event limit per frame, independent of transport chunking", async () => {
+    const wire = Array.from({ length: 10 }, (_, i) => `data: ${i}\n\n`).join(
+      "",
+    );
+    const read = async (chunks: string[]) => {
+      const events: string[] = [];
+      for await (const event of parseSSEStream(readerFromChunks(chunks), {
+        maxEventBytes: 16,
+      })) {
+        events.push(event.data);
+      }
+      return events;
+    };
+
+    await expect(read([wire])).resolves.toEqual(
+      Array.from({ length: 10 }, (_, i) => String(i)),
+    );
+    await expect(read(Array.from(wire))).resolves.toEqual(
+      Array.from({ length: 10 }, (_, i) => String(i)),
+    );
+  });
+
   test("rejects an unlimited sequence of small frames", async () => {
     const reader = readerFromChunks([
       "data: one\n\ndata: two\n\ndata: three\n\n",
@@ -156,6 +357,24 @@ describe("parseSSEStream", () => {
     };
     await expect(collectBounded()).rejects.toThrow(
       "SSE stream exceeded 2 frame limit",
+    );
+  });
+
+  test("counts blank, comment-only, and yielded event frames toward the limit", async () => {
+    const reader = readerFromChunks([
+      "\n\n" +
+        ": heartbeat\n\n" +
+        'event: ping\ndata: {"type":"ping"}\n\n' +
+        "\n\n",
+    ]);
+    const consume = async (): Promise<void> => {
+      for await (const _event of parseSSEStream(reader, { maxFrames: 3 })) {
+        // The fourth delimiter is blank but must still consume frame budget.
+      }
+    };
+
+    await expect(consume()).rejects.toThrow(
+      "SSE stream exceeded 3 frame limit",
     );
   });
 
@@ -549,6 +768,469 @@ describe("buildSSETextResponse", () => {
 });
 
 describe("accumulateSSEResponse", () => {
+  test("stops at message_stop without waiting for transport EOF", async () => {
+    let cancelled = false;
+    const sse = buildSSETextResponse("id_terminal", "claude-x", "done", {
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(sse));
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise(() => {});
+        },
+      }),
+    );
+
+    const resp = await accumulateSSEResponse(response, {
+      stopAtTerminal: true,
+      strict: true,
+    });
+
+    expect(resp.content).toEqual([{ type: "text", text: "done" }]);
+    expect(cancelled).toBe(true);
+    expect(response.body?.locked).toBe(false);
+  });
+
+  test("rejects EOF before message_stop in strict worker mode", async () => {
+    const truncated = buildSSETextResponse(
+      "id_truncated",
+      "claude-x",
+      "partial",
+      { inputTokens: 1, outputTokens: 1 },
+    ).replace('event: message_stop\ndata: {"type":"message_stop"}\n\n', "");
+
+    await expect(
+      accumulateSSEResponse(new Response(truncated), {
+        stopAtTerminal: true,
+        strict: true,
+      }),
+    ).rejects.toThrow("missing Anthropic message_stop terminal");
+  });
+
+  test("rejects an unterminated terminal frame in strict worker mode", async () => {
+    await expect(
+      accumulateSSEResponse(
+        new Response('event: message_stop\ndata: {"type":"message_stop"}'),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("unterminated SSE event at EOF");
+  });
+
+  test("rejects malformed JSON before a valid terminal", async () => {
+    await expect(
+      accumulateSSEResponse(
+        new Response(
+          "event: content_block_delta\ndata: {not-json}\n\n" +
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+        ),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Anthropic stream event");
+  });
+
+  test("rejects orphan lifecycle events in strict worker mode", async () => {
+    await expect(
+      accumulateSSEResponse(
+        new Response(
+          'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"orphan"}}\n\n' +
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+        ),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Anthropic stream event");
+  });
+
+  test("rejects explicit upstream error events in strict worker mode", async () => {
+    await expect(
+      accumulateSSEResponse(
+        new Response(
+          'event: error\ndata: {"type":"error","error":{"message":"failed"}}\n\n',
+        ),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("Anthropic stream error event");
+  });
+
+  test("rejects reused block indices and blocks after message_delta", async () => {
+    const messageStart =
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"claude","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n';
+    const block =
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+      'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n';
+    const messageDelta =
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":0}}\n\n';
+
+    await expect(
+      accumulateSSEResponse(
+        new Response(messageStart + block + block + messageDelta),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed Anthropic stream event");
+    await expect(
+      accumulateSSEResponse(new Response(messageStart + messageDelta + block), {
+        stopAtTerminal: true,
+        strict: true,
+      }),
+    ).rejects.toThrow("malformed Anthropic stream event");
+  });
+
+  test("rejects duplicate tool_use IDs across block indices", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      formatSSEEvent(type, JSON.stringify({ type, ...data }));
+    const wire =
+      buildSSEMessageStart({
+        id: "duplicate-tool-id",
+        model: "claude-x",
+        content: [],
+        stopReason: "end_turn",
+        usage: { inputTokens: 1, outputTokens: 0 },
+      }) +
+      event("content_block_start", {
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_shared",
+          name: "a",
+          input: {},
+        },
+      }) +
+      event("content_block_stop", { index: 0 }) +
+      event("content_block_start", {
+        index: 1,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_shared",
+          name: "b",
+          input: {},
+        },
+      });
+
+    await expect(
+      accumulateSSEResponse(new Response(wire), {
+        stopAtTerminal: true,
+        strict: true,
+      }),
+    ).rejects.toThrow("malformed Anthropic stream event");
+  });
+
+  test("rejects empty and cross-type duplicate server tool identities", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      formatSSEEvent(type, JSON.stringify({ type, ...data }));
+    const start = buildSSEMessageStart({
+      id: "server-tool-identities",
+      model: "claude-x",
+      content: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 0 },
+    });
+    const serverTool = (index: number, id: string) =>
+      event("content_block_start", {
+        index,
+        content_block: {
+          type: "server_tool_use",
+          id,
+          name: "web_search",
+          input: {},
+        },
+      });
+
+    await expect(
+      accumulateSSEResponse(new Response(start + serverTool(0, "")), {
+        stopAtTerminal: true,
+        strict: true,
+      }),
+    ).rejects.toThrow("malformed Anthropic stream event");
+
+    const duplicate =
+      start +
+      event("content_block_start", {
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "tool-shared",
+          name: "client_tool",
+          input: {},
+        },
+      }) +
+      event("content_block_stop", { index: 0 }) +
+      serverTool(1, "tool-shared");
+    await expect(
+      accumulateSSEResponse(new Response(duplicate), {
+        stopAtTerminal: true,
+        strict: true,
+      }),
+    ).rejects.toThrow("malformed Anthropic stream event");
+  });
+
+  test("permits repeated deltas for one tool identity", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      formatSSEEvent(type, JSON.stringify({ type, ...data }));
+    const wire =
+      buildSSEMessageStart({
+        id: "repeated-tool-deltas",
+        model: "claude-x",
+        content: [],
+        stopReason: "tool_use",
+        usage: { inputTokens: 1, outputTokens: 0 },
+      }) +
+      event("content_block_start", {
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "tool-repeat",
+          name: "lookup",
+          input: {},
+        },
+      }) +
+      event("content_block_delta", {
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"a":' },
+      }) +
+      event("content_block_delta", {
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: "1}" },
+      }) +
+      event("content_block_stop", { index: 0 }) +
+      event("message_delta", {
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      }) +
+      event("message_stop", {});
+
+    const result = await accumulateSSEResponse(new Response(wire), {
+      stopAtTerminal: true,
+      strict: true,
+    });
+    expect(result.content).toEqual([
+      {
+        type: "tool_use",
+        id: "tool-repeat",
+        name: "lookup",
+        input: { a: 1 },
+      },
+    ]);
+  });
+
+  test.each([
+    [
+      "unknown event name",
+      (wire: string) =>
+        wire.replace(
+          "event: message_start",
+          'event: future_event\ndata: {"type":"future_event"}\n\nevent: message_start',
+        ),
+    ],
+    [
+      "unknown content block type",
+      (wire: string) =>
+        wire.replace(
+          '"content_block":{"type":"text"',
+          '"content_block":{"type":"future_block"',
+        ),
+    ],
+    [
+      "unknown delta type",
+      (wire: string) =>
+        wire.replace(
+          '"delta":{"type":"text_delta","text":"done"}',
+          '"delta":{"type":"future_delta","text":"done"}',
+        ),
+    ],
+    [
+      "incompatible delta type",
+      (wire: string) =>
+        wire.replace(
+          '"delta":{"type":"text_delta","text":"done"}',
+          '"delta":{"type":"input_json_delta","partial_json":"{}"}',
+        ),
+    ],
+    [
+      "malformed message id",
+      (wire: string) => wire.replace('"id":"strict"', '"id":1'),
+    ],
+    [
+      "malformed message content",
+      (wire: string) => wire.replace('"content":[]', '"content":null'),
+    ],
+    [
+      "negative message-start usage",
+      (wire: string) => wire.replace('"input_tokens":1', '"input_tokens":-1'),
+    ],
+    [
+      "infinite message-start usage",
+      (wire: string) =>
+        wire.replace('"input_tokens":1', '"input_tokens":1e309'),
+    ],
+    [
+      "malformed message delta",
+      (wire: string) =>
+        wire.replace(
+          '"delta":{"stop_reason":"end_turn","stop_sequence":null}',
+          '"delta":null',
+        ),
+    ],
+    [
+      "negative message-delta usage",
+      (wire: string) =>
+        wire.replace(
+          '"usage":{"output_tokens":1}}',
+          '"usage":{"output_tokens":-1}}',
+        ),
+    ],
+    [
+      "invalid stop reason",
+      (wire: string) =>
+        wire.replace(
+          '"stop_reason":"end_turn"',
+          '"stop_reason":"future_reason"',
+        ),
+    ],
+  ] as const)("rejects %s", async (_case, mutate) => {
+    const valid = buildSSETextResponse("strict", "claude-x", "done", {
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+    await expect(
+      accumulateSSEResponse(new Response(mutate(valid)), {
+        stopAtTerminal: true,
+        strict: true,
+      }),
+    ).rejects.toThrow("malformed Anthropic stream event");
+  });
+
+  test("accepts official citation/server-tool/result/fallback block variants", async () => {
+    const event = (type: string, data: Record<string, unknown>) =>
+      formatSSEEvent(type, JSON.stringify({ type, ...data }));
+    const start = buildSSEMessageStart({
+      id: "official-variants",
+      model: "claude-x",
+      content: [],
+      stopReason: "end_turn",
+      usage: { inputTokens: 2, outputTokens: 0 },
+    });
+    const wire =
+      start +
+      event("content_block_start", {
+        index: 0,
+        content_block: { type: "text", text: "", citations: [] },
+      }) +
+      event("content_block_delta", {
+        index: 0,
+        delta: { type: "citations_delta", citation: { type: "page_location" } },
+      }) +
+      event("content_block_delta", {
+        index: 0,
+        delta: { type: "text_delta", text: "answer" },
+      }) +
+      event("content_block_stop", { index: 0 }) +
+      event("content_block_start", {
+        index: 1,
+        content_block: {
+          type: "server_tool_use",
+          id: "srvtoolu_1",
+          name: "web_search",
+          input: {},
+        },
+      }) +
+      event("content_block_delta", {
+        index: 1,
+        delta: { type: "input_json_delta", partial_json: "{}" },
+      }) +
+      event("content_block_stop", { index: 1 }) +
+      event("content_block_start", {
+        index: 2,
+        content_block: {
+          type: "web_search_tool_result",
+          tool_use_id: "srvtoolu_1",
+          content: [],
+        },
+      }) +
+      event("content_block_stop", { index: 2 }) +
+      event("content_block_start", {
+        index: 3,
+        content_block: { type: "fallback" },
+      }) +
+      event("content_block_stop", { index: 3 }) +
+      event("message_delta", {
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: {
+          input_tokens: 2,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          output_tokens: 1,
+          output_tokens_details: { thinking_tokens: 0 },
+          server_tool_use: { web_search_requests: 1, web_fetch_requests: 0 },
+        },
+      }) +
+      event("message_stop", {});
+
+    const result = await accumulateSSEResponse(new Response(wire), {
+      stopAtTerminal: true,
+      strict: true,
+    });
+    expect(result.content).toEqual([{ type: "text", text: "answer" }]);
+  });
+
+  test("normalizes Anthropic refusal to content_filter", async () => {
+    const wire = buildSSETextResponse("refusal", "claude-x", "", {
+      inputTokens: 1,
+      outputTokens: 0,
+    }).replace('"stop_reason":"end_turn"', '"stop_reason":"refusal"');
+
+    const result = await accumulateSSEResponse(new Response(wire), {
+      stopAtTerminal: true,
+      strict: true,
+    });
+    expect(result.stopReason).toBe("content_filter");
+  });
+
+  test("accepts official nullable cumulative usage fields", async () => {
+    const wire = buildSSETextResponse("nullable", "claude-x", "ok", {
+      inputTokens: 1,
+      outputTokens: 1,
+    })
+      .replace(
+        '"input_tokens":1,"output_tokens":1',
+        '"input_tokens":1,"output_tokens":1,"cache_read_input_tokens":null,"cache_creation_input_tokens":null',
+      )
+      .replace(
+        '"usage":{"output_tokens":1}',
+        '"usage":{"input_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"output_tokens":1,"output_tokens_details":null,"server_tool_use":null}',
+      );
+
+    await expect(
+      accumulateSSEResponse(new Response(wire), {
+        stopAtTerminal: true,
+        strict: true,
+      }),
+    ).resolves.toMatchObject({ stopReason: "end_turn" });
+  });
+
+  test("accepts multiple cumulative message_delta events", async () => {
+    const first = buildSSETextResponse("id_multi_delta", "claude-x", "done", {
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+    const extraDelta =
+      'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n';
+    const stream = first.replace(
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+      `${extraDelta}event: message_stop\ndata: {"type":"message_stop"}\n\n`,
+    );
+    expect(stream.match(/event: message_delta/g)).toHaveLength(2);
+
+    const result = await accumulateSSEResponse(new Response(stream), {
+      stopAtTerminal: true,
+      strict: true,
+    });
+    expect(result.content).toEqual([{ type: "text", text: "done" }]);
+  });
+
   test("round-trips a synthetic text response back into a GatewayResponse", async () => {
     const sse = buildSSETextResponse("id_1", "claude-x", "Round trip", {
       inputTokens: 7,
@@ -629,5 +1311,21 @@ describe("buildSSEResponse", () => {
     );
     expect(round.content).toEqual([]);
     expect(round.stopReason).toBe("end_turn");
+  });
+
+  test("maps internal content_filter back to Anthropic refusal on the wire", async () => {
+    const sse = buildSSEResponse({
+      id: "msg_refusal",
+      model: "claude-x",
+      content: [],
+      stopReason: "content_filter",
+      usage: { inputTokens: 1, outputTokens: 0 },
+    });
+    expect(sse).toContain('"stop_reason":"refusal"');
+    const round = await accumulateSSEResponse(new Response(sse), {
+      stopAtTerminal: true,
+      strict: true,
+    });
+    expect(round.stopReason).toBe("content_filter");
   });
 });

--- a/packages/gateway/test/stream-openai.test.ts
+++ b/packages/gateway/test/stream-openai.test.ts
@@ -6,7 +6,11 @@
  * but the final delta (the silent-empty bug this guards — LOREAI-GATEWAY finding).
  */
 import { describe, test, expect } from "vitest";
-import { accumulateOpenAISSEStream } from "../src/stream/openai";
+import {
+  accumulateOpenAISSEStream,
+  translateAnthropicStreamToOpenAI,
+} from "../src/stream/openai";
+import { validateOpenAIUsage } from "../src/usage-validation";
 
 /** Each entry is one SSE event; events are blank-line delimited per the spec. */
 function sse(lines: string[]): Response {
@@ -16,6 +20,406 @@ function sse(lines: string[]): Response {
 }
 
 describe("accumulateOpenAISSEStream", () => {
+  test("validates all choices while projecting only choice zero", async () => {
+    const result = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"index":0,"delta":{"content":"chosen","tool_calls":[{"index":0,"id":"call-zero","function":{"name":"zero","arguments":"{}"}}]},"finish_reason":"tool_calls"},{"index":1,"delta":{"content":"ignored","tool_calls":[{"index":0,"id":"call-one","function":{"name":"one","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}',
+      ]),
+      { strict: true, stopAtTerminal: true },
+    );
+    expect(result.content).toEqual([
+      { type: "text", text: "chosen" },
+      { type: "tool_use", id: "call-zero", name: "zero", input: {} },
+    ]);
+  });
+
+  test("rejects duplicate tool identity in choice one", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"index":0,"delta":{"content":"chosen"},"finish_reason":"stop"},{"index":1,"delta":{"tool_calls":[{"index":0,"id":"duplicate","function":{"name":"one","arguments":"{}"}},{"index":1,"id":"duplicate","function":{"name":"two","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}',
+        ]),
+        { strict: true, stopAtTerminal: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("permits the same tool identity in independent choices", async () => {
+    const result = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"shared","function":{"name":"zero","arguments":"{}"}}]},"finish_reason":"tool_calls"},{"index":1,"delta":{"tool_calls":[{"index":0,"id":"shared","function":{"name":"one","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}',
+      ]),
+      { strict: true, stopAtTerminal: true },
+    );
+    expect(result.content).toEqual([
+      { type: "tool_use", id: "shared", name: "zero", input: {} },
+    ]);
+  });
+
+  test("retains trailing usage after finish_reason through [DONE]", async () => {
+    const result = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"index":0,"delta":{"content":"done"},"finish_reason":null}]}',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":2,"total_tokens":9}}',
+        "data: [DONE]",
+      ]),
+      { strict: true, stopAtTerminal: true, consumeUntilDone: true },
+    );
+    expect(result.content).toEqual([{ type: "text", text: "done" }]);
+    expect(result.usage).toMatchObject({ inputTokens: 7, outputTokens: 2 });
+  });
+
+  test("consumeUntilDone rejects truncation after finish_reason", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse(['data: {"choices":[{"delta":{},"finish_reason":"stop"}]}']),
+        { strict: true, stopAtTerminal: true, consumeUntilDone: true },
+      ),
+    ).rejects.toThrow("missing OpenAI [DONE] terminal");
+  });
+  test("stops at [DONE] without waiting for transport EOF", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices":[{"delta":{"content":"done"}}]}\n\n' +
+                'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n' +
+                "data: [DONE]\n\n",
+            ),
+          );
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise(() => {});
+        },
+      }),
+    );
+
+    const resp = await accumulateOpenAISSEStream(response, {
+      stopAtTerminal: true,
+      strict: true,
+    });
+
+    expect(resp.content).toEqual([{ type: "text", text: "done" }]);
+    expect(cancelled).toBe(true);
+    expect(response.body?.locked).toBe(false);
+  });
+
+  test("stops after finish_reason and preserves usage on its frame", async () => {
+    let cancelled = false;
+    const wire =
+      'data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":2}}\n\n';
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(wire));
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise(() => {});
+        },
+      }),
+    );
+
+    const resp = await accumulateOpenAISSEStream(response, {
+      stopAtTerminal: true,
+      strict: true,
+    });
+
+    expect(resp.content).toEqual([{ type: "text", text: "done" }]);
+    expect(resp.usage).toMatchObject({ inputTokens: 7, outputTokens: 2 });
+    expect(cancelled).toBe(true);
+  });
+
+  test("rejects EOF before finish_reason in strict worker mode", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse(['data: {"choices":[{"delta":{"content":"partial"}}]}']),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("missing OpenAI finish_reason terminal");
+  });
+
+  test("rejects an unterminated terminal frame in strict worker mode", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        new Response('data: {"choices":[{"delta":{},"finish_reason":"stop"}]}'),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("unterminated SSE event at EOF");
+  });
+
+  test("rejects malformed JSON before a valid terminal", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          "data: {not-json}",
+          'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("rejects malformed consumed fields in strict worker mode", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"delta":{"content":42},"finish_reason":"stop"}]}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("rejects cross-chunk response identity changes", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"id":"chat-a","model":"model-a","choices":[{"delta":{"content":"partial"}}]}',
+          'data: {"id":"chat-b","model":"model-b","choices":[{"delta":{},"finish_reason":"stop"}]}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test.each([
+    [
+      "explicit to omitted",
+      'data: {"choices":[{"index":1,"delta":{"content":"partial"},"finish_reason":null}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+    ],
+    [
+      "omitted to a different explicit index",
+      'data: {"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}',
+      'data: {"choices":[{"index":1,"delta":{},"finish_reason":"stop"}]}',
+    ],
+  ])("rejects projected choice index transition: %s", async (_name, a, b) => {
+    await expect(
+      accumulateOpenAISSEStream(sse([a, b]), {
+        strict: true,
+        stopAtTerminal: true,
+      }),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test.each([
+    [
+      "omitted throughout",
+      'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+    ],
+    [
+      "same explicit index",
+      'data: {"choices":[{"index":7,"delta":{"content":"ok"},"finish_reason":null}]}',
+      'data: {"choices":[{"index":7,"delta":{},"finish_reason":"stop"}]}',
+    ],
+    [
+      "omitted fallback then matching explicit zero",
+      'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}',
+      'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+    ],
+  ])("accepts stable projected choice index: %s", async (_name, a, b) => {
+    const response = await accumulateOpenAISSEStream(sse([a, b]), {
+      strict: true,
+      stopAtTerminal: true,
+    });
+    expect(response.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  test("rejects negative tool indices and malformed usage", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":-1,"id":"call","function":{"name":"tool","arguments":"{}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":-5,"completion_tokens":1.5}}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test.each([
+    [
+      "cache sum overflow without prompt_tokens",
+      {
+        completion_tokens: 1,
+        prompt_tokens_details: {
+          cached_tokens: Number.MAX_SAFE_INTEGER,
+          cache_write_tokens: 1,
+        },
+      },
+    ],
+    ["unsafe prompt usage", { prompt_tokens: Number.MAX_SAFE_INTEGER + 1 }],
+    ["malformed detail container", { prompt_tokens_details: [] }],
+  ])("rejects %s", async (_case, usage) => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          `data: ${JSON.stringify({
+            choices: [{ delta: {}, finish_reason: "stop" }],
+            usage,
+          })}`,
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("rejects total_tokens that contradict prompt and completion totals", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":6}}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("rejects total_tokens when a parent component is absent", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"total_tokens":2}}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("validates every choice, not only choices[0]", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          `data: ${JSON.stringify({
+            choices: [
+              { index: 0, delta: {}, finish_reason: "stop" },
+              { index: 1, delta: { content: 42 }, finish_reason: null },
+            ],
+          })}`,
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("accepts nullable optional usage detail containers", async () => {
+    const result = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"prompt_tokens_details":null,"completion_tokens_details":null}}',
+      ]),
+      { stopAtTerminal: true, strict: true },
+    );
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  test("rejects tool identity changes across chunks", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-a","function":{"name":"tool-a","arguments":"{"}}]}}]}',
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-b","function":{"name":"tool-b","arguments":"}"}}]},"finish_reason":"tool_calls"}]}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("rejects duplicate tool-call IDs across indices but permits repeated deltas", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-shared","function":{"name":"first","arguments":"{"}}]}}]}',
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-shared","function":{"arguments":"}"}}]}}]}',
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call-shared","function":{"name":"second","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("permits repeated same-index tool identity deltas and accumulates arguments", async () => {
+    const result = await accumulateOpenAISSEStream(
+      sse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-repeat","function":{"name":"lookup","arguments":"{\\"a\\":"}}]}}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-repeat","function":{"name":"lookup","arguments":"1}"}}]},"finish_reason":"tool_calls"}]}',
+      ]),
+      { stopAtTerminal: true, strict: true },
+    );
+    expect(result.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call-repeat",
+        name: "lookup",
+        input: { a: 1 },
+      },
+    ]);
+  });
+
+  test("rejects a terminal tool call without a non-empty ID", async () => {
+    await expect(
+      accumulateOpenAISSEStream(
+        sse([
+          'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}',
+        ]),
+        { stopAtTerminal: true, strict: true },
+      ),
+    ).rejects.toThrow("malformed OpenAI stream event");
+  });
+
+  test("rejects a stalled worker stream after its inactivity deadline", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n',
+            ),
+          );
+        },
+      }),
+    );
+
+    await expect(
+      accumulateOpenAISSEStream(response, {
+        stopAtTerminal: true,
+        strict: true,
+        inactivityMs: 10,
+      }),
+    ).rejects.toThrow("SSE stream inactivity deadline exceeded");
+  });
+
+  test("stops after finish_reason when no usage frame or EOF follows", async () => {
+    let cancelled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices":[{"delta":{"content":"done"},"finish_reason":"stop"}]}\n\n',
+            ),
+          );
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise(() => {});
+        },
+      }),
+    );
+
+    const resp = await accumulateOpenAISSEStream(response, {
+      stopAtTerminal: true,
+      strict: true,
+    });
+
+    expect(resp.content).toEqual([{ type: "text", text: "done" }]);
+    expect(cancelled).toBe(true);
+  });
+
   test("merges multi-chunk text deltas into the full string", async () => {
     const resp = await accumulateOpenAISSEStream(
       sse([
@@ -123,4 +527,104 @@ describe("accumulateOpenAISSEStream", () => {
     );
     expect(resp.content).toEqual([{ type: "text", text: "plain" }]);
   });
+});
+
+test("Anthropic translator completes at message_stop and cancels an open source", async () => {
+  const event = (type: string, data: Record<string, unknown>) =>
+    `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+  const wire =
+    event("message_start", {
+      message: {
+        id: "msg-open",
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    }) +
+    event("content_block_start", {
+      index: 0,
+      content_block: { type: "text", text: "" },
+    }) +
+    event("content_block_delta", {
+      index: 0,
+      delta: { type: "text_delta", text: "done" },
+    }) +
+    event("content_block_stop", { index: 0 }) +
+    event("message_delta", {
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 1 },
+    }) +
+    event("message_stop", {});
+  let cancelled = false;
+  const upstream = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(wire));
+      },
+      pull() {
+        return new Promise(() => {});
+      },
+      cancel() {
+        cancelled = true;
+        return new Promise<void>(() => {});
+      },
+    }),
+  );
+  const translated = translateAnthropicStreamToOpenAI(upstream);
+  await new Promise((resolve) => setImmediate(resolve));
+  const output = await translated.text();
+  expect(output).toContain("done");
+  expect(output.match(/data: \[DONE\]/g)).toHaveLength(1);
+  expect(cancelled).toBe(true);
+  expect(upstream.body?.locked).toBe(false);
+});
+
+test("Anthropic translator emits inclusive OpenAI cache usage", async () => {
+  const event = (type: string, data: Record<string, unknown>) =>
+    `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
+  const upstream = new Response(
+    event("message_start", {
+      message: {
+        id: "msg_usage",
+        type: "message",
+        role: "assistant",
+        model: "claude-test",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 10,
+          cache_read_input_tokens: 90,
+          cache_creation_input_tokens: 20,
+          output_tokens: 0,
+        },
+      },
+    }) +
+      event("message_delta", {
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      }) +
+      event("message_stop", {}),
+  );
+  const output = await translateAnthropicStreamToOpenAI(upstream, {
+    strict: true,
+  }).text();
+  const usage = output
+    .split("\n")
+    .filter((line) => line.startsWith("data: {") && line.includes('"usage"'))
+    .map((line) => JSON.parse(line.slice(6)) as Record<string, unknown>)
+    .at(-1)?.usage as Record<string, unknown>;
+  expect(usage).toEqual({
+    prompt_tokens: 120,
+    completion_tokens: 1,
+    total_tokens: 121,
+    prompt_tokens_details: { cached_tokens: 90, cache_write_tokens: 20 },
+  });
+  expect(() =>
+    validateOpenAIUsage(usage, "invalid translated usage"),
+  ).not.toThrow();
 });

--- a/packages/gateway/test/temporal-adapter.test.ts
+++ b/packages/gateway/test/temporal-adapter.test.ts
@@ -7,6 +7,11 @@ import type { GatewayMessage } from "../src/translate/types";
 import type { LorePart } from "@loreai/core";
 import { isToolPart } from "@loreai/core";
 import { estimateMessages } from "../../core/src/gradient";
+import { loreMessagesToGateway } from "../src/pipeline";
+import {
+  buildGeminiUpstreamRequest,
+  parseGeminiRequest,
+} from "../src/translate/gemini";
 
 // Test-local view of a tool part's state covering all status variants.
 type TestToolState = {
@@ -342,5 +347,75 @@ describe("resolveToolResults", () => {
     expect(messages[0].parts).toHaveLength(1);
     expect(messages[0].hiddenInputTokens).toBeGreaterThan(1_000);
     expect(estimateMessages(messages)).toBeGreaterThan(1_000);
+  });
+
+  test("preserves distinct Gemini call id and name through Lore and egress", () => {
+    const parsed = parseGeminiRequest(
+      {
+        contents: [
+          {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  id: "call-1",
+                  name: "lookup",
+                  args: { query: "x" },
+                },
+              },
+            ],
+          },
+          {
+            role: "user",
+            parts: [
+              {
+                functionResponse: {
+                  id: "call-1",
+                  name: "lookup",
+                  response: { value: 1 },
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {},
+      "gemini-test",
+      false,
+    );
+    const lore = gatewayMessagesToLore(parsed.messages, "sess-gemini-id");
+    resolveToolResults(lore);
+    const reconstructed = loreMessagesToGateway(lore);
+    expect(reconstructed[0].content[0]).toMatchObject({
+      type: "tool_use",
+      id: "call-1",
+      name: "lookup",
+    });
+    expect(reconstructed[1].content[0]).toMatchObject({
+      type: "tool_result",
+      toolUseId: "call-1",
+      toolName: "lookup",
+    });
+    const body = buildGeminiUpstreamRequest(
+      { ...parsed, messages: reconstructed },
+      "https://gemini.example",
+    ).body as Record<string, unknown>;
+    const contents = body.contents as Array<{
+      parts: Array<Record<string, unknown>>;
+    }>;
+    expect(contents[0].parts[0]).toEqual({
+      functionCall: {
+        id: "call-1",
+        name: "lookup",
+        args: { query: "x" },
+      },
+    });
+    expect(contents[1].parts[0]).toEqual({
+      functionResponse: {
+        id: "call-1",
+        name: "lookup",
+        response: { value: 1 },
+      },
+    });
   });
 });

--- a/packages/gateway/test/translate-types.test.ts
+++ b/packages/gateway/test/translate-types.test.ts
@@ -68,12 +68,12 @@ describe("looksLikeSSE", () => {
     expect(looksLikeSSE("", '\uFEFF{"a":1}')).toBe(false);
   });
 
-  it("does NOT false-positive on plaintext beginning with id:/retry:/`:` (only data:/event: count)", () => {
-    // A completion SSE stream always opens with data: or event:. Narrowing the
-    // sniff to those two avoids treating a plaintext error body as SSE.
-    expect(looksLikeSSE("text/plain", "retry: later please")).toBe(false);
-    expect(looksLikeSSE("text/plain", "id: 12345 not found")).toBe(false);
-    expect(looksLikeSSE("text/plain", ": a leading comment line")).toBe(false);
+  it("recognizes legal id/retry/comment prefixes", () => {
+    expect(looksLikeSSE("text/plain", "\uFEFF id: stream-1\n\ndata: x")).toBe(
+      true,
+    );
+    expect(looksLikeSSE("text/plain", "retry: 1000\n\ndata: x")).toBe(true);
+    expect(looksLikeSSE("text/plain", ": a leading comment line")).toBe(true);
     expect(looksLikeSSE("text/plain", "404 page not found")).toBe(false);
   });
 });

--- a/packages/gateway/test/vertex.test.ts
+++ b/packages/gateway/test/vertex.test.ts
@@ -9,7 +9,7 @@
  * profile, and the ADC token seam. End-to-end routing is covered in
  * `vertex-routing.test.ts`.
  */
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   buildVertexUpstream,
   isVertexHost,
@@ -28,6 +28,7 @@ import {
   getVertexAccessToken,
   resolveVertexProject,
 } from "../src/vertex-auth";
+import { createForegroundAbortScope } from "../src/pipeline";
 
 describe("toVertexModelId", () => {
   test("passes through short ids that Vertex uses verbatim", () => {
@@ -235,6 +236,39 @@ describe("resolveWorkerProtocol — ChatGPT backend (openai → openai-codex-res
     ).toBe("openai-codex-responses");
   });
 
+  test("recognizes a ChatGPT-compatible /backend-api proxy", () => {
+    expect(
+      resolveWorkerProtocol(
+        "openai",
+        undefined,
+        "gpt-5.6-terra",
+        "https://proxy.internal/backend-api",
+      ),
+    ).toBe("openai-codex-responses");
+  });
+
+  test.each([
+    "https://proxy.internal/backend-apiary",
+    "https://proxy.internal/backend-api-v2",
+    "https://chatgpt.com/v1",
+    "https://proxy.internal/v1?next=/backend-api",
+  ])("rejects non-backend paths: %s", (url) => {
+    expect(
+      resolveWorkerProtocol("openai", undefined, "gpt-5.6-terra", url),
+    ).toBe("openai");
+  });
+
+  test("recognizes backend-api as a complete nested path segment", () => {
+    expect(
+      resolveWorkerProtocol(
+        "openai",
+        undefined,
+        "gpt-5.6-terra",
+        "https://proxy.internal/prefix/backend-api/",
+      ),
+    ).toBe("openai-codex-responses");
+  });
+
   test("openai providerID + api.openai.com URL → openai (no collapse)", () => {
     // The real OpenAI endpoint serves BOTH Chat Completions and Responses —
     // the legacy Chat Completions path is correct here. The guard must NOT
@@ -393,6 +427,100 @@ describe("vertex-auth — ADC token seam", () => {
   test("getVertexAccessToken returns the injected test token", async () => {
     _setTestVertexTokenProvider(() => Promise.resolve("test-token-123"));
     expect(await getVertexAccessToken()).toBe("test-token-123");
+  });
+
+  test.each(["AbortError", "TimeoutError"])(
+    "getVertexAccessToken propagates %s while its provider is stalled",
+    async (name) => {
+      _setTestVertexTokenProvider(() => new Promise<string>(() => {}));
+      const controller = new AbortController();
+      const pending = getVertexAccessToken(controller.signal);
+      controller.abort(new DOMException("cancelled", name));
+
+      await expect(pending).rejects.toMatchObject({ name });
+    },
+  );
+
+  test("abort immediately removes its listener and observes a late provider rejection", async () => {
+    let rejectProvider!: (error: unknown) => void;
+    _setTestVertexTokenProvider(
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectProvider = reject;
+        }),
+    );
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, "removeEventListener");
+    const pending = getVertexAccessToken(controller.signal);
+    const rejected = expect(pending).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+    await rejected;
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
+
+    rejectProvider(new Error("late provider failure"));
+    await Promise.resolve();
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  test("an already-aborted signal does not invoke the token provider", async () => {
+    let calls = 0;
+    _setTestVertexTokenProvider(async () => {
+      calls++;
+      return "must not run";
+    });
+    const controller = new AbortController();
+    controller.abort(new DOMException("already aborted", "AbortError"));
+    await expect(getVertexAccessToken(controller.signal)).rejects.toMatchObject(
+      {
+        name: "AbortError",
+      },
+    );
+    expect(calls).toBe(0);
+  });
+
+  test("observes provider rejection when abort wins during factory invocation", async () => {
+    const controller = new AbortController();
+    _setTestVertexTokenProvider(() => {
+      controller.abort(new DOMException("raced abort", "AbortError"));
+      return Promise.reject(new Error("provider rejected after abort"));
+    });
+    await expect(getVertexAccessToken(controller.signal)).rejects.toMatchObject(
+      {
+        name: "AbortError",
+      },
+    );
+    await Promise.resolve();
+  });
+
+  test("foreground caller cancellation aborts a stalled Vertex token provider", async () => {
+    _setTestVertexTokenProvider(() => new Promise<string>(() => {}));
+    const caller = new AbortController();
+    const scope = createForegroundAbortScope(caller.signal);
+    const pending = getVertexAccessToken(scope.signal);
+    caller.abort(new DOMException("client disconnected", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    scope.dispose();
+  });
+
+  test("foreground deadline aborts a stalled Vertex token provider and clears its timer", async () => {
+    vi.useFakeTimers();
+    try {
+      _setTestVertexTokenProvider(() => new Promise<string>(() => {}));
+      const scope = createForegroundAbortScope();
+      const pending = getVertexAccessToken(scope.signal);
+      const rejected = expect(pending).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      await vi.advanceTimersByTimeAsync(300_000);
+      await rejected;
+      scope.dispose();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("resolveVertexProject prefers the configured project (no ADC call)", async () => {

--- a/packages/gateway/test/worker-codex-sse-path.test.ts
+++ b/packages/gateway/test/worker-codex-sse-path.test.ts
@@ -42,29 +42,35 @@ const CODEX_RESPONSES_SSE = [
   'data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5-codex"}}',
   "",
   "event: response.output_item.added",
-  'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant"}}',
+  'data: {"type":"response.output_item.added","item":{"type":"message","id":"msg_1","role":"assistant"}}',
   "",
   "event: response.output_text.delta",
-  'data: {"type":"response.output_text.delta","output_index":0,"delta":"worker "}',
+  'data: {"type":"response.output_text.delta","item_id":"msg_1","delta":"worker "}',
   "",
   "event: response.output_text.delta",
-  'data: {"type":"response.output_text.delta","output_index":0,"delta":"text"}',
+  'data: {"type":"response.output_text.delta","item_id":"msg_1","delta":"text"}',
   "",
-  "event: response.completed",
-  'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":{"input_tokens":5,"output_tokens":2},"model":"gpt-5-codex"}}',
+  "event: response.done",
+  'data: {"type":"response.done","response":{"id":"resp_1","incomplete_details":null,"usage":{"input_tokens":5,"output_tokens":2},"model":"gpt-5-codex"}}',
   "",
   "data: [DONE]",
   "",
 ].join("\n");
 
-function sseResponse(contentType: string): Response {
-  return new Response(CODEX_RESPONSES_SSE, {
+function sseResponse(
+  contentType: string,
+  stream = CODEX_RESPONSES_SSE,
+): Response {
+  return new Response(stream, {
     status: 200,
     headers: { "content-type": contentType },
   });
 }
 
-async function runCodexWorker(contentType: string): Promise<string | null> {
+async function runCodexWorker(
+  contentType: string,
+  stream = CODEX_RESPONSES_SSE,
+): Promise<string | null> {
   const client = createGatewayLLMClient(
     UPSTREAMS,
     (_sid, providerID) =>
@@ -73,7 +79,7 @@ async function runCodexWorker(contentType: string): Promise<string | null> {
         : null,
     { providerID: "openai-codex", modelID: "gpt-5-codex" },
   );
-  mockFetch.mockResolvedValue(sseResponse(contentType));
+  mockFetch.mockResolvedValue(sseResponse(contentType, stream));
   return client.prompt("system-prompt", "user-prompt", {
     sessionID: "sess-codex",
     workerID: "lore-distill",
@@ -100,5 +106,20 @@ describe("worker codex responses-SSE path", () => {
     // last-data-line reader would only ever see the terminal event → empty.
     const result = await runCodexWorker("text/event-stream");
     expect(result).toBe("worker text");
+  });
+
+  test("done-only message content produces worker text", async () => {
+    const stream = [
+      "event: response.output_item.done",
+      'data: {"type":"response.output_item.done","item":{"type":"message","id":"msg_done","content":[{"type":"output_text","text":"done-only worker text"}]}}',
+      "",
+      "event: response.completed",
+      'data: {"type":"response.completed","response":{"status":"completed"}}',
+      "",
+      "",
+    ].join("\n");
+
+    const result = await runCodexWorker("text/event-stream", stream);
+    expect(result).toBe("done-only worker text");
   });
 });

--- a/packages/gateway/test/worker-gemini-path.test.ts
+++ b/packages/gateway/test/worker-gemini-path.test.ts
@@ -16,7 +16,10 @@ import { fetchArgUrl } from "./helpers/fetch-url";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
-import { createGatewayLLMClient } from "../src/llm-adapter";
+import {
+  createGatewayLLMClient,
+  parseGeminiWorkerResponse,
+} from "../src/llm-adapter";
 import { upstreamFetch } from "../src/fetch";
 import { clearAllCosts } from "../src/cost-tracker";
 import { resetBackgroundLimiter } from "../src/background-limiter";
@@ -72,6 +75,25 @@ async function runWorker(cred: AuthCredential | null) {
 }
 
 describe("worker gemini native path", () => {
+  test("uses disjoint cached/tool/thought accounting in worker JSON", () => {
+    const parsed = parseGeminiWorkerResponse({
+      candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      usageMetadata: {
+        promptTokenCount: 100,
+        cachedContentTokenCount: 80,
+        candidatesTokenCount: 20,
+        thoughtsTokenCount: 10,
+        toolUsePromptTokenCount: 5,
+        totalTokenCount: 135,
+      },
+    });
+    expect(parsed.usage).toMatchObject({
+      input_tokens: 25,
+      cache_read_input_tokens: 80,
+      output_tokens: 30,
+    });
+  });
+
   beforeEach(() => {
     mockFetch.mockReset();
     mockFetch.mockResolvedValue(geminiOkResponse());
@@ -114,5 +136,133 @@ describe("worker gemini native path", () => {
     });
     expect(headers?.Authorization).toBe("Bearer oauth_tok");
     expect(headers?.["x-goog-api-key"]).toBeUndefined();
+  });
+
+  test("non-stream worker validates later candidates and permits same-name calls with distinct IDs", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: { parts: [{ text: "worker ok" }] },
+              finishReason: "STOP",
+            },
+            {
+              content: {
+                parts: [
+                  { functionCall: { id: "one", name: "lookup", args: {} } },
+                  { functionCall: { id: "two", name: "lookup", args: {} } },
+                ],
+              },
+            },
+          ],
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { result } = await runWorker({ scheme: "api-key", value: "g_key" });
+    expect(result).toContain("worker ok");
+  });
+
+  test("non-stream worker permits the same tool identity in independent candidates", async () => {
+    expect(
+      parseGeminiWorkerResponse({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: "worker ok" },
+                { functionCall: { id: "shared", name: "lookup", args: {} } },
+              ],
+            },
+          },
+          {
+            content: {
+              parts: [
+                { functionCall: { id: "shared", name: "lookup", args: {} } },
+              ],
+            },
+          },
+        ],
+      }).text,
+    ).toBe("worker ok");
+  });
+
+  test("non-stream worker rejects duplicate effective IDs in a later candidate", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            { content: { parts: [{ text: "must not escape" }] } },
+            {
+              content: {
+                parts: [
+                  { functionCall: { id: "duplicate", name: "one" } },
+                  { functionCall: { id: "duplicate", name: "two" } },
+                ],
+              },
+            },
+          ],
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { result } = await runWorker({ scheme: "api-key", value: "g_key" });
+    expect(result).toBeNull();
+  });
+
+  test("SSE worker preserves valid provider IDs and rejects ambiguous legacy calls", async () => {
+    const frame = (parts: unknown[]) =>
+      `data: ${JSON.stringify({ candidates: [{ content: { parts }, finishReason: "STOP" }] })}\n\n`;
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        frame([
+          { text: "worker ok" },
+          { functionCall: { id: "one", name: "lookup", args: {} } },
+          { functionCall: { id: "two", name: "lookup", args: {} } },
+        ]),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+    const valid = await runWorker({ scheme: "api-key", value: "g_key" });
+    expect(valid.result).not.toBeNull();
+
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        frame([
+          { functionCall: { name: "lookup", args: {} } },
+          { functionCall: { name: "lookup", args: {} } },
+        ]),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+    const invalid = await runWorker({ scheme: "api-key", value: "g_key" });
+    expect(invalid.result).toBeNull();
+  });
+
+  test("worker success-body inspection rejects invalid and split-invalid JSON UTF-8", async () => {
+    for (const chunks of [
+      [new Uint8Array([0xff])],
+      [new Uint8Array([0xe2]), new Uint8Array([0x28, 0xa1])],
+    ]) {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              for (const chunk of chunks) controller.enqueue(chunk);
+              controller.close();
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+      const { result } = await runWorker({ scheme: "api-key", value: "g_key" });
+      expect(result).toBeNull();
+      // Partial malformed bodies are authoritative upstream responses, not
+      // zero-byte transport failures eligible for an automatic retry.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    }
   });
 });

--- a/packages/gateway/test/worker-health.test.ts
+++ b/packages/gateway/test/worker-health.test.ts
@@ -701,8 +701,9 @@ describe("worker-health", () => {
       expect(isCapabilityEmpty("max_tokens")).toBe(false);
     });
 
-    test("NOT capability: content_filter and tool calls", () => {
+    test("NOT capability: filtering/refusal and tool calls", () => {
       expect(isCapabilityEmpty("content_filter")).toBe(false);
+      expect(isCapabilityEmpty("refusal")).toBe(false);
       expect(isCapabilityEmpty("tool_calls")).toBe(false);
       expect(isCapabilityEmpty("tool_use")).toBe(false);
     });
@@ -749,6 +750,15 @@ describe("worker-health", () => {
         ).toBe(false);
       }
       expect(isWorkerIncapable("opencode", "m")).toBe(false);
+    });
+
+    test("raw Anthropic refusal defensively never marks a model incapable", () => {
+      for (let i = 0; i < 10; i++) {
+        expect(recordEmptyWorkerResponse("anthropic", "m", "refusal")).toBe(
+          false,
+        );
+      }
+      expect(isWorkerIncapable("anthropic", "m")).toBe(false);
     });
   });
 

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -1774,6 +1774,23 @@ describe("openai worker selection: ChatGPT-backend reuse + luna preference", () 
     expect(result?.modelID).toBe("gpt-5.6-sol");
   });
 
+  test.each([
+    "https://proxy.internal/backend-apiary",
+    "https://proxy.internal/backend-api-v2",
+    "https://chatgpt.com/v1",
+  ])(
+    "does not reuse the session model for a non-backend path: %s",
+    async (url) => {
+      await warmCache(openaiCatalog());
+      const result = getWorkerModel({
+        providerID: "openai",
+        model: "gpt-5.6-sol",
+        url,
+      });
+      expect(result?.modelID).toBe("gpt-5.6-luna");
+    },
+  );
+
   test("real api.openai.com session prefers gpt-5.6-luna (not terra, not mini)", async () => {
     await warmCache(openaiCatalog());
 

--- a/packages/gateway/test/worker-reasoning-parse.test.ts
+++ b/packages/gateway/test/worker-reasoning-parse.test.ts
@@ -16,6 +16,7 @@ import {
   createGatewayLLMClient,
   gatewayResponseToWorkerResult,
   parseOpenAIResponse,
+  parseResponsesWorkerResponse,
   parseAnthropicResponse,
 } from "../src/llm-adapter";
 import { upstreamFetch } from "../src/fetch";
@@ -94,17 +95,38 @@ describe("parseOpenAIResponse — reasoning-model fallback", () => {
     expect(r.text).toBe("fallback reasoning");
   });
 
-  test("ignores a non-string reasoning field", () => {
+  test("rejects a non-string reasoning field", () => {
+    expect(() =>
+      parseOpenAIResponse({
+        choices: [
+          {
+            message: {
+              reasoning_content: 42 as unknown as string,
+            },
+          },
+        ],
+      }),
+    ).toThrow("malformed OpenAI response body");
+  });
+
+  test("treats an official refusal as usable worker text", () => {
     const r = parseOpenAIResponse({
       choices: [
         {
-          message: {
-            reasoning_content: 42 as unknown as string,
-          },
+          message: { content: null as unknown as string, refusal: "refused" },
+          finish_reason: "stop",
         },
       ],
     });
-    expect(r.text).toBeNull();
+    expect(r.text).toBe("refused");
+  });
+
+  test("rejects a malformed message container", () => {
+    expect(() =>
+      parseOpenAIResponse({
+        choices: [{ message: [] as never, finish_reason: "stop" }],
+      }),
+    ).toThrow("malformed OpenAI response body");
   });
 
   test("negative: no choices returns null", () => {
@@ -112,6 +134,181 @@ describe("parseOpenAIResponse — reasoning-model fallback", () => {
     expect(r.text).toBeNull();
   });
 });
+
+test("parseResponsesWorkerResponse extracts a non-streaming refusal", () => {
+  const result = parseResponsesWorkerResponse({
+    status: "completed",
+    output_text: "",
+    output: [
+      {
+        type: "message",
+        id: "msg-refusal",
+        content: [{ type: "refusal", refusal: "cannot comply" }],
+      },
+    ],
+  });
+
+  expect(result.text).toBe("cannot comply");
+});
+
+test("non-SSE worker parsers reject missing and duplicate tool identities", () => {
+  expect(() =>
+    parseOpenAIResponse({
+      choices: [
+        {
+          message: {
+            tool_calls: [{ id: "call-shared" }, { id: "call-shared" }],
+          },
+        },
+      ],
+    }),
+  ).toThrow("malformed OpenAI response body");
+  expect(() =>
+    parseResponsesWorkerResponse({
+      output: [
+        {
+          type: "function_call",
+          id: "",
+          call_id: "",
+          name: "lookup",
+          arguments: "{}",
+        },
+      ],
+    }),
+  ).toThrow("malformed Responses response body");
+  expect(() =>
+    parseResponsesWorkerResponse({
+      output: [
+        {
+          type: "function_call",
+          id: "item-shared",
+          call_id: "call-a",
+          name: "a",
+          arguments: "{}",
+        },
+        {
+          type: "function_call",
+          id: "item-shared",
+          call_id: "call-b",
+          name: "b",
+          arguments: "{}",
+        },
+      ],
+    }),
+  ).toThrow("malformed Responses response body");
+  expect(() =>
+    parseAnthropicResponse({
+      content: [
+        { type: "tool_use", id: "tool-shared", name: "a", input: {} },
+        {
+          type: "server_tool_use",
+          id: "tool-shared",
+          name: "b",
+          input: {},
+        },
+      ],
+    }),
+  ).toThrow("malformed Anthropic response body");
+});
+
+test("OpenAI worker permits the same tool identity in independent choices", () => {
+  expect(() =>
+    parseOpenAIResponse({
+      choices: [
+        { index: 0, message: { tool_calls: [{ id: "call-shared" }] } },
+        { index: 1, message: { tool_calls: [{ id: "call-shared" }] } },
+      ],
+    }),
+  ).not.toThrow();
+});
+
+test("OpenAI worker rejects duplicate logical choice indices before tool validation", () => {
+  expect(() =>
+    parseOpenAIResponse({
+      choices: [
+        { index: 2, message: { content: "first" } },
+        { index: 2, message: { tool_calls: "malformed" as never } },
+      ],
+    }),
+  ).toThrow("malformed OpenAI response body");
+});
+
+test("OpenAI worker fallback indices cannot collide with explicit indices", () => {
+  expect(() =>
+    parseOpenAIResponse({
+      choices: [
+        { index: 1, message: { content: "first" } },
+        { message: { content: "second" } },
+      ],
+    }),
+  ).toThrow("malformed OpenAI response body");
+});
+
+test.each([{}, 7, ""])(
+  "Responses worker rejects non-string or empty item id %#",
+  (id) => {
+    expect(() =>
+      parseResponsesWorkerResponse({
+        output: [{ type: "message", id: id as never, content: [] }],
+      }),
+    ).toThrow("malformed Responses response body");
+  },
+);
+
+test("Responses worker validates incomplete_details against status", () => {
+  expect(
+    parseResponsesWorkerResponse({
+      status: "completed",
+      incomplete_details: null,
+      output_text: "ok",
+    }).text,
+  ).toBe("ok");
+  expect(
+    parseResponsesWorkerResponse({
+      status: "incomplete",
+      incomplete_details: null,
+      output: [],
+    }),
+  ).toMatchObject({ text: null, incompleteDetails: null });
+  expect(
+    parseResponsesWorkerResponse({
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+      output: [],
+    }).incompleteDetails,
+  ).toEqual({ reason: "max_output_tokens" });
+  expect(() =>
+    parseResponsesWorkerResponse({
+      status: "completed",
+      incomplete_details: { reason: "max_output_tokens" },
+    }),
+  ).toThrow("malformed Responses response body");
+  expect(() =>
+    parseResponsesWorkerResponse({
+      status: "incomplete",
+      incomplete_details: { reason: 7 as never },
+    }),
+  ).toThrow("malformed Responses response body");
+});
+
+test.each([{}, 7, ""])(
+  "Responses worker rejects non-string or empty call_id %#",
+  (call_id) => {
+    expect(() =>
+      parseResponsesWorkerResponse({
+        output: [
+          {
+            type: "function_call",
+            id: "item-call",
+            call_id: call_id as never,
+            name: "lookup",
+            arguments: "{}",
+          },
+        ],
+      }),
+    ).toThrow("malformed Responses response body");
+  },
+);
 
 describe("parseAnthropicResponse — thinking-block fallback", () => {
   test("positive: normal text block still parses unchanged", () => {
@@ -208,6 +405,23 @@ describe("gatewayResponseToWorkerResult — streaming thinking-block fallback (#
       content: [],
     });
     expect(r.text).toBeNull();
+  });
+
+  test("projects a Responses refusal as usable worker text", () => {
+    const r = gatewayResponseToWorkerResult({
+      ...base,
+      content: [
+        {
+          type: "opaque",
+          responsesItem: true,
+          raw: {
+            type: "message",
+            content: [{ type: "refusal", refusal: "cannot comply" }],
+          },
+        },
+      ],
+    });
+    expect(r.text).toBe("cannot comply");
   });
 });
 

--- a/packages/gateway/test/worker-route-provenance.test.ts
+++ b/packages/gateway/test/worker-route-provenance.test.ts
@@ -1,0 +1,503 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { MockAgent } from "undici";
+import { setUpstreamDispatcherForTest } from "../src/fetch";
+import {
+  createGatewayLLMClient,
+  canonicalWorkerProviderID,
+  getLastWorkerError,
+  normalizedWorkerHostname,
+  resolveTarget,
+  workerOriginProtocolFamilies,
+} from "../src/llm-adapter";
+
+describe("worker route provenance", () => {
+  let mock: MockAgent | undefined;
+
+  afterEach(async () => {
+    setUpstreamDispatcherForTest(null);
+    await mock?.close();
+    mock = undefined;
+  });
+
+  test("OpenAI Responses with no OpenAI upstream never leaks to Anthropic", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let anthropicRequests = 0;
+    mock
+      .get("https://api.anthropic.com")
+      .intercept({ path: () => true, method: "POST" })
+      .reply(() => {
+        anthropicRequests++;
+        return { statusCode: 200, data: "{}" };
+      });
+    setUpstreamDispatcherForTest(mock);
+
+    const client = createGatewayLLMClient(
+      { anthropic: "https://api.anthropic.com", openai: "" },
+      (_session, provider) =>
+        provider === "openai"
+          ? { scheme: "api-key", value: "sk-openai-secret" }
+          : null,
+      { providerID: "openai", modelID: "gpt-5.6-sol" },
+    );
+    await expect(
+      client.prompt("system", "user", {
+        sessionID: "sess-route-provenance",
+        workerID: "lore-distill",
+        upstreamProviderID: "openai",
+        protocol: "openai-responses",
+      }),
+    ).resolves.toBeNull();
+    expect(anthropicRequests).toBe(0);
+    expect(getLastWorkerError()).toContain("no upstream route for openai");
+  });
+
+  test.each([
+    [
+      "Gemini Developer API",
+      "https://generativelanguage.googleapis.com",
+      ["gemini", "openai"],
+    ],
+    [
+      "Vertex regional",
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/proj/locations/us-central1/publishers/google",
+      ["gemini", "vertex"],
+    ],
+    [
+      "Vertex global",
+      "https://aiplatform.googleapis.com/v1/projects/proj/locations/global/publishers/google",
+      ["gemini", "vertex"],
+    ],
+    ["OpenAI", "https://api.openai.com/v1", ["openai"]],
+    ["Anthropic", "https://api.anthropic.com/v1", ["anthropic"]],
+    ["ChatGPT", "https://chatgpt.com/backend-api", ["openai"]],
+  ])("classifies the %s canonical origin", (_name, url, expected) => {
+    expect([...(workerOriginProtocolFamilies(url) ?? [])].sort()).toEqual(
+      [...expected].sort(),
+    );
+  });
+
+  test.each([
+    ["OpenAI", "https://API.OPENAI.COM./v1", "api.openai.com", ["openai"]],
+    [
+      "Anthropic",
+      "https://API.ANTHROPIC.COM./v1",
+      "api.anthropic.com",
+      ["anthropic"],
+    ],
+    ["ChatGPT", "https://CHATGPT.COM./backend-api", "chatgpt.com", ["openai"]],
+    [
+      "Gemini",
+      "https://GENERATIVELANGUAGE.GOOGLEAPIS.COM./v1beta",
+      "generativelanguage.googleapis.com",
+      ["gemini", "openai"],
+    ],
+    [
+      "Vertex regional",
+      "https://US-CENTRAL1-AIPLATFORM.GOOGLEAPIS.COM./v1/projects/p/locations/us-central1",
+      "us-central1-aiplatform.googleapis.com",
+      ["gemini", "vertex"],
+    ],
+    [
+      "Vertex global",
+      "https://AIPLATFORM.GOOGLEAPIS.COM./v1/projects/p/locations/global",
+      "aiplatform.googleapis.com",
+      ["gemini", "vertex"],
+    ],
+  ])(
+    "normalizes the %s terminal root dot for canonical classification",
+    (_name, url, hostname, expected) => {
+      expect(normalizedWorkerHostname(url)).toBe(hostname);
+      expect([...(workerOriginProtocolFamilies(url) ?? [])].sort()).toEqual(
+        [...expected].sort(),
+      );
+    },
+  );
+
+  test("supports only explicit provider alias families", () => {
+    for (const id of ["vertex", "google-vertex", "google-vertex-anthropic"]) {
+      expect(canonicalWorkerProviderID(id)).toBe("vertex");
+    }
+    for (const id of ["bedrock", "amazon-bedrock"]) {
+      expect(canonicalWorkerProviderID(id)).toBe("bedrock");
+    }
+    for (const id of [
+      "google",
+      "gemini",
+      "openai",
+      "vertex-custom",
+      "google-vertexx",
+      "amazon-bedrock-custom",
+    ]) {
+      expect(canonicalWorkerProviderID(id)).toBe(id);
+    }
+  });
+
+  test("allows pairwise aliases while rejecting near-name and cross-Google providers", () => {
+    const defaults = {
+      anthropic: "https://api.anthropic.com",
+      openai: "https://api.openai.com",
+    };
+    const vertexUrl =
+      "https://us-east1-aiplatform.googleapis.com/v1/projects/p/locations/us-east1";
+    const vertexAliases = [
+      "vertex",
+      "google-vertex",
+      "google-vertex-anthropic",
+    ];
+    for (const modelProvider of vertexAliases) {
+      for (const sessionProvider of vertexAliases) {
+        expect(
+          resolveTarget(
+            defaults,
+            "vertex",
+            vertexUrl,
+            modelProvider,
+            sessionProvider,
+          ),
+        ).toMatchObject({ url: vertexUrl, protocol: "vertex" });
+      }
+    }
+    const bedrockUrl = "https://bedrock-mantle.us-east-1.api.aws/anthropic";
+    for (const modelProvider of ["bedrock", "amazon-bedrock"]) {
+      for (const sessionProvider of ["bedrock", "amazon-bedrock"]) {
+        expect(
+          resolveTarget(
+            defaults,
+            "anthropic",
+            bedrockUrl,
+            modelProvider,
+            sessionProvider,
+          ),
+        ).toMatchObject({ url: bedrockUrl, protocol: "anthropic" });
+      }
+    }
+    for (const nearName of [
+      "vertex-custom",
+      "google-vertexx",
+      "amazon-bedrock-custom",
+    ]) {
+      expect(
+        resolveTarget(defaults, "vertex", vertexUrl, "vertex", nearName),
+      ).toMatchObject({ routeUnavailable: true, url: "" });
+    }
+    expect(
+      resolveTarget(defaults, "gemini", vertexUrl, "google", "google"),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+    expect(
+      resolveTarget(
+        defaults,
+        "gemini",
+        "https://generativelanguage.googleapis.com",
+        "vertex",
+        "vertex",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+  });
+
+  test("applies exact protocol capabilities after alias-family matching", () => {
+    const defaults = {
+      anthropic: "https://api.anthropic.com",
+      openai: "https://api.openai.com",
+    };
+    const vertexUrl =
+      "https://us-east1-aiplatform.googleapis.com/v1/projects/p/locations/us-east1";
+    const vertexProviders = [
+      "vertex",
+      "google-vertex",
+      "google-vertex-anthropic",
+    ] as const;
+    const protocols = ["vertex", "gemini", "openai", "anthropic"] as const;
+    for (const modelProvider of vertexProviders) {
+      for (const sessionProvider of vertexProviders) {
+        for (const protocol of protocols) {
+          const allowed =
+            protocol === "vertex" ||
+            (protocol === "gemini" &&
+              modelProvider === "google-vertex" &&
+              sessionProvider === "google-vertex");
+          const target = resolveTarget(
+            defaults,
+            protocol,
+            vertexUrl,
+            modelProvider,
+            sessionProvider,
+          );
+          if (allowed) {
+            expect(target).toMatchObject({ url: vertexUrl, protocol });
+          } else {
+            expect(target).toMatchObject({ routeUnavailable: true, url: "" });
+          }
+        }
+      }
+    }
+
+    const bedrockUrl = "https://bedrock-mantle.us-east-1.api.aws/anthropic";
+    for (const modelProvider of ["bedrock", "amazon-bedrock"] as const) {
+      for (const sessionProvider of ["bedrock", "amazon-bedrock"] as const) {
+        for (const protocol of protocols) {
+          const target = resolveTarget(
+            defaults,
+            protocol,
+            bedrockUrl,
+            modelProvider,
+            sessionProvider,
+          );
+          if (protocol === "anthropic") {
+            expect(target).toMatchObject({ url: bedrockUrl, protocol });
+          } else {
+            expect(target).toMatchObject({ routeUnavailable: true, url: "" });
+          }
+        }
+      }
+    }
+  });
+
+  test.each([
+    ["OpenAI", "api.openai.com", "/v1", "openai", "openai"],
+    ["Anthropic", "api.anthropic.com", "/v1", "anthropic", "anthropic"],
+    ["ChatGPT", "chatgpt.com", "/backend-api", "openai", "openai"],
+    [
+      "Gemini",
+      "generativelanguage.googleapis.com",
+      "/v1beta",
+      "google",
+      "gemini",
+    ],
+    [
+      "Vertex regional",
+      "us-east1-aiplatform.googleapis.com",
+      "/v1/projects/p/locations/us-east1",
+      "vertex",
+      "vertex",
+    ],
+    [
+      "Vertex global",
+      "aiplatform.googleapis.com",
+      "/v1/projects/p/locations/global",
+      "vertex",
+      "vertex",
+    ],
+  ] as const)(
+    "requires HTTPS on the effective default port for %s canonical evidence",
+    (_name, host, path, provider, protocol) => {
+      const defaults = {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      };
+      for (const url of [
+        `https://${host}${path}`,
+        `https://${host.toUpperCase()}.:443${path}`,
+      ]) {
+        expect(workerOriginProtocolFamilies(url)?.size).toBeGreaterThan(0);
+        expect(
+          resolveTarget(defaults, protocol, url, provider, provider),
+        ).not.toMatchObject({ routeUnavailable: true });
+      }
+      for (const url of [
+        `http://${host}${path}`,
+        `ftp://${host}${path}`,
+        `ws://${host}${path}`,
+        `https://${host}:444${path}`,
+      ]) {
+        expect(workerOriginProtocolFamilies(url)).toEqual(new Set());
+        expect(
+          resolveTarget(defaults, protocol, url, provider, provider),
+        ).toMatchObject({ routeUnavailable: true, url: "" });
+      }
+    },
+  );
+
+  test("does not reclassify known invalid canonical origins as custom", () => {
+    const defaults = {
+      anthropic: "https://api.anthropic.com",
+      openai: "https://api.openai.com",
+    };
+    expect(
+      workerOriginProtocolFamilies("https://chatgpt.com/custom-api"),
+    ).toEqual(new Set());
+    expect(
+      resolveTarget(
+        defaults,
+        "openai-codex-responses",
+        "https://chatgpt.com/custom-api",
+        "openai",
+        "openai",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+
+    // Unknown custom hosts retain the explicit-provenance behavior.
+    expect(
+      resolveTarget(
+        defaults,
+        "openai",
+        "http://custom.internal:444/api",
+        "custom-provider",
+        "custom-provider",
+      ),
+    ).toMatchObject({
+      url: "http://custom.internal:444/api",
+      protocol: "openai",
+    });
+  });
+
+  test("normalizes accepted canonical targets and rejects trailing-dot relabeling", () => {
+    const defaults = {
+      anthropic: "https://api.anthropic.com.",
+      openai: "https://api.openai.com.",
+    };
+    expect(
+      resolveTarget(defaults, "anthropic", undefined, "anthropic").url,
+    ).toBe("https://api.anthropic.com");
+    expect(
+      resolveTarget(defaults, "openai-responses", undefined, "openai").url,
+    ).toBe("https://api.openai.com");
+    expect(
+      resolveTarget(
+        defaults,
+        "openai-responses",
+        "https://api.anthropic.com.",
+        "openai",
+        "openai",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+    expect(
+      resolveTarget(
+        defaults,
+        "anthropic",
+        "https://api.openai.com.",
+        "anthropic",
+        "anthropic",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+  });
+
+  test("resolves canonical and configured provider aliases without crossing families", () => {
+    const defaults = {
+      anthropic: "https://api.anthropic.com",
+      openai: "https://api.openai.com",
+    };
+
+    expect(
+      resolveTarget(defaults, "gemini", undefined, "google"),
+    ).toMatchObject({
+      url: "https://generativelanguage.googleapis.com",
+      protocol: "gemini",
+      providerName: "google",
+    });
+    for (const vertexUrl of [
+      "https://europe-west1-aiplatform.googleapis.com/v1/projects/p/locations/europe-west1/publishers/google",
+      "https://aiplatform.googleapis.com/v1/projects/p/locations/global/publishers/google",
+    ]) {
+      expect(
+        resolveTarget(
+          defaults,
+          "gemini",
+          vertexUrl,
+          "google-vertex",
+          "google-vertex",
+        ),
+      ).toMatchObject({ url: vertexUrl, protocol: "gemini" });
+      expect(
+        resolveTarget(defaults, "vertex", vertexUrl, "vertex", "vertex"),
+      ).toMatchObject({ url: vertexUrl, protocol: "vertex" });
+    }
+
+    expect(
+      resolveTarget(
+        { ...defaults, openai: "https://openai.internal/api" },
+        "openai-responses",
+        undefined,
+        "openai",
+      ),
+    ).toMatchObject({
+      url: "https://openai.internal/api",
+      protocol: "openai-responses",
+    });
+    expect(
+      resolveTarget(
+        { ...defaults, anthropic: "https://anthropic.internal/api" },
+        "anthropic",
+        undefined,
+        "anthropic",
+      ),
+    ).toMatchObject({
+      url: "https://anthropic.internal/api",
+      protocol: "anthropic",
+    });
+    expect(
+      resolveTarget(
+        defaults,
+        "gemini",
+        "https://gemini.internal/base",
+        "google",
+        "google",
+      ),
+    ).toMatchObject({
+      url: "https://gemini.internal/base",
+      protocol: "gemini",
+    });
+    expect(
+      resolveTarget(
+        defaults,
+        "openai-codex-responses",
+        "https://chatgpt.com/backend-api",
+        "openai",
+        "openai",
+      ),
+    ).toMatchObject({
+      url: "https://chatgpt.com/backend-api",
+      protocol: "openai-codex-responses",
+    });
+
+    // Canonical provider ownership cannot be forged by a matching label.
+    expect(
+      resolveTarget(
+        defaults,
+        "openai-responses",
+        "https://api.anthropic.com",
+        "openai",
+        "openai",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+    expect(
+      resolveTarget(
+        defaults,
+        "gemini",
+        "https://generativelanguage.googleapis.com",
+        "unrelated-provider",
+        "unrelated-provider",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+    expect(
+      resolveTarget(
+        defaults,
+        "anthropic",
+        "https://api.openai.com",
+        "anthropic",
+        "anthropic",
+      ),
+    ).toMatchObject({ routeUnavailable: true, url: "" });
+
+    // A foreign explicit override is rejected; resolution stays on the model's
+    // own trusted route rather than sending credentials to that override.
+    expect(
+      resolveTarget(
+        defaults,
+        "openai-responses",
+        "https://api.anthropic.com",
+        "openai",
+        "anthropic",
+      ).url,
+    ).toBe("https://api.openai.com");
+    expect(
+      resolveTarget(
+        defaults,
+        "anthropic",
+        "https://api.openai.com",
+        "anthropic",
+        "openai",
+      ).url,
+    ).toBe("https://api.anthropic.com");
+  });
+});


### PR DESCRIPTION
## Summary

- harden foreground and worker streaming lifecycle validation across Anthropic, OpenAI, Responses, and Gemini protocols
- propagate cancellation and deadlines through ingress, early flush, recall, compaction, provider fetches, and Node response bridging
- enforce bounded request, response, SSE, diagnostic, decompression, queue, and Bedrock payload handling
- prevent cross-provider credential leakage and preserve provider route, tool identity, usage, and terminal-state provenance
- add adversarial regressions for malformed framing, retries after partial output, backpressure, listener cleanup, numeric overflow, and trust-boundary behavior

## Security and correctness

- request decompression uses asynchronous abort-aware codecs with independent 32 MiB wire and expanded limits
- Bedrock runtime strips hop-by-hop, proxy, cookie, connection-nominated, and internal Lore headers across the origin boundary
- fragmented SSE parsing avoids repeated full-prefix scans while retaining frame, event, aggregate, UTF-8, and terminal bounds
- early-flush Responses streaming is demand-driven and aborts unresolved pre-response work on downstream cancellation
- native Gemini safety reasons and provider tool identities survive accumulation and egress unchanged
- recall usage aggregation rejects per-field and combined safe-integer overflow

## Validation

- `pnpm test`: 394 files passed, 15 skipped; 8,002 tests passed, 227 skipped
- `pnpm run typecheck`: passed
- `pnpm run lint`: passed with the existing warning baseline
- `pnpm run format:check`: passed across 732 files
- `git diff --check`: passed
- adversarial stability battery: 8,240/8,240 passed
- security property and stability batteries: 5,420/5,420 passed

## Independent review

- adversarial/correctness: MERGE
- security/pentest: MERGE
- both reviewers independently certified binary diff SHA-256 `3f766e1bfb399971eabb8146d4021b6effae77efdb69489a99af177ae47f1894` with unchanged before/after tree hashes