### PR TITLE
fix(core): support large semantic lint diffs

### DIFF
--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -265,11 +265,16 @@ export function enforcementLevel(entry: {
 // Git range auto-detection (Craft-style: resolve base/head automatically)
 // ---------------------------------------------------------------------------
 
+// Node's 1 MiB child-process default is too small for ordinary large PR diffs.
+// Keep Git output bounded because pull-request diff content is untrusted.
+export const MAX_GIT_OUTPUT_BYTES = 16 * 1024 * 1024;
+
 function git(args: string[], cwd: string): string {
   return execFileSync("git", args, {
     cwd,
     encoding: "utf8",
     timeout: 10_000,
+    maxBuffer: MAX_GIT_OUTPUT_BYTES,
     stdio: ["pipe", "pipe", "pipe"],
   }).trim();
 }
@@ -397,12 +402,46 @@ export interface DiffHunk {
   text: string;
 }
 
+export type DiffFailureCode = "diff-command-failed" | "diff-too-large";
+
+export interface DiffFailure {
+  code: DiffFailureCode;
+  message: string;
+}
+
 export type DiffResult =
   | { kind: "success"; hunks: DiffHunk[] }
   | {
       kind: "failure";
-      failure: { code: "diff-command-failed"; message: string };
+      failure: DiffFailure;
     };
+
+/** Downstream bounds for untrusted pull-request diff content. */
+export const MAX_DIFF_HUNKS = 1_000;
+export const MAX_DIFF_TEXT_BYTES = 4 * 1024 * 1024;
+export const MAX_HUNK_TEXT_BYTES = 32 * 1024;
+const HUNK_TRUNCATION_MARKER = "\n... [hunk truncated by Lore] ...\n";
+
+class DiffLimitError extends Error {
+  override name = "DiffLimitError";
+}
+
+function truncateHunkText(text: string): string {
+  const bytes = Buffer.from(text);
+  if (bytes.length <= MAX_HUNK_TEXT_BYTES) return text;
+
+  const markerBytes = Buffer.byteLength(HUNK_TRUNCATION_MARKER);
+  const available = MAX_HUNK_TEXT_BYTES - markerBytes;
+  const headBudget = Math.ceil(available / 2);
+  const tailBudget = Math.floor(available / 2);
+  let headEnd = headBudget;
+  while (headEnd > 0 && (bytes[headEnd] & 0xc0) === 0x80) headEnd--;
+  let tailStart = bytes.length - tailBudget;
+  while (tailStart < bytes.length && (bytes[tailStart] & 0xc0) === 0x80)
+    tailStart++;
+
+  return `${bytes.subarray(0, headEnd).toString("utf8")}${HUNK_TRUNCATION_MARKER}${bytes.subarray(tailStart).toString("utf8")}`;
+}
 
 /**
  * Files whose changes are NEVER judged: they are machine-authored or are lore's
@@ -480,11 +519,15 @@ export function parseDiffResult(
     );
     return { kind: "success", hunks: raw ? splitDiff(raw) : [] };
   } catch (error) {
+    const limited = error instanceof DiffLimitError;
     return {
       kind: "failure",
       failure: {
-        code: "diff-command-failed",
-        message: boundedMessage(error, "git diff failed"),
+        code: limited ? "diff-too-large" : "diff-command-failed",
+        message: boundedMessage(
+          error,
+          limited ? "Diff exceeds semantic lint limits" : "git diff failed",
+        ),
       },
     };
   }
@@ -495,6 +538,7 @@ export function parseDiffResult(
  *  call (or manufactures a false positive) on non-code changes. */
 export function splitDiff(raw: string): DiffHunk[] {
   const hunks: DiffHunk[] = [];
+  let textBytes = 0;
   const lines = raw.split("\n");
   let file = "";
   // Fallback path from the `--- a/` line, used for DELETED files whose `+++`
@@ -505,8 +549,21 @@ export function splitDiff(raw: string): DiffHunk[] {
   let cur: string[] | null = null;
   const flush = () => {
     const f = file || oldFile;
-    if (cur && f && cur.length && !isIgnoredFile(f))
-      hunks.push({ file: f, text: cur.join("\n") });
+    if (cur && f && cur.length && !isIgnoredFile(f)) {
+      if (hunks.length >= MAX_DIFF_HUNKS) {
+        throw new DiffLimitError(
+          `Diff exceeds semantic lint limit of ${MAX_DIFF_HUNKS} hunks`,
+        );
+      }
+      const text = truncateHunkText(cur.join("\n"));
+      textBytes += Buffer.byteLength(text);
+      if (textBytes > MAX_DIFF_TEXT_BYTES) {
+        throw new DiffLimitError(
+          `Diff exceeds semantic lint limit of ${MAX_DIFF_TEXT_BYTES} parsed text bytes`,
+        );
+      }
+      hunks.push({ file: f, text });
+    }
     cur = null;
   };
   for (const line of lines) {
@@ -841,7 +898,7 @@ export type HealthStatus = "healthy" | "degraded" | "failed" | "not-run";
 export interface DiffHealth {
   status: Extract<HealthStatus, "healthy" | "failed">;
   hunks: number;
-  failure?: { code: "diff-command-failed"; message: string };
+  failure?: DiffFailure;
 }
 
 export interface VectorHealth {
@@ -1866,9 +1923,8 @@ function loadInvariantVecs(entries: KnowledgeEntry[]): {
 
 /** Max characters of a single hunk fed to the embedder. A giant hunk (e.g. a
  *  generated/docs file) posts an oversized ONNX tensor → OOM (#1072 class). We
- *  only need enough text to gauge TOPICAL similarity for the prefilter, so the
- *  embed input is capped; the JUDGE still receives the full hunk. Mirrors the
- *  worker's own truncateTexts fallback. */
+ *  only need enough text to gauge TOPICAL similarity for the prefilter. Parsed
+ *  hunks already have a separate byte cap for judging and reporting. */
 export const MAX_EMBED_CHARS_PER_HUNK = 8_000;
 
 /** Embed all hunks (local ONNX → free), OOM-safely. Each hunk's embed text is

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../src/db";
 import { storeEmbedding } from "../src/db/vec-store";
@@ -12,7 +16,12 @@ import {
   isEnforceableInvariant,
   isEnumerationInvariant,
   isIgnoredFile,
+  MAX_DIFF_HUNKS,
+  MAX_DIFF_TEXT_BYTES,
+  MAX_GIT_OUTPUT_BYTES,
+  MAX_HUNK_TEXT_BYTES,
   overrideMatchesFinding,
+  parseDiffResult,
   parseInvariantVerdict,
   parseOverrides,
   selectCandidates,
@@ -106,6 +115,37 @@ const FAKE_RANGE: ResolvedRange = {
   head: "bbbb",
   source: "test",
 };
+
+function initGitRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "lore-large-diff-"));
+  execFileSync("git", ["init", "--quiet"], { cwd: repo });
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: repo,
+  });
+  execFileSync("git", ["config", "user.name", "Lore Test"], { cwd: repo });
+  return repo;
+}
+
+function commitAll(repo: string, message: string): string {
+  execFileSync("git", ["add", "-A"], { cwd: repo });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "commit.gpgSign=false",
+      "commit",
+      "--quiet",
+      "--no-verify",
+      "-m",
+      message,
+    ],
+    { cwd: repo },
+  );
+  return execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: repo,
+    encoding: "utf8",
+  }).trim();
+}
 
 beforeEach(() => {
   vi.spyOn(embedding, "embed").mockResolvedValue([v(0, 0, 1)]);
@@ -225,6 +265,118 @@ describe("splitDiff", () => {
         text: "@@ -1 +1,2 @@\n const marker = true;\n+++ b/.lore.md",
       },
     ]);
+  });
+});
+
+describe("parseDiffResult", () => {
+  it("bounds hunks from diffs larger than Node's default buffer before judging", async () => {
+    const repo = initGitRepo();
+    try {
+      writeFileSync(join(repo, "large.txt"), "");
+      const base = commitAll(repo, "base");
+
+      writeFileSync(join(repo, "large.txt"), `${"x".repeat(1_100_000)}\n`);
+      const head = commitAll(repo, "large diff");
+
+      const result = parseDiffResult(repo, base, head);
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.hunks).toHaveLength(1);
+        expect(result.hunks[0].file).toBe("large.txt");
+        expect(Buffer.byteLength(result.hunks[0].text)).toBeLessThanOrEqual(
+          MAX_HUNK_TEXT_BYTES,
+        );
+        expect(result.hunks[0].text).toContain("hunk truncated by Lore");
+
+        await seed(
+          repo,
+          "large file boundary",
+          "large.txt must never bypass the shared boundary",
+          v(1, 0, 0),
+        );
+        vi.spyOn(embedding, "embedInTokenBatches").mockResolvedValue([
+          v(1, 0, 0),
+        ]);
+        const { judge, judgeCall } = stubJudge(() => ({
+          kind: "verdict",
+          verdict: "satisfies",
+          reason: "bounded",
+          stats: { semanticCalls: 1, transportAttempts: 1 },
+        }));
+        await checkInvariants({
+          projectPath: repo,
+          diff: result,
+          range: { base, head, source: "test" },
+          judge,
+          sessionID: "large-real-git-hunk",
+        });
+        expect(judgeCall).toHaveBeenCalledWith(
+          expect.objectContaining({ hunk: result.hunks[0].text }),
+        );
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("returns diff-too-large before embedding excessive hunk counts", () => {
+    const repo = initGitRepo();
+    try {
+      const blocks = Array.from({ length: MAX_DIFF_HUNKS + 1 }, (_, index) =>
+        [
+          `old-${index}`,
+          ...Array.from(
+            { length: 7 },
+            (__, offset) => `context-${index}-${offset}`,
+          ),
+        ].join("\n"),
+      );
+      writeFileSync(join(repo, "many.txt"), `${blocks.join("\n")}\n`);
+      const base = commitAll(repo, "base");
+      writeFileSync(
+        join(repo, "many.txt"),
+        `${blocks.map((block, index) => block.replace(`old-${index}`, `new-${index}`)).join("\n")}\n`,
+      );
+      const head = commitAll(repo, "many hunks");
+
+      expect(parseDiffResult(repo, base, head)).toMatchObject({
+        kind: "failure",
+        failure: { code: "diff-too-large" },
+      });
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps aggregate parsed hunk text bounded", () => {
+    const hunkCount = Math.floor(MAX_DIFF_TEXT_BYTES / MAX_HUNK_TEXT_BYTES) + 1;
+    const raw = Array.from(
+      { length: hunkCount },
+      (_, index) =>
+        `diff --git a/file-${index}.txt b/file-${index}.txt\n--- a/file-${index}.txt\n+++ b/file-${index}.txt\n@@ -0,0 +1 @@\n+${"x".repeat(MAX_HUNK_TEXT_BYTES)}`,
+    ).join("\n");
+
+    expect(() => splitDiff(raw)).toThrow(/parsed text bytes/);
+  });
+
+  it("rejects Git output above the 16 MiB security ceiling", () => {
+    const repo = initGitRepo();
+    try {
+      writeFileSync(join(repo, "oversized.txt"), "");
+      const base = commitAll(repo, "base");
+      writeFileSync(
+        join(repo, "oversized.txt"),
+        `${"x".repeat(MAX_GIT_OUTPUT_BYTES + 1024)}\n`,
+      );
+      const head = commitAll(repo, "oversized diff");
+
+      expect(parseDiffResult(repo, base, head)).toMatchObject({
+        kind: "failure",
+        failure: { code: "diff-command-failed" },
+      });
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -162,7 +162,7 @@ export async function runSemanticLint(
         effort,
         range,
         phase,
-        code: "diff-command-failed",
+        code: diff.failure.code,
         error: diff.failure.message,
       });
       await options.publishReport?.(report);

--- a/packages/gateway/src/cli/lint-report.ts
+++ b/packages/gateway/src/cli/lint-report.ts
@@ -161,6 +161,7 @@ const CANDIDATE_FAILURE_CODES = new Set([
 const PHASE_FAILURE_CODES = new Set([
   "range-resolution-failed",
   "diff-command-failed",
+  "diff-too-large",
   "invariant-source-read-failed",
   "invariant-source-import-failed",
   "invariant-vector-load-failed",

--- a/packages/gateway/test/invariant-check-orchestration.test.ts
+++ b/packages/gateway/test/invariant-check-orchestration.test.ts
@@ -9,6 +9,50 @@ afterEach(() => {
 });
 
 describe("runSemanticLint cancellation", () => {
+  it("preserves typed diff limit failures in the published report", async () => {
+    const range = { base: "base", head: "head", source: "test" };
+    const startGateway = vi.fn();
+    vi.doMock("@loreai/core", () => ({
+      config: () => ({
+        model: undefined,
+        invariantCheck: { effort: "off" },
+      }),
+      embedding: {},
+      importLoreFile: vi.fn(),
+      invariantCheck: {
+        resolveRange: () => range,
+        parseDiffResult: () => ({
+          kind: "failure",
+          failure: {
+            code: "diff-too-large",
+            message: "too many hunks",
+          },
+        }),
+      },
+      parseReasoningEffort: vi.fn(),
+    }));
+    vi.doMock("../src/llm-adapter", () => ({
+      createGatewayLLMClient: () => ({}),
+      createGatewayInvariantJudge: () => ({}),
+    }));
+    vi.doMock("../src/cli/start", () => ({ startGateway }));
+
+    const { runSemanticLint } = await import("../src/cli/invariant-check");
+    const report = await runSemanticLint({
+      project: ".",
+      gate: false,
+      importLoreMd: false,
+      deadlineMs: 1_000,
+      candidateTimeoutMs: 100,
+    });
+
+    expect(report.health.diff).toMatchObject({
+      status: "failed",
+      failure: { code: "diff-too-large", message: "too many hunks" },
+    });
+    expect(startGateway).not.toHaveBeenCalled();
+  });
+
   it("attributes expiry after range resolution to the diff phase", async () => {
     let now = 0;
     const range = { base: "base", head: "head", source: "test" };


### PR DESCRIPTION
## Summary
Prevents semantic lint from failing on ordinary diffs above Node's 1 MiB child-process default while bounding downstream work from untrusted pull-request content.

## Changes
- Raises the bounded Git output buffer to 16 MiB.
- Truncates each parsed hunk to a deterministic 32 KiB head/tail excerpt before embedding, judging, or reporting.
- Rejects more than 1,000 hunks or 4 MiB of aggregate parsed hunk text with a typed `diff-too-large` health failure.
- Adds real-Git regressions for the original >1 MiB failure, judge input bounds, excessive hunk counts, signing-independent commits, and the 16 MiB security ceiling.

## Verification
- `pnpm vitest run packages/core/test/invariant-check.test.ts packages/gateway/test/invariant-check-orchestration.test.ts packages/gateway/test/cli-lint-contract.test.ts`
- `pnpm --filter @loreai/core run typecheck`
- `pnpm --filter @loreai/gateway run typecheck`
- `pnpm exec oxlint --type-aware ...`
- Original failing SHA range succeeds: 454 hunks, 32 KiB maximum hunk, 1,002,784 aggregate hunk bytes.