### PR TITLE
fix(gateway): preserve provider routing options

### DIFF
--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -127,6 +127,10 @@ interface PendingRequest {
   sessionID?: string;
   /** Worker ID for cost attribution (e.g. "lore-distill", "lore-curator"). */
   workerID?: string;
+  /** Dispatch-time route snapshot for synchronous fallback. */
+  upstreamUrl?: string;
+  upstreamProviderID?: string;
+  protocol?: NonNullable<Parameters<LLMClient["prompt"]>[2]>["protocol"];
 }
 
 /** A batch that has been submitted and is being polled for results. */
@@ -1134,6 +1138,13 @@ export function createBatchLLMClient(
             const result = await inner.prompt(system, user, {
               sessionID: item.sessionID,
               workerID: item.workerID,
+              model: {
+                providerID: item.providerID,
+                modelID: item.params.model,
+              },
+              upstreamUrl: item.upstreamUrl,
+              upstreamProviderID: item.upstreamProviderID,
+              protocol: item.protocol,
               maxTokens: item.params.max_tokens,
               ...(item.params.temperature != null && {
                 temperature: item.params.temperature,
@@ -1236,6 +1247,9 @@ export function createBatchLLMClient(
           providerID: model.providerID,
           sessionID: opts?.sessionID,
           workerID: opts?.workerID,
+          upstreamUrl: opts?.upstreamUrl,
+          upstreamProviderID: opts?.upstreamProviderID,
+          protocol: opts?.protocol,
         });
       });
 

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -65,6 +65,7 @@ import type { GatewayConfig } from "./config";
 import type { SessionState } from "./translate/types";
 import { getWorkerModel, getModelEntrySync } from "./worker-model";
 import { buildSessionMetadata } from "./session-metadata";
+import { hasWorkerSessionAuth } from "./worker-auth";
 import {
   isCircuitBreakerTripped,
   pruneExpiredCircuitBreakers,
@@ -668,7 +669,11 @@ export function startIdleScheduler(
       if (
         !config.workerApiKey &&
         idleWorkerModel &&
-        !resolveAuth(sessionID, idleWorkerModel.providerID)
+        !hasWorkerSessionAuth(
+          sessionID,
+          idleWorkerModel.providerID,
+          state.upstreamByProvider.get(idleWorkerModel.providerID)?.protocol,
+        )
       ) {
         continue;
       }

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -1286,7 +1286,7 @@ export function canonicalWorkerProviderID(providerID: string): string {
   return providerID;
 }
 
-function workerProviderAliasIDs(providerID: string): readonly string[] {
+export function workerProviderAliasIDs(providerID: string): readonly string[] {
   for (const family of WORKER_PROVIDER_ALIAS_FAMILIES) {
     if (family.has(providerID)) {
       return [providerID, ...[...family].filter((id) => id !== providerID)];
@@ -1299,7 +1299,7 @@ function workerProvidersEquivalent(left: string, right: string): boolean {
   return canonicalWorkerProviderID(left) === canonicalWorkerProviderID(right);
 }
 
-function workerProviderSupportsProtocol(
+export function workerProviderSupportsProtocol(
   providerID: string,
   protocol: WorkerProtocol,
 ): boolean {
@@ -1931,26 +1931,24 @@ function buildOpenAIWorkerRequest(
   maxTokens: number,
   temperature?: number,
   reasoningEffort?: ReasoningEffort,
+  providerOptions?: Readonly<Record<string, unknown>>,
 ): { url: string; headers: Record<string, string>; body: string } {
   const messages: Array<{ role: string; content: string }> = [];
   if (system) messages.push({ role: "system", content: system });
   messages.push({ role: "user", content: user });
 
-  // OpenRouter-only cost lever: route background worker calls to the cheapest
-  // provider for the chosen model (equivalent to the `:floor` slug suffix, i.e.
-  // `provider.sort: "price"`). This is safe here because `buildOpenAIWorkerRequest`
-  // only ever builds BACKGROUND worker calls (distillation, curation, query
-  // expansion) — never the live conversation, which goes through the proxy path
-  // and needs OpenRouter's default load-balancing for reliability. Worker calls
-  // are latency-tolerant with no user waiting, so trading load-balancing for the
-  // lowest price is pure upside. The field is OpenRouter-specific; other OpenAI-
-  // protocol providers ignore an unknown `provider` key. NOTE: `:floor` can land
-  // on a quantized endpoint — if distillation/curation quality degrades, a user
-  // can pin precision via their own worker model config (see docs). Other OpenAI-
-  // protocol upstreams never see this block (gated on providerName).
+  // OpenRouter workers inherit the owning session's explicit routing policy.
+  // Without one, retain Lore's existing cheapest-provider default for
+  // latency-tolerant background work. Other providers never see this field.
+  const validProviderOptions =
+    providerOptions !== null &&
+    typeof providerOptions === "object" &&
+    !Array.isArray(providerOptions)
+      ? providerOptions
+      : undefined;
   const providerPrefs =
     target.providerName === "openrouter"
-      ? { provider: { sort: "price" } }
+      ? { provider: validProviderOptions ?? { sort: "price" } }
       : undefined;
 
   // Reasoning models honor `reasoning_effort`; non-reasoning models (gpt-4o-mini,
@@ -2824,6 +2822,7 @@ async function buildWorkerRequest(
   vertexProject?: string,
   disableThinking = false,
   reasoningEffort?: ReasoningEffort,
+  providerOptions?: Readonly<Record<string, unknown>>,
   signal?: AbortSignal,
 ): Promise<{ url: string; headers: Record<string, string>; body: string }> {
   switch (target.protocol) {
@@ -2859,6 +2858,7 @@ async function buildWorkerRequest(
         maxTokens,
         temperature,
         reasoningEffort,
+        providerOptions,
       );
     case "vertex":
       return buildVertexWorkerRequest(
@@ -3256,13 +3256,24 @@ export type PromptOutcome =
       attempts: number;
     };
 
-type PromptOptions = NonNullable<Parameters<LLMClient["prompt"]>[2]>;
+type CorePromptOptions = NonNullable<Parameters<LLMClient["prompt"]>[2]>;
+
+/** Gateway-private prompt extensions that must not leak into @loreai/core. */
+export interface GatewayPromptOptions extends CorePromptOptions {
+  /** Validated OpenRouter provider routing policy from the matching snapshot. */
+  providerOptions?: Readonly<Record<string, unknown>>;
+}
 
 export interface GatewayLLMClient extends LLMClient {
+  prompt(
+    system: string,
+    user: string,
+    opts?: GatewayPromptOptions,
+  ): Promise<string | null>;
   promptDetailed(
     system: string,
     user: string,
-    opts?: PromptOptions,
+    opts?: GatewayPromptOptions,
   ): Promise<PromptOutcome>;
 }
 
@@ -3682,6 +3693,7 @@ export function createGatewayLLMClient(
             factoryVertexProject,
             effectiveDisableThinking,
             reasoningEffort,
+            opts?.providerOptions,
             requestSignal,
           ),
         );

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -108,6 +108,8 @@ import {
   isEmptyCompletion,
   looksLikeSSE,
   forwardClientHeaders,
+  providerRoutingValue,
+  requestTargetsOpenRouter,
   ZERO_USAGE,
 } from "./translate/types";
 import type { GatewayConfig } from "./config";
@@ -225,8 +227,11 @@ import {
   deterministicID,
 } from "./temporal-adapter";
 import {
+  canonicalWorkerProviderID,
   createGatewayLLMClient,
   disjointOpenAIInputTokens,
+  workerProviderSupportsProtocol,
+  type GatewayPromptOptions,
 } from "./llm-adapter";
 import { createBatchLLMClient } from "./batch-queue";
 import {
@@ -252,9 +257,9 @@ import { flushPendingImport } from "./pending-import";
 import { upstreamErrorHint } from "./upstream-error-hint";
 import { makeTemporalBackfillGate } from "./backfill-gate";
 import { buildSessionMetadata } from "./session-metadata";
+import { hasWorkerSessionAuth } from "./worker-auth";
 import {
   makeWorkerHealth,
-  recordWorkerFailure,
   allowWorkerProbe,
   isWorkerCreditPaused,
   getDegradationWarning,
@@ -599,6 +604,20 @@ function containsGitCommit(req: GatewayRequest): boolean {
 
 /** Active upstream interceptor — used for recording/replay. */
 let activeInterceptor: UpstreamInterceptor | undefined;
+/** Monotonic request-start order for concurrency-safe upstream snapshots. */
+let upstreamRequestOrder = 0;
+/** Test-only seam for forcing adversarial request ordering before capture. */
+let beforeUpstreamCaptureForTest:
+  | ((req: GatewayRequest, state: SessionState) => Promise<void>)
+  | undefined;
+
+export function setBeforeUpstreamCaptureForTest(
+  hook:
+    | ((req: GatewayRequest, state: SessionState) => Promise<void>)
+    | undefined,
+): void {
+  beforeUpstreamCaptureForTest = hook;
+}
 
 /**
  * Set (or clear) the module-level upstream interceptor.
@@ -671,6 +690,7 @@ export async function resetPipelineState(opts?: {
   }
   llmClient = null;
   activeInterceptor = undefined;
+  beforeUpstreamCaptureForTest = undefined;
   if (stopFileWatcher) {
     stopFileWatcher();
     stopFileWatcher = null;
@@ -3193,78 +3213,6 @@ function getLLMClient(config: GatewayConfig): LLMClient {
       },
     );
 
-    // Workers always use the same provider as the session. Route worker
-    // calls through the session's upstream URL and wire protocol so they
-    // use the session's credentials, endpoint, and request format. The
-    // protocol from the UpstreamSnapshot is the source of truth — it was
-    // resolved at conversation-turn time and correctly handles aggregator
-    // providers (e.g. OpenCode Zen) whose route has protocol=null.
-    //
-    // When a dedicated worker API key is set (LORE_WORKER_API_KEY), skip
-    // injection — the worker uses its own credentials and default upstream.
-    //
-    // CROSS-PROVIDER GUARD: The model was resolved at idle-handler start
-    // from state.lastUpstream, but the URL is resolved HERE (lazily) from
-    // the CURRENT state.lastUpstream. If the user switched providers
-    // between those two points, the model and URL come from different
-    // providers → 404. Detect this and re-resolve the worker model from
-    // the current upstream. See: LOREAI-GATEWAY-2A.
-    const inner: LLMClient = {
-      async prompt(system, user, opts) {
-        if (opts?.sessionID && !opts.upstreamUrl && !workerApiKey) {
-          const state = sessions.get(opts.sessionID);
-          if (state?.lastUpstream?.url) {
-            // Cross-provider guard: if the model's provider doesn't match
-            // the current upstream provider, re-resolve to avoid sending
-            // e.g. MiniMax-M3 to api.anthropic.com.
-            //
-            // When opts.model is undefined, the rawClient will use
-            // defaultModel (hardcoded at construction time, typically
-            // Anthropic). We must also guard against THAT mismatch —
-            // otherwise an unknown-provider session (MiniMax, xAI, etc.)
-            // gets the Anthropic defaultModel sent to its upstream URL.
-            let effectiveOpts = opts;
-            const modelProvider =
-              opts?.model?.providerID ?? defaultModel.providerID;
-            const upstreamProvider = state.lastUpstream.providerID;
-            if (upstreamProvider && modelProvider !== upstreamProvider) {
-              const reResolved = getWorkerModel(state.lastUpstream);
-              if (reResolved) {
-                effectiveOpts = { ...opts, model: reResolved };
-              } else {
-                // Can't resolve a valid worker model for the current
-                // provider — skip this call rather than send cross-provider.
-                log.warn(
-                  `worker cross-provider guard: model=${modelProvider}/${opts?.model?.modelID ?? defaultModel.modelID} vs upstream=${upstreamProvider} — skipping (worker=${opts?.workerID ?? "unknown"}, session=${opts.sessionID})`,
-                );
-                recordWorkerFailure(
-                  opts.sessionID,
-                  opts?.workerID ?? "unknown",
-                  "cross-provider",
-                );
-                return null;
-              }
-            }
-            // Thread the session's provider so the adapter can enforce
-            // cross-provider safety: it only honors `upstreamUrl` when the
-            // (possibly re-resolved) worker model's provider matches
-            // `upstreamProviderID`. If a configured `workerModel` re-resolves
-            // to a DIFFERENT provider than the session (the production
-            // minimax-on-Anthropic case), the adapter routes by the worker
-            // model's own provider route — or fails closed if it has none —
-            // instead of sending it to the session's foreign endpoint.
-            return rawClient.prompt(system, user, {
-              ...effectiveOpts,
-              upstreamUrl: state.lastUpstream.url,
-              upstreamProviderID: upstreamProvider,
-              protocol: state.lastUpstream.protocol,
-            });
-          }
-        }
-        return rawClient.prompt(system, user, opts);
-      },
-    };
-
     // Wrap with batch queue for 50% cost savings on non-urgent worker calls.
     // Enabled by default — disable via LORE_BATCH_DISABLED=1.
     /**
@@ -3280,20 +3228,66 @@ function getLLMClient(config: GatewayConfig): LLMClient {
     if (Sentry.isInitialized()) {
       Sentry.setTag("batch_enabled", String(!batchDisabled));
     }
-    if (batchDisabled) {
-      llmClient = inner;
-      batchQueueEnabled = false;
-    } else {
-      llmClient = createBatchLLMClient(
-        inner,
-        workerUpstreams,
-        getWorkerAuth,
-        defaultModel,
-      );
-      batchQueueEnabled = true;
+    const dispatchClient = batchDisabled
+      ? rawClient
+      : createBatchLLMClient(
+          rawClient,
+          workerUpstreams,
+          getWorkerAuth,
+          defaultModel,
+        );
+    batchQueueEnabled = !batchDisabled;
+
+    // Resolve routing BEFORE the batch client sees opts. Batch enqueue chooses
+    // provider, model, auth, and grouping immediately; wrapping it on the inside
+    // would queue stale/default opts and only correct them during sync fallback.
+    // Current session state is authoritative over a caller's stale opts.model.
+    const routedClient: LLMClient & {
+      shutdown?: (options?: { drainQueue?: boolean }) => Promise<void>;
+      stats?: () => unknown;
+    } = {
+      async prompt(system, user, opts) {
+        if (!opts?.sessionID || opts.upstreamUrl) {
+          return dispatchClient.prompt(system, user, opts);
+        }
+        const state = sessions.get(opts.sessionID);
+        const effectiveModel =
+          (state ? getWorkerModel(state.lastUpstream) : undefined) ??
+          opts.model ??
+          defaultModel;
+        const snapshot = state
+          ? matchingProviderSnapshot(state, effectiveModel.providerID)
+          : undefined;
+        const effectiveOpts: GatewayPromptOptions = {
+          ...opts,
+          model: effectiveModel,
+        };
+        if (
+          snapshot?.providerOptions &&
+          canonicalWorkerProviderID(effectiveModel.providerID) === "openrouter"
+        ) {
+          effectiveOpts.providerOptions = snapshot.providerOptions;
+        }
+        if (!workerApiKey && snapshot?.url && snapshot.providerID) {
+          effectiveOpts.upstreamUrl = snapshot.url;
+          effectiveOpts.upstreamProviderID = snapshot.providerID;
+          effectiveOpts.protocol = snapshot.protocol;
+        }
+        return dispatchClient.prompt(system, user, effectiveOpts);
+      },
+    };
+    if ("shutdown" in dispatchClient && "stats" in dispatchClient) {
+      routedClient.shutdown = (options) => dispatchClient.shutdown(options);
+      routedClient.stats = () => dispatchClient.stats();
     }
+    llmClient = routedClient;
   }
   return llmClient;
+}
+
+/** Test-only access to the fully wrapped gateway worker client. */
+export function getLLMClientForTest(config: GatewayConfig): LLMClient {
+  return getLLMClient(config);
 }
 
 // ---------------------------------------------------------------------------
@@ -3664,6 +3658,283 @@ function syntheticToolUseResponse(
 // Session management helpers
 // ---------------------------------------------------------------------------
 
+const UPSTREAM_STATE_VERSION = 2;
+const MAX_UPSTREAM_SNAPSHOTS_PER_SESSION = 16;
+const MAX_PROVIDER_OPTIONS_BYTES = 64 * 1024;
+const UPSTREAM_PROTOCOLS = new Set<UpstreamSnapshot["protocol"]>([
+  "anthropic",
+  "openai",
+  "openai-responses",
+  "vertex",
+  "gemini",
+]);
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function freezeRecursively<T>(value: T): T {
+  if (value === null || typeof value !== "object" || Object.isFrozen(value)) {
+    return value;
+  }
+  for (const child of Object.values(value)) freezeRecursively(child);
+  return Object.freeze(value);
+}
+
+function freezeUpstreamSnapshot(snapshot: UpstreamSnapshot): UpstreamSnapshot {
+  const providerOptions = snapshot.providerOptions
+    ? freezeRecursively(structuredClone(snapshot.providerOptions))
+    : undefined;
+  return Object.freeze({
+    ...snapshot,
+    headers: Object.freeze({ ...snapshot.headers }),
+    ...(providerOptions ? { providerOptions } : {}),
+  });
+}
+
+function validatedUpstreamSnapshot(value: unknown): UpstreamSnapshot | null {
+  if (!isPlainRecord(value)) return null;
+  if (typeof value.url !== "string") return null;
+  if (!UPSTREAM_PROTOCOLS.has(value.protocol as UpstreamSnapshot["protocol"])) {
+    return null;
+  }
+  if (typeof value.model !== "string" || value.model.length === 0) return null;
+  if (
+    value.providerID !== undefined &&
+    (typeof value.providerID !== "string" || value.providerID.length === 0)
+  ) {
+    return null;
+  }
+  if (
+    !isPlainRecord(value.headers) ||
+    !Object.values(value.headers).every((header) => typeof header === "string")
+  ) {
+    return null;
+  }
+  if (
+    Object.hasOwn(value, "providerOptions") &&
+    !isPlainRecord(value.providerOptions)
+  ) {
+    return null;
+  }
+  return freezeUpstreamSnapshot({
+    url: value.url,
+    protocol: value.protocol as UpstreamSnapshot["protocol"],
+    ...(value.providerID ? { providerID: value.providerID } : {}),
+    model: value.model,
+    headers: value.headers as Record<string, string>,
+    ...(isPlainRecord(value.providerOptions)
+      ? { providerOptions: value.providerOptions }
+      : {}),
+  });
+}
+
+function providersEquivalent(left: string, right: string): boolean {
+  return canonicalWorkerProviderID(left) === canonicalWorkerProviderID(right);
+}
+
+function matchingProviderSnapshot(
+  state: SessionState,
+  providerID: string,
+): UpstreamSnapshot | undefined {
+  const direct = state.upstreamByProvider.get(providerID);
+  if (direct?.providerID === providerID) return direct;
+  for (const snapshot of state.upstreamByProvider.values()) {
+    if (
+      snapshot.providerID &&
+      providersEquivalent(snapshot.providerID, providerID) &&
+      workerProviderSupportsProtocol(providerID, snapshot.protocol)
+    ) {
+      return snapshot;
+    }
+  }
+  return undefined;
+}
+
+/** Test-only visibility into protocol-aware alias selection. */
+export function matchingProviderSnapshotForTest(
+  state: SessionState,
+  providerID: string,
+): UpstreamSnapshot | undefined {
+  return matchingProviderSnapshot(state, providerID);
+}
+
+function serializeUpstreamState(state: SessionState): string {
+  const stripHeaders = (snapshot: UpstreamSnapshot) => ({
+    ...snapshot,
+    headers: {},
+  });
+  const upstreamByProvider: Record<string, unknown> = Object.create(null);
+  for (const [providerID, snapshot] of state.upstreamByProvider) {
+    upstreamByProvider[providerID] = stripHeaders(snapshot);
+  }
+  return JSON.stringify({
+    version: UPSTREAM_STATE_VERSION,
+    ...(state.lastUpstream
+      ? { lastUpstream: stripHeaders(state.lastUpstream) }
+      : {}),
+    upstreamByProvider,
+  });
+}
+
+function deserializeUpstreamState(serialized: string): {
+  lastUpstream?: UpstreamSnapshot;
+  upstreamByProvider: Map<string, UpstreamSnapshot>;
+} {
+  const parsed = JSON.parse(serialized) as unknown;
+  const legacy = validatedUpstreamSnapshot(parsed);
+  if (legacy) {
+    return {
+      lastUpstream: legacy,
+      upstreamByProvider: new Map(
+        legacy.providerID ? [[legacy.providerID, legacy]] : [],
+      ),
+    };
+  }
+  if (
+    !isPlainRecord(parsed) ||
+    parsed.version !== UPSTREAM_STATE_VERSION ||
+    !isPlainRecord(parsed.upstreamByProvider)
+  ) {
+    throw new Error("invalid persisted upstream state");
+  }
+
+  const upstreamByProvider = new Map<string, UpstreamSnapshot>();
+  for (const [providerID, rawSnapshot] of Object.entries(
+    parsed.upstreamByProvider,
+  )) {
+    const snapshot = validatedUpstreamSnapshot(rawSnapshot);
+    if (
+      providerID.length === 0 ||
+      !snapshot?.providerID ||
+      providerID !== snapshot.providerID
+    ) {
+      throw new Error("invalid persisted provider upstream snapshot");
+    }
+    upstreamByProvider.set(providerID, snapshot);
+  }
+
+  let lastUpstream: UpstreamSnapshot | undefined;
+  if (Object.hasOwn(parsed, "lastUpstream")) {
+    lastUpstream = validatedUpstreamSnapshot(parsed.lastUpstream) ?? undefined;
+    if (!lastUpstream) throw new Error("invalid persisted last upstream");
+    const lastProviderID = lastUpstream.providerID;
+    if (lastProviderID) {
+      const providerSnapshot = upstreamByProvider.get(lastProviderID);
+      if (
+        !providerSnapshot ||
+        providerSnapshot.url !== lastUpstream.url ||
+        providerSnapshot.protocol !== lastUpstream.protocol ||
+        providerSnapshot.model !== lastUpstream.model ||
+        JSON.stringify(providerSnapshot.providerOptions) !==
+          JSON.stringify(lastUpstream.providerOptions)
+      ) {
+        throw new Error("inconsistent persisted last upstream");
+      }
+    }
+  }
+  return { lastUpstream, upstreamByProvider };
+}
+
+function buildRequestUpstreamSnapshot(
+  req: GatewayRequest,
+  config: GatewayConfig,
+  route: ResolvedRequestUpstreamRoute,
+): UpstreamSnapshot {
+  const providerRouting = providerRoutingValue(req);
+  const providerOptions =
+    !req.codex &&
+    requestTargetsOpenRouter(req, route.effectiveUpstreamBase) &&
+    providerRouting.present &&
+    isPlainRecord(providerRouting.value)
+      ? providerRouting.value
+      : undefined;
+  if (
+    providerOptions &&
+    Buffer.byteLength(JSON.stringify(providerOptions)) >
+      MAX_PROVIDER_OPTIONS_BYTES
+  ) {
+    throw new Error(
+      `OpenRouter provider routing options exceed ${MAX_PROVIDER_OPTIONS_BYTES} bytes`,
+    );
+  }
+  const snapshot: UpstreamSnapshot = {
+    url: route.effectiveUpstreamBase,
+    protocol: route.effectiveProtocol,
+    ...(route.providerID ? { providerID: route.providerID } : {}),
+    model: req.model,
+    headers: forwardClientHeaders(req.rawHeaders),
+    ...(providerOptions ? { providerOptions } : {}),
+  };
+  applyUpstreamExtraHeaders(snapshot.headers, config.upstreamExtraHeaders);
+  return freezeUpstreamSnapshot(snapshot);
+}
+
+/**
+ * Capture request routing before awaiting the upstream. Failed tightening
+ * requests remain authoritative, while request-start order prevents an older
+ * concurrent turn from rolling back a newer policy when it resumes later.
+ */
+function captureRequestUpstream(
+  req: GatewayRequest,
+  state: SessionState,
+  config: GatewayConfig,
+  requestOrder: number,
+): ResolvedRequestUpstreamRoute {
+  const route = resolveRequestUpstreamRoute(req, config);
+  const snapshot = buildRequestUpstreamSnapshot(req, config, route);
+  let changed = false;
+
+  if (requestOrder >= (state._upstreamRequestOrder ?? 0)) {
+    const previous = state.lastUpstream;
+    if (
+      previous &&
+      (previous.model !== snapshot.model ||
+        previous.providerID !== snapshot.providerID)
+    ) {
+      state.cacheAnalytics.lastRequestBody = null;
+    }
+    state.lastUpstream = snapshot;
+    state._upstreamRequestOrder = requestOrder;
+    changed = true;
+  }
+
+  if (snapshot.providerID) {
+    state._upstreamRequestOrderByProvider ??= new Map();
+    const previousOrder =
+      state._upstreamRequestOrderByProvider.get(snapshot.providerID) ?? 0;
+    if (requestOrder >= previousOrder) {
+      if (
+        !state.upstreamByProvider.has(snapshot.providerID) &&
+        state.upstreamByProvider.size >= MAX_UPSTREAM_SNAPSHOTS_PER_SESSION
+      ) {
+        const oldestProviderID = state.upstreamByProvider.keys().next().value;
+        if (oldestProviderID !== undefined) {
+          state.upstreamByProvider.delete(oldestProviderID);
+          state._upstreamRequestOrderByProvider.delete(oldestProviderID);
+        }
+      }
+      state.upstreamByProvider.set(snapshot.providerID, snapshot);
+      state._upstreamRequestOrderByProvider.set(
+        snapshot.providerID,
+        requestOrder,
+      );
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    saveSessionTracking(state.sessionID, {
+      lastUpstream: serializeUpstreamState(state),
+    });
+  }
+  return route;
+}
+
 function getOrCreateSession(
   sessionID: string,
   projectPath: string,
@@ -3805,35 +4076,9 @@ function getOrCreateSession(
     }
     if (persisted?.lastUpstream != null) {
       try {
-        const parsed = JSON.parse(persisted.lastUpstream) as unknown;
-        if (
-          parsed &&
-          typeof parsed === "object" &&
-          typeof (parsed as UpstreamSnapshot).url === "string" &&
-          [
-            "anthropic",
-            "openai",
-            "openai-responses",
-            "vertex",
-            "gemini",
-          ].includes((parsed as UpstreamSnapshot).protocol) &&
-          typeof (parsed as UpstreamSnapshot).model === "string" &&
-          (parsed as UpstreamSnapshot).model.length > 0 &&
-          (parsed as UpstreamSnapshot).headers &&
-          typeof (parsed as UpstreamSnapshot).headers === "object" &&
-          !Array.isArray((parsed as UpstreamSnapshot).headers) &&
-          Object.values((parsed as UpstreamSnapshot).headers).every(
-            (value) => typeof value === "string",
-          )
-        ) {
-          state.lastUpstream = parsed as UpstreamSnapshot;
-          if (state.lastUpstream.providerID) {
-            state.upstreamByProvider.set(
-              state.lastUpstream.providerID,
-              state.lastUpstream,
-            );
-          }
-        }
+        const restored = deserializeUpstreamState(persisted.lastUpstream);
+        state.lastUpstream = restored.lastUpstream;
+        state.upstreamByProvider = restored.upstreamByProvider;
       } catch {
         log.warn(
           `corrupt last upstream for session ${sessionID.slice(0, 16)}, ignoring`,
@@ -4453,6 +4698,104 @@ async function identifySession(
 // Upstream forwarding
 // ---------------------------------------------------------------------------
 
+type EffectiveUpstreamProtocol = UpstreamSnapshot["protocol"];
+
+type ResolvedRequestUpstreamRoute = {
+  /** Explicit, sanitized X-Lore-Provider value (not inferred signals). */
+  providerHeader?: string;
+  /** Provider identity actually selected, including Copilot inference. */
+  providerID?: string;
+  headerUpstream?: string;
+  headerUpstreamPath?: string;
+  providerRoute: ReturnType<typeof resolveProviderRoute>;
+  modelRoute: ReturnType<typeof resolveUpstreamRoute>;
+  effectiveProtocol: EffectiveUpstreamProtocol;
+  effectiveUpstreamBase: string;
+  bedrockMantle: boolean;
+};
+
+/**
+ * Single source of truth for foreground routing and its durable snapshot.
+ * This is deliberately synchronous: dynamic models.dev lookup is cache-only,
+ * so capture can run before any fetch/interceptor and failed requests still
+ * retain the exact route intent used by forwardToUpstream.
+ */
+function resolveRequestUpstreamRoute(
+  req: GatewayRequest,
+  config: GatewayConfig,
+): ResolvedRequestUpstreamRoute {
+  const headerUpstream = extractUpstreamUrlHeader(req.rawHeaders);
+  const headerUpstreamPath = extractUpstreamPathHeader(req.rawHeaders);
+  const providerHeader = extractProviderHeader(req.rawHeaders);
+  let providerID = providerHeader;
+  let providerRoute = providerID ? resolveProviderRoute(providerID) : null;
+  if (!providerRoute && providerID) {
+    providerRoute = lookupProviderRoute(providerID);
+  }
+  if (
+    !providerRoute &&
+    !headerUpstream &&
+    hasCopilotIntegrationHeader(req.rawHeaders)
+  ) {
+    providerID = "github-copilot";
+    providerRoute = resolveProviderRoute(providerID);
+  }
+  const modelRoute = resolveUpstreamRoute(req.model);
+  const selfUrlBuildingProtocol =
+    providerRoute?.bedrockMantle === true ||
+    providerRoute?.protocol === "vertex";
+  const providerRouteUsable =
+    providerRoute &&
+    (providerRoute.url != null || headerUpstream || selfUrlBuildingProtocol)
+      ? providerRoute
+      : null;
+  const nativeIngressAnthropicOverride =
+    providerHeader != null && providerRouteUsable?.protocol === "anthropic";
+  const effectiveProtocol: EffectiveUpstreamProtocol =
+    req.protocol === "openai-responses"
+      ? nativeIngressAnthropicOverride
+        ? "anthropic"
+        : "openai-responses"
+      : req.protocol === "gemini"
+        ? nativeIngressAnthropicOverride
+          ? "anthropic"
+          : "gemini"
+        : (providerRouteUsable?.protocol ??
+          modelRoute?.protocol ??
+          req.protocol);
+  const bedrockMantle = isBedrockMantleDispatch(
+    providerRouteUsable,
+    effectiveProtocol,
+  );
+  const selfBuiltUpstreamUrl = bedrockMantle
+    ? bedrockMantleUrl(config.bedrockRegion)
+    : effectiveProtocol === "vertex"
+      ? `https://${vertexHost(config.vertexRegion)}`
+      : null;
+  const effectiveUpstreamBase =
+    headerUpstream ??
+    selfBuiltUpstreamUrl ??
+    providerRoute?.url ??
+    modelRoute?.url ??
+    (effectiveProtocol === "anthropic"
+      ? config.upstreamAnthropic
+      : effectiveProtocol === "gemini"
+        ? GEMINI_DEFAULT_UPSTREAM
+        : config.upstreamOpenAI);
+
+  return {
+    providerHeader,
+    providerID,
+    headerUpstream,
+    headerUpstreamPath,
+    providerRoute,
+    modelRoute,
+    effectiveProtocol,
+    effectiveUpstreamBase,
+    bedrockMantle,
+  };
+}
+
 /** Result from forwardToUpstream — includes the serialized body for cache analytics. */
 type UpstreamResult = {
   response: Response;
@@ -4483,131 +4826,24 @@ async function forwardToUpstream(
   interceptor?: UpstreamInterceptor,
   cache?: AnthropicCacheOptions,
   signal?: AbortSignal,
+  resolvedRoute?: ResolvedRequestUpstreamRoute,
 ): Promise<UpstreamResult> {
   let url: string;
   let headers: Record<string, string>;
   let body: unknown;
 
-  // Resolve upstream URL and protocol via a four-tier priority chain:
-  //   1. X-Lore-Upstream-URL header  (explicit user override)
-  //   2. X-Lore-Provider header      (plugin identifies the provider)
-  //      a. Static PROVIDER_ROUTES table (fast, no network)
-  //      b. Dynamic models.dev lookup  (async, cached 1h, covers new providers)
-  //   3. Model prefix route           (fallback for bare agents like Claude Code)
-  //   4. Config defaults              (upstreamAnthropic / upstreamOpenAI)
-  // Preserve "openai-responses" from ingress — model prefix routing returns
-  // "openai" for OpenAI models, but we must not downgrade the wire protocol.
-  const headerUpstream = extractUpstreamUrlHeader(req.rawHeaders);
-  // The client's ORIGINAL endpoint pathname (set by the fetch interceptor), used
-  // below to forward verbatim instead of synthesizing a canonical `/v1/...` path.
-  const headerUpstreamPath = extractUpstreamPathHeader(req.rawHeaders);
-  const providerID = extractProviderHeader(req.rawHeaders);
-  let providerRoute = providerID ? resolveProviderRoute(providerID) : null;
-  // Dynamic fallback: look up unknown providers from models.dev cache.
-  // Non-blocking — returns cached data or null (triggers background refresh).
-  if (!providerRoute && providerID) {
-    providerRoute = lookupProviderRoute(providerID);
-  }
-  // GitHub Copilot CLI (default GitHub-hosted mode) is redirected at the gateway
-  // via COPILOT_API_URL. It sends OpenAI-format requests with its own exchanged
-  // Copilot bearer token and a `Copilot-Integration-Id` header, but has no way to
-  // set X-Lore-Provider — so its model ids (gpt-*, claude-*, gemini-*) would route
-  // by model prefix to the WRONG upstream (api.openai.com / api.anthropic.com).
-  // Treat the integration header as the routing signal → github-copilot upstream
-  // (api.githubcopilot.com). Explicit X-Lore-Provider and X-Lore-Upstream-URL
-  // (incl. BYOK, where the user points COPILOT_PROVIDER_BASE_URL at the gateway)
-  // still win, since both set providerRoute / headerUpstream first.
-  if (
-    !providerRoute &&
-    !headerUpstream &&
-    hasCopilotIntegrationHeader(req.rawHeaders)
-  ) {
-    providerRoute = resolveProviderRoute("github-copilot");
-  }
-  const modelRoute = resolveUpstreamRoute(req.model);
-
-  // Only use provider route protocol when we also have a usable URL from it
-  // (either providerRoute.url or headerUpstream). When url is null (local/
-  // custom providers like vllm, github-copilot), the protocol should come
-  // from whichever tier actually provides the URL to avoid mismatches.
-  //
-  // EXCEPTION: self-URL-building routes are usable with a null url and no
-  // X-Lore-Upstream-URL because they build a region-specific base from config:
-  //   - bedrock-mantle: `bedrock-mantle.<region>.api.aws/anthropic` (Anthropic
-  //     protocol — only the base URL + model id differ from native Anthropic);
-  //   - vertex: `<region>-aiplatform.googleapis.com` (part 2, not yet wired).
-  // Without this, `X-Lore-Provider: bedrock` would fall through to the model-
-  // prefix route (api.anthropic.com for claude-* IDs) and silently bypass it.
-  const selfUrlBuildingProtocol =
-    providerRoute?.bedrockMantle === true ||
-    providerRoute?.protocol === "vertex";
-  const providerRouteUsable =
-    providerRoute &&
-    (providerRoute.url != null || headerUpstream || selfUrlBuildingProtocol)
-      ? providerRoute
-      : null;
-
-  // Protocol resolution: provider routes with `protocol: null` are proxy/
-  // aggregator providers (OpenCode Zen, Vercel AI Gateway) that accept
-  // whichever protocol the client sent — preserve the ingress protocol.
-  // Direct providers (DeepSeek, Groq, etc.) specify their protocol explicitly
-  // so the gateway can translate (e.g., Claude Code → OpenAI-only backend).
-  const nativeIngressAnthropicOverride =
-    providerID != null && providerRouteUsable?.protocol === "anthropic";
-  const effectiveProtocol =
-    req.protocol === "openai-responses"
-      ? nativeIngressAnthropicOverride
-        ? "anthropic"
-        : "openai-responses"
-      : req.protocol === "gemini"
-        ? // A native Gemini ingress normally stays gemini. The provider route still
-          // supplies the upstream URL (e.g. X-Lore-Provider: google →
-          // generativelanguage), but its protocol must not downgrade a native
-          // generateContent request: the `gemini-` model-prefix route and the
-          // `google` provider route are both the OpenAI-compat layer
-          // (protocol "openai"), which would wrongly re-translate to Chat
-          // Completions. opencode/pi's @ai-sdk/google speaks native generateContent.
-          // An explicit Anthropic-wire provider is the narrow exception: meta
-          // calls use the strict Anthropic→Gemini translator below.
-          nativeIngressAnthropicOverride
-          ? "anthropic"
-          : "gemini"
-        : (providerRouteUsable?.protocol ??
-          modelRoute?.protocol ??
-          req.protocol);
-
-  // Self-URL-building routes derive their base from config (region), not from
-  // the route tables. This must take precedence over `modelRoute?.url`: a
-  // claude-* model ID resolves to api.anthropic.com via the model-prefix route,
-  // which would otherwise mask the real Bedrock/Vertex base. For bedrock-mantle
-  // the base is the regional mantle endpoint and the wire protocol stays
-  // `anthropic` (so the normal Anthropic path handles it; only body.model is
-  // remapped below). An explicit X-Lore-Upstream-URL header still wins.
-  // bedrock-mantle ALWAYS rides the anthropic wire path (the model remap below
-  // lives only in the anthropic branch). Shared with the snapshot path so the
-  // two can never diverge; see isBedrockMantleDispatch for the invariant.
-  const bedrockMantle = isBedrockMantleDispatch(
-    providerRouteUsable,
+  const route = resolvedRoute ?? resolveRequestUpstreamRoute(req, config);
+  const {
+    providerHeader,
+    providerID,
+    headerUpstream,
+    headerUpstreamPath,
+    providerRoute,
+    modelRoute,
     effectiveProtocol,
-  );
-  const selfBuiltUpstreamUrl = bedrockMantle
-    ? bedrockMantleUrl(config.bedrockRegion)
-    : effectiveProtocol === "vertex"
-      ? `https://${vertexHost(config.vertexRegion)}`
-      : null;
-  const effectiveUpstreamBase =
-    headerUpstream ??
-    selfBuiltUpstreamUrl ??
-    providerRoute?.url ??
-    modelRoute?.url ??
-    (effectiveProtocol === "anthropic"
-      ? config.upstreamAnthropic
-      : effectiveProtocol === "gemini"
-        ? // Native Gemini default upstream (Generative Language API). `gemini-*`
-          // models resolve this via modelRoute.url already; this covers a native
-          // gemini ingress whose model id doesn't match the `gemini-` prefix.
-          GEMINI_DEFAULT_UPSTREAM
-        : config.upstreamOpenAI);
+    effectiveUpstreamBase,
+    bedrockMantle,
+  } = route;
 
   // Warn when a provider route exists but has no URL and no header override —
   // the request will fall through to config defaults which likely have wrong
@@ -4875,7 +5111,7 @@ async function forwardToUpstream(
     req.rawHeaders["content-encoding"],
     buildUpstreamRouteContext({
       upstreamUrlHeader: headerUpstream,
-      providerHeader: providerID,
+      providerHeader,
       ingressProtocol: req.protocol,
       effectiveProtocol,
       ingressUpstreamBase,
@@ -4974,6 +5210,7 @@ export function buildStreamingResponse(
     config: GatewayConfig;
     sessionState: SessionState;
     cacheOptions: AnthropicCacheOptions;
+    upstreamRoute?: ResolvedRequestUpstreamRoute;
     /** True iff the inbound CLIENT speaks Anthropic SSE. Controls whether the
      *  recall marker is emitted as its own Anthropic SSE message envelope
      *  (split) or as an inline synthetic text content block (which the
@@ -5495,6 +5732,7 @@ export function buildStreamingResponse(
                       cacheConversation: false,
                     },
                     signal,
+                    recallContext.upstreamRoute,
                   ),
                 // JSON parsing is unused on the streaming path (assertSSEResponse
                 // guarantees an SSE body); provide a guard that throws if reached.
@@ -9596,94 +9834,6 @@ function postResponse(
         }
       }
     }
-    // Capture the full routing snapshot from this request. Workers, cache
-    // warmer, and idle handler all read from this single source of truth
-    // instead of reconstructing from individual last* fields.
-    const lpProvider = extractProviderHeader(req.rawHeaders);
-    const lpRoute = lpProvider ? resolveProviderRoute(lpProvider) : null;
-    const lpHeaderUpstream = extractUpstreamUrlHeader(req.rawHeaders);
-    // MUST mirror `providerRouteUsable` in forwardToUpstream: self-URL-building
-    // routes (bedrock-mantle builds its region URL from config; vertex likewise)
-    // are usable with a null route url. Without this, a `X-Lore-Provider:
-    // bedrock` session would record the wrong base URL in the UpstreamSnapshot
-    // that workers/warmer/idle treat as source of truth.
-    const lpSelfUrlBuilding =
-      lpRoute?.bedrockMantle === true || lpRoute?.protocol === "vertex";
-    const lpRouteUsable =
-      lpRoute && (lpRoute.url != null || lpHeaderUpstream || lpSelfUrlBuilding)
-        ? lpRoute
-        : null;
-    const snapshotProtocol:
-      | "anthropic"
-      | "openai"
-      | "openai-responses"
-      | "vertex"
-      | "gemini" =
-      req.protocol === "openai-responses"
-        ? "openai-responses"
-        : req.protocol === "gemini"
-          ? // Mirror forwardToUpstream: native gemini ingress always stays gemini.
-            "gemini"
-          : (lpRouteUsable?.protocol ??
-            resolveUpstreamRoute(req.model)?.protocol ??
-            req.protocol);
-    // Mirror forwardToUpstream exactly (same shared predicate).
-    const lpBedrockMantle = isBedrockMantleDispatch(
-      lpRouteUsable,
-      snapshotProtocol,
-    );
-
-    // Self-URL-building routes derive their base from config (region) — mirror
-    // effectiveUpstreamBase so the snapshot url isn't empty/wrong. bedrock-mantle
-    // uses the regional mantle endpoint (wire protocol stays anthropic).
-    const lpSelfBuiltUrl = lpBedrockMantle
-      ? bedrockMantleUrl(config.bedrockRegion)
-      : snapshotProtocol === "vertex"
-        ? `https://${vertexHost(config.vertexRegion)}`
-        : null;
-
-    const upstreamSnapshot: UpstreamSnapshot = {
-      url: lpHeaderUpstream ?? lpSelfBuiltUrl ?? lpRoute?.url ?? "",
-      protocol: snapshotProtocol,
-      providerID: lpProvider || undefined,
-      model: req.model,
-      headers: forwardClientHeaders(req.rawHeaders),
-    };
-    // Apply LORE_UPSTREAM_EXTRA_HEADERS to the snapshot so cache-warming
-    // and other session-level follow-up requests inherit the user-supplied
-    // extra headers. (The per-request `forwardToUpstream` already overlays
-    // extras on the actual upstream call — this keeps the snapshot in sync
-    // for any consumer that reads it back.)
-    applyUpstreamExtraHeaders(
-      upstreamSnapshot.headers,
-      config.upstreamExtraHeaders,
-    );
-    // Detect provider switch: if the model or provider changed, the cached
-    // warmup body is stale (different model field at byte 10). Clear it to
-    // avoid false cache-bust warnings ("early divergence at byte 10") and
-    // wasted warmup requests that can never hit the cache prefix.
-    const prevUpstream = sessionState.lastUpstream;
-    if (
-      prevUpstream &&
-      (prevUpstream.model !== upstreamSnapshot.model ||
-        prevUpstream.providerID !== upstreamSnapshot.providerID)
-    ) {
-      sessionState.cacheAnalytics.lastRequestBody = null;
-    }
-
-    sessionState.lastUpstream = upstreamSnapshot;
-    saveSessionTracking(sessionID, {
-      lastUpstream: JSON.stringify({ ...upstreamSnapshot, headers: {} }),
-    });
-    // Store per-provider snapshot so workers/cache-warmer can look up the
-    // correct URL and credentials when the session uses multiple providers.
-    if (upstreamSnapshot.providerID) {
-      sessionState.upstreamByProvider.set(
-        upstreamSnapshot.providerID,
-        upstreamSnapshot,
-      );
-    }
-
     // Reset warming state if session was marked dead or had active warming.
     // Dead flag is cleared so the next break gets a fresh ROI analysis.
     // warmupCount is reset so the break-even cap starts from 0 on the next break.
@@ -9769,7 +9919,7 @@ function trackBackground(p: Promise<unknown>): void {
   void p.finally(() => inFlightBackground.delete(p));
 }
 
-function scheduleBackgroundWork(
+export function scheduleBackgroundWork(
   sessionState: SessionState,
   config: GatewayConfig,
 ): void {
@@ -9807,7 +9957,11 @@ function scheduleBackgroundWork(
   if (
     !config.workerApiKey &&
     model &&
-    !resolveAuth(sessionID, model.providerID)
+    !hasWorkerSessionAuth(
+      sessionID,
+      model.providerID,
+      matchingProviderSnapshot(sessionState, model.providerID)?.protocol,
+    )
   )
     return;
 
@@ -11360,6 +11514,7 @@ export function mergeRecallUsage(
 async function handleConversationTurn(
   req: GatewayRequest,
   config: GatewayConfig,
+  requestOrder: number,
 ): Promise<Response> {
   // --- 1. Project path & init ---
   // Enrich headers with context markers injected by lore-hermes plugin.
@@ -11400,6 +11555,18 @@ async function handleConversationTurn(
     cred ? authFingerprint(cred) : "",
   );
   let projectPath = resolveSessionProjectPath(pathResult, sessionState, config);
+
+  // Routing and policy are request intent, not a property of a successful
+  // response. Capture now so a failed policy-tightening request still governs
+  // workers, and use the order assigned synchronously in handleRequest so an
+  // older concurrent turn can never overwrite a newer one.
+  await beforeUpstreamCaptureForTest?.(req, sessionState);
+  const requestUpstreamRoute = captureRequestUpstream(
+    req,
+    sessionState,
+    config,
+    requestOrder,
+  );
 
   // --- Synthetic project-resolution: capture a returning tool_result ---
   // If we previously injected a synthetic tool_use for project detection,
@@ -13051,20 +13218,9 @@ async function handleConversationTurn(
     attributes: {
       "gen_ai.operation.name": "chat",
       "gen_ai.request.model": req.model,
-      "gen_ai.provider.name": (() => {
-        if (req.protocol === "openai-responses") return "openai-responses";
-        // Apply the same providerRouteUsable guard as forwardToUpstream:
-        // only trust provider route protocol when it has a usable URL.
-        const pid = extractProviderHeader(req.rawHeaders);
-        const pr = pid ? resolveProviderRoute(pid) : null;
-        const hdrUp = extractUpstreamUrlHeader(req.rawHeaders);
-        const prUsable = pr && (pr.url != null || hdrUp) ? pr : null;
-        return (
-          prUsable?.protocol ??
-          resolveUpstreamRoute(req.model)?.protocol ??
-          "anthropic"
-        );
-      })(),
+      "gen_ai.provider.name":
+        requestUpstreamRoute.providerID ??
+        requestUpstreamRoute.effectiveProtocol,
       "gen_ai.response.streaming": req.stream,
       // NO gen_ai.input.messages — privacy (proxy for other people's projects)
     },
@@ -13078,6 +13234,7 @@ async function handleConversationTurn(
       undefined,
       cacheOptions,
       foregroundAbort.signal,
+      requestUpstreamRoute,
     );
   } catch (error) {
     foregroundAbort.dispose();
@@ -13334,6 +13491,7 @@ async function handleConversationTurn(
               cacheConversation: false,
             },
             signal,
+            requestUpstreamRoute,
           ),
         parseJSON: (response, protocol, signal) =>
           accumulateNonStreamResponse(response, protocol, false, signal),
@@ -13676,6 +13834,7 @@ async function handleConversationTurn(
                         cacheConversation: false,
                       },
                       followUpSignal,
+                      requestUpstreamRoute,
                     ),
                   parseJSON: () => {
                     throw new Error(
@@ -13776,6 +13935,7 @@ async function handleConversationTurn(
             config,
             sessionState,
             cacheOptions,
+            upstreamRoute: requestUpstreamRoute,
             clientSpeaksAnthropic: req.protocol === "anthropic",
             stableLtmText,
             ...(pendingKnowledgeDelta ? { pendingKnowledgeDelta } : {}),
@@ -14687,6 +14847,7 @@ export async function handleRequest(
   config: GatewayConfig,
 ): Promise<Response> {
   const requestStartMs = Date.now();
+  const requestOrder = ++upstreamRequestOrder;
   try {
     // Guard against malformed invocations (e.g. fuzzers / direct module calls
     // that pass an undefined or header-less request). The real server path
@@ -14781,12 +14942,13 @@ export async function handleRequest(
     // keepalive while the gateway prepares.
     if (req.stream && req.protocol === "openai-responses") {
       return earlyFlushStreamingResponse(
-        (signal) => handleConversationTurn({ ...req, signal }, config),
+        (signal) =>
+          handleConversationTurn({ ...req, signal }, config, requestOrder),
         req.model,
         req.signal,
       );
     }
-    return await handleConversationTurn(req, config);
+    return await handleConversationTurn(req, config, requestOrder);
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Unknown gateway error";

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -19,7 +19,13 @@ import type {
   GatewayTool,
   GatewayUsage,
 } from "./types";
-import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
+import {
+  blocksToText,
+  forwardClientHeaders,
+  providerRoutingValue,
+  requestTargetsOpenRouter,
+  ZERO_USAGE,
+} from "./types";
 import { extractAuth } from "../auth";
 import { safeTokenSum } from "../usage-validation";
 
@@ -101,6 +107,9 @@ export function parseOpenAIResponsesRequest(
   }
   if (typeof raw.user === "string") {
     extras.user = raw.user;
+  }
+  if (Object.hasOwn(raw, "provider")) {
+    extras.provider = raw.provider;
   }
   // Responses API-specific extras
   if (raw.previous_response_id !== undefined) {
@@ -561,6 +570,15 @@ export function buildOpenAIResponsesUpstreamRequest(
     if (req.extras.parallel_tool_calls !== undefined) {
       body.parallel_tool_calls = req.extras.parallel_tool_calls;
     }
+  }
+
+  const providerRouting = providerRoutingValue(req);
+  if (
+    !req.codex &&
+    providerRouting.present &&
+    requestTargetsOpenRouter(req, upstreamBase)
+  ) {
+    body.provider = providerRouting.value;
   }
 
   // Codex (ChatGPT) is the OpenAI Responses wire format plus a small, cohesive

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -12,7 +12,13 @@ import type {
   GatewayTool,
   GatewayUsage,
 } from "./types";
-import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
+import {
+  blocksToText,
+  forwardClientHeaders,
+  providerRoutingValue,
+  requestTargetsOpenRouter,
+  ZERO_USAGE,
+} from "./types";
 import type { AnthropicCacheOptions } from "./anthropic";
 import { asString } from "@loreai/core";
 import { extractAuth } from "../auth";
@@ -86,6 +92,9 @@ export function parseOpenAIRequest(
   }
   if (typeof raw.top_logprobs === "number") {
     extras.top_logprobs = raw.top_logprobs;
+  }
+  if (Object.hasOwn(raw, "provider")) {
+    extras.provider = raw.provider;
   }
   if (raw.stream_options && typeof raw.stream_options === "object") {
     const so = raw.stream_options as Record<string, unknown>;
@@ -771,6 +780,11 @@ export function buildOpenAIUpstreamRequest(
     if (req.extras.stream_options !== undefined) {
       body.stream_options = req.extras.stream_options;
     }
+  }
+
+  const providerRouting = providerRoutingValue(req);
+  if (providerRouting.present && requestTargetsOpenRouter(req, upstreamBase)) {
+    body.provider = providerRouting.value;
   }
 
   return {

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -242,6 +242,8 @@ export type GatewayRequest = {
     user?: string;
     logprobs?: boolean;
     top_logprobs?: number;
+    /** OpenRouter provider routing preferences, preserved verbatim. */
+    provider?: unknown;
     /** OpenAI Responses API: previous response ID for conversation continuation. */
     previous_response_id?: string;
     /** OpenAI Responses API: reasoning configuration. */
@@ -456,7 +458,7 @@ export type CacheAnalytics = {
   probePrefixSha?: string;
 };
 
-/** Routing snapshot captured from the last successful session request.
+/** Routing snapshot captured from a session request before upstream dispatch.
  *  Workers (distillation, curation) and the cache warmer use this
  *  to route through the same upstream with matching credentials.
  *  Single source of truth — replaces lastModel, lastProtocol,
@@ -472,6 +474,41 @@ export interface UpstreamSnapshot {
   model: string;
   /** Non-managed headers to forward upstream (anthropic-beta, etc.). */
   headers: Record<string, string>;
+  /** OpenRouter routing preferences inherited by same-provider workers. */
+  providerOptions?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Resolve OpenRouter's top-level `provider` value without losing presence.
+ * OpenAI ingress stores it in `extras`; Anthropic ingress stores unknown fields
+ * in `metadata`. An explicitly present extras property wins even when its value
+ * is null (or undefined in a directly constructed test request).
+ */
+export function providerRoutingValue(
+  req: GatewayRequest,
+): { present: true; value: unknown } | { present: false } {
+  if (req.extras && Object.hasOwn(req.extras, "provider")) {
+    return { present: true, value: req.extras.provider };
+  }
+  if (Object.hasOwn(req.metadata, "provider")) {
+    return { present: true, value: req.metadata.provider };
+  }
+  return { present: false };
+}
+
+/** Whether an OpenAI-compatible request is actually routed to OpenRouter. */
+export function requestTargetsOpenRouter(
+  req: GatewayRequest,
+  upstreamBase: string,
+): boolean {
+  if (req.rawHeaders["x-lore-provider"]?.toLowerCase() === "openrouter") {
+    return true;
+  }
+  try {
+    return new URL(upstreamBase).hostname.toLowerCase() === "openrouter.ai";
+  } catch {
+    return false;
+  }
 }
 
 /** Per-session state tracked by the gateway for Lore pipeline decisions. */
@@ -587,7 +624,7 @@ export type SessionState = {
   warmup?: WarmupState;
   /** Per-session survival model (inter-turn gap histogram). */
   survivalModel?: InterTurnHistogram;
-  /** Routing snapshot from the most recent session request.
+  /** Routing snapshot from the most recent session request start.
    *  Used by cache warmer (targets the most-recent provider) and as
    *  a convenience accessor. For provider-specific lookups (workers,
    *  auth), use `upstreamByProvider` instead. */
@@ -597,6 +634,10 @@ export type SessionState = {
    *  this to find the correct URL/credentials when the session has used
    *  multiple providers within the same conversation. */
   upstreamByProvider: Map<string, UpstreamSnapshot>;
+  /** Request-start order of the current `lastUpstream` (transient). */
+  _upstreamRequestOrder?: number;
+  /** Request-start order per raw provider ID (transient). */
+  _upstreamRequestOrderByProvider?: Map<string, number>;
 
   // --- Synthetic project-resolution probe ---
 

--- a/packages/gateway/src/worker-auth.ts
+++ b/packages/gateway/src/worker-auth.ts
@@ -1,0 +1,25 @@
+import { resolveAuth } from "./auth";
+import {
+  workerProviderAliasIDs,
+  workerProviderSupportsProtocol,
+  type WorkerProtocol,
+} from "./llm-adapter";
+
+/**
+ * Mirror the worker adapter's provider-alias credential lookup for scheduling
+ * guards. A guard must not reject `bedrock` merely because the owning session
+ * stored the same credential under `amazon-bedrock`, but unrelated providers
+ * remain fail-closed.
+ */
+export function hasWorkerSessionAuth(
+  sessionID: string,
+  providerID: string,
+  protocol?: WorkerProtocol,
+): boolean {
+  for (const aliasID of workerProviderAliasIDs(providerID)) {
+    if (protocol && !workerProviderSupportsProtocol(aliasID, protocol))
+      continue;
+    if (resolveAuth(sessionID, aliasID)) return true;
+  }
+  return false;
+}

--- a/packages/gateway/test/openai-codex.test.ts
+++ b/packages/gateway/test/openai-codex.test.ts
@@ -91,6 +91,19 @@ describe("buildOpenAIResponsesUpstreamRequest (codex)", () => {
     expect(body.service_tier).toBe("priority");
   });
 
+  test("does not send OpenRouter provider options to the Codex backend", () => {
+    const req = parseOpenAICodexRequest(
+      { ...codexBody, provider: { only: ["google-vertex/europe"] } },
+      {},
+    );
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://chatgpt.com/backend-api",
+    ).body as Record<string, unknown>;
+
+    expect(body.provider).toBeUndefined();
+  });
+
   test("forces store:false even when the client omits store", () => {
     const { store: _omit, ...noStore } = codexBody;
     const req = parseOpenAICodexRequest(noStore, {});

--- a/packages/gateway/test/openai-parse.test.ts
+++ b/packages/gateway/test/openai-parse.test.ts
@@ -12,7 +12,11 @@
  * placeholders).
  */
 import { describe, test, expect } from "vitest";
-import { parseOpenAIRequest } from "../src/translate/openai";
+import {
+  buildOpenAIUpstreamRequest,
+  parseOpenAIRequest,
+} from "../src/translate/openai";
+import { parseAnthropicRequest } from "../src/translate/anthropic";
 import {
   loreMessagesToGateway,
   removeOrphanedToolResults,
@@ -338,5 +342,111 @@ describe("parseOpenAIRequest — tool message coalescing", () => {
     );
     if (!assistant) throw new Error("expected assistant message");
     expect(toolUseIds(assistant.content).sort()).toEqual(["call_A", "call_B"]);
+  });
+});
+
+describe("OpenAI provider routing passthrough", () => {
+  test("preserves OpenRouter provider preferences in the upstream body", () => {
+    const provider = {
+      only: ["google-vertex/europe", "amazon-bedrock/eu-west-1"],
+      allow_fallbacks: false,
+    };
+    const req = parseOpenAIRequest(
+      {
+        model: "anthropic/claude-sonnet-4-6",
+        messages: [{ role: "user", content: "Hello" }],
+        provider,
+      },
+      headers,
+    );
+
+    expect(req.extras?.provider).toEqual(provider);
+    const body = buildOpenAIUpstreamRequest(req, "https://openrouter.ai/api/v1")
+      .body as Record<string, unknown>;
+    expect(body.provider).toEqual(provider);
+  });
+
+  test("preserves provider preferences when translating Anthropic ingress", () => {
+    const provider = {
+      only: ["google-vertex/europe"],
+      allow_fallbacks: false,
+    };
+    const req = parseAnthropicRequest(
+      {
+        model: "anthropic/claude-sonnet-4-6",
+        max_tokens: 4096,
+        messages: [{ role: "user", content: "Hello" }],
+        provider,
+      },
+      headers,
+    );
+
+    const body = buildOpenAIUpstreamRequest(req, "https://openrouter.ai/api/v1")
+      .body as Record<string, unknown>;
+    expect(body.provider).toEqual(provider);
+  });
+
+  test.each([
+    ["explicit null", null],
+    ["empty object", {}],
+  ])(
+    "preserves %s provider values by property presence",
+    (_label, provider) => {
+      const req = parseOpenAIRequest(
+        {
+          model: "anthropic/claude-sonnet-4-6",
+          messages: [{ role: "user", content: "Hello" }],
+          provider,
+        },
+        headers,
+      );
+      req.metadata.provider = { only: ["stale-metadata-provider"] };
+
+      const body = buildOpenAIUpstreamRequest(
+        req,
+        "https://openrouter.ai/api/v1",
+      ).body as Record<string, unknown>;
+      expect(Object.hasOwn(body, "provider")).toBe(true);
+      expect(body.provider).toEqual(provider);
+    },
+  );
+
+  test.each([
+    ["explicit null", null],
+    ["empty object", {}],
+  ])(
+    "preserves Anthropic-ingress %s provider values when forwarding to OpenAI",
+    (_label, provider) => {
+      const req = parseAnthropicRequest(
+        {
+          model: "anthropic/claude-sonnet-4-6",
+          max_tokens: 4096,
+          messages: [{ role: "user", content: "Hello" }],
+          provider,
+        },
+        headers,
+      );
+      const body = buildOpenAIUpstreamRequest(
+        req,
+        "https://openrouter.ai/api/v1",
+      ).body as Record<string, unknown>;
+      expect(Object.hasOwn(body, "provider")).toBe(true);
+      expect(body.provider).toEqual(provider);
+    },
+  );
+
+  test("does not forward OpenRouter provider options to another provider", () => {
+    const req = parseOpenAIRequest(
+      {
+        model: "deepseek-chat",
+        messages: [{ role: "user", content: "Hello" }],
+        provider: { only: ["must-not-leak"] },
+      },
+      { ...headers, "x-lore-provider": "deepseek" },
+    );
+    const body = buildOpenAIUpstreamRequest(req, "https://api.deepseek.com")
+      .body as Record<string, unknown>;
+
+    expect(Object.hasOwn(body, "provider")).toBe(false);
   });
 });

--- a/packages/gateway/test/openai-responses.test.ts
+++ b/packages/gateway/test/openai-responses.test.ts
@@ -701,6 +701,7 @@ describe("parseOpenAIResponsesRequest", () => {
         previous_response_id: "resp_abc123",
         reasoning: { effort: "high" },
         truncation: "auto",
+        provider: { only: ["google-vertex/europe"], allow_fallbacks: false },
       },
       headers,
     );
@@ -708,6 +709,10 @@ describe("parseOpenAIResponsesRequest", () => {
     expect(req.extras?.previous_response_id).toBe("resp_abc123");
     expect(req.extras?.reasoning).toEqual({ effort: "high" });
     expect(req.extras?.truncation).toBe("auto");
+    expect(req.extras?.provider).toEqual({
+      only: ["google-vertex/europe"],
+      allow_fallbacks: false,
+    });
   });
 
   test("parses message with content array (input_text parts)", () => {
@@ -761,16 +766,17 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
         stream: true,
         max_output_tokens: 2048,
         temperature: 0.5,
+        provider: { only: ["google-vertex/europe"] },
       },
       { authorization: "Bearer sk-test" },
     );
 
     const result = buildOpenAIResponsesUpstreamRequest(
       req,
-      "https://api.openai.com",
+      "https://openrouter.ai/api",
     );
 
-    expect(result.url).toBe("https://api.openai.com/v1/responses");
+    expect(result.url).toBe("https://openrouter.ai/api/v1/responses");
     expect(result.headers["content-type"]).toBe("application/json");
     expect(result.headers.Authorization).toBe("Bearer sk-test");
 
@@ -780,7 +786,47 @@ describe("buildOpenAIResponsesUpstreamRequest", () => {
     expect(body.instructions).toBe("Be helpful");
     expect(body.max_output_tokens).toBe(2048);
     expect(body.temperature).toBe(0.5);
+    expect(body.provider).toEqual({ only: ["google-vertex/europe"] });
     expect(Array.isArray(body.input)).toBe(true);
+  });
+
+  test("does not forward OpenRouter provider options to another provider", () => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "gpt-5-mini",
+        input: "Hello",
+        provider: { only: ["must-not-leak"] },
+      },
+      { "x-lore-provider": "openai" },
+    );
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://api.openai.com",
+    ).body as Record<string, unknown>;
+
+    expect(Object.hasOwn(body, "provider")).toBe(false);
+  });
+
+  test.each([
+    ["explicit null", null],
+    ["empty object", {}],
+  ])("preserves %s OpenRouter provider values", (_label, provider) => {
+    const req = parseOpenAIResponsesRequest(
+      {
+        model: "anthropic/claude-sonnet-4-6",
+        input: "Hello",
+        provider,
+      },
+      {},
+    );
+    req.metadata.provider = { only: ["stale-metadata-provider"] };
+
+    const body = buildOpenAIResponsesUpstreamRequest(
+      req,
+      "https://openrouter.ai/api",
+    ).body as Record<string, unknown>;
+    expect(Object.hasOwn(body, "provider")).toBe(true);
+    expect(body.provider).toEqual(provider);
   });
 
   test("round-trips tool definitions", () => {

--- a/packages/gateway/test/openrouter-provider-routing.test.ts
+++ b/packages/gateway/test/openrouter-provider-routing.test.ts
@@ -1,0 +1,1003 @@
+/**
+ * Load-bearing integration coverage for foreground OpenRouter routing policy
+ * capture, persistence, and real urgent worker dispatch.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { existsSync, unlinkSync } from "node:fs";
+import {
+  close as closeDB,
+  loadSessionTracking,
+  saveSessionTracking,
+} from "@loreai/core";
+import { upstreamFetch } from "../src/fetch";
+import { setSessionAuth } from "../src/auth";
+import type { GatewayConfig } from "../src/config";
+import { fetchArgUrl } from "./helpers/fetch-url";
+
+vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
+
+const mockFetch = vi.mocked(upstreamFetch);
+const SESSION_ID = "provider-routing-fixed-session";
+const SESSION_UPSTREAM = "https://session-route.invalid/openrouter";
+const DEDICATED_KEY = "dedicated-worker-key";
+const OPENROUTER_MODEL = "openrouter/deepseek/deepseek-chat";
+
+type Started = {
+  baseURL: string;
+  config: GatewayConfig;
+  dbPath: string;
+  server: { stop(): void };
+  previousEnv: Map<string, string | undefined>;
+};
+
+let started: Started | undefined;
+
+function openAIResponse(content = "hello"): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl_openrouter",
+      object: "chat.completion",
+      model: "anthropic/claude-sonnet-4-6",
+      content: [{ type: "text", text: content }],
+      stop_reason: "end_turn",
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content },
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 2,
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function recallResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl_recall",
+      object: "chat.completion",
+      model: "anthropic/claude-sonnet-4-6",
+      content: [
+        {
+          type: "tool_use",
+          id: "call_recall",
+          name: "recall",
+          input: { query: "provider routing" },
+        },
+      ],
+      stop_reason: "tool_use",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_recall",
+                type: "function",
+                function: {
+                  name: "recall",
+                  arguments: JSON.stringify({ query: "provider routing" }),
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 2,
+        prompt_tokens: 10,
+        completion_tokens: 2,
+        total_tokens: 12,
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function responsesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: "resp_codex",
+      object: "response",
+      created_at: 1,
+      status: "completed",
+      model: "gpt-5.1-codex-mini",
+      output: [
+        {
+          type: "message",
+          id: "msg_codex",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "output_text", text: "done", annotations: [] }],
+        },
+      ],
+      usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function workerResponse(content = "[]"): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl_worker",
+      content: [{ type: "text", text: content }],
+      stop_reason: "end_turn",
+      choices: [
+        { message: { role: "assistant", content }, finish_reason: "stop" },
+      ],
+      model: "worker-model",
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+async function start(
+  options: {
+    workerModel?: string;
+    dedicatedKey?: boolean;
+    batchDisabled?: boolean;
+  } = {},
+): Promise<Started> {
+  const env = {
+    LORE_DB_PATH: `/tmp/lore-openrouter-routing-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    LORE_LISTEN_PORT: "0",
+    LORE_DEBUG: "false",
+    LORE_BATCH_DISABLED: options.batchDisabled === false ? undefined : "1",
+    LORE_WORKER_MODEL: options.workerModel,
+    LORE_WORKER_API_KEY: options.dedicatedKey ? DEDICATED_KEY : undefined,
+  };
+  const previousEnv = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(env)) {
+    previousEnv.set(key, process.env[key]);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  const { resetPipelineState } = await import("../src/pipeline");
+  const { startServer } = await import("../src/server");
+  const { loadConfig } = await import("../src/config");
+  closeDB();
+  await resetPipelineState();
+  mockFetch.mockReset();
+  mockFetch.mockImplementation(async (input) =>
+    fetchArgUrl(input).includes("models.dev")
+      ? new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      : workerResponse(),
+  );
+  const config = loadConfig();
+  const server = await startServer(config);
+  started = {
+    baseURL: `http://127.0.0.1:${server.port}`,
+    config,
+    dbPath: env.LORE_DB_PATH,
+    server,
+    previousEnv,
+  };
+  return started;
+}
+
+async function stop(): Promise<void> {
+  if (!started) return;
+  const current = started;
+  started = undefined;
+  current.server.stop();
+  const { resetPipelineState, setUpstreamInterceptor } =
+    await import("../src/pipeline");
+  const { _setTestVertexTokenProvider } = await import("../src/vertex-auth");
+  _setTestVertexTokenProvider(null);
+  setUpstreamInterceptor(undefined);
+  await resetPipelineState();
+  closeDB();
+  for (const [key, value] of current.previousEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const path = `${current.dbPath}${suffix}`;
+    if (existsSync(path)) unlinkSync(path);
+  }
+  mockFetch.mockReset();
+}
+
+afterEach(stop);
+
+function requestHeaders(
+  providerID: string,
+  upstreamUrl = SESSION_UPSTREAM,
+): Record<string, string> {
+  return {
+    authorization: "Bearer foreground-session-key",
+    "content-type": "application/json",
+    "x-lore-agent": "coder",
+    "x-lore-provider": providerID,
+    "x-lore-session-id": SESSION_ID,
+    "x-lore-upstream-url": upstreamUrl,
+  };
+}
+
+function chatBody(
+  provider: unknown,
+  options: { includeProvider?: boolean; message?: string } = {},
+): Record<string, unknown> {
+  return {
+    model: "anthropic/claude-sonnet-4-6",
+    messages: [{ role: "user", content: options.message ?? "Hello" }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "noop",
+          description: "Keep this on the conversation path",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ],
+    ...(options.includeProvider === false ? {} : { provider }),
+  };
+}
+
+async function foreground(
+  run: Started,
+  options: {
+    providerID?: string;
+    provider?: unknown;
+    includeProvider?: boolean;
+    message?: string;
+    upstreamUrl?: string;
+  } = {},
+): Promise<Response> {
+  return fetch(`${run.baseURL}/v1/chat/completions`, {
+    method: "POST",
+    headers: requestHeaders(
+      options.providerID ?? "openrouter",
+      options.upstreamUrl,
+    ),
+    body: JSON.stringify(
+      chatBody(options.provider, {
+        includeProvider: options.includeProvider,
+        message: options.message,
+      }),
+    ),
+  });
+}
+
+function workerCalls() {
+  return mockFetch.mock.calls.filter(
+    (call) =>
+      typeof (call[1] as { body?: unknown } | undefined)?.body === "string",
+  );
+}
+
+function workerBodies(from = 0): Array<Record<string, unknown>> {
+  return workerCalls()
+    .slice(from)
+    .map((call) => {
+      const options = call[1] as { body: string };
+      return JSON.parse(options.body) as Record<string, unknown>;
+    });
+}
+
+async function useNormalForegroundInterceptor(): Promise<void> {
+  const { setUpstreamInterceptor } = await import("../src/pipeline");
+  setUpstreamInterceptor(async () => openAIResponse());
+}
+
+async function useRecallForegroundInterceptor(): Promise<void> {
+  const { setUpstreamInterceptor } = await import("../src/pipeline");
+  let calls = 0;
+  setUpstreamInterceptor(async () =>
+    calls++ === 0 ? recallResponse() : openAIResponse("continued"),
+  );
+}
+
+function activeSession() {
+  // Fixed x-lore-session-id makes this deterministic; no polling or fuzzy match.
+  return import("../src/pipeline").then(({ getActiveSessions }) => {
+    const state = [...getActiveSessions().values()].find(
+      (candidate) => candidate.headerSessionId === SESSION_ID,
+    );
+    if (!state) throw new Error("fixed test session was not identified");
+    return state;
+  });
+}
+
+describe("OpenRouter provider routing", () => {
+  test.each([
+    ["explicit null", null],
+    ["empty object", {}],
+  ])(
+    "preserves %s through the real foreground pipeline",
+    async (_label, provider) => {
+      const run = await start();
+      const { setUpstreamInterceptor } = await import("../src/pipeline");
+      let forwarded: Record<string, unknown> | undefined;
+      setUpstreamInterceptor(async (body) => {
+        forwarded = body as Record<string, unknown>;
+        return openAIResponse();
+      });
+
+      await (await foreground(run, { provider })).text();
+      if (!forwarded) throw new Error("foreground request was not forwarded");
+      expect(Object.hasOwn(forwarded, "provider")).toBe(true);
+      expect(forwarded.provider).toEqual(provider);
+      expect((await activeSession()).lastUpstream?.providerOptions).toEqual(
+        provider === null ? undefined : provider,
+      );
+    },
+  );
+
+  test("snapshots the exact shared route for protocol overrides and Copilot inference", async () => {
+    const run = await start();
+    await useNormalForegroundInterceptor();
+    const minimaxHeaders = requestHeaders("minimax");
+    delete minimaxHeaders["x-lore-upstream-url"];
+    const responses = await fetch(`${run.baseURL}/v1/responses`, {
+      method: "POST",
+      headers: minimaxHeaders,
+      body: JSON.stringify({
+        model: "anthropic/claude-sonnet-4-6",
+        input: "Responses ingress to Anthropic route",
+      }),
+    });
+    expect(responses.ok).toBe(true);
+    await responses.text();
+    expect((await activeSession()).lastUpstream).toMatchObject({
+      providerID: "minimax",
+      protocol: "anthropic",
+      url: "https://api.minimax.io/anthropic",
+    });
+
+    const copilotHeaders = requestHeaders("openai");
+    delete copilotHeaders["x-lore-provider"];
+    delete copilotHeaders["x-lore-upstream-url"];
+    copilotHeaders["copilot-integration-id"] = "copilot-cli";
+    const copilot = await fetch(`${run.baseURL}/v1/chat/completions`, {
+      method: "POST",
+      headers: copilotHeaders,
+      body: JSON.stringify(chatBody(undefined, { includeProvider: false })),
+    });
+    expect(copilot.ok).toBe(true);
+    await copilot.text();
+    expect((await activeSession()).lastUpstream).toMatchObject({
+      providerID: "github-copilot",
+      protocol: "openai",
+      url: "https://api.githubcopilot.com",
+    });
+  });
+
+  test("hands exact foreground policy to a real urgent recall worker using the configured model", async () => {
+    const run = await start({
+      workerModel: OPENROUTER_MODEL,
+      dedicatedKey: true,
+    });
+    const policy = {
+      only: ["google-vertex/europe", "amazon-bedrock/eu-west-1"],
+      allow_fallbacks: false,
+      data_collection: "deny",
+    };
+    const { setUpstreamInterceptor } = await import("../src/pipeline");
+    let foregroundCalls = 0;
+    setUpstreamInterceptor(async () =>
+      foregroundCalls++ === 0 ? recallResponse() : openAIResponse("continued"),
+    );
+    mockFetch.mockImplementation(async () =>
+      workerResponse('["provider routing policy"]'),
+    );
+
+    const response = await foreground(run, { provider: policy });
+    expect(response.ok).toBe(true);
+    await response.text();
+
+    expect(workerCalls()).toHaveLength(1);
+    const body = workerBodies()[0];
+    expect(body.provider).toEqual(policy);
+    expect(body.model).toBe("deepseek/deepseek-chat");
+    expect(fetchArgUrl(workerCalls()[0][0])).toContain(
+      "openrouter.ai/api/v1/chat/completions",
+    );
+    expect(fetchArgUrl(workerCalls()[0][0])).not.toContain(
+      "session-route.invalid",
+    );
+    const headers = (
+      workerCalls()[0][1] as {
+        headers: Record<string, string>;
+      }
+    ).headers;
+    expect(headers["x-api-key"]).toBe(DEDICATED_KEY);
+
+    const state = await activeSession();
+    expect(Object.isFrozen(state.lastUpstream?.providerOptions)).toBe(true);
+    expect(Object.isFrozen(state.lastUpstream?.providerOptions?.only)).toBe(
+      true,
+    );
+  });
+
+  test("resolves stale opts.model before a batch-eligible provider queues it", async () => {
+    const run = await start({ batchDisabled: false });
+    await useNormalForegroundInterceptor();
+    const customOpenAIUpstream = "https://custom-openai.invalid/v1";
+    await (
+      await foreground(run, {
+        providerID: "openai",
+        includeProvider: false,
+        upstreamUrl: customOpenAIUpstream,
+      })
+    ).text();
+    const state = await activeSession();
+    setSessionAuth(
+      state.sessionID,
+      { scheme: "api-key", value: "sk-openai-batch" },
+      "openai",
+    );
+    const { getLLMClientForTest, resetPipelineState } =
+      await import("../src/pipeline");
+    const client = getLLMClientForTest(run.config) as ReturnType<
+      typeof getLLMClientForTest
+    > & {
+      stats(): { queued: number };
+    };
+    const before = workerCalls().length;
+    const pending = client.prompt("system", "batch me", {
+      sessionID: state.sessionID,
+      workerID: "lore-distill",
+      model: { providerID: "anthropic", modelID: "stale-claude-model" },
+    });
+
+    expect(client.stats().queued).toBe(1);
+    await resetPipelineState();
+    await pending;
+    const dispatched = workerCalls()[before];
+    expect(dispatched).toBeDefined();
+    expect(fetchArgUrl(dispatched[0])).toContain(
+      "custom-openai.invalid/v1/responses",
+    );
+    const body = JSON.parse((dispatched[1] as { body: string }).body) as Record<
+      string,
+      unknown
+    >;
+    expect(body.model).not.toBe("stale-claude-model");
+  });
+
+  test("replaces P1 with P2 and clears P2 when a newer request omits provider", async () => {
+    const run = await start({ workerModel: OPENROUTER_MODEL });
+    await useNormalForegroundInterceptor();
+    const p1 = { only: ["p1"], allow_fallbacks: false };
+    const p2 = { only: ["p2"], allow_fallbacks: false };
+
+    await (await foreground(run, { provider: p1, message: "P1" })).text();
+    await useRecallForegroundInterceptor();
+    const beforeP2Worker = workerCalls().length;
+    await (await foreground(run, { provider: p2, message: "P2" })).text();
+    const p2Bodies = workerBodies(beforeP2Worker);
+    expect(p2Bodies.length).toBeGreaterThan(0);
+    expect(
+      p2Bodies.every(
+        (body) => JSON.stringify(body.provider) === JSON.stringify(p2),
+      ),
+    ).toBe(true);
+
+    await useRecallForegroundInterceptor();
+    const beforeDefaultWorker = workerCalls().length;
+    await (
+      await foreground(run, {
+        includeProvider: false,
+        message: "provider omitted",
+      })
+    ).text();
+    expect(
+      (await activeSession()).lastUpstream?.providerOptions,
+    ).toBeUndefined();
+    const defaultBodies = workerBodies(beforeDefaultWorker);
+    expect(defaultBodies.length).toBeGreaterThan(0);
+    expect(
+      defaultBodies.every(
+        (body) =>
+          JSON.stringify(body.provider) === JSON.stringify({ sort: "price" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("provider switches use the effective worker provider's own stored snapshot", async () => {
+    const run = await start({ workerModel: OPENROUTER_MODEL });
+    await useNormalForegroundInterceptor();
+    const openRouterPolicy = { only: ["openrouter-owned-endpoint"] };
+    await (await foreground(run, { provider: openRouterPolicy })).text();
+    const { setUpstreamInterceptor } = await import("../src/pipeline");
+    const deepseekBodies: Array<Record<string, unknown>> = [];
+    let deepseekCalls = 0;
+    setUpstreamInterceptor(async (body) => {
+      deepseekBodies.push(body as Record<string, unknown>);
+      return deepseekCalls++ === 0
+        ? recallResponse()
+        : openAIResponse("continued");
+    });
+    const before = workerCalls().length;
+    await (
+      await foreground(run, {
+        providerID: "deepseek",
+        provider: { only: ["foreign-deepseek-policy"] },
+        message: "switch provider",
+        upstreamUrl: "https://api.deepseek.com",
+      })
+    ).text();
+    expect(Object.hasOwn(deepseekBodies[0], "provider")).toBe(false);
+    const bodies = workerBodies(before);
+    expect(bodies.length).toBeGreaterThan(0);
+    expect(
+      bodies.every(
+        (body) =>
+          JSON.stringify(body.provider) === JSON.stringify(openRouterPolicy),
+      ),
+    ).toBe(true);
+    expect(fetchArgUrl(workerCalls()[before][0])).toContain(
+      "session-route.invalid/openrouter",
+    );
+    expect(fetchArgUrl(workerCalls()[before][0])).not.toContain("deepseek");
+  });
+
+  test("different-provider dedicated worker gets no foreign policy", async () => {
+    const run = await start({
+      workerModel: "deepseek/deepseek-chat",
+      dedicatedKey: true,
+    });
+    await useNormalForegroundInterceptor();
+    await useRecallForegroundInterceptor();
+    await (
+      await foreground(run, { provider: { only: ["openrouter-only"] } })
+    ).text();
+
+    const bodies = workerBodies();
+    expect(bodies.length).toBeGreaterThan(0);
+    expect(bodies.every((body) => !Object.hasOwn(body, "provider"))).toBe(true);
+    expect(fetchArgUrl(workerCalls()[0][0])).toContain("api.deepseek.com");
+  });
+
+  test("dedicated OpenRouter worker falls back to price after an omitted policy", async () => {
+    const run = await start({
+      workerModel: OPENROUTER_MODEL,
+      dedicatedKey: true,
+    });
+    await useRecallForegroundInterceptor();
+    await (await foreground(run, { includeProvider: false })).text();
+
+    const bodies = workerBodies();
+    expect(bodies.length).toBeGreaterThan(0);
+    expect(
+      bodies.every(
+        (body) =>
+          JSON.stringify(body.provider) === JSON.stringify({ sort: "price" }),
+      ),
+    ).toBe(true);
+    expect(fetchArgUrl(workerCalls()[0][0])).not.toContain(
+      "session-route.invalid",
+    );
+  });
+
+  test("protocol-distinct Vertex aliases coexist, persist, and select compatibly", async () => {
+    const run = await start();
+    await useNormalForegroundInterceptor();
+    const gemini = await fetch(
+      `${run.baseURL}/v1beta/models/gemini-2.5-flash:generateContent`,
+      {
+        method: "POST",
+        headers: requestHeaders(
+          "google-vertex",
+          "https://gemini-route.invalid",
+        ),
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: "native Gemini" }] }],
+        }),
+      },
+    );
+    await gemini.text();
+    expect((await activeSession()).lastUpstream).toMatchObject({
+      providerID: "google-vertex",
+      protocol: "gemini",
+      url: "https://gemini-route.invalid",
+    });
+
+    const { _setTestVertexTokenProvider } = await import("../src/vertex-auth");
+    _setTestVertexTokenProvider(async () => "vertex-test-token");
+    run.config.vertexProject = "vertex-test-project";
+    await (
+      await foreground(run, {
+        providerID: "google-vertex-anthropic",
+        includeProvider: false,
+        upstreamUrl: "https://vertex-route.invalid",
+        message: "Vertex Claude",
+      })
+    ).text();
+
+    const {
+      matchingProviderSnapshotForTest,
+      resetPipelineState,
+      setUpstreamInterceptor,
+    } = await import("../src/pipeline");
+    let state = await activeSession();
+    expect(state.upstreamByProvider.get("google-vertex")).toMatchObject({
+      protocol: "gemini",
+    });
+    expect(
+      state.upstreamByProvider.get("google-vertex-anthropic"),
+    ).toMatchObject({ protocol: "vertex" });
+    expect(
+      matchingProviderSnapshotForTest(state, "google-vertex")?.protocol,
+    ).toBe("gemini");
+    expect(
+      matchingProviderSnapshotForTest(state, "google-vertex-anthropic")
+        ?.protocol,
+    ).toBe("vertex");
+    expect(matchingProviderSnapshotForTest(state, "vertex")?.protocol).toBe(
+      "vertex",
+    );
+
+    const persisted = loadSessionTracking(state.sessionID)?.lastUpstream;
+    if (!persisted)
+      throw new Error("Vertex alias snapshots were not persisted");
+    const envelope = JSON.parse(persisted) as {
+      upstreamByProvider: Record<string, unknown>;
+    };
+    expect(Object.keys(envelope.upstreamByProvider)).toEqual(
+      expect.arrayContaining(["google-vertex", "google-vertex-anthropic"]),
+    );
+
+    await resetPipelineState();
+    setUpstreamInterceptor(async () => openAIResponse());
+    await (
+      await foreground(run, {
+        provider: { only: ["restore-trigger"] },
+        message: "restore aliases",
+      })
+    ).text();
+    state = await activeSession();
+    expect(state.upstreamByProvider.has("google-vertex")).toBe(true);
+    expect(state.upstreamByProvider.has("google-vertex-anthropic")).toBe(true);
+  });
+
+  test("canonical worker-provider aliases share the matching snapshot route", async () => {
+    const run = await start({
+      workerModel: "bedrock/anthropic.claude-haiku-4-5-v1:0",
+    });
+    await useRecallForegroundInterceptor();
+    const aliasRoute = "https://bedrock-alias.invalid/anthropic";
+    await (
+      await foreground(run, {
+        providerID: "amazon-bedrock",
+        includeProvider: false,
+        upstreamUrl: aliasRoute,
+      })
+    ).text();
+
+    expect(workerCalls()).toHaveLength(1);
+    expect(fetchArgUrl(workerCalls()[0][0])).toContain(
+      "bedrock-alias.invalid/anthropic/v1/messages",
+    );
+  });
+
+  test("persists last + provider map, restores policy, supports legacy, and rejects malformed options", async () => {
+    const run = await start({
+      workerModel: OPENROUTER_MODEL,
+      dedicatedKey: true,
+    });
+    await useNormalForegroundInterceptor();
+    const restoredPolicy = { only: ["restored-openrouter"] };
+    await (await foreground(run, { provider: restoredPolicy })).text();
+    await (
+      await foreground(run, {
+        providerID: "anthropic",
+        includeProvider: false,
+        upstreamUrl: "https://api.anthropic.com",
+        message: "make anthropic last",
+      })
+    ).text();
+    const sid = (await activeSession()).sessionID;
+    const persisted = loadSessionTracking(sid)?.lastUpstream;
+    if (!persisted) throw new Error("upstream state was not persisted");
+    const envelope = JSON.parse(persisted) as {
+      version: number;
+      lastUpstream: { providerID?: string; headers: Record<string, string> };
+      upstreamByProvider: Record<
+        string,
+        { providerOptions?: unknown; headers: Record<string, string> }
+      >;
+    };
+    expect(envelope.version).toBe(2);
+    expect(envelope.lastUpstream.providerID).toBe("anthropic");
+    expect(envelope.lastUpstream.headers).toEqual({});
+    expect(envelope.upstreamByProvider.openrouter.providerOptions).toEqual(
+      restoredPolicy,
+    );
+    expect(envelope.upstreamByProvider.openrouter.headers).toEqual({});
+
+    const { resetPipelineState, setUpstreamInterceptor } =
+      await import("../src/pipeline");
+    await resetPipelineState();
+    let restartCalls = 0;
+    setUpstreamInterceptor(async () =>
+      restartCalls++ === 0 ? recallResponse() : openAIResponse("continued"),
+    );
+    const restoredStart = workerCalls().length;
+    await (
+      await foreground(run, {
+        providerID: "anthropic",
+        includeProvider: false,
+        upstreamUrl: "https://api.anthropic.com",
+        message: "restart",
+      })
+    ).text();
+    expect(
+      (await activeSession()).upstreamByProvider.get("openrouter")
+        ?.providerOptions,
+    ).toEqual(restoredPolicy);
+    expect(workerBodies(restoredStart)[0].provider).toEqual(restoredPolicy);
+
+    const legacyPolicy = { only: ["legacy-openrouter"] };
+    saveSessionTracking(sid, {
+      lastUpstream: JSON.stringify({
+        url: "https://openrouter.ai/api",
+        protocol: "openai",
+        providerID: "openrouter",
+        model: "anthropic/claude-sonnet-4-6",
+        headers: {},
+        providerOptions: legacyPolicy,
+      }),
+    });
+    await resetPipelineState();
+    let legacyCalls = 0;
+    setUpstreamInterceptor(async () =>
+      legacyCalls++ === 0 ? recallResponse() : openAIResponse("continued"),
+    );
+    const legacyStart = workerCalls().length;
+    await (
+      await foreground(run, {
+        providerID: "anthropic",
+        includeProvider: false,
+        upstreamUrl: "https://api.anthropic.com",
+        message: "legacy restart",
+      })
+    ).text();
+    expect(workerBodies(legacyStart)[0].provider).toEqual(legacyPolicy);
+
+    saveSessionTracking(sid, {
+      lastUpstream: JSON.stringify({
+        url: "https://openrouter.ai/api",
+        protocol: "openai",
+        providerID: "openrouter",
+        model: "anthropic/claude-sonnet-4-6",
+        headers: {},
+        providerOptions: ["malformed"],
+      }),
+    });
+    await resetPipelineState();
+    let malformedCalls = 0;
+    setUpstreamInterceptor(async () =>
+      malformedCalls++ === 0 ? recallResponse() : openAIResponse("continued"),
+    );
+    const malformedStart = workerCalls().length;
+    await (
+      await foreground(run, {
+        providerID: "anthropic",
+        includeProvider: false,
+        upstreamUrl: "https://api.anthropic.com",
+        message: "malformed restart",
+      })
+    ).text();
+    expect((await activeSession()).upstreamByProvider.has("openrouter")).toBe(
+      false,
+    );
+    expect(workerBodies(malformedStart)[0].provider).toEqual({ sort: "price" });
+
+    const validV2Snapshot = {
+      url: "https://openrouter.ai/api",
+      protocol: "openai",
+      providerID: "openrouter",
+      model: "anthropic/claude-sonnet-4-6",
+      headers: {},
+      providerOptions: { only: ["v2-policy"] },
+    };
+    const invalidV2States = [
+      {
+        version: 999,
+        lastUpstream: validV2Snapshot,
+        upstreamByProvider: { openrouter: validV2Snapshot },
+      },
+      {
+        version: 2,
+        lastUpstream: {
+          ...validV2Snapshot,
+          providerOptions: ["malformed-v2"],
+        },
+        upstreamByProvider: {
+          openrouter: {
+            ...validV2Snapshot,
+            providerOptions: ["malformed-v2"],
+          },
+        },
+      },
+    ];
+    for (const [index, invalidState] of invalidV2States.entries()) {
+      saveSessionTracking(sid, {
+        lastUpstream: JSON.stringify(invalidState),
+      });
+      await resetPipelineState();
+      setUpstreamInterceptor(async () => openAIResponse());
+      await (
+        await foreground(run, {
+          providerID: "anthropic",
+          includeProvider: false,
+          upstreamUrl: "https://api.anthropic.com",
+          message: `invalid v2 restart ${index}`,
+        })
+      ).text();
+      expect((await activeSession()).upstreamByProvider.has("openrouter")).toBe(
+        false,
+      );
+    }
+  });
+
+  test("captures failed tightening and rejects an older request that resumes before capture", async () => {
+    const run = await start();
+    const { setBeforeUpstreamCaptureForTest, setUpstreamInterceptor } =
+      await import("../src/pipeline");
+    const failedPolicy = { only: ["failed-but-authoritative"] };
+    setUpstreamInterceptor(
+      async () =>
+        new Response('{"error":"denied"}', {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const failed = await foreground(run, { provider: failedPolicy });
+    expect(failed.status).toBe(403);
+    expect((await activeSession()).lastUpstream?.providerOptions).toEqual(
+      failedPolicy,
+    );
+
+    let releaseOld!: () => void;
+    let markOldStarted!: () => void;
+    const oldStarted = new Promise<void>((resolve) => {
+      markOldStarted = resolve;
+    });
+    const oldGate = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    setBeforeUpstreamCaptureForTest(async (req) => {
+      const text = req.messages
+        .flatMap((message) => message.content)
+        .filter((block) => block.type === "text")
+        .map((block) => block.text)
+        .join("\n");
+      if (text.includes("old slow turn")) {
+        markOldStarted();
+        await oldGate;
+      }
+    });
+    setUpstreamInterceptor(async () => openAIResponse());
+    const oldPolicy = { only: ["old-slow-turn"] };
+    const newPolicy = { only: ["new-fast-turn"] };
+    const oldRequest = foreground(run, {
+      provider: oldPolicy,
+      message: "old slow turn",
+    });
+    await oldStarted;
+    await (
+      await foreground(run, { provider: newPolicy, message: "new fast turn" })
+    ).text();
+    releaseOld();
+    await (await oldRequest).text();
+
+    const state = await activeSession();
+    expect(state.lastUpstream?.providerOptions).toEqual(newPolicy);
+    expect(state.upstreamByProvider.get("openrouter")?.providerOptions).toEqual(
+      newPolicy,
+    );
+    const persisted = loadSessionTracking(state.sessionID)?.lastUpstream;
+    if (!persisted) throw new Error("concurrent policy was not persisted");
+    const envelope = JSON.parse(persisted) as {
+      lastUpstream: { providerOptions?: unknown };
+      upstreamByProvider: Record<string, { providerOptions?: unknown }>;
+    };
+    expect(envelope.lastUpstream.providerOptions).toEqual(newPolicy);
+    expect(envelope.upstreamByProvider.openrouter.providerOptions).toEqual(
+      newPolicy,
+    );
+  });
+
+  test("Codex neither forwards nor durably snapshots provider options", async () => {
+    const run = await start();
+    const { setUpstreamInterceptor } = await import("../src/pipeline");
+    let forwarded: Record<string, unknown> | undefined;
+    setUpstreamInterceptor(async (body) => {
+      forwarded = body as Record<string, unknown>;
+      return responsesResponse();
+    });
+
+    const response = await fetch(`${run.baseURL}/v1/codex/responses`, {
+      method: "POST",
+      headers: requestHeaders(
+        "openai-codex",
+        "https://chatgpt.com/backend-api",
+      ),
+      body: JSON.stringify({
+        model: "gpt-5.1-codex-mini",
+        input: "Hello",
+        stream: false,
+        provider: { only: ["must-not-survive"] },
+        tools: [
+          {
+            type: "function",
+            name: "noop",
+            description: "Keep this on the conversation path",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      }),
+    });
+    expect(response.ok).toBe(true);
+    await response.text();
+    if (!forwarded) throw new Error("Codex request was not forwarded");
+    expect(Object.hasOwn(forwarded, "provider")).toBe(false);
+    const state = await activeSession();
+    expect(state.lastUpstream?.providerOptions).toBeUndefined();
+    const persisted = loadSessionTracking(state.sessionID)?.lastUpstream ?? "";
+    expect(persisted).not.toContain("must-not-survive");
+    expect(persisted).not.toContain("providerOptions");
+  });
+
+  test("bounds persisted provider history and rejects oversized policies", async () => {
+    const run = await start();
+    await useNormalForegroundInterceptor();
+
+    for (let index = 0; index < 20; index++) {
+      const response = await foreground(run, {
+        providerID: `custom-provider-${index}`,
+        includeProvider: false,
+        message: `provider ${index}`,
+        upstreamUrl: `https://custom-provider-${index}.invalid/v1`,
+      });
+      expect(response.ok).toBe(true);
+      await response.text();
+    }
+
+    const state = await activeSession();
+    expect(state.upstreamByProvider.size).toBe(16);
+    const persisted = loadSessionTracking(state.sessionID)?.lastUpstream;
+    if (!persisted) throw new Error("bounded upstream state was not persisted");
+    const envelope = JSON.parse(persisted) as {
+      upstreamByProvider: Record<string, unknown>;
+    };
+    expect(Object.keys(envelope.upstreamByProvider)).toHaveLength(16);
+
+    const oversized = await foreground(run, {
+      provider: { only: ["x".repeat(65 * 1024)] },
+      message: "oversized policy",
+    });
+    expect(oversized.status).toBe(502);
+    expect(await oversized.text()).toContain(
+      "OpenRouter provider routing options exceed 65536 bytes",
+    );
+  });
+});

--- a/packages/gateway/test/worker-auth-guards.test.ts
+++ b/packages/gateway/test/worker-auth-guards.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { distillation } from "@loreai/core";
+import { loadConfig } from "../src/config";
+import { startIdleScheduler } from "../src/idle";
+import { resetPipelineState, scheduleBackgroundWork } from "../src/pipeline";
+import {
+  _resetAuthForTest,
+  setSessionAuth,
+  type AuthCredential,
+} from "../src/auth";
+import type { SessionState, UpstreamSnapshot } from "../src/translate/types";
+
+const workerModel = "bedrock/anthropic.claude-haiku-4-5-v1:0";
+let previousWorkerModel: string | undefined;
+
+function snapshot(providerID = "amazon-bedrock"): UpstreamSnapshot {
+  return {
+    url: "https://bedrock-alias.invalid/anthropic",
+    protocol: "anthropic",
+    providerID,
+    model: "anthropic.claude-haiku-4-5-v1:0",
+    headers: {},
+  };
+}
+
+function state(sessionID: string): SessionState {
+  const upstream = snapshot();
+  return {
+    sessionID,
+    projectPath: `/tmp/${sessionID}`,
+    fingerprint: "fingerprint",
+    lastRequestTime: 0,
+    lastUserTurnTime: 0,
+    messageCount: 1,
+    turnsSinceCuration: 0,
+    consecutiveTextOnlyTurns: 0,
+    recallStore: new Map(),
+    cacheAnalytics: {
+      lastRequestBody: null,
+      lastRequestBodyLength: 0,
+      lastCacheRead: 0,
+      lastCacheCreation: 0,
+      turnCount: 0,
+      bustCount: 0,
+    },
+    lastUpstream: upstream,
+    upstreamByProvider: new Map([["amazon-bedrock", upstream]]),
+  };
+}
+
+function credential(value: string): AuthCredential {
+  return { scheme: "api-key", value };
+}
+
+beforeEach(async () => {
+  previousWorkerModel = process.env.LORE_WORKER_MODEL;
+  process.env.LORE_WORKER_MODEL = workerModel;
+  _resetAuthForTest();
+  await resetPipelineState();
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  _resetAuthForTest();
+  await resetPipelineState();
+  if (previousWorkerModel === undefined) delete process.env.LORE_WORKER_MODEL;
+  else process.env.LORE_WORKER_MODEL = previousWorkerModel;
+});
+
+describe("alias-aware worker auth guards", () => {
+  test("normal scheduling accepts amazon-bedrock auth for a bedrock worker only", async () => {
+    const config = loadConfig();
+    const aliasState = state("alias-normal");
+    aliasState.compactionAnomalyPending = true;
+    setSessionAuth(
+      aliasState.sessionID,
+      credential("amazon-bedrock-key"),
+      "amazon-bedrock",
+    );
+    const unrelatedState = state("unrelated-normal");
+    unrelatedState.compactionAnomalyPending = true;
+    setSessionAuth(
+      unrelatedState.sessionID,
+      credential("deepseek-key"),
+      "deepseek",
+    );
+    const run = vi
+      .spyOn(distillation, "run")
+      .mockResolvedValue({ distilled: 0, rounds: 0 });
+
+    scheduleBackgroundWork(aliasState, config);
+    scheduleBackgroundWork(unrelatedState, config);
+    await Promise.resolve();
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0][0]).toMatchObject({
+      sessionID: aliasState.sessionID,
+      model: { providerID: "bedrock" },
+    });
+  });
+
+  test("idle scheduling accepts the alias and rejects unrelated credentials", async () => {
+    vi.useFakeTimers();
+    const config = { ...loadConfig(), idleTimeoutSeconds: 1 };
+    const aliasState = state("alias-idle");
+    const unrelatedState = state("unrelated-idle");
+    setSessionAuth(
+      aliasState.sessionID,
+      credential("amazon-bedrock-key"),
+      "amazon-bedrock",
+    );
+    setSessionAuth(
+      unrelatedState.sessionID,
+      credential("deepseek-key"),
+      "deepseek",
+    );
+    const sessions = new Map([
+      [aliasState.sessionID, aliasState],
+      [unrelatedState.sessionID, unrelatedState],
+    ]);
+    const doIdleWork = vi.fn(async () => {});
+    const stop = startIdleScheduler(config, sessions, doIdleWork);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    stop();
+
+    expect(doIdleWork).toHaveBeenCalledTimes(1);
+    expect(doIdleWork).toHaveBeenCalledWith(aliasState.sessionID, aliasState);
+  });
+});

--- a/packages/gateway/test/worker-cross-provider.test.ts
+++ b/packages/gateway/test/worker-cross-provider.test.ts
@@ -241,6 +241,31 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
     expect(body.provider).toEqual({ sort: "price" });
   });
 
+  test("openrouter worker request inherits explicit session provider routing", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "or-worker-key" }),
+      { providerID: "openrouter", modelID: "deepseek/deepseek-chat" },
+    );
+    const providerOptions = {
+      only: ["google-vertex/europe", "amazon-bedrock/eu-west-1"],
+      allow_fallbacks: false,
+    };
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-openrouter-explicit-routing",
+      workerID: "lore-distill",
+      model: { providerID: "openrouter", modelID: "deepseek/deepseek-chat" },
+      protocol: "openai",
+      providerOptions,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const opts = mockFetch.mock.calls[0][1] as { body: string };
+    const body = JSON.parse(opts.body) as { provider?: unknown };
+    expect(body.provider).toEqual(providerOptions);
+  });
+
   test("openrouter worker request sets :floor even when the session supplies an upstreamUrl (production path)", async () => {
     // Regression for the resolveTarget override-matches branch: a real OpenRouter
     // session forwards its endpoint as `upstreamUrl` + `upstreamProviderID`. That
@@ -290,5 +315,63 @@ describe("worker cross-provider routing matrix (structural guard)", () => {
     const opts = mockFetch.mock.calls[0][1] as { body: string };
     const body = JSON.parse(opts.body) as { provider?: unknown };
     expect(body.provider).toBeUndefined();
+  });
+
+  test.each([
+    ["DeepSeek", "deepseek", "deepseek-chat", "openai"],
+    ["direct OpenAI", "openai", "gpt-5-mini", "openai"],
+    [
+      "GitHub Copilot Responses",
+      "github-copilot",
+      "gpt-5.4-mini",
+      "openai-responses",
+    ],
+    ["Codex", "openai-codex", "gpt-5.1-codex-mini", "openai-responses"],
+  ] as const)(
+    "%s worker rejects foreign provider body options",
+    async (_label, providerID, modelID, protocol) => {
+      const client = createGatewayLLMClient(
+        UPSTREAMS,
+        () => ({ scheme: "api-key", value: "poison-test-key" }),
+        { providerID, modelID },
+        { dedicatedWorkerKey: true },
+      );
+
+      await client.prompt("system", "user", {
+        sessionID: `sess-poison-${providerID}`,
+        workerID: "lore-query-expand",
+        model: { providerID, modelID },
+        protocol,
+        providerOptions: { only: ["poison-foreign-endpoint"] },
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const options = mockFetch.mock.calls[0][1] as { body: string };
+      const body = JSON.parse(options.body) as Record<string, unknown>;
+      expect(body.provider).toBeUndefined();
+    },
+  );
+
+  test("OpenRouter treats a malformed providerOptions array as absent", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "or-worker-key" }),
+      { providerID: "openrouter", modelID: "deepseek/deepseek-chat" },
+    );
+
+    await client.prompt("system", "user", {
+      sessionID: "sess-openrouter-malformed-routing",
+      workerID: "lore-distill",
+      model: {
+        providerID: "openrouter",
+        modelID: "deepseek/deepseek-chat",
+      },
+      protocol: "openai",
+      providerOptions: ["poison"] as unknown as Record<string, unknown>,
+    });
+
+    const options = mockFetch.mock.calls[0][1] as { body: string };
+    const body = JSON.parse(options.body) as Record<string, unknown>;
+    expect(body.provider).toEqual({ sort: "price" });
   });
 });


### PR DESCRIPTION
## Summary
Preserves OpenRouter provider-routing policy across the Lore gateway and applies the matching policy to background workers.

Fixes #1622.

## Changes
- Forward top-level `provider` options for OpenRouter Chat and Responses requests without leaking them to other providers or Codex.
- Capture request-ordered, provider-specific upstream snapshots before dispatch, persist them across restarts with bounded state, and preserve protocol-distinct aliases.
- Resolve worker model, auth, route, and policy before batching so normal and dedicated-key workers use the correct provider snapshot.
- Add adversarial coverage for policy replacement/clearing, provider switches, failed and concurrent turns, batching fallback, persistence compatibility, alias auth, and malformed input.

## Verification
- 809 routing, worker, pipeline, server, and OpenCode tests passed.
- Workspace typecheck passed.
- Changed-file formatting and type-aware lint passed.
- Three independent adversarial review rounds completed and all actionable findings addressed.