### PR TITLE
fix: make setup and uninstall reversible

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -20,7 +20,7 @@ artifactProvider:
     artifacts:
       # CI workflow uploads three artifact groups on release branches:
       #   npm-tarball      — workspace .tgz files for npm publish
-      #   release-binaries — gzipped standalone CLI binaries per platform
+      #   release-binaries — gzipped standalone CLI binaries + checksums
       #   release-patches  — delta patches from previous stable release
       CI:
         - npm-tarball
@@ -55,9 +55,11 @@ targets:
     access: public
     oidc: true
     includeNames: /^loreai-onnxruntime-.*\.tgz$/
-  # Create GitHub Release with binaries and delta patches attached.
-  # The includeNames filter ensures only .gz binaries and .patch deltas
+  # Create GitHub Release with binaries, deterministic checksum metadata, and
+  # delta patches attached. GitHub's API adds its own SHA-256 digest to the
+  # checksum asset, which installers verify before trusting its entries.
+  # The includeNames filter ensures only those distribution artifacts
   # are uploaded as release assets — npm tarballs are published via the
   # npm targets above, not attached to the GitHub Release.
   - name: github
-    includeNames: /\.(gz|patch)$/
+    includeNames: /(\.(gz|patch)|^lore-checksums\.txt)$/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
           node packages/gateway/dist/bin.cjs help
 
           # Start gateway, hit health endpoint, shut down
-          node packages/gateway/dist/bin.cjs start -p 7990 &
+          node packages/gateway/dist/bin.cjs start --local -p 7990 &
           SERVER_PID=$!
           sleep 2
           curl -sf http://127.0.0.1:7990/health | jq .
@@ -359,7 +359,7 @@ jobs:
             || (echo "::error::read-worker offload seam broken in linux-x64 binary: $ro"; exit 1)
 
           # Start gateway, hit health endpoint, shut down
-          ./packages/gateway/dist-bin/lore-linux-x64 start -p 7991 &
+          ./packages/gateway/dist-bin/lore-linux-x64 start --local -p 7991 &
           SERVER_PID=$!
           sleep 2
           curl -sf http://127.0.0.1:7991/health | jq .
@@ -485,6 +485,16 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FOSSILIZE_CACHE_DIR: ${{ github.workspace }}/.node-cache
 
+      - name: Generate deterministic release checksums
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          node scripts/generate-release-checksums.mjs \
+            packages/gateway/dist-bin \
+            packages/gateway/dist-bin \
+            packages/gateway/dist-bin/lore-checksums.txt
+          echo "--- Release checksums: ---"
+          cat packages/gateway/dist-bin/lore-checksums.txt
+
       - name: Upload tarballs
         if: startsWith(github.ref, 'refs/heads/release/')
         uses: actions/upload-artifact@v7
@@ -497,7 +507,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-binaries
-          path: packages/gateway/dist-bin/*.gz
+          path: |
+            packages/gateway/dist-bin/*.gz
+            packages/gateway/dist-bin/lore-checksums.txt
 
       # Also upload uncompressed release binaries (needed for patch generation)
       - name: Upload uncompressed release binaries
@@ -508,6 +520,7 @@ jobs:
           path: |
             packages/gateway/dist-bin/lore-*
             !packages/gateway/dist-bin/*.gz
+            !packages/gateway/dist-bin/lore-checksums.txt
 
   # ---------------------------------------------------------------------------
   # Doc-generation drift check.
@@ -1073,6 +1086,15 @@ jobs:
         with:
           name: nightly-patches
           path: .delta-patches
+
+      - name: Generate deterministic nightly checksums
+        run: |
+          node scripts/generate-release-checksums.mjs \
+            binaries \
+            artifacts \
+            artifacts/lore-checksums.txt
+          echo "--- Nightly checksums: ---"
+          cat artifacts/lore-checksums.txt
 
       - name: Publish nightly + patches to GHCR
         uses: ./packages/binpatch/action

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ lore run
 
 `lore run` starts the gateway and auto-detects your AI agent (Claude Code, OpenCode, Pi, Codex, Hermes), configuring everything automatically. Per-harness setup, manual configs, and remote-gateway instructions live at [withlore.ai/docs/install](https://withlore.ai/docs/install/) and the [guides section](https://withlore.ai/docs/guides/).
 
+To remove Lore, run `lore uninstall` (preserves your memory database) or inspect a full data removal with `lore uninstall --purge --dry-run`. See the [uninstall documentation](https://withlore.ai/docs/install/#uninstall) for every installed/runtime path and package-manager cleanup.
+
 ## How it works
 
 Lore is a transparent HTTP proxy that sits between an AI harness and its upstream LLM provider. Every supported harness already speaks a standard LLM HTTP API (Anthropic's `/v1/messages`, OpenAI's `/v1/chat/completions`, Codex's `/v1/codex/responses`); Lore redirects those requests to its own gateway, where the conversation is parsed, persisted, and transformed before being forwarded to the real upstream.
@@ -126,6 +128,15 @@ All destructive commands prompt for confirmation. Use `--yes` to skip (for scrip
 ### Web dashboard
 
 When the gateway is running, visit **http://localhost:3207/ui** for a web-based dashboard that lets you browse all projects, knowledge entries, sessions, and distillations; view full detail for any entry; search across all data sources (using the same recall engine); and delete entries or clear project data. Server-rendered HTML — no external dependencies.
+
+The dashboard and `/api/*` management endpoints accept only loopback clients, even when the data-plane listener is exposed on `0.0.0.0`, a LAN address, or Tailscale. To manage a gateway on another machine, tunnel its loopback listener and open the local URL:
+
+```bash
+ssh -N -L 3207:127.0.0.1:3207 user@gateway-host
+# Then open http://localhost:3207/ui
+```
+
+Keep `127.0.0.1` in `LORE_LISTEN_HOST` on the gateway (multiple hosts are comma-separated) so the tunnel has a loopback listener to reach. Remote agent/data-plane routes such as `/v1/messages` remain available on the configured non-loopback listeners.
 
 ## lat.md compatibility
 

--- a/packages/binpatch/action/action.yml
+++ b/packages/binpatch/action/action.yml
@@ -380,11 +380,14 @@ runs:
         SOURCE_URL: ${{ github.server_url }}/${{ github.repository }}
       run: |
         set -euo pipefail
-        oras push "${REGISTRY}/${REPO}:${NIGHTLY_TAG}" \
-          --artifact-type "${ARTIFACT_TYPE_PREFIX}.nightly" \
-          --annotation "org.opencontainers.image.source=${SOURCE_URL}" \
-          --annotation "version=${VERSION}" \
-          ./*.gz
+          # lore-checksums.txt is deterministic metadata for every raw and
+          # compressed target. Each layer, including this metadata, is itself
+          # content-addressed by the resulting OCI manifest.
+          oras push "${REGISTRY}/${REPO}:${NIGHTLY_TAG}" \
+            --artifact-type "${ARTIFACT_TYPE_PREFIX}.nightly" \
+            --annotation "org.opencontainers.image.source=${SOURCE_URL}" \
+            --annotation "version=${VERSION}" \
+            ./*.gz ./lore-checksums.txt
 
     - name: Tag versioned nightly
       # Immutable versioned tag via zero-copy `oras tag` so patch-chain

--- a/packages/core/src/credential-headers.ts
+++ b/packages/core/src/credential-headers.ts
@@ -1,0 +1,184 @@
+/** Shared credential-header policy and free-text redaction. */
+
+/** Internal gateway access credential. Never forward, learn, persist, or log. */
+export const GATEWAY_AUTH_HEADER = "x-lore-gateway-token";
+
+export const KNOWN_SESSION_HEADERS = [
+  "x-lore-session-id",
+  "x-claude-code-session-id",
+  "x-session-id",
+  "x-session-affinity",
+] as const;
+
+const KNOWN_SAFE_HEADER_NAMES = new Set<string>([
+  ...KNOWN_SESSION_HEADERS,
+  "idempotency-key",
+  "sec-websocket-key",
+  "session-id",
+]);
+
+const KNOWN_CREDENTIAL_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "cookie2",
+  GATEWAY_AUTH_HEADER,
+  "x-api-key",
+  "x-goog-api-key",
+]);
+
+const CREDENTIAL_HEADER_PATTERN =
+  /(?:^|-)(?:(?:api|access|auth|bearer|client|consumer|identity|private|refresh|security|subscription)-?(?:id|key|secret|token)|auth|authenticate|authentication|authorisation|authorization|bearer|cookies?|credentials?|jwt|key|oauth|passphrase|passwd|password|secret|signature|token)(?:-|$)/;
+
+const COLLAPSED_CREDENTIAL_HEADER_PATTERN =
+  /^x(?:apikey|(?:auth|oauth|bearer|secret|token|key)sessionid)$/;
+
+const CREDENTIAL_ASSIGNMENT_PATTERN =
+  /(?:(['"])([A-Za-z][A-Za-z0-9._-]*)\1|([A-Za-z][A-Za-z0-9._-]*))(\s*[:=]\s*)/g;
+
+const FOLLOWING_ASSIGNMENT_PATTERN =
+  /\s+(?=(?:(?:['"])[A-Za-z][A-Za-z0-9._-]*(?:['"])|[A-Za-z][A-Za-z0-9._-]*)\s*[:=])/g;
+
+function normalizeHeaderName(name: string): string {
+  return name
+    .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[._-]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function isCredentialHeaderName(name: string): boolean {
+  const normalized = normalizeHeaderName(name);
+  if (KNOWN_SAFE_HEADER_NAMES.has(normalized)) return false;
+  if (KNOWN_CREDENTIAL_HEADER_NAMES.has(normalized)) return true;
+  if (COLLAPSED_CREDENTIAL_HEADER_PATTERN.test(normalized.replaceAll("-", "")))
+    return true;
+  return CREDENTIAL_HEADER_PATTERN.test(normalized);
+}
+
+function quotedValueEnd(value: string, start: number): number {
+  const quote = value[start];
+  for (let index = start + 1; index < value.length; index++) {
+    if (value[index] === "\\") {
+      index++;
+    } else if (value[index] === quote) {
+      return index + 1;
+    }
+  }
+  return value.length;
+}
+
+function structuredValueEnd(value: string, start: number): number {
+  const closing: string[] = [value[start] === "{" ? "}" : "]"];
+  let quote = "";
+
+  for (let index = start + 1; index < value.length; index++) {
+    const character = value[index];
+    if (quote) {
+      if (character === "\\") index++;
+      else if (character === quote) quote = "";
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === "{") {
+      closing.push("}");
+    } else if (character === "[") {
+      closing.push("]");
+    } else if (character === closing.at(-1)) {
+      closing.pop();
+      if (closing.length === 0) return index + 1;
+    }
+  }
+  return value.length;
+}
+
+function unquotedValueEnd(
+  value: string,
+  start: number,
+  compound: boolean,
+): number {
+  let compoundAssignment = false;
+  FOLLOWING_ASSIGNMENT_PATTERN.lastIndex = start;
+  for (
+    let match = FOLLOWING_ASSIGNMENT_PATTERN.exec(value);
+    match;
+    match = FOLLOWING_ASSIGNMENT_PATTERN.exec(value)
+  ) {
+    const beforeAssignment = value.slice(start, match.index);
+    const lineBreak = beforeAssignment.search(/[\r\n]/);
+    if (lineBreak !== -1) return start + lineBreak;
+
+    const trimmed = beforeAssignment.trimEnd();
+
+    if (trimmed.endsWith(";") || trimmed.endsWith(",")) {
+      compoundAssignment = true;
+      continue;
+    }
+    return start + trimmed.length;
+  }
+
+  for (let index = start; index < value.length; index++) {
+    if (value[index] === "\r" || value[index] === "\n") return index;
+    if (value[index] === "}" || value[index] === "]") return index;
+    if (!compound && !compoundAssignment && value[index] === ",") {
+      const remainder = value.slice(index + 1);
+      if (
+        /^\s*(?:(?:['"])[A-Za-z][A-Za-z0-9._-]*(?:['"])|[A-Za-z][A-Za-z0-9._-]*)\s*:/.test(
+          remainder,
+        )
+      ) {
+        return index;
+      }
+    }
+  }
+  return value.length;
+}
+
+function credentialValueEnd(value: string, start: number, key: string): number {
+  if (value[start] === '"' || value[start] === "'") {
+    return quotedValueEnd(value, start);
+  }
+  if (value[start] === "{" || value[start] === "[") {
+    return structuredValueEnd(value, start);
+  }
+  const compound = /(?:^|-)cookies?2?(?:-|$)/.test(normalizeHeaderName(key));
+  return unquotedValueEnd(value, start, compound);
+}
+
+/** Redact assignments whose key is classified as a credential header. */
+export function redactCredentialHeaderAssignments(
+  value: string,
+  replacement = "[Filtered]",
+): string {
+  let redacted = "";
+  let copiedThrough = 0;
+  CREDENTIAL_ASSIGNMENT_PATTERN.lastIndex = 0;
+
+  for (let match = CREDENTIAL_ASSIGNMENT_PATTERN.exec(value); match;) {
+    const key = match[2] ?? match[3];
+    if (!isCredentialHeaderName(key)) {
+      match = CREDENTIAL_ASSIGNMENT_PATTERN.exec(value);
+      continue;
+    }
+
+    const valueStart = CREDENTIAL_ASSIGNMENT_PATTERN.lastIndex;
+    const valueEnd = credentialValueEnd(value, valueStart, key);
+    const valueQuote =
+      (value[valueStart] === '"' || value[valueStart] === "'") &&
+      value[valueEnd - 1] === value[valueStart]
+        ? value[valueStart]
+        : "";
+
+    redacted += value.slice(copiedThrough, valueStart);
+    redacted += `${valueQuote}${replacement}${valueQuote}`;
+    copiedThrough = valueEnd;
+    CREDENTIAL_ASSIGNMENT_PATTERN.lastIndex = valueEnd;
+    match = CREDENTIAL_ASSIGNMENT_PATTERN.exec(value);
+  }
+
+  CREDENTIAL_ASSIGNMENT_PATTERN.lastIndex = 0;
+  return copiedThrough === 0 ? value : redacted + value.slice(copiedThrough);
+}

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,4 +1,4 @@
-import { Database } from "#db/driver";
+import { Database, registerScalarFunction } from "#db/driver";
 import { isVecAvailable, loadVecExtension, resetVecState } from "./db/vec";
 import {
   ensureVec0Store,
@@ -13,6 +13,7 @@ import { getGitRemote } from "./git";
 import { isHostedMode } from "./hosted";
 import { dataDir } from "./data-dir";
 import { tracedDatabase } from "./db/traced";
+import { currentTenantId } from "./tenant";
 
 /**
  * Callback fired when project rows are created or mutated (merge, rename, etc.).
@@ -87,6 +88,10 @@ export function fireProjectRemoteBackfilled(projectId: string): void {
  * branch is intentionally left uncached so lazy backfill keeps retrying.
  */
 const projectIdByPathCache = new WeakMap<Database, Map<string, string>>();
+
+function tenantPathKey(path: string): string {
+  return `${currentTenantId()}\x1f${path}`;
+}
 
 function projectIdCacheFor(conn: Database): Map<string, string> {
   let m = projectIdByPathCache.get(conn);
@@ -1930,6 +1935,18 @@ const MIGRATIONS: string[] = [
   // Version 79: local-only routing snapshot for restart-safe explicit compaction.
   // Auth headers are excluded before serialization by gateway forwardClientHeaders().
   `ALTER TABLE session_state ADD COLUMN last_upstream TEXT;`,
+  // Version 80: durable tenant ownership for shared remote/hosted storage.
+  // Applied by applyTenantOwnership(): projects/path aliases and entity aliases
+  // require table recreation to widen legacy global UNIQUE constraints.
+  `-- Version 80: see applyTenantOwnership — no-op SQL marker.`,
+  // Version 81: tag sync bookkeeping with its capture tenant. The migration
+  // quarantines every pre-v81 row as untrusted (tenant_id=NULL); local reconcile
+  // safely rebuilds live upserts, while ambiguous legacy deletes never cross an
+  // account boundary. Applied atomically by applySyncTenantIsolation().
+  `-- Version 81: see applySyncTenantIsolation — no-op SQL marker.`,
+  // Version 82: tenant/session-safe temporal and tool-call identities. Applied
+  // idempotently by applyTemporalIdentity() because tool_calls needs a PK rebuild.
+  `-- Version 82: see applyTemporalIdentity — no-op SQL marker.`,
 ];
 
 // Index of the migration whose work is performed by a column-presence-aware JS
@@ -1957,6 +1974,393 @@ const REF_FK_DROP_MIGRATION_INDEX = 65; // 0-based index of version-66
 // mid-recreate rolls back instead of boot-looping. Idempotent (skips if key_epoch already
 // in the PK). The MIGRATIONS entry at this index is a no-op documentation marker.
 const SCOPE_KEY_EPOCH_MIGRATION_INDEX = 68; // 0-based index of version-69
+const TENANT_OWNERSHIP_MIGRATION_INDEX = 79; // 0-based index of version-80
+const SYNC_TENANT_ISOLATION_MIGRATION_INDEX = 80; // 0-based index of version-81
+const TEMPORAL_IDENTITY_MIGRATION_INDEX = 81; // 0-based index of version-82
+
+/**
+ * Add durable tenant ownership without re-keying or deleting historical local
+ * rows. The empty tenant is the legacy local namespace. Table recreation is
+ * required because projects.path and entity aliases were globally unique.
+ */
+function applyTenantOwnership(database: Database): void {
+  const hasColumn = (table: string, column: string): boolean =>
+    (
+      database.query(`PRAGMA table_info(${table})`).all() as Array<{
+        name: string;
+      }>
+    ).some((entry) => entry.name === column);
+
+  if (!hasColumn("knowledge", "tenant_id")) {
+    database.exec(
+      "ALTER TABLE knowledge ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';",
+    );
+  }
+  if (!hasColumn("entities", "tenant_id")) {
+    database.exec(
+      "ALTER TABLE entities ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';",
+    );
+  }
+  if (!hasColumn("knowledge_tombstones", "tenant_id")) {
+    database.exec(
+      "ALTER TABLE knowledge_tombstones ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';",
+    );
+  }
+  if (!hasColumn("dedup_feedback", "tenant_id")) {
+    database.exec(
+      "ALTER TABLE dedup_feedback ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';",
+    );
+  }
+
+  if (!hasColumn("knowledge_contradictions", "tenant_id")) {
+    database.exec(`
+      BEGIN IMMEDIATE;
+      CREATE TABLE knowledge_contradictions_tenant_v80 (
+        tenant_id   TEXT NOT NULL DEFAULT '',
+        logical_id_a TEXT NOT NULL,
+        logical_id_b TEXT NOT NULL,
+        project_id   TEXT,
+        similarity   REAL NOT NULL DEFAULT 0,
+        rationale    TEXT,
+        status       TEXT NOT NULL DEFAULT 'open',
+        detected_at  INTEGER NOT NULL,
+        updated_at   INTEGER NOT NULL,
+        PRIMARY KEY (tenant_id, logical_id_a, logical_id_b)
+      );
+      INSERT INTO knowledge_contradictions_tenant_v80
+        (tenant_id, logical_id_a, logical_id_b, project_id, similarity,
+         rationale, status, detected_at, updated_at)
+      SELECT '', logical_id_a, logical_id_b, project_id, similarity,
+             rationale, status, detected_at, updated_at
+        FROM knowledge_contradictions;
+      DROP TABLE knowledge_contradictions;
+      ALTER TABLE knowledge_contradictions_tenant_v80
+        RENAME TO knowledge_contradictions;
+      CREATE INDEX idx_knowledge_contradictions_status
+        ON knowledge_contradictions (tenant_id, status);
+      COMMIT;
+    `);
+  }
+
+  if (!hasColumn("projects", "tenant_id")) {
+    database.exec("PRAGMA foreign_keys = OFF");
+    try {
+      database.exec(`
+        BEGIN IMMEDIATE;
+        CREATE TABLE projects_tenant_v80 (
+          id TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          name TEXT,
+          created_at INTEGER NOT NULL,
+          git_remote TEXT,
+          last_import_at INTEGER,
+          last_decay_at INTEGER,
+          last_refcheck_at INTEGER,
+          scope_id TEXT,
+          promotion_policy TEXT,
+          tenant_id TEXT NOT NULL DEFAULT '',
+          UNIQUE (tenant_id, path)
+        );
+        INSERT INTO projects_tenant_v80
+          (id, path, name, created_at, git_remote, last_import_at, last_decay_at,
+           last_refcheck_at, scope_id, promotion_policy, tenant_id)
+        SELECT id, path, name, created_at, git_remote, last_import_at, last_decay_at,
+               last_refcheck_at, scope_id, promotion_policy, ''
+          FROM projects;
+
+        CREATE TABLE project_path_aliases_tenant_v80 (
+          tenant_id TEXT NOT NULL DEFAULT '',
+          path TEXT NOT NULL,
+          project_id TEXT NOT NULL REFERENCES projects_tenant_v80(id) ON DELETE CASCADE,
+          PRIMARY KEY (tenant_id, path)
+        );
+        INSERT INTO project_path_aliases_tenant_v80 (tenant_id, path, project_id)
+          SELECT '', path, project_id FROM project_path_aliases;
+
+        DROP TABLE project_path_aliases;
+        DROP TABLE projects;
+        ALTER TABLE projects_tenant_v80 RENAME TO projects;
+        ALTER TABLE project_path_aliases_tenant_v80 RENAME TO project_path_aliases;
+        CREATE INDEX idx_projects_git_remote ON projects(git_remote);
+        CREATE INDEX idx_projects_tenant_remote ON projects(tenant_id, git_remote);
+        CREATE INDEX idx_project_aliases_project ON project_path_aliases(project_id);
+        COMMIT;
+      `);
+    } catch (error) {
+      try {
+        database.exec("ROLLBACK");
+      } catch {
+        // no active transaction
+      }
+      throw error;
+    } finally {
+      database.exec("PRAGMA foreign_keys = ON");
+    }
+  }
+
+  if (!hasColumn("entity_aliases", "tenant_id")) {
+    database.exec("PRAGMA foreign_keys = OFF");
+    try {
+      database.exec(`
+        BEGIN IMMEDIATE;
+        DROP TRIGGER IF EXISTS entity_aliases_fts_insert;
+        DROP TRIGGER IF EXISTS entity_aliases_fts_delete;
+        DROP TRIGGER IF EXISTS entity_aliases_fts_update;
+        CREATE TABLE entity_aliases_tenant_v80 (
+          id TEXT PRIMARY KEY,
+          entity_id TEXT NOT NULL REFERENCES entities(id) ON DELETE CASCADE,
+          alias_type TEXT NOT NULL,
+          alias_value TEXT NOT NULL,
+          source TEXT,
+          created_at INTEGER NOT NULL,
+          tenant_id TEXT NOT NULL DEFAULT '',
+          UNIQUE(tenant_id, alias_type, alias_value)
+        );
+        INSERT INTO entity_aliases_tenant_v80
+          (id, entity_id, alias_type, alias_value, source, created_at, tenant_id)
+        SELECT a.id, a.entity_id, a.alias_type, a.alias_value, a.source,
+               a.created_at, COALESCE(e.tenant_id, '')
+          FROM entity_aliases a JOIN entities e ON e.id = a.entity_id;
+        DROP TABLE entity_aliases;
+        ALTER TABLE entity_aliases_tenant_v80 RENAME TO entity_aliases;
+        CREATE INDEX idx_entity_aliases_value ON entity_aliases(alias_value COLLATE NOCASE);
+        CREATE INDEX idx_entity_aliases_entity ON entity_aliases(entity_id);
+        CREATE INDEX idx_entity_aliases_tenant_value
+          ON entity_aliases(tenant_id, alias_type, alias_value);
+        CREATE TRIGGER entity_aliases_fts_insert AFTER INSERT ON entity_aliases BEGIN
+          INSERT INTO entity_aliases_fts(rowid, alias_value)
+          VALUES (new.rowid, new.alias_value);
+        END;
+        CREATE TRIGGER entity_aliases_fts_delete AFTER DELETE ON entity_aliases BEGIN
+          INSERT INTO entity_aliases_fts(entity_aliases_fts, rowid, alias_value)
+          VALUES('delete', old.rowid, old.alias_value);
+        END;
+        CREATE TRIGGER entity_aliases_fts_update AFTER UPDATE ON entity_aliases BEGIN
+          INSERT INTO entity_aliases_fts(entity_aliases_fts, rowid, alias_value)
+          VALUES('delete', old.rowid, old.alias_value);
+          INSERT INTO entity_aliases_fts(rowid, alias_value)
+          VALUES (new.rowid, new.alias_value);
+        END;
+        INSERT INTO entity_aliases_fts(entity_aliases_fts) VALUES('rebuild');
+        COMMIT;
+      `);
+    } catch (error) {
+      try {
+        database.exec("ROLLBACK");
+      } catch {
+        // no active transaction
+      }
+      throw error;
+    } finally {
+      database.exec("PRAGMA foreign_keys = ON");
+    }
+  }
+
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_knowledge_tenant_project
+      ON knowledge(tenant_id, project_id);
+    CREATE INDEX IF NOT EXISTS idx_entities_tenant_project
+      ON entities(tenant_id, project_id);
+    CREATE INDEX IF NOT EXISTS idx_dedup_feedback_tenant_project
+      ON dedup_feedback(tenant_id, project_id);
+  `);
+}
+
+/**
+ * Add tenant provenance to the installation-global cloud-sync bookkeeping.
+ *
+ * Existing rows cannot be attributed safely: an outbox delete has no live row
+ * to inspect, and sync_state historically carried no storage owner. Quarantine
+ * all rows that predate this migration with NULL rather than guessing that they
+ * belong to the currently configured cloud account. New local rows default to
+ * the historical local tenant (empty string), while trigger capture writes the
+ * active tenant explicitly. ALTER + quarantine are one transaction so a crash
+ * cannot leave legacy rows mislabeled as local.
+ */
+function applySyncTenantIsolation(database: Database): void {
+  const hasColumn = (table: string): boolean =>
+    (
+      database.query(`PRAGMA table_info(${table})`).all() as Array<{
+        name: string;
+      }>
+    ).some((entry) => entry.name === "tenant_id");
+
+  const outboxMissing = !hasColumn("sync_outbox");
+  const stateMissing = !hasColumn("sync_state");
+  if (!outboxMissing && !stateMissing) return;
+
+  database.exec("BEGIN IMMEDIATE");
+  try {
+    if (outboxMissing) {
+      database.exec(
+        "ALTER TABLE sync_outbox ADD COLUMN tenant_id TEXT DEFAULT '';",
+      );
+      database.exec("UPDATE sync_outbox SET tenant_id = NULL");
+    }
+    if (stateMissing) {
+      database.exec(
+        "ALTER TABLE sync_state ADD COLUMN tenant_id TEXT DEFAULT '';",
+      );
+      database.exec("UPDATE sync_state SET tenant_id = NULL");
+    }
+    // The next local enable/cycle re-seeds every live local row. This recovers
+    // trustworthy pending upserts without ever guessing ownership for legacy
+    // deletes (which remain quarantined).
+    database.exec(
+      `INSERT INTO kv_meta (key, value)
+       VALUES ('sync.tenantIsolationReconcile', '1')
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+    );
+    database.exec("COMMIT");
+  } catch (error) {
+    try {
+      database.exec("ROLLBACK");
+    } catch {
+      // no active transaction
+    }
+    throw error;
+  }
+}
+
+/**
+ * Separate caller-supplied temporal IDs from global storage IDs and scope raw
+ * provider tool-call IDs to their durable project/session owner.
+ *
+ * Existing temporal primary keys are intentionally preserved: distillation
+ * source_ids, sync bookkeeping, recall links, and vector rows all refer to
+ * them. `source_id=id` lets a re-delivered legacy message find that same row.
+ */
+function applyTemporalIdentity(database: Database): void {
+  const temporalColumns = database
+    .query("PRAGMA table_info(temporal_messages)")
+    .all() as Array<{ name: string }>;
+  if (!temporalColumns.some((column) => column.name === "source_id")) {
+    database.exec("SAVEPOINT temporal_source_identity_v82");
+    try {
+      database.exec("ALTER TABLE temporal_messages ADD COLUMN source_id TEXT;");
+      database.exec(
+        "UPDATE temporal_messages SET source_id = id WHERE source_id IS NULL;",
+      );
+      database.exec(
+        `CREATE INDEX idx_temporal_source_identity
+           ON temporal_messages(project_id, session_id, source_id);`,
+      );
+      database.exec("RELEASE temporal_source_identity_v82");
+    } catch (error) {
+      database.exec("ROLLBACK TO temporal_source_identity_v82");
+      database.exec("RELEASE temporal_source_identity_v82");
+      throw error;
+    }
+  } else {
+    const sourceIndex = database
+      .query(
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_temporal_source_identity'",
+      )
+      .get() as { sql: string } | null;
+    // Normalize an interrupted development build that created this as UNIQUE.
+    // Dedup is enforced by the deterministic global PK; keeping this a lookup
+    // index avoids introducing a local-only sync convergence constraint.
+    if (sourceIndex && /CREATE\s+UNIQUE\s+INDEX/i.test(sourceIndex.sql)) {
+      database.exec("DROP INDEX idx_temporal_source_identity;");
+    }
+    database.exec(
+      `CREATE INDEX IF NOT EXISTS idx_temporal_source_identity
+         ON temporal_messages(project_id, session_id, source_id);`,
+    );
+  }
+
+  let toolColumns = database
+    .query("PRAGMA table_info(tool_calls)")
+    .all() as Array<{
+    name: string;
+    pk: number;
+  }>;
+  if (toolColumns.length === 0) {
+    database.exec(`
+      CREATE TABLE tool_calls (
+        call_id          TEXT NOT NULL,
+        message_id       TEXT NOT NULL,
+        project_id       TEXT NOT NULL,
+        session_id       TEXT NOT NULL,
+        tool             TEXT NOT NULL,
+        status           TEXT NOT NULL,
+        error_type       TEXT,
+        error_message    TEXT,
+        duration_ms      INTEGER,
+        created_at       INTEGER NOT NULL,
+        verifier         INTEGER,
+        input_paths_json TEXT,
+        PRIMARY KEY (project_id, session_id, call_id)
+      );
+    `);
+    toolColumns = database
+      .query("PRAGMA table_info(tool_calls)")
+      .all() as Array<{
+      name: string;
+      pk: number;
+    }>;
+  }
+  if (!toolColumns.some((column) => column.name === "verifier")) {
+    database.exec("ALTER TABLE tool_calls ADD COLUMN verifier INTEGER;");
+  }
+  if (!toolColumns.some((column) => column.name === "input_paths_json")) {
+    database.exec("ALTER TABLE tool_calls ADD COLUMN input_paths_json TEXT;");
+  }
+
+  const primaryKey = toolColumns
+    .filter((column) => column.pk > 0)
+    .sort((a, b) => a.pk - b.pk)
+    .map((column) => column.name);
+  if (
+    primaryKey.length !== 3 ||
+    primaryKey[0] !== "project_id" ||
+    primaryKey[1] !== "session_id" ||
+    primaryKey[2] !== "call_id"
+  ) {
+    database.exec("SAVEPOINT tool_call_identity_v82");
+    try {
+      database.exec(`
+        DROP TABLE IF EXISTS tool_calls_identity_v82;
+        CREATE TABLE tool_calls_identity_v82 (
+          call_id          TEXT NOT NULL,
+          message_id       TEXT NOT NULL,
+          project_id       TEXT NOT NULL,
+          session_id       TEXT NOT NULL,
+          tool             TEXT NOT NULL,
+          status           TEXT NOT NULL,
+          error_type       TEXT,
+          error_message    TEXT,
+          duration_ms      INTEGER,
+          created_at       INTEGER NOT NULL,
+          verifier         INTEGER,
+          input_paths_json TEXT,
+          PRIMARY KEY (project_id, session_id, call_id)
+        );
+        INSERT INTO tool_calls_identity_v82
+          (call_id, message_id, project_id, session_id, tool, status,
+           error_type, error_message, duration_ms, created_at, verifier,
+           input_paths_json)
+        SELECT call_id, message_id, project_id, session_id, tool, status,
+               error_type, error_message, duration_ms, created_at, verifier,
+               input_paths_json
+          FROM tool_calls;
+        DROP TABLE tool_calls;
+        ALTER TABLE tool_calls_identity_v82 RENAME TO tool_calls;
+      `);
+      database.exec("RELEASE tool_call_identity_v82");
+    } catch (error) {
+      database.exec("ROLLBACK TO tool_call_identity_v82");
+      database.exec("RELEASE tool_call_identity_v82");
+      throw error;
+    }
+  }
+  database.exec(`
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_project_tool_status
+      ON tool_calls (project_id, tool, status);
+    CREATE INDEX IF NOT EXISTS idx_tool_calls_project_session
+      ON tool_calls (project_id, session_id);
+  `);
+}
 
 /**
  * Idempotent, column-presence-aware application of the v55 knowledge_meta register
@@ -2456,6 +2860,10 @@ export function db(): Database {
   // module-level singleton must remain undefined so the next db() call
   // retries initialization instead of returning an un-migrated handle.
   const database = new Database(path);
+  // TEMP sync-capture triggers consult the live AsyncLocalStorage tenant on
+  // every statement. Register before migrations/trigger installation so a
+  // connection can never capture with a missing or stale tenant value.
+  registerScalarFunction(database, "lore_current_tenant", currentTenantId);
   // The DB stores bearer credentials (the Supabase auth session / refresh
   // token in team_config) — make it owner-only so another local user/process
   // can't read it. Best-effort: chmod is a no-op / may throw on Windows & some
@@ -2540,7 +2948,8 @@ function installSyncCapture(database: Database) {
     "CREATE TEMP TABLE IF NOT EXISTS _sync_applying (marker INTEGER)",
   );
   const gate =
-    "(SELECT value FROM team_config WHERE key='sync.enabled')='1' " +
+    "lore_current_tenant() = '' " +
+    "AND (SELECT value FROM team_config WHERE key='sync.enabled')='1' " +
     "AND NOT EXISTS (SELECT 1 FROM temp._sync_applying)";
   const ts = "CAST(strftime('%s','now') AS INTEGER)*1000";
   // P2 (#1246) content git_remote gates. A row syncs only if it is REMOTE-BACKED or
@@ -2602,8 +3011,8 @@ function installSyncCapture(database: Database) {
         CREATE TEMP TRIGGER IF NOT EXISTS ${t}_outbox_${suffix}
         AFTER ${evt} ON ${t} WHEN (${gate}${contentGate})
         BEGIN
-          INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-          VALUES ('${t}', ${rowExpr}, '${op}', ${ts});
+          INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+          VALUES ('${t}', ${rowExpr}, '${op}', ${ts}, lore_current_tenant());
         END;`;
     }
   }
@@ -2616,14 +3025,14 @@ function installSyncCapture(database: Database) {
     AFTER INSERT ON knowledge_entity_refs
     WHEN (${gate} AND ${knowledgeParentGate("new.knowledge_id")} AND ${entityParentGate("new.entity_id")})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('knowledge_entity_refs', new.knowledge_id || char(31) || new.entity_id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('knowledge_entity_refs', new.knowledge_id || char(31) || new.entity_id, 'upsert', ${ts}, lore_current_tenant());
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_entity_refs_outbox_del
     AFTER DELETE ON knowledge_entity_refs WHEN (${gate})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('knowledge_entity_refs', old.knowledge_id || char(31) || old.entity_id, 'delete', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('knowledge_entity_refs', old.knowledge_id || char(31) || old.entity_id, 'delete', ${ts}, lore_current_tenant());
     END;`;
   // A2 sub-PR 3b-2: knowledge_meta base register, keyed by logical_id. Only the
   // IMMUTABLE base_confidence syncs, so the UPDATE trigger fires ONLY when it
@@ -2635,15 +3044,15 @@ function installSyncCapture(database: Database) {
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_outbox_ins
     AFTER INSERT ON knowledge_meta WHEN (${gate} AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts}, lore_current_tenant());
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_outbox_upd
     AFTER UPDATE ON knowledge_meta
     WHEN ((${gate}) AND new.base_confidence IS NOT old.base_confidence AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('knowledge_meta', new.logical_id, 'upsert', ${ts}, lore_current_tenant());
     END;`;
   // A2 sub-PR 3b-2: knowledge_meta_crdt grow-only counters, composite key
   // (logical_id || US || replica_id). Single-owner per (logical_id, replica_id):
@@ -2655,15 +3064,15 @@ function installSyncCapture(database: Database) {
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_crdt_outbox_ins
     AFTER INSERT ON knowledge_meta_crdt WHEN (${gate} AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts}, lore_current_tenant());
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS knowledge_meta_crdt_outbox_upd
     AFTER UPDATE ON knowledge_meta_crdt
     WHEN (${gate} AND (new.pos > old.pos OR new.neg > old.neg) AND ${knowledgeParentGate("new.logical_id")})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('knowledge_meta_crdt', new.logical_id || char(31) || new.replica_id, 'upsert', ${ts}, lore_current_tenant());
     END;`;
   // C-3 (#825): encryption key store. account_escrow is single-row (keyed by id=1);
   // scope_keys is keyed by (member_user_id, key_epoch) — one wrap per member PER epoch since
@@ -2673,26 +3082,26 @@ function installSyncCapture(database: Database) {
     CREATE TEMP TRIGGER IF NOT EXISTS account_escrow_outbox_ins
     AFTER INSERT ON account_escrow WHEN (${gate})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('account_escrow', new.id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('account_escrow', new.id, 'upsert', ${ts}, lore_current_tenant());
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS account_escrow_outbox_upd
     AFTER UPDATE ON account_escrow WHEN (${gate})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('account_escrow', new.id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('account_escrow', new.id, 'upsert', ${ts}, lore_current_tenant());
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS scope_keys_outbox_ins
     AFTER INSERT ON scope_keys WHEN (${gate})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('scope_keys', new.member_user_id || char(31) || new.key_epoch, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('scope_keys', new.member_user_id || char(31) || new.key_epoch, 'upsert', ${ts}, lore_current_tenant());
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS scope_keys_outbox_upd
     AFTER UPDATE ON scope_keys WHEN (${gate})
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('scope_keys', new.member_user_id || char(31) || new.key_epoch, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('scope_keys', new.member_user_id || char(31) || new.key_epoch, 'upsert', ${ts}, lore_current_tenant());
     END;`;
   // #1246: projects identity mapping (id→git_remote). Gated on git_remote IS NOT NULL —
   // only remote-backed projects sync (a remote-less project's random id can't correlate
@@ -2707,14 +3116,14 @@ function installSyncCapture(database: Database) {
     CREATE TEMP TRIGGER IF NOT EXISTS projects_outbox_ins
     AFTER INSERT ON projects WHEN (${gate} AND new.git_remote IS NOT NULL)
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('projects', new.id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('projects', new.id, 'upsert', ${ts}, lore_current_tenant());
     END;
     CREATE TEMP TRIGGER IF NOT EXISTS projects_outbox_upd
     AFTER UPDATE ON projects WHEN (${gate} AND new.git_remote IS NOT NULL)
     BEGIN
-      INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-      VALUES ('projects', new.id, 'upsert', ${ts});
+      INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+      VALUES ('projects', new.id, 'upsert', ${ts}, lore_current_tenant());
     END;`;
   // D (#826): Pro-tier distillation-fanout capture. Installed ONLY when the plan
   // tier (from the pulled profiles mirror) is pro/max — a free user creating
@@ -2748,18 +3157,18 @@ function installSyncCapture(database: Database) {
       CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_ins
       AFTER INSERT ON distillations WHEN (${gate} AND ${projectRemoteGate("new.project_id")})
       BEGIN
-        INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-        VALUES ('distillations', new.id, 'upsert', ${ts});
-        INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-        SELECT 'temporal_messages', value, 'upsert', ${ts} FROM json_each(new.source_ids)
+        INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+        VALUES ('distillations', new.id, 'upsert', ${ts}, lore_current_tenant());
+        INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+        SELECT 'temporal_messages', value, 'upsert', ${ts}, lore_current_tenant() FROM json_each(new.source_ids)
          WHERE EXISTS (SELECT 1 FROM temporal_messages t
                         WHERE t.id = value AND ${projectRemoteGate("t.project_id")});
       END;
       CREATE TEMP TRIGGER IF NOT EXISTS distillations_outbox_upd
       AFTER UPDATE ON distillations WHEN (${gate} AND ${projectRemoteGate("new.project_id")})
       BEGIN
-        INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-        VALUES ('distillations', new.id, 'upsert', ${ts});
+        INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+        VALUES ('distillations', new.id, 'upsert', ${ts}, lore_current_tenant());
       END;`;
   } else {
     sql += `
@@ -2966,6 +3375,12 @@ function migrate(database: Database) {
       // Recreate scope_keys with key_epoch in the PK, atomically (SAVEPOINT), idempotent
       // (skips if already migrated) so a partial apply can't boot-loop (#827 E-4c-3a).
       applyScopeKeyEpochPk(database);
+    } else if (i === TENANT_OWNERSHIP_MIGRATION_INDEX) {
+      applyTenantOwnership(database);
+    } else if (i === SYNC_TENANT_ISOLATION_MIGRATION_INDEX) {
+      applySyncTenantIsolation(database);
+    } else if (i === TEMPORAL_IDENTITY_MIGRATION_INDEX) {
+      applyTemporalIdentity(database);
     } else {
       // Pre-strip any column-side ALTERs that are already satisfied by the
       // current schema (ADD COLUMN where the column exists, RENAME COLUMN
@@ -3087,6 +3502,7 @@ function stripAppliedAlters(migration: string, database: Database): string {
  * aborting the exec before a subsequent CREATE TABLE in the same string).
  */
 function recoverMissingObjects(database: Database) {
+  applyTenantOwnership(database);
   database.exec(`
     CREATE TABLE IF NOT EXISTS kv_meta (
       key TEXT PRIMARY KEY,
@@ -3098,8 +3514,10 @@ function recoverMissingObjects(database: Database) {
       updated_at INTEGER NOT NULL
     );
     CREATE TABLE IF NOT EXISTS project_path_aliases (
-      path TEXT PRIMARY KEY,
-      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE
+      tenant_id TEXT NOT NULL DEFAULT '',
+      path TEXT NOT NULL,
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      PRIMARY KEY (tenant_id, path)
     );
     CREATE TABLE IF NOT EXISTS entities (
       id             TEXT PRIMARY KEY,
@@ -3164,7 +3582,7 @@ function recoverMissingObjects(database: Database) {
       PRIMARY KEY (day, bucket)
     );
     CREATE TABLE IF NOT EXISTS tool_calls (
-      call_id       TEXT PRIMARY KEY,
+      call_id       TEXT NOT NULL,
       message_id    TEXT NOT NULL,
       project_id    TEXT NOT NULL,
       session_id    TEXT NOT NULL,
@@ -3174,7 +3592,9 @@ function recoverMissingObjects(database: Database) {
       error_message TEXT,
       duration_ms   INTEGER,
       created_at    INTEGER NOT NULL,
-      verifier      INTEGER
+      verifier      INTEGER,
+      input_paths_json TEXT,
+      PRIMARY KEY (project_id, session_id, call_id)
     );
     CREATE INDEX IF NOT EXISTS idx_tool_calls_project_tool_status
       ON tool_calls (project_id, tool, status);
@@ -3211,6 +3631,7 @@ function recoverMissingObjects(database: Database) {
       PRIMARY KEY (logical_id, kind, anchor)
     );
     CREATE TABLE IF NOT EXISTS knowledge_contradictions (
+      tenant_id   TEXT NOT NULL DEFAULT '',
       logical_id_a TEXT NOT NULL,
       logical_id_b TEXT NOT NULL,
       project_id   TEXT,
@@ -3219,10 +3640,10 @@ function recoverMissingObjects(database: Database) {
       status       TEXT NOT NULL DEFAULT 'open',
       detected_at  INTEGER NOT NULL,
       updated_at   INTEGER NOT NULL,
-      PRIMARY KEY (logical_id_a, logical_id_b)
+      PRIMARY KEY (tenant_id, logical_id_a, logical_id_b)
     );
     CREATE INDEX IF NOT EXISTS idx_knowledge_contradictions_status
-      ON knowledge_contradictions (status);
+      ON knowledge_contradictions (tenant_id, status);
     CREATE TABLE IF NOT EXISTS knowledge_transfers (
       knowledge_id           TEXT NOT NULL,
       recalled_in_project_id TEXT NOT NULL,
@@ -3249,7 +3670,8 @@ function recoverMissingObjects(database: Database) {
       table_name TEXT NOT NULL,
       row_id     TEXT NOT NULL,
       op         TEXT NOT NULL,
-      changed_at INTEGER NOT NULL
+      changed_at INTEGER NOT NULL,
+      tenant_id  TEXT DEFAULT ''
     );
     CREATE INDEX IF NOT EXISTS idx_sync_outbox_table_row
       ON sync_outbox (table_name, row_id, seq);
@@ -3261,6 +3683,7 @@ function recoverMissingObjects(database: Database) {
       content_hash      TEXT,
       revision          INTEGER NOT NULL DEFAULT 0,
       remote_updated_at TEXT,
+      tenant_id         TEXT DEFAULT '',
       PRIMARY KEY (table_name, row_id)
     );
     CREATE TABLE IF NOT EXISTS sync_conflicts (
@@ -3601,6 +4024,13 @@ function recoverMissingObjects(database: Database) {
       database.exec("ALTER TABLE sync_state ADD COLUMN scope_id TEXT;");
     }
   }
+  // Version 81: restore missing sync tenant-provenance columns. If either
+  // column was lost, applySyncTenantIsolation quarantines that table's existing
+  // rows rather than assigning an unverifiable local owner.
+  applySyncTenantIsolation(database);
+  // Version 82: restore temporal source identity/index and the ownership-scoped
+  // tool-call primary key after partial migration or manual object loss.
+  applyTemporalIdentity(database);
 }
 
 /**
@@ -3624,16 +4054,19 @@ function recoverMissingObjects(database: Database) {
  * rows) and OUTSIDE any transaction (mergeProjectInternal opens its own BEGIN IMMEDIATE).
  */
 export function convergeProjectsByRemote(): void {
+  const tenantId = currentTenantId();
   const dupes = db()
     .query(
-      "SELECT git_remote FROM projects WHERE git_remote IS NOT NULL GROUP BY git_remote HAVING COUNT(*) > 1",
+      "SELECT git_remote FROM projects WHERE tenant_id = ? AND git_remote IS NOT NULL GROUP BY git_remote HAVING COUNT(*) > 1",
     )
-    .all() as { git_remote: string }[];
+    .all(tenantId) as { git_remote: string }[];
   for (const { git_remote } of dupes) {
     const ids = (
       db()
-        .query("SELECT id FROM projects WHERE git_remote = ? ORDER BY id")
-        .all(git_remote) as { id: string }[]
+        .query(
+          "SELECT id FROM projects WHERE tenant_id = ? AND git_remote = ? ORDER BY id",
+        )
+        .all(tenantId, git_remote) as { id: string }[]
     ).map((r) => r.id);
     const winner = ids[0]; // lexicographically smallest — identical on every device
     for (const loser of ids.slice(1)) mergeProjectInternal(loser, winner);
@@ -3642,6 +4075,16 @@ export function convergeProjectsByRemote(): void {
 
 export function mergeProjectInternal(sourceId: string, targetId: string): void {
   const d = db();
+  const owners = d
+    .query("SELECT id, tenant_id FROM projects WHERE id IN (?, ?)")
+    .all(sourceId, targetId) as Array<{ id: string; tenant_id: string }>;
+  if (
+    owners.length !== 2 ||
+    owners[0].tenant_id !== owners[1].tenant_id ||
+    owners[0].tenant_id !== currentTenantId()
+  ) {
+    throw new Error("cannot merge projects across tenant boundaries");
+  }
   d.exec("BEGIN IMMEDIATE");
   try {
     d.query("UPDATE knowledge SET project_id = ? WHERE project_id = ?").run(
@@ -3719,12 +4162,12 @@ export function mergeProjectInternal(sourceId: string, targetId: string): void {
     ).run(targetId, sourceId);
     // Register source's path as alias of target
     const sourceRow = d
-      .query("SELECT path FROM projects WHERE id = ?")
-      .get(sourceId) as { path: string } | null;
+      .query("SELECT path, tenant_id FROM projects WHERE id = ?")
+      .get(sourceId) as { path: string; tenant_id: string } | null;
     if (sourceRow) {
       d.query(
-        "INSERT OR IGNORE INTO project_path_aliases (path, project_id) VALUES (?, ?)",
-      ).run(sourceRow.path, targetId);
+        "INSERT OR IGNORE INTO project_path_aliases (tenant_id, path, project_id) VALUES (?, ?, ?)",
+      ).run(sourceRow.tenant_id, sourceRow.path, targetId);
     }
     d.query("DELETE FROM projects WHERE id = ?").run(sourceId);
     d.exec("COMMIT");
@@ -4146,14 +4589,18 @@ export function ensureProject(
 
   // 0. Memoized fast path — the same session path is resolved many times per
   // request (see projectIdByPathCache docs / LOREAI-GATEWAY-3K).
+  const tenantId = currentTenantId();
+  const cacheKey = tenantPathKey(path);
   const cache = projectIdCacheFor(db());
-  const cached = cache.get(path);
+  const cached = cache.get(cacheKey);
   if (cached !== undefined) return cached;
 
   // 1. Exact path match (fast path)
   const existing = db()
-    .query("SELECT id, git_remote FROM projects WHERE path = ?")
-    .get(path) as { id: string; git_remote: string | null } | null;
+    .query(
+      "SELECT id, git_remote FROM projects WHERE tenant_id = ? AND path = ?",
+    )
+    .get(tenantId, path) as { id: string; git_remote: string | null } | null;
   if (existing) {
     // Lazy backfill: populate git_remote on pre-v14 rows. NOTE: this branch is
     // intentionally left UNCACHED — git_remote is still NULL, so backfill must
@@ -4166,9 +4613,9 @@ export function ensureProject(
         // If so, merge the conflicting project into this one (one-time).
         const conflict = db()
           .query(
-            "SELECT id FROM projects WHERE git_remote = ? AND id != ? LIMIT 1",
+            "SELECT id FROM projects WHERE tenant_id = ? AND git_remote = ? AND id != ? LIMIT 1",
           )
-          .get(resolvedRemote, existing.id) as { id: string } | null;
+          .get(tenantId, resolvedRemote, existing.id) as { id: string } | null;
         if (conflict) {
           mergeProjectInternal(conflict.id, existing.id);
         }
@@ -4182,7 +4629,7 @@ export function ensureProject(
         // above (it is the merge TARGET) — memoize so the next call for this
         // path skips the exact-path lookup. fireProjectRemoteBackfilled cleared
         // the map, so this set must come AFTER it.
-        cache.set(path, existing.id);
+        cache.set(cacheKey, existing.id);
         return existing.id;
       }
       // Still remote-less (no remote resolved) — leave uncached so a later call
@@ -4190,16 +4637,18 @@ export function ensureProject(
       return existing.id;
     }
     // Settled remote-backed row — stable mapping, safe to memoize.
-    cache.set(path, existing.id);
+    cache.set(cacheKey, existing.id);
     return existing.id;
   }
 
   // 2. Check path aliases (worktree/clone re-visits) — the hot 3K path.
   const alias = db()
-    .query("SELECT project_id FROM project_path_aliases WHERE path = ?")
-    .get(path) as { project_id: string } | null;
+    .query(
+      "SELECT project_id FROM project_path_aliases WHERE tenant_id = ? AND path = ?",
+    )
+    .get(tenantId, path) as { project_id: string } | null;
   if (alias) {
-    cache.set(path, alias.project_id);
+    cache.set(cacheKey, alias.project_id);
     return alias.project_id;
   }
 
@@ -4207,16 +4656,18 @@ export function ensureProject(
   const gitRemote = resolveTrustedRemote(path, suppliedGitRemote);
   if (gitRemote) {
     const byRemote = db()
-      .query("SELECT id FROM projects WHERE git_remote = ? LIMIT 1")
-      .get(gitRemote) as { id: string } | null;
+      .query(
+        "SELECT id FROM projects WHERE tenant_id = ? AND git_remote = ? LIMIT 1",
+      )
+      .get(tenantId, gitRemote) as { id: string } | null;
     if (byRemote) {
       // Register this path as an alias for O(1) future lookups
       db()
         .query(
-          "INSERT OR IGNORE INTO project_path_aliases (path, project_id) VALUES (?, ?)",
+          "INSERT OR IGNORE INTO project_path_aliases (tenant_id, path, project_id) VALUES (?, ?, ?)",
         )
-        .run(path, byRemote.id);
-      cache.set(path, byRemote.id);
+        .run(tenantId, path, byRemote.id);
+      cache.set(cacheKey, byRemote.id);
       return byRemote.id;
     }
   }
@@ -4233,43 +4684,49 @@ export function ensureProject(
       "unknown");
   db()
     .query(
-      "INSERT INTO projects (id, path, name, git_remote, created_at) VALUES (?, ?, ?, ?, ?)",
+      "INSERT INTO projects (id, path, name, git_remote, created_at, tenant_id) VALUES (?, ?, ?, ?, ?, ?)",
     )
-    .run(id, path, derivedName, gitRemote, Date.now());
+    .run(id, path, derivedName, gitRemote, Date.now(), tenantId);
   // fireProjectMutation() clears the memo (same map ref); populate AFTER it so
   // the just-created mapping survives. Only memoize when the new project is
   // already settled (has a remote): a remote-less project can still be
   // git_remote-backfilled by a later ensureProject(path, suppliedGitRemote)
   // call, so leave it uncached (mirrors the NULL-git_remote existing branch).
   fireProjectMutation();
-  if (gitRemote) cache.set(path, id);
+  if (gitRemote) cache.set(cacheKey, id);
   return id;
 }
 
 export function projectId(path: string): string | undefined {
+  const tenantId = currentTenantId();
+  const cacheKey = tenantPathKey(path);
   // Shares ensureProject's per-connection memo (LOREAI-GATEWAY-3K).
   const cache = projectIdCacheFor(db());
-  const cached = cache.get(path);
+  const cached = cache.get(cacheKey);
   if (cached !== undefined) return cached;
 
   const row = db()
-    .query("SELECT id, git_remote FROM projects WHERE path = ?")
-    .get(path) as { id: string; git_remote: string | null } | null;
+    .query(
+      "SELECT id, git_remote FROM projects WHERE tenant_id = ? AND path = ?",
+    )
+    .get(tenantId, path) as { id: string; git_remote: string | null } | null;
   if (row) {
     // Mirror ensureProject: only memoize a settled (remote-backed) exact-path
     // row so a NULL-git_remote project still gets its lazy backfill retried
     // there. An unsettled row is returned but left uncached.
-    if (row.git_remote) cache.set(path, row.id);
+    if (row.git_remote) cache.set(cacheKey, row.id);
     return row.id;
   }
 
   // Check path aliases (worktree/clone paths registered by ensureProject). An
   // alias only exists for an already-resolved project — safe to memoize.
   const alias = db()
-    .query("SELECT project_id FROM project_path_aliases WHERE path = ?")
-    .get(path) as { project_id: string } | null;
+    .query(
+      "SELECT project_id FROM project_path_aliases WHERE tenant_id = ? AND path = ?",
+    )
+    .get(tenantId, path) as { project_id: string } | null;
   if (alias) {
-    cache.set(path, alias.project_id);
+    cache.set(cacheKey, alias.project_id);
     return alias.project_id;
   }
   return undefined;
@@ -4286,8 +4743,10 @@ export function resolveProjectByRemoteOrPath(
 ): string | null {
   if (gitRemote) {
     const row = db()
-      .query("SELECT id FROM projects WHERE git_remote = ? LIMIT 1")
-      .get(gitRemote) as { id: string } | null;
+      .query(
+        "SELECT id FROM projects WHERE tenant_id = ? AND git_remote = ? LIMIT 1",
+      )
+      .get(currentTenantId(), gitRemote) as { id: string } | null;
     if (row) return row.id;
   }
   if (path) {
@@ -4324,8 +4783,8 @@ export function projectKnownPaths(path: string): string[] {
   const paths: string[] = [];
   try {
     const row = db()
-      .query("SELECT path FROM projects WHERE id = ?")
-      .get(projId) as { path: string } | null;
+      .query("SELECT path FROM projects WHERE id = ? AND tenant_id = ?")
+      .get(projId, currentTenantId()) as { path: string } | null;
     if (row?.path) paths.push(row.path);
 
     const aliasRows = db()
@@ -4344,18 +4803,27 @@ export function projectKnownPaths(path: string): string[] {
  * that require a path argument.
  */
 export function projectPath(id: string): string | null {
-  const row = db().query("SELECT path FROM projects WHERE id = ?").get(id) as {
-    path: string;
-  } | null;
+  const row = db()
+    .query("SELECT path FROM projects WHERE id = ? AND tenant_id = ?")
+    .get(id, currentTenantId()) as { path: string } | null;
   return row?.path ?? null;
 }
 
 /** Look up a project's normalized git remote by its internal ID, or null. */
 export function projectGitRemote(id: string): string | null {
   const row = db()
-    .query("SELECT git_remote FROM projects WHERE id = ?")
-    .get(id) as { git_remote: string | null } | null;
+    .query("SELECT git_remote FROM projects WHERE id = ? AND tenant_id = ?")
+    .get(id, currentTenantId()) as { git_remote: string | null } | null;
   return row?.git_remote ?? null;
+}
+
+/** Durable opaque owner for a project ID, visible only inside that owner scope. */
+export function projectTenantId(id: string): string | null {
+  const tenantId = currentTenantId();
+  const row = db()
+    .query("SELECT tenant_id FROM projects WHERE id = ? AND tenant_id = ?")
+    .get(id, tenantId) as { tenant_id: string } | null;
+  return row?.tenant_id ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -4368,14 +4836,16 @@ export function projectGitRemote(id: string): string | null {
  */
 export function projectScope(id: string): string | null {
   const row = db()
-    .query("SELECT scope_id FROM projects WHERE id = ?")
-    .get(id) as { scope_id: string | null } | null;
+    .query("SELECT scope_id FROM projects WHERE tenant_id = ? AND id = ?")
+    .get(currentTenantId(), id) as { scope_id: string | null } | null;
   return row?.scope_id ?? null;
 }
 
 /** Bind (scopeId) or unbind (null) a project to a team scope. */
 export function setProjectScope(id: string, scopeId: string | null): void {
-  db().query("UPDATE projects SET scope_id = ? WHERE id = ?").run(scopeId, id);
+  db()
+    .query("UPDATE projects SET scope_id = ? WHERE tenant_id = ? AND id = ?")
+    .run(scopeId, currentTenantId(), id);
 }
 
 /**
@@ -4387,8 +4857,10 @@ export function setProjectPromotionPolicy(
   policy: "manual" | "auto" | null,
 ): void {
   db()
-    .query("UPDATE projects SET promotion_policy = ? WHERE id = ?")
-    .run(policy, id);
+    .query(
+      "UPDATE projects SET promotion_policy = ? WHERE tenant_id = ? AND id = ?",
+    )
+    .run(policy, currentTenantId(), id);
 }
 
 /**
@@ -4398,8 +4870,10 @@ export function setProjectPromotionPolicy(
  */
 export function effectivePromotionPolicy(id: string): "manual" | "auto" {
   const p = db()
-    .query("SELECT scope_id, promotion_policy FROM projects WHERE id = ?")
-    .get(id) as {
+    .query(
+      "SELECT scope_id, promotion_policy FROM projects WHERE tenant_id = ? AND id = ?",
+    )
+    .get(currentTenantId(), id) as {
     scope_id: string | null;
     promotion_policy: string | null;
   } | null;
@@ -4462,9 +4936,9 @@ export function scopeMemberRole(
 
 /** Look up a project's display name by its internal ID. */
 export function projectName(id: string): string | null {
-  const row = db().query("SELECT name FROM projects WHERE id = ?").get(id) as {
-    name: string;
-  } | null;
+  const row = db()
+    .query("SELECT name FROM projects WHERE id = ? AND tenant_id = ?")
+    .get(id, currentTenantId()) as { name: string } | null;
   return row?.name ?? null;
 }
 
@@ -4473,9 +4947,9 @@ export function projectName(id: string): string | null {
  * Must be called before ensureProject() to get an accurate result.
  */
 export function isFirstRun(): boolean {
-  const row = db().query("SELECT COUNT(*) as count FROM projects").get() as {
-    count: number;
-  };
+  const row = db()
+    .query("SELECT COUNT(*) as count FROM projects WHERE tenant_id = ?")
+    .get(currentTenantId()) as { count: number };
   return row.count === 0;
 }
 

--- a/packages/core/src/db/driver.bun.ts
+++ b/packages/core/src/db/driver.bun.ts
@@ -12,6 +12,15 @@ import { createHash } from "node:crypto";
 
 export { Database };
 
+/** Register a connection-local scalar function used by TEMP trigger guards. */
+export function registerScalarFunction(
+  database: Database,
+  name: string,
+  fn: () => string,
+): void {
+  database.function(name, fn);
+}
+
 /** Stable SHA-256 hex digest — replaces the Bun-only `Bun.CryptoHasher`. */
 export function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");

--- a/packages/core/src/db/driver.node.ts
+++ b/packages/core/src/db/driver.node.ts
@@ -72,6 +72,15 @@ export class Database extends DatabaseSync {
   }
 }
 
+/** Register a connection-local scalar function used by TEMP trigger guards. */
+export function registerScalarFunction(
+  database: Database,
+  name: string,
+  fn: () => string,
+): void {
+  database.function(name, fn);
+}
+
 export function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
 }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -72,6 +72,7 @@ import {
   type VectorQuerySpec,
 } from "./vector-query";
 import { tryPoolVectorSearch, VECTOR_SEARCH_TIMED_OUT } from "./vector-pool";
+import { currentTenantId } from "./tenant";
 
 // The cosine/BLOB helpers moved to ./vector-query (a leaf module the read
 // worker can import without pulling in the provider chain). Re-exported here so
@@ -517,27 +518,36 @@ class VoyageProvider implements EmbeddingProvider {
     texts: string[],
     inputType: "document" | "query",
   ): Promise<Float32Array[]> {
-    const res = await fetch(VOYAGE_API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${this.apiKey}`,
-      },
-      body: JSON.stringify({
-        input: texts,
-        model: this.model,
-        input_type: inputType,
-        output_dimension: this.dimensions,
-      }),
-      signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
-    });
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => "");
-      throw new Error(`Voyage API ${res.status}: ${body}`);
+    let res: Response;
+    try {
+      res = await fetch(VOYAGE_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({
+          input: texts,
+          model: this.model,
+          input_type: inputType,
+          output_dimension: this.dimensions,
+        }),
+        signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
+      });
+    } catch {
+      throw new Error("Voyage embeddings API request failed");
     }
 
-    const json = (await res.json()) as VoyageResponse;
+    if (!res.ok) {
+      throw new Error(`Voyage embeddings API failed with HTTP ${res.status}`);
+    }
+
+    let json: VoyageResponse;
+    try {
+      json = (await res.json()) as VoyageResponse;
+    } catch {
+      throw new Error("Voyage embeddings API returned malformed JSON");
+    }
     const sorted = [...json.data].sort((a, b) => a.index - b.index);
     return sorted.map((d) => new Float32Array(d.embedding));
   }
@@ -591,8 +601,7 @@ class OpenAIProvider implements EmbeddingProvider {
     });
 
     if (!res.ok) {
-      const responseBody = await res.text().catch(() => "");
-      throw new Error(`OpenAI API ${res.status}: ${responseBody}`);
+      throw new Error(`OpenAI embeddings API failed with HTTP ${res.status}`);
     }
 
     const json = (await res.json()) as OpenAIResponse;
@@ -2620,7 +2629,12 @@ export async function vectorSearch(
   excludeCategories?: string[],
 ): Promise<VectorHit[]> {
   return await poolOrInProcess(
-    { kind: "knowledge", limit, excludeCategories },
+    {
+      kind: "knowledge",
+      tenantId: currentTenantId(),
+      limit,
+      excludeCategories,
+    },
     queryEmbedding,
   );
 }
@@ -2633,7 +2647,10 @@ export async function vectorSearchEntities(
   queryEmbedding: Float32Array,
   limit = 10,
 ): Promise<VectorHit[]> {
-  return await poolOrInProcess({ kind: "entities", limit }, queryEmbedding);
+  return await poolOrInProcess(
+    { kind: "entities", tenantId: currentTenantId(), limit },
+    queryEmbedding,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -2649,7 +2666,7 @@ export async function vectorSearchDistillations(
   limit = 10,
 ): Promise<VectorHit[]> {
   return await poolOrInProcess(
-    { kind: "distillations", limit },
+    { kind: "distillations", tenantId: currentTenantId(), limit },
     queryEmbedding,
   );
 }

--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -19,6 +19,7 @@ import { config } from "./config";
 import { getGitUser } from "./git";
 import * as log from "./log";
 import * as embedding from "./embedding";
+import { currentTenantId } from "./tenant";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -55,6 +56,7 @@ export type AliasType =
 
 export type Entity = {
   id: string;
+  tenant_id: string;
   project_id: string | null;
   entity_type: EntityType;
   canonical_name: string;
@@ -152,11 +154,11 @@ const IDENTITY_ALIAS_TYPES: ReadonlySet<AliasType> = new Set([
 
 /** Columns to SELECT for Entity — avoids pulling unnecessary data. */
 const ENTITY_COLS =
-  "id, project_id, entity_type, canonical_name, metadata, cross_project, created_at, updated_at";
+  "id, tenant_id, project_id, entity_type, canonical_name, metadata, cross_project, created_at, updated_at";
 
 /** Same columns with table alias prefix for use in JOIN queries. */
 const ENTITY_COLS_E =
-  "e.id, e.project_id, e.entity_type, e.canonical_name, e.metadata, e.cross_project, e.created_at, e.updated_at";
+  "e.id, e.tenant_id, e.project_id, e.entity_type, e.canonical_name, e.metadata, e.cross_project, e.created_at, e.updated_at";
 
 // ---------------------------------------------------------------------------
 // CRUD — Entities
@@ -182,6 +184,7 @@ export function create(input: {
   crossProject?: boolean;
   id?: string;
 }): CreateResult {
+  const tenantId = currentTenantId();
   // Runtime validation — TypeScript types are erased, curator may pass garbage
   if (!ENTITY_TYPES.includes(input.entityType)) {
     throw new Error(`invalid entity type: ${input.entityType}`);
@@ -202,17 +205,17 @@ export function create(input: {
     const existing = pid
       ? (d
           .query(
-            `SELECT id, metadata FROM entities WHERE canonical_name = ? COLLATE NOCASE AND (project_id = ? OR project_id IS NULL)`,
+            `SELECT id, metadata FROM entities WHERE tenant_id = ? AND canonical_name = ? COLLATE NOCASE AND (project_id = ? OR project_id IS NULL)`,
           )
-          .get(input.canonicalName, pid) as {
+          .get(tenantId, input.canonicalName, pid) as {
           id: string;
           metadata: string | null;
         } | null)
       : (d
           .query(
-            `SELECT id, metadata FROM entities WHERE canonical_name = ? COLLATE NOCASE AND project_id IS NULL`,
+            `SELECT id, metadata FROM entities WHERE tenant_id = ? AND canonical_name = ? COLLATE NOCASE AND project_id IS NULL`,
           )
-          .get(input.canonicalName) as {
+          .get(tenantId, input.canonicalName) as {
           id: string;
           metadata: string | null;
         } | null);
@@ -244,10 +247,11 @@ export function create(input: {
     const now = Date.now();
 
     d.query(
-      `INSERT INTO entities (id, project_id, entity_type, canonical_name, metadata, cross_project, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO entities (id, tenant_id, project_id, entity_type, canonical_name, metadata, cross_project, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       id,
+      tenantId,
       pid,
       input.entityType,
       input.canonicalName,
@@ -290,8 +294,8 @@ export function create(input: {
  */
 export function reembedEntity(id: string): void {
   const row = db()
-    .query("SELECT canonical_name FROM entities WHERE id = ?")
-    .get(id) as { canonical_name: string } | null;
+    .query("SELECT canonical_name FROM entities WHERE tenant_id = ? AND id = ?")
+    .get(currentTenantId(), id) as { canonical_name: string } | null;
   if (!row) return;
   embedding.embedEntity(id, row.canonical_name, aliasValues(id));
 }
@@ -305,6 +309,7 @@ export function update(
     crossProject?: boolean;
   },
 ): void {
+  if (!get(id)) return;
   const sets: string[] = [];
   const params: (string | number | null)[] = [];
 
@@ -328,8 +333,10 @@ export function update(
   params.push(id);
 
   db()
-    .query(`UPDATE entities SET ${sets.join(", ")} WHERE id = ?`)
-    .run(...params);
+    .query(
+      `UPDATE entities SET ${sets.join(", ")} WHERE tenant_id = ? AND id = ?`,
+    )
+    .run(...params.slice(0, -1), currentTenantId(), id);
 
   // When canonical name changes, update the auto-generated "name" alias
   if (input.canonicalName !== undefined) {
@@ -349,6 +356,7 @@ export function update(
 
 /** Delete an entity, its aliases, relations, and knowledge refs. */
 export function remove(id: string): void {
+  if (!get(id)) return;
   db().query("DELETE FROM knowledge_entity_refs WHERE entity_id = ?").run(id);
   db()
     .query("DELETE FROM entity_relations WHERE entity_a = ? OR entity_b = ?")
@@ -370,9 +378,9 @@ export function remove(id: string): void {
 export function getSelfEntity(): EntityWithAliases | null {
   const row = db()
     .query(
-      `SELECT ${ENTITY_COLS} FROM entities WHERE entity_type = 'self' LIMIT 1`,
+      `SELECT ${ENTITY_COLS} FROM entities WHERE tenant_id = ? AND entity_type = 'self' LIMIT 1`,
     )
-    .get() as Entity | null;
+    .get(currentTenantId()) as Entity | null;
   if (!row) return null;
   const aliases = db()
     .query(
@@ -521,8 +529,10 @@ export function mergeSelfPersonDuplicates(
 
   // Find all "person" entities
   const persons = db()
-    .query(`SELECT ${ENTITY_COLS} FROM entities WHERE entity_type = 'person'`)
-    .all() as Entity[];
+    .query(
+      `SELECT ${ENTITY_COLS} FROM entities WHERE tenant_id = ? AND entity_type = 'person'`,
+    )
+    .all(currentTenantId()) as Entity[];
 
   // Batch-load every person's aliases in a single query instead of one query
   // per person. Behaviorally equivalent to per-iteration reads: a person's own
@@ -580,8 +590,10 @@ export function mergeSelfPersonDuplicates(
 export function get(id: string): Entity | null {
   return (
     (db()
-      .query(`SELECT ${ENTITY_COLS} FROM entities WHERE id = ?`)
-      .get(id) as Entity | null) ?? null
+      .query(
+        `SELECT ${ENTITY_COLS} FROM entities WHERE tenant_id = ? AND id = ?`,
+      )
+      .get(currentTenantId(), id) as Entity | null) ?? null
   );
 }
 
@@ -666,14 +678,23 @@ export function addAlias(
   aliasValue: string,
   source?: string,
 ): string | null {
+  if (!get(entityId)) return null;
   const id = uuidv7();
   try {
     db()
       .query(
-        `INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO entity_aliases (id, entity_id, alias_type, alias_value, source, created_at, tenant_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(id, entityId, aliasType, aliasValue, source ?? null, Date.now());
+      .run(
+        id,
+        entityId,
+        aliasType,
+        aliasValue,
+        source ?? null,
+        Date.now(),
+        currentTenantId(),
+      );
     return id;
   } catch (e: unknown) {
     // UNIQUE constraint violation — alias already exists (possibly on another entity)
@@ -687,11 +708,14 @@ export function addAlias(
 
 /** Remove a specific alias by its ID. */
 export function removeAlias(aliasId: string): void {
-  db().query("DELETE FROM entity_aliases WHERE id = ?").run(aliasId);
+  db()
+    .query("DELETE FROM entity_aliases WHERE tenant_id = ? AND id = ?")
+    .run(currentTenantId(), aliasId);
 }
 
 /** Get all aliases for an entity. */
 export function getAliases(entityId: string): EntityAlias[] {
+  if (!get(entityId)) return [];
   return db()
     .query(
       "SELECT * FROM entity_aliases WHERE entity_id = ? ORDER BY alias_type, alias_value",
@@ -715,10 +739,10 @@ export function resolve(mention: string): Entity | null {
       `SELECT ${ENTITY_COLS_E}
        FROM entities e
        JOIN entity_aliases a ON a.entity_id = e.id
-       WHERE a.alias_value = ? COLLATE NOCASE
+       WHERE e.tenant_id = ? AND a.alias_value = ? COLLATE NOCASE
        LIMIT 1`,
     )
-    .get(mention) as Entity | null;
+    .get(currentTenantId(), mention) as Entity | null;
 
   if (aliasMatch) return aliasMatch;
 
@@ -726,10 +750,10 @@ export function resolve(mention: string): Entity | null {
   const nameMatch = db()
     .query(
       `SELECT ${ENTITY_COLS} FROM entities
-       WHERE canonical_name = ? COLLATE NOCASE
+       WHERE tenant_id = ? AND canonical_name = ? COLLATE NOCASE
        LIMIT 1`,
     )
-    .get(mention) as Entity | null;
+    .get(currentTenantId(), mention) as Entity | null;
 
   if (nameMatch) return nameMatch;
 
@@ -742,11 +766,11 @@ export function resolve(mention: string): Entity | null {
       `SELECT ${ENTITY_COLS_E}
        FROM entities e
        JOIN entities_fts f ON f.rowid = e.rowid
-       WHERE entities_fts MATCH ?
+       WHERE entities_fts MATCH ? AND e.tenant_id = ?
        ORDER BY rank
        LIMIT 1`,
     )
-    .get(fts) as Entity | null;
+    .get(fts, currentTenantId()) as Entity | null;
 
   return ftsMatch ?? null;
 }
@@ -767,8 +791,12 @@ export function resolveWithAliases(mention: string): EntityWithAliases | null {
  */
 export function aliasValues(entityId: string): string[] {
   const rows = db()
-    .query("SELECT alias_value FROM entity_aliases WHERE entity_id = ?")
-    .all(entityId) as Array<{ alias_value: string }>;
+    .query(
+      `SELECT a.alias_value
+       FROM entity_aliases a JOIN entities e ON e.id = a.entity_id
+       WHERE e.tenant_id = ? AND a.entity_id = ?`,
+    )
+    .all(currentTenantId(), entityId) as Array<{ alias_value: string }>;
   return rows.map((r) => r.alias_value);
 }
 
@@ -873,6 +901,8 @@ function withAliases(rows: Entity[]): EntityWithAliases[] {
  * `entity_aliases`, this MUST switch to an explicit non-BLOB column list, or the
  * BLOB will be copied across the boundary on every recall.
  */
+const MAX_OFFLOAD_BOUND_PARAMS = 900;
+
 async function batchLoadAliasesOffloaded(
   entityIds: string[],
 ): Promise<Map<string, EntityAlias[]>> {
@@ -884,7 +914,7 @@ async function batchLoadAliasesOffloaded(
   // sync batchLoadAliases). Chunks partition entityIds, so every alias of a given
   // entity lands in exactly one chunk — per-entity ordering from the per-chunk
   // ORDER BY is preserved. One offloadAll round-trip per chunk.
-  const CHUNK = 900;
+  const CHUNK = MAX_OFFLOAD_BOUND_PARAMS;
   const chunks: Promise<unknown[]>[] = [];
   for (let i = 0; i < entityIds.length; i += CHUNK) {
     const chunk = entityIds.slice(i, i + CHUNK);
@@ -925,19 +955,19 @@ export async function getManyWithAliasesOffloaded(
 ): Promise<Map<string, EntityWithAliases>> {
   const map = new Map<string, EntityWithAliases>();
   if (!ids.length) return map;
-  // Chunk the IN list at 900 (mirrors batchLoadAliasesOffloaded). Chunks
+  // Reserve one bind slot for tenant_id. Chunks
   // partition ids, so each entity row comes back from exactly one chunk; the
   // unioned set is order-independent here (callers key by id). One offloadAll
   // round-trip per chunk.
-  const CHUNK = 900;
+  const CHUNK = MAX_OFFLOAD_BOUND_PARAMS - 1;
   const chunks: Promise<unknown[]>[] = [];
   for (let i = 0; i < ids.length; i += CHUNK) {
     const chunk = ids.slice(i, i + CHUNK);
     const placeholders = chunk.map(() => "?").join(",");
     chunks.push(
       offloadAll(
-        `SELECT ${ENTITY_COLS} FROM entities WHERE id IN (${placeholders})`,
-        chunk,
+        `SELECT ${ENTITY_COLS} FROM entities WHERE tenant_id = ? AND id IN (${placeholders})`,
+        [currentTenantId(), ...chunk],
       ),
     );
   }
@@ -959,12 +989,12 @@ function forProjectEntityQuery(
 ): { sql: string; params: ReadParam[] } {
   const sql = includeCross
     ? `SELECT ${ENTITY_COLS} FROM entities
-         WHERE project_id = ? OR project_id IS NULL OR cross_project = 1
+         WHERE tenant_id = ? AND (project_id = ? OR project_id IS NULL OR cross_project = 1)
          ORDER BY entity_type, canonical_name`
     : `SELECT ${ENTITY_COLS} FROM entities
-         WHERE project_id = ?
+         WHERE tenant_id = ? AND project_id = ?
          ORDER BY entity_type, canonical_name`;
-  return { sql, params: [pid] };
+  return { sql, params: [currentTenantId(), pid] };
 }
 
 /** List entities for a project, optionally including cross-project entities. */
@@ -1024,9 +1054,9 @@ export async function forProjectOffloaded(
 export function listAll(): EntityWithAliases[] {
   const rows = db()
     .query(
-      `SELECT ${ENTITY_COLS} FROM entities ORDER BY entity_type, canonical_name`,
+      `SELECT ${ENTITY_COLS} FROM entities WHERE tenant_id = ? ORDER BY entity_type, canonical_name`,
     )
-    .all() as Entity[];
+    .all(currentTenantId()) as Entity[];
 
   return withAliases(rows);
 }
@@ -1053,11 +1083,11 @@ export function search(input: {
         `SELECT ${ENTITY_COLS_E}
          FROM entities e
          JOIN entities_fts f ON f.rowid = e.rowid
-         WHERE entities_fts MATCH ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
+         WHERE entities_fts MATCH ? AND e.tenant_id = ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
          ORDER BY rank
          LIMIT ?`,
       )
-      .all(fts, pid, limit) as Entity[];
+      .all(fts, currentTenantId(), pid, limit) as Entity[];
 
     aliasMatches = db()
       .query(
@@ -1065,22 +1095,22 @@ export function search(input: {
          FROM entities e
          JOIN entity_aliases a ON a.entity_id = e.id
          JOIN entity_aliases_fts af ON af.rowid = a.rowid
-         WHERE entity_aliases_fts MATCH ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
+         WHERE entity_aliases_fts MATCH ? AND e.tenant_id = ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
          ORDER BY rank
          LIMIT ?`,
       )
-      .all(fts, pid, limit) as Entity[];
+      .all(fts, currentTenantId(), pid, limit) as Entity[];
   } else {
     nameMatches = db()
       .query(
         `SELECT ${ENTITY_COLS_E}
          FROM entities e
          JOIN entities_fts f ON f.rowid = e.rowid
-         WHERE entities_fts MATCH ?
+         WHERE entities_fts MATCH ? AND e.tenant_id = ?
          ORDER BY rank
          LIMIT ?`,
       )
-      .all(fts, limit) as Entity[];
+      .all(fts, currentTenantId(), limit) as Entity[];
 
     aliasMatches = db()
       .query(
@@ -1088,11 +1118,11 @@ export function search(input: {
          FROM entities e
          JOIN entity_aliases a ON a.entity_id = e.id
          JOIN entity_aliases_fts af ON af.rowid = a.rowid
-         WHERE entity_aliases_fts MATCH ?
+         WHERE entity_aliases_fts MATCH ? AND e.tenant_id = ?
          ORDER BY rank
          LIMIT ?`,
       )
-      .all(fts, limit) as Entity[];
+      .all(fts, currentTenantId(), limit) as Entity[];
   }
 
   // Merge and dedupe
@@ -1129,13 +1159,13 @@ export async function searchAsync(input: {
     ? `SELECT ${ENTITY_COLS_E}
          FROM entities e
          JOIN entities_fts f ON f.rowid = e.rowid
-         WHERE entities_fts MATCH ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
+         WHERE entities_fts MATCH ? AND e.tenant_id = ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
          ORDER BY rank
          LIMIT ?`
     : `SELECT ${ENTITY_COLS_E}
          FROM entities e
          JOIN entities_fts f ON f.rowid = e.rowid
-         WHERE entities_fts MATCH ?
+         WHERE entities_fts MATCH ? AND e.tenant_id = ?
          ORDER BY rank
          LIMIT ?`;
   const aliasSQL = pid
@@ -1143,18 +1173,22 @@ export async function searchAsync(input: {
          FROM entities e
          JOIN entity_aliases a ON a.entity_id = e.id
          JOIN entity_aliases_fts af ON af.rowid = a.rowid
-         WHERE entity_aliases_fts MATCH ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
+         WHERE entity_aliases_fts MATCH ? AND e.tenant_id = ? AND (e.project_id = ? OR e.project_id IS NULL OR e.cross_project = 1)
          ORDER BY rank
          LIMIT ?`
     : `SELECT DISTINCT ${ENTITY_COLS_E}
          FROM entities e
          JOIN entity_aliases a ON a.entity_id = e.id
          JOIN entity_aliases_fts af ON af.rowid = a.rowid
-         WHERE entity_aliases_fts MATCH ?
+         WHERE entity_aliases_fts MATCH ? AND e.tenant_id = ?
          ORDER BY rank
          LIMIT ?`;
-  const nameParams = pid ? [fts, pid, limit] : [fts, limit];
-  const aliasParams = pid ? [fts, pid, limit] : [fts, limit];
+  const nameParams = pid
+    ? [fts, currentTenantId(), pid, limit]
+    : [fts, currentTenantId(), limit];
+  const aliasParams = pid
+    ? [fts, currentTenantId(), pid, limit]
+    : [fts, currentTenantId(), limit];
 
   // Independent degrade (each scan → [] on pool timeout) is deliberate here,
   // unlike forSession's shared-fate offloadAllOrTimeout (#966 B). Entity FTS is
@@ -1214,14 +1248,15 @@ export function searchCrossProjectRepos(input: {
        FROM entities e
        JOIN entities_fts f ON f.rowid = e.rowid
        WHERE entities_fts MATCH ?
-         AND e.entity_type = 'repo'
+          AND e.tenant_id = ?
+          AND e.entity_type = 'repo'
          AND e.cross_project = 0
          AND e.project_id IS NOT NULL
          AND e.project_id != ?
        ORDER BY rank
        LIMIT ?`,
     )
-    .all(fts, pid, limit) as Entity[];
+    .all(fts, currentTenantId(), pid, limit) as Entity[];
 
   const aliasMatches = db()
     .query(
@@ -1230,14 +1265,15 @@ export function searchCrossProjectRepos(input: {
        JOIN entity_aliases a ON a.entity_id = e.id
        JOIN entity_aliases_fts af ON af.rowid = a.rowid
        WHERE entity_aliases_fts MATCH ?
-         AND e.entity_type = 'repo'
+          AND e.tenant_id = ?
+          AND e.entity_type = 'repo'
          AND e.cross_project = 0
          AND e.project_id IS NOT NULL
          AND e.project_id != ?
        ORDER BY rank
        LIMIT ?`,
     )
-    .all(fts, pid, limit) as Entity[];
+    .all(fts, currentTenantId(), pid, limit) as Entity[];
 
   // Merge and dedupe (preserve name-match ordering first)
   const seen = new Set<string>();
@@ -1271,7 +1307,8 @@ export async function searchCrossProjectReposAsync(input: {
        FROM entities e
        JOIN entities_fts f ON f.rowid = e.rowid
        WHERE entities_fts MATCH ?
-         AND e.entity_type = 'repo'
+          AND e.tenant_id = ?
+          AND e.entity_type = 'repo'
          AND e.cross_project = 0
          AND e.project_id IS NOT NULL
          AND e.project_id != ?
@@ -1282,7 +1319,8 @@ export async function searchCrossProjectReposAsync(input: {
        JOIN entity_aliases a ON a.entity_id = e.id
        JOIN entity_aliases_fts af ON af.rowid = a.rowid
        WHERE entity_aliases_fts MATCH ?
-         AND e.entity_type = 'repo'
+          AND e.tenant_id = ?
+          AND e.entity_type = 'repo'
          AND e.cross_project = 0
          AND e.project_id IS NOT NULL
          AND e.project_id != ?
@@ -1291,8 +1329,8 @@ export async function searchCrossProjectReposAsync(input: {
 
   // Independent degrade (see searchAsync) — best-effort supplemental RRF list.
   const [nameMatches, aliasMatches] = (await Promise.all([
-    offloadAll(nameSQL, [fts, pid, limit]),
-    offloadAll(aliasSQL, [fts, pid, limit]),
+    offloadAll(nameSQL, [fts, currentTenantId(), pid, limit]),
+    offloadAll(aliasSQL, [fts, currentTenantId(), pid, limit]),
   ])) as [Entity[], Entity[]];
 
   const seen = new Set<string>();
@@ -1315,6 +1353,9 @@ export async function searchCrossProjectReposAsync(input: {
  * from `sourceId`, then delete `sourceId`.
  */
 export function merge(targetId: string, sourceId: string): void {
+  if (!get(targetId) || !get(sourceId)) {
+    throw new Error("cannot merge entities across tenant boundaries");
+  }
   const d = db();
   d.exec("BEGIN IMMEDIATE");
   try {
@@ -1392,6 +1433,9 @@ export function addRelation(
   relation: RelationType,
   opts?: { metadata?: Record<string, unknown>; source?: string },
 ): string | null {
+  if (!get(entityA) || !get(entityB)) {
+    throw new Error("cannot relate entities across tenant boundaries");
+  }
   if (entityA === entityB) {
     log.info(`skipping self-referential relation: ${entityA} (${relation})`);
     return null;
@@ -1431,7 +1475,12 @@ export function addRelation(
 
 /** Remove a relation by its ID. */
 export function removeRelation(id: string): void {
-  db().query("DELETE FROM entity_relations WHERE id = ?").run(id);
+  db()
+    .query(
+      `DELETE FROM entity_relations
+       WHERE id = ? AND entity_a IN (SELECT id FROM entities WHERE tenant_id = ?)`,
+    )
+    .run(id, currentTenantId());
 }
 
 /**
@@ -1448,13 +1497,15 @@ export function relationsFor(entityId: string): EntityRelationResolved[] {
        FROM entity_relations r
        JOIN entities ea ON ea.id = r.entity_a
        JOIN entities eb ON eb.id = r.entity_b
-       WHERE r.entity_a = ? OR r.entity_b = ?
+       WHERE ea.tenant_id = ? AND eb.tenant_id = ? AND (r.entity_a = ? OR r.entity_b = ?)
        ORDER BY r.relation, other_name`,
     )
     .all(
       entityId,
       entityId,
       entityId,
+      currentTenantId(),
+      currentTenantId(),
       entityId,
       entityId,
     ) as EntityRelationResolved[];
@@ -1470,6 +1521,7 @@ export function getRelation(
   entityB: string,
   relation?: RelationType,
 ): EntityRelation[] {
+  if (!get(entityA) || !get(entityB)) return [];
   if (relation) {
     const row = db()
       .query(
@@ -1513,11 +1565,17 @@ export function formatRelationsForPrompt(entityId: string): string {
 /** Resolve a knowledge id (current or, post-2b, a superseded version) to its
  *  stable logical_id — the key all knowledge_entity_refs rows use (A2, #823).
  *  No-op today: a v1 row has id == logical_id. */
-function logicalIdOf(knowledgeId: string): string {
+function logicalIdOf(knowledgeId: string): string | null {
   const r = db()
-    .query("SELECT logical_id FROM knowledge WHERE id = ?")
-    .get(knowledgeId) as { logical_id: string } | null;
-  return r?.logical_id ?? knowledgeId;
+    .query(
+      `SELECT logical_id FROM knowledge
+       WHERE tenant_id = ? AND (id = ? OR logical_id = ?)
+       ORDER BY is_current DESC LIMIT 1`,
+    )
+    .get(currentTenantId(), knowledgeId, knowledgeId) as {
+    logical_id: string;
+  } | null;
+  return r?.logical_id ?? null;
 }
 
 /**
@@ -1534,10 +1592,10 @@ export function recomputeEntityRank(entityId: string): void {
   db()
     .query(
       `UPDATE entities SET sync_rank =
-         (SELECT COUNT(*) FROM knowledge_entity_refs WHERE entity_id = ?)
-       WHERE id = ?`,
+          (SELECT COUNT(*) FROM knowledge_entity_refs WHERE entity_id = ?)
+       WHERE tenant_id = ? AND id = ?`,
     )
-    .run(entityId, entityId);
+    .run(entityId, currentTenantId(), entityId);
 }
 
 /**
@@ -1549,23 +1607,27 @@ export function recomputeEntityRank(entityId: string): void {
  * entity delete uses the precise {@link recomputeEntityRank} instead.
  */
 export function resyncStaleEntityRanks(): void {
-  db().exec(
-    `UPDATE entities SET sync_rank =
+  db()
+    .query(
+      `UPDATE entities SET sync_rank =
        (SELECT COUNT(*) FROM knowledge_entity_refs r WHERE r.entity_id = entities.id)
-     WHERE sync_rank <>
+     WHERE tenant_id = ? AND sync_rank <>
        (SELECT COUNT(*) FROM knowledge_entity_refs r WHERE r.entity_id = entities.id)`,
-  );
+    )
+    .run(currentTenantId());
 }
 
 /** Link a knowledge entry to an entity. */
 export function linkKnowledge(knowledgeId: string, entityId: string): void {
+  const logicalId = logicalIdOf(knowledgeId);
+  if (!logicalId || !get(entityId)) return;
   try {
     db()
       .query(
         `INSERT OR IGNORE INTO knowledge_entity_refs (knowledge_id, entity_id)
          VALUES (?, ?)`,
       )
-      .run(logicalIdOf(knowledgeId), entityId);
+      .run(logicalId, entityId);
     recomputeEntityRank(entityId);
   } catch (e: unknown) {
     // FK violation (entity or knowledge entry doesn't exist) — ignore
@@ -1581,29 +1643,34 @@ export function linkKnowledge(knowledgeId: string, entityId: string): void {
 
 /** Unlink a knowledge entry from an entity. */
 export function unlinkKnowledge(knowledgeId: string, entityId: string): void {
+  const logicalId = logicalIdOf(knowledgeId);
+  if (!logicalId || !get(entityId)) return;
   db()
     .query(
       "DELETE FROM knowledge_entity_refs WHERE knowledge_id = ? AND entity_id = ?",
     )
-    .run(logicalIdOf(knowledgeId), entityId);
+    .run(logicalId, entityId);
   recomputeEntityRank(entityId);
 }
 
 /** Get all entities referenced by a knowledge entry. */
 export function entitiesForKnowledge(knowledgeId: string): Entity[] {
+  const logicalId = logicalIdOf(knowledgeId);
+  if (!logicalId) return [];
   return db()
     .query(
       `SELECT ${ENTITY_COLS_E}
        FROM entities e
        JOIN knowledge_entity_refs r ON r.entity_id = e.id
-       WHERE r.knowledge_id = ?`,
+       WHERE e.tenant_id = ? AND r.knowledge_id = ?`,
     )
-    .all(logicalIdOf(knowledgeId)) as Entity[];
+    .all(currentTenantId(), logicalId) as Entity[];
 }
 
 /** Get all knowledge logical_ids referencing an entity (A2: callers resolve the
  *  current entry via ltm.getByLogical, not ltm.get). */
 export function knowledgeForEntity(entityId: string): string[] {
+  if (!get(entityId)) return [];
   const rows = db()
     .query("SELECT knowledge_id FROM knowledge_entity_refs WHERE entity_id = ?")
     .all(entityId) as Array<{ knowledge_id: string }>;
@@ -2034,11 +2101,16 @@ export interface EntityMatchRegistry {
 /** Load the entity + alias registry (two full-table scans). */
 function loadEntityMatchRegistry(): EntityMatchRegistry {
   const entities = db()
-    .query("SELECT id, canonical_name FROM entities")
-    .all() as Array<{ id: string; canonical_name: string }>;
+    .query("SELECT id, canonical_name FROM entities WHERE tenant_id = ?")
+    .all(currentTenantId()) as Array<{ id: string; canonical_name: string }>;
   const aliases = db()
-    .query("SELECT entity_id, alias_value FROM entity_aliases")
-    .all() as Array<{ entity_id: string; alias_value: string }>;
+    .query(
+      "SELECT entity_id, alias_value FROM entity_aliases WHERE tenant_id = ?",
+    )
+    .all(currentTenantId()) as Array<{
+    entity_id: string;
+    alias_value: string;
+  }>;
   return { entities, aliases };
 }
 
@@ -2051,6 +2123,7 @@ export function syncEntityRefs(
   // appends. The FK to knowledge(id) stays satisfied because logical_id equals
   // the never-physically-deleted first version's id.
   const logicalId = logicalIdOf(knowledgeId);
+  if (!logicalId) return 0;
 
   // Capture the entities that WILL lose a ref so their sync_rank is recomputed after the
   // rebuild (union with the newly-linked set below) — #1191b PR2b.
@@ -2605,9 +2678,12 @@ export function getDismissedEntityPairs(): Set<string> {
     .query(
       `SELECT entry_a_title, entry_b_title FROM dedup_feedback
        WHERE kind = 'entity' AND accepted = 0 AND source = 'dashboard'
-         AND project_id IS NULL`,
+          AND tenant_id = ? AND project_id IS NULL`,
     )
-    .all() as Array<{ entry_a_title: string; entry_b_title: string }>;
+    .all(currentTenantId()) as Array<{
+    entry_a_title: string;
+    entry_b_title: string;
+  }>;
   const dismissed = new Set<string>();
   for (const r of rows) {
     dismissed.add(`${r.entry_a_title}\x1f${r.entry_b_title}`);
@@ -2633,10 +2709,11 @@ export function recordEntityDedupFeedback(input: {
   db()
     .query(
       `INSERT INTO dedup_feedback
-         (project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at, kind)
-       VALUES (?, ?, ?, ?, ?, ?, ?, 'entity')`,
+          (tenant_id, project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at, kind)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'entity')`,
     )
     .run(
+      currentTenantId(),
       input.projectId,
       input.entryATitle,
       input.entryBTitle,
@@ -2719,14 +2796,14 @@ export function getEntityDedupFeedback(
     projectId !== null
       ? db()
           .query(
-            "SELECT similarity, accepted, source FROM dedup_feedback WHERE kind = 'entity' AND source != 'self_merge' AND project_id = ? ORDER BY similarity",
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE tenant_id = ? AND kind = 'entity' AND source != 'self_merge' AND project_id = ? ORDER BY similarity",
           )
-          .all(projectId)
+          .all(currentTenantId(), projectId)
       : db()
           .query(
-            "SELECT similarity, accepted, source FROM dedup_feedback WHERE kind = 'entity' AND source != 'self_merge' AND project_id IS NULL ORDER BY similarity",
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE tenant_id = ? AND kind = 'entity' AND source != 'self_merge' AND project_id IS NULL ORDER BY similarity",
           )
-          .all()
+          .all(currentTenantId())
   ) as Array<{ similarity: number; accepted: number; source: string }>;
   return rows.map((r) => ({
     similarity: r.similarity,
@@ -2741,14 +2818,14 @@ export function getEntityDedupFeedbackCount(projectId: string | null): number {
     projectId !== null
       ? db()
           .query(
-            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE kind = 'entity' AND source != 'self_merge' AND project_id = ?",
+            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE tenant_id = ? AND kind = 'entity' AND source != 'self_merge' AND project_id = ?",
           )
-          .get(projectId)
+          .get(currentTenantId(), projectId)
       : db()
           .query(
-            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE kind = 'entity' AND source != 'self_merge' AND project_id IS NULL",
+            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE tenant_id = ? AND kind = 'entity' AND source != 'self_merge' AND project_id IS NULL",
           )
-          .get()
+          .get(currentTenantId())
   ) as { cnt: number } | null;
   return row?.cnt ?? 0;
 }
@@ -2764,20 +2841,20 @@ export function pruneEntityDedupFeedback(projectId: string | null): void {
     db()
       .query(
         `DELETE FROM dedup_feedback WHERE id IN (
-           SELECT id FROM dedup_feedback WHERE kind = 'entity' AND source != 'self_merge' AND project_id = ?
-           ORDER BY created_at ASC LIMIT ?
-         )`,
+            SELECT id FROM dedup_feedback WHERE tenant_id = ? AND kind = 'entity' AND source != 'self_merge' AND project_id = ?
+            ORDER BY created_at ASC LIMIT ?
+          )`,
       )
-      .run(projectId, excess);
+      .run(currentTenantId(), projectId, excess);
   } else {
     db()
       .query(
         `DELETE FROM dedup_feedback WHERE id IN (
-           SELECT id FROM dedup_feedback WHERE kind = 'entity' AND source != 'self_merge' AND project_id IS NULL
-           ORDER BY created_at ASC LIMIT ?
-         )`,
+            SELECT id FROM dedup_feedback WHERE tenant_id = ? AND kind = 'entity' AND source != 'self_merge' AND project_id IS NULL
+            ORDER BY created_at ASC LIMIT ?
+          )`,
       )
-      .run(excess);
+      .run(currentTenantId(), excess);
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,7 @@ export type {
 export { isTextPart, isReasoningPart, isToolPart } from "./types";
 
 export { dataDir } from "./data-dir";
+export { currentTenantId, withTenant, LOCAL_TENANT_ID } from "./tenant";
 export { isVecAvailable } from "./db/vec";
 export {
   checkVecWorker,
@@ -114,6 +115,7 @@ export {
   projectPath,
   projectKnownPaths,
   projectGitRemote,
+  projectTenantId,
   projectScope,
   setProjectScope,
   setProjectPromotionPolicy,
@@ -187,6 +189,12 @@ export {
   getGitUser,
   clearGitUserCache,
 } from "./git";
+export {
+  GATEWAY_AUTH_HEADER,
+  KNOWN_SESSION_HEADERS,
+  isCredentialHeaderName,
+  redactCredentialHeaderAssignments,
+} from "./credential-headers";
 export {
   enableHostedMode,
   isHostedMode,

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -23,7 +23,20 @@
  * Use `lore logs` to view; disabled during tests (`NODE_ENV=test`).
  */
 
-import { appendFileSync, renameSync, statSync, mkdirSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+  type Stats,
+} from "node:fs";
+import { redactCredentialHeaderAssignments } from "./credential-headers";
 import { join } from "node:path";
 import { dataDir } from "./data-dir";
 
@@ -150,16 +163,211 @@ function findError(args: unknown[]): Error | undefined {
   return undefined;
 }
 
+const LOG_FILTERED = "[Filtered]";
+const LOG_SENSITIVE_KEY = String.raw`(?:proxy[\s._-]*authorization|authorization|x[\s._-]*api[\s._-]*key|api[\s._-]*key|(?:api|access|auth|bearer|client|consumer|identity|private|refresh|security|subscription)[\s._-]*(?:id|key|secret|token)|ocp[\s._-]*apim[\s._-]*subscription[\s._-]*key|cf[\s._-]*access[\s._-]*client[\s._-]*id|set[\s._-]*cookie|(?:[a-z0-9]+[\s._-]+)*signatures?|token|secret|password|passwd|passphrase|credentials?|cookies?)`;
+
+/**
+ * Redact practical credential/header forms before text reaches stderr, an
+ * external sink, or persistent storage. This deliberately preserves ordinary
+ * operational text, paths, and entity names; raw response bodies are omitted
+ * at their call sites because free-form text cannot identify them reliably.
+ */
+export function redactSensitiveLogText(value: string): string {
+  return redactCredentialHeaderAssignments(value, LOG_FILTERED)
+    .replace(
+      /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+      LOG_FILTERED,
+    )
+    .replace(
+      /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi,
+      (match, scheme: string, offset: number, source: string) =>
+        /(?:^|[\s._-])scheme\s*=\s*$/i.test(
+          source.slice(Math.max(0, offset - 32), offset),
+        )
+          ? match
+          : `${scheme} ${LOG_FILTERED}`,
+    )
+    .replace(
+      new RegExp(
+        String.raw`(^|[\r\n])([\t ]*(?:${LOG_SENSITIVE_KEY})[\t ]*:[\t ]*)[^\r\n]*`,
+        "gi",
+      ),
+      `$1$2${LOG_FILTERED}`,
+    )
+    .replace(/\bsk-[A-Za-z0-9_-]{12,}\b/g, LOG_FILTERED)
+    .replace(/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, LOG_FILTERED)
+    .replace(/\bAKIA[A-Z0-9]{16}\b/g, LOG_FILTERED)
+    .replace(
+      /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
+      LOG_FILTERED,
+    );
+}
+
+function safeArgs(args: unknown[]): string[] {
+  return args.map((arg) =>
+    redactSensitiveLogText(
+      typeof arg === "string"
+        ? arg
+        : arg instanceof Error
+          ? (arg.stack ?? arg.message)
+          : String(arg),
+    ),
+  );
+}
+
+function sanitizedError(error: Error): Error {
+  const copy = new Error(redactSensitiveLogText(error.message));
+  copy.name = error.name;
+  if (error.stack) copy.stack = redactSensitiveLogText(error.stack);
+  return copy;
+}
+
 // ---------------------------------------------------------------------------
 // File sink — persistent log file, independent of LORE_DEBUG
 // ---------------------------------------------------------------------------
 
 const LOG_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const ROTATION_CHECK_INTERVAL = 1000; // check size every N writes
+const LOG_DIRECTORY_MODE = 0o700;
+const LOG_FILE_MODE = 0o600;
+const NO_FOLLOW = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
 
 let logPath: string | undefined;
 let logPathResolved = false;
 let writeCount = 0;
+
+function assertCurrentOwner(info: Stats, path: string): void {
+  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+    throw new Error(`Refusing log path not owned by the current user: ${path}`);
+  }
+}
+
+function assertSameFile(before: Stats, after: Stats, path: string): void {
+  if (before.dev !== after.dev || before.ino !== after.ino) {
+    throw new Error(`Log path changed while opening: ${path}`);
+  }
+}
+
+function validateLogDirectory(dir: string): void {
+  const pathInfo = lstatSync(dir);
+  if (pathInfo.isSymbolicLink() || !pathInfo.isDirectory()) {
+    throw new Error(`Refusing non-directory log data path: ${dir}`);
+  }
+  assertCurrentOwner(pathInfo, dir);
+
+  if (process.platform === "win32") return;
+  const fd = openSync(
+    dir,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const info = fstatSync(fd);
+    if (!info.isDirectory()) {
+      throw new Error(`Refusing non-directory log data path: ${dir}`);
+    }
+    assertCurrentOwner(info, dir);
+    assertSameFile(pathInfo, info, dir);
+    if ((info.mode & 0o7777) !== LOG_DIRECTORY_MODE) {
+      fchmodSync(fd, LOG_DIRECTORY_MODE);
+    }
+    const finalInfo = fstatSync(fd);
+    if ((finalInfo.mode & 0o077) !== 0) {
+      throw new Error(`Log data directory is not owner-only: ${dir}`);
+    }
+    assertSameFile(lstatSync(dir), finalInfo, dir);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function openLogFileForAppend(path: string): number {
+  let existing: Stats | undefined;
+  try {
+    existing = lstatSync(path);
+    if (!existing.isFile() || existing.isSymbolicLink()) {
+      throw new Error(`Refusing non-regular log file: ${path}`);
+    }
+    assertCurrentOwner(existing, path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  // O_NONBLOCK prevents a raced-in FIFO from blocking before fstat rejects it.
+  const fd = openSync(
+    path,
+    constants.O_WRONLY |
+      constants.O_APPEND |
+      constants.O_CREAT |
+      constants.O_NONBLOCK |
+      NO_FOLLOW,
+    LOG_FILE_MODE,
+  );
+  try {
+    const info = fstatSync(fd);
+    if (!info.isFile())
+      throw new Error(`Refusing non-regular log file: ${path}`);
+    assertCurrentOwner(info, path);
+    validateLogDirectory(dataDir());
+    assertSameFile(lstatSync(path), info, path);
+    if (existing) assertSameFile(existing, info, path);
+    if (process.platform !== "win32") fchmodSync(fd, LOG_FILE_MODE);
+    return fd;
+  } catch (error) {
+    closeSync(fd);
+    throw error;
+  }
+}
+
+function tightenExistingLogFile(path: string): void {
+  const existing = lstatSync(path);
+  if (!existing.isFile() || existing.isSymbolicLink()) {
+    throw new Error(`Refusing non-regular log file: ${path}`);
+  }
+  assertCurrentOwner(existing, path);
+  const fd = openSync(
+    path,
+    constants.O_WRONLY | constants.O_APPEND | constants.O_NONBLOCK | NO_FOLLOW,
+  );
+  try {
+    const info = fstatSync(fd);
+    if (!info.isFile())
+      throw new Error(`Refusing non-regular log file: ${path}`);
+    assertCurrentOwner(info, path);
+    assertSameFile(existing, info, path);
+    if (process.platform !== "win32") fchmodSync(fd, LOG_FILE_MODE);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function removeExistingRotationBackup(path: string): void {
+  let existing: Stats;
+  try {
+    existing = lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (!existing.isFile() || existing.isSymbolicLink()) {
+    throw new Error(`Refusing non-regular rotated log file: ${path}`);
+  }
+  assertCurrentOwner(existing, path);
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW,
+  );
+  try {
+    const info = fstatSync(fd);
+    if (!info.isFile()) {
+      throw new Error(`Refusing non-regular rotated log file: ${path}`);
+    }
+    assertCurrentOwner(info, path);
+    assertSameFile(existing, info, path);
+    unlinkSync(path);
+  } finally {
+    closeSync(fd);
+  }
+}
 
 /**
  * Resolve the log file path. Returns `undefined` in test environments
@@ -169,8 +377,19 @@ function resolveLogPath(): string | undefined {
   if (process.env.NODE_ENV === "test") return undefined;
   try {
     const dir = dataDir();
-    mkdirSync(dir, { recursive: true });
-    return join(dir, "lore.log");
+    mkdirSync(dir, { recursive: true, mode: LOG_DIRECTORY_MODE });
+    validateLogDirectory(dir);
+    const path = join(dir, "lore.log");
+    // Harden both active and previously rotated logs immediately. Otherwise a
+    // legacy 0644 backup could remain readable indefinitely.
+    for (const existingPath of [path, `${path}.1`]) {
+      try {
+        tightenExistingLogFile(existingPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+    return path;
   } catch {
     return undefined;
   }
@@ -188,13 +407,25 @@ export function logFilePath(): string | undefined {
 /** Rotate the log file if it exceeds the size cap. */
 function maybeRotate(): void {
   if (!logPath) return;
+  let fd: number | undefined;
   try {
-    const stat = statSync(logPath);
+    // Tighten the active file before it becomes the rotated backup.
+    fd = openLogFileForAppend(logPath);
+    const stat = fstatSync(fd);
     if (stat.size > LOG_MAX_BYTES) {
-      renameSync(logPath, `${logPath}.1`);
+      closeSync(fd);
+      fd = undefined;
+      const backup = `${logPath}.1`;
+      removeExistingRotationBackup(backup);
+      renameSync(logPath, backup);
+      // Another process may have raced the rename. Validate what now occupies
+      // the backup name before leaving it as persistent sensitive data.
+      tightenExistingLogFile(backup);
     }
   } catch {
     // File doesn't exist yet or stat failed — fine
+  } finally {
+    if (fd !== undefined) closeSync(fd);
   }
 }
 
@@ -214,10 +445,14 @@ function writeToFile(level: string, message: string): void {
   const flat = message.replace(/\n/g, "\\n");
   const line = `${ts} [${tag}] ${flat}\n`;
 
+  let fd: number | undefined;
   try {
-    appendFileSync(path, line);
+    fd = openLogFileForAppend(path);
+    writeFileSync(fd, line, "utf8");
   } catch {
     // Silently degrade — logging failure shouldn't crash the app
+  } finally {
+    if (fd !== undefined) closeSync(fd);
   }
 }
 
@@ -227,16 +462,18 @@ function writeToFile(level: string, message: string): void {
 
 /** Log an informational status message. Suppressed unless LORE_DEBUG=1. */
 export function info(...args: unknown[]): void {
-  if (isDebug && !readStderrSilenced()) console.error("[lore]", ...args);
-  const msg = formatArgs(args);
+  const msg = redactSensitiveLogText(formatArgs(args));
+  if (isDebug && !readStderrSilenced())
+    console.error("[lore]", ...safeArgs(args));
   sink?.info(msg);
   writeToFile("info", msg);
 }
 
 /** Log a warning. Suppressed unless LORE_DEBUG=1. */
 export function warn(...args: unknown[]): void {
-  if (isDebug && !readStderrSilenced()) console.error("[lore] WARN:", ...args);
-  const msg = formatArgs(args);
+  const msg = redactSensitiveLogText(formatArgs(args));
+  if (isDebug && !readStderrSilenced())
+    console.error("[lore] WARN:", ...safeArgs(args));
   sink?.warn(msg);
   writeToFile("warn", msg);
 }
@@ -250,19 +487,19 @@ export function warn(...args: unknown[]): void {
  * silenced on stderr in embedded/TUI mode but still hits the file and sink.
  */
 export function notice(...args: unknown[]): void {
-  if (!readStderrSilenced()) console.error("[lore]", ...args);
-  const msg = formatArgs(args);
+  const msg = redactSensitiveLogText(formatArgs(args));
+  if (!readStderrSilenced()) console.error("[lore]", ...safeArgs(args));
   sink?.warn(msg);
   writeToFile("warn", msg);
 }
 
 /** Log an error. Always visible — these indicate real failures. */
 export function error(...args: unknown[]): void {
-  if (!readStderrSilenced()) console.error("[lore]", ...args);
-  const msg = formatArgs(args);
+  const msg = redactSensitiveLogText(formatArgs(args));
+  if (!readStderrSilenced()) console.error("[lore]", ...safeArgs(args));
   sink?.error(msg);
   writeToFile("error", msg);
 
   const err = findError(args);
-  if (err) sink?.captureException(err);
+  if (err) sink?.captureException(sanitizedError(err));
 }

--- a/packages/core/src/ltm.ts
+++ b/packages/core/src/ltm.ts
@@ -43,6 +43,7 @@ import {
 } from "./references";
 import * as log from "./log";
 import { estimateTokens } from "./tokenize";
+import { currentTenantId } from "./tenant";
 
 /** Sensitivity classification — product hint guiding auto-promotion decisions. */
 export type Sensitivity = "normal" | "sensitive" | "restricted";
@@ -113,6 +114,7 @@ export type KnowledgeEntry = {
    *  this equals `id`; cross-reference linkages (refs/transfers/markers) key on
    *  this, never the per-version `id`. */
   logical_id: string;
+  tenant_id: string;
   project_id: string | null;
   category: string;
   title: string;
@@ -148,7 +150,7 @@ export type KnowledgeEntry = {
 /** Columns to select for KnowledgeEntry — excludes the embedding BLOB
  *  (4KB per entry) which is only needed by vectorSearch() in embedding.ts. */
 const KNOWLEDGE_COLS =
-  "id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at, metadata, created_by, updated_by, sensitivity, promotion_status, promoted_at, approval_status, approved_by, approved_at, source_user_id, source_entry_id, last_accessed_at, worker_provider_id, worker_model_id, last_reinforced_at, logical_id";
+  "id, tenant_id, project_id, category, title, content, source_session, cross_project, confidence, created_at, updated_at, metadata, created_by, updated_by, sensitivity, promotion_status, promoted_at, approval_status, approved_by, approved_at, source_user_id, source_entry_id, last_accessed_at, worker_provider_id, worker_model_id, last_reinforced_at, logical_id";
 
 /** Same columns with table alias prefix for use in JOIN queries. `confidence` and
  *  `last_reinforced_at` live on the metric register (alias `m`), not the immutable
@@ -156,7 +158,7 @@ const KNOWLEDGE_COLS =
  *  `LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id` (LEFT + COALESCE
  *  default mirrors the knowledge_current view, so a meta-less row never vanishes). */
 const KNOWLEDGE_COLS_K =
-  "k.id, k.project_id, k.category, k.title, k.content, k.source_session, k.cross_project, COALESCE(m.confidence, 1.0) AS confidence, k.created_at, k.updated_at, k.metadata, k.created_by, k.updated_by, k.sensitivity, k.promotion_status, k.promoted_at, k.approval_status, k.approved_by, k.approved_at, k.source_user_id, k.source_entry_id, k.last_accessed_at, k.worker_provider_id, k.worker_model_id, m.last_reinforced_at, k.logical_id";
+  "k.id, k.tenant_id, k.project_id, k.category, k.title, k.content, k.source_session, k.cross_project, COALESCE(m.confidence, 1.0) AS confidence, k.created_at, k.updated_at, k.metadata, k.created_by, k.updated_by, k.sensitivity, k.promotion_status, k.promoted_at, k.approval_status, k.approved_by, k.approved_at, k.source_user_id, k.source_entry_id, k.last_accessed_at, k.worker_provider_id, k.worker_model_id, m.last_reinforced_at, k.logical_id";
 
 /**
  * Upsert the metric-register row for a logical entry (A2 sub-PR 3b, #823).
@@ -286,6 +288,7 @@ export function create(input: {
    *  never opt in). Parsed back into a typed object on read. */
   metadata?: KnowledgeMetadata;
 }): string {
+  const tenantId = currentTenantId();
   const pid =
     input.scope === "project" && input.projectPath
       ? ensureProject(input.projectPath)
@@ -315,9 +318,9 @@ export function create(input: {
             .get(pid, input.title)
         : db()
             .query(
-              "SELECT logical_id FROM knowledge_current WHERE project_id IS NULL AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+              "SELECT logical_id FROM knowledge_current WHERE tenant_id = ? AND project_id IS NULL AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
             )
-            .get(input.title)
+            .get(tenantId, input.title)
     ) as { logical_id: string } | null;
 
     // Build the update payload — forward confidence when the caller provided one
@@ -336,9 +339,9 @@ export function create(input: {
     // duplicates of entries that already exist as cross-project knowledge.
     const crossExisting = db()
       .query(
-        "SELECT logical_id FROM knowledge_current WHERE cross_project = 1 AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+        "SELECT logical_id FROM knowledge_current WHERE tenant_id = ? AND cross_project = 1 AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
       )
-      .get(input.title) as { logical_id: string } | null;
+      .get(tenantId, input.title) as { logical_id: string } | null;
 
     if (crossExisting) {
       update(crossExisting.logical_id, dedupUpdate);
@@ -379,12 +382,13 @@ export function create(input: {
   }
   db()
     .query(
-      `INSERT INTO knowledge (id, logical_id, project_id, category, title, content, source_session, cross_project, created_at, updated_at, created_by, sensitivity, worker_provider_id, worker_model_id, metadata, approval_status, approved_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO knowledge (id, logical_id, tenant_id, project_id, category, title, content, source_session, cross_project, created_at, updated_at, created_by, sensitivity, worker_provider_id, worker_model_id, metadata, approval_status, approved_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       id,
       id, // logical_id: a fresh entry is its own logical identity (version 1)
+      tenantId,
       pid,
       input.category,
       input.title,
@@ -457,9 +461,9 @@ export function appendVersion(
   const ok = withTransaction(() => {
     const cur = db()
       .query(
-        "SELECT id FROM knowledge WHERE logical_id = ? AND is_current = 1 LIMIT 1",
+        "SELECT id FROM knowledge WHERE tenant_id = ? AND logical_id = ? AND is_current = 1 LIMIT 1",
       )
-      .get(logicalId) as { id: string } | undefined;
+      .get(currentTenantId(), logicalId) as { id: string } | undefined;
     if (!cur) return false;
     // vec0 layout has no `embedding` column on `knowledge` (dropped at cutover):
     // omit it from the forward-copy, and drop the demoted version's vec0 row so
@@ -475,20 +479,20 @@ export function appendVersion(
         // confidence/last_reinforced_at are NOT copied — they live on the register
         // (knowledge_meta), keyed by the stable logical_id, unchanged by an append.
         `INSERT INTO knowledge (
-           id, project_id, category, title, content, source_session, cross_project,
+           id, tenant_id, project_id, category, title, content, source_session, cross_project,
            created_at, updated_at, metadata, ${embCol}created_by,
            updated_by, sensitivity, promotion_status, promoted_at, approval_status,
            approved_by, approved_at, source_user_id, source_entry_id, last_accessed_at,
            worker_provider_id, worker_model_id,
            logical_id, version, is_deleted, is_current)
          SELECT
-           ?, project_id, COALESCE(?, category), COALESCE(?, title), COALESCE(?, content),
+            ?, tenant_id, project_id, COALESCE(?, category), COALESCE(?, title), COALESCE(?, content),
            source_session, cross_project, created_at, ?, COALESCE(?, metadata), ${embSel}created_by,
            updated_by, sensitivity, promotion_status, promoted_at,
            approval_status, approved_by, approved_at, source_user_id, source_entry_id,
            last_accessed_at, worker_provider_id, worker_model_id,
            logical_id, version + 1, ?, 1
-         FROM knowledge WHERE id = ?`,
+          FROM knowledge WHERE id = ? AND tenant_id = ?`,
       )
       .run(
         newId,
@@ -501,6 +505,7 @@ export function appendVersion(
         stringifyMetadata(overrides.metadata),
         overrides.isDeleted ? 1 : 0,
         cur.id,
+        currentTenantId(),
       );
     return true;
   });
@@ -525,6 +530,7 @@ export function tryCreate(input: Parameters<typeof create>[0]): {
   created: boolean;
   previousContent?: string;
 } {
+  const tenantId = currentTenantId();
   // Use the same dedup logic as create(): a return value where the id
   // matches an existing row means we hit a dedup branch. We probe for the
   // existence of the title BEFORE calling create() to know which branch fired.
@@ -543,9 +549,9 @@ export function tryCreate(input: Parameters<typeof create>[0]): {
             .get(pid, input.title)
         : db()
             .query(
-              "SELECT id, content FROM knowledge_current WHERE project_id IS NULL AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+              "SELECT id, content FROM knowledge_current WHERE tenant_id = ? AND project_id IS NULL AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
             )
-            .get(input.title)
+            .get(tenantId, input.title)
     ) as { id: string; content: string } | null;
 
     if (existing) {
@@ -556,9 +562,9 @@ export function tryCreate(input: Parameters<typeof create>[0]): {
 
     const crossExisting = db()
       .query(
-        "SELECT id, content FROM knowledge_current WHERE cross_project = 1 AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
+        "SELECT id, content FROM knowledge_current WHERE tenant_id = ? AND cross_project = 1 AND LOWER(title) = LOWER(?) AND confidence > 0 LIMIT 1",
       )
-      .get(input.title) as { id: string; content: string } | null;
+      .get(tenantId, input.title) as { id: string; content: string } | null;
     if (crossExisting) {
       const id = create(input);
       return { id, created: false, previousContent: crossExisting.content };
@@ -607,23 +613,23 @@ export function listPendingTeamPromotions(
   projectId?: string,
 ): TeamPromotionCandidate[] {
   const where =
-    "p.scope_id IS NOT NULL AND k.approval_status NOT IN ('approved','rejected')";
+    "p.tenant_id = ? AND p.scope_id IS NOT NULL AND k.approval_status NOT IN ('approved','rejected')";
   const rows = (
     projectId
       ? db()
           .query(
             `SELECT k.logical_id, k.title, k.category, k.project_id
              FROM knowledge_current k JOIN projects p ON p.id = k.project_id
-             WHERE ${where} AND k.project_id = ? ORDER BY k.updated_at DESC`,
+              WHERE ${where} AND k.project_id = ? ORDER BY k.updated_at DESC`,
           )
-          .all(projectId)
+          .all(currentTenantId(), projectId)
       : db()
           .query(
             `SELECT k.logical_id, k.title, k.category, k.project_id
              FROM knowledge_current k JOIN projects p ON p.id = k.project_id
              WHERE ${where} ORDER BY k.updated_at DESC`,
           )
-          .all()
+          .all(currentTenantId())
   ) as Array<{
     logical_id: string;
     title: string;
@@ -674,9 +680,9 @@ export function approveForTeam(
 ): boolean {
   const res = db()
     .query(
-      "UPDATE knowledge SET approval_status = 'approved', approved_by = ?, approved_at = ? WHERE logical_id = ? AND is_current = 1",
+      "UPDATE knowledge SET approval_status = 'approved', approved_by = ?, approved_at = ? WHERE tenant_id = ? AND logical_id = ? AND is_current = 1",
     )
-    .run(approvedBy ?? null, Date.now(), logicalId);
+    .run(approvedBy ?? null, Date.now(), currentTenantId(), logicalId);
   // The knowledge row's own migration rides its UPDATE (column-agnostic capture trigger); its linked
   // entity graph has no such trigger from this UPDATE, so re-enqueue it explicitly (#1307).
   if (res.changes > 0) teamPromotionChangedCb?.(logicalId);
@@ -690,9 +696,9 @@ export function approveForTeam(
 export function rejectForTeam(logicalId: string): boolean {
   const res = db()
     .query(
-      "UPDATE knowledge SET approval_status = 'rejected', approved_by = NULL, approved_at = NULL WHERE logical_id = ? AND is_current = 1",
+      "UPDATE knowledge SET approval_status = 'rejected', approved_by = NULL, approved_at = NULL WHERE tenant_id = ? AND logical_id = ? AND is_current = 1",
     )
-    .run(logicalId);
+    .run(currentTenantId(), logicalId);
   // Symmetric with approveForTeam: re-enqueue the linked graph so it migrates BACK to personal
   // (unless an entity is still linked to OTHER team-approved knowledge — the resolver decides).
   if (res.changes > 0) teamPromotionChangedCb?.(logicalId);
@@ -727,11 +733,13 @@ function titleCollides(
       ? "(project_id IS NULL OR cross_project = 1 OR project_id = ?)"
       : "(project_id IS NULL OR cross_project = 1)";
   const params: unknown[] =
-    pid !== null ? [logicalId, newTitle, pid] : [logicalId, newTitle];
+    pid !== null
+      ? [currentTenantId(), logicalId, newTitle, pid]
+      : [currentTenantId(), logicalId, newTitle];
   const hit = db()
     .query(
       `SELECT 1 FROM knowledge_current
-         WHERE logical_id != ? AND confidence > 0 AND LOWER(title) = LOWER(?)
+         WHERE tenant_id = ? AND logical_id != ? AND confidence > 0 AND LOWER(title) = LOWER(?)
            AND ${scopeClause}
          LIMIT 1`,
     )
@@ -761,6 +769,7 @@ export function update(
   // `id` may be a current OR superseded version id — resolve to the logical_id.
   const logicalId = logicalIdOf(id);
   const cur = getByLogical(logicalId);
+  if (!cur) return;
 
   // Re-title guard (D1b): `title` is BOTH the top-weighted FTS field AND the
   // exact-match dedup identity key. `appendVersion` will happily write any title,
@@ -922,9 +931,9 @@ export function remove(id: string, metadata?: KnowledgeMetadata) {
   // (the user resolved it by removing one side, or it was pruned). (#1123)
   db()
     .query(
-      "DELETE FROM knowledge_contradictions WHERE logical_id_a = ? OR logical_id_b = ?",
+      "DELETE FROM knowledge_contradictions WHERE tenant_id = ? AND (logical_id_a = ? OR logical_id_b = ?)",
     )
-    .run(logicalId, logicalId);
+    .run(currentTenantId(), logicalId, logicalId);
 }
 
 /** True when the entry for this logical_id was deleted (tombstoned). */
@@ -932,15 +941,15 @@ export function isTombstoned(id: string): boolean {
   // A2: the current version is an is_deleted death certificate.
   const deathCert = db()
     .query(
-      "SELECT 1 FROM knowledge WHERE logical_id = ? AND is_current = 1 AND is_deleted = 1 LIMIT 1",
+      "SELECT 1 FROM knowledge WHERE tenant_id = ? AND logical_id = ? AND is_current = 1 AND is_deleted = 1 LIMIT 1",
     )
-    .get(id) as { 1: number } | null;
+    .get(currentTenantId(), id) as { 1: number } | null;
   if (deathCert) return true;
   // Legacy: entries deleted before the append-only flip left a tombstone row and
   // no death-cert version (they were physically deleted).
   const legacy = db()
-    .query("SELECT 1 FROM knowledge_tombstones WHERE id = ?")
-    .get(id) as { 1: number } | null;
+    .query("SELECT 1 FROM knowledge_tombstones WHERE tenant_id = ? AND id = ?")
+    .get(currentTenantId(), id) as { 1: number } | null;
   return legacy != null;
 }
 
@@ -963,34 +972,35 @@ export function findTombstonedByTitle(input: {
   title: string;
   projectId: string | null;
 }): boolean {
+  const tenantId = currentTenantId();
   // A live current version with this title takes precedence — it is an update
   // target, not a resurrection. Only report "tombstoned" when NO live row exists.
   const live =
     input.projectId !== null
       ? (db()
           .query(
-            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 0 AND (project_id = ? OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+            "SELECT 1 FROM knowledge WHERE tenant_id = ? AND is_current = 1 AND is_deleted = 0 AND (project_id = ? OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
           )
-          .get(input.projectId, input.title) as { 1: number } | null)
+          .get(tenantId, input.projectId, input.title) as { 1: number } | null)
       : (db()
           .query(
-            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 0 AND (project_id IS NULL OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+            "SELECT 1 FROM knowledge WHERE tenant_id = ? AND is_current = 1 AND is_deleted = 0 AND (project_id IS NULL OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
           )
-          .get(input.title) as { 1: number } | null);
+          .get(tenantId, input.title) as { 1: number } | null);
   if (live) return false;
 
   const deathCert =
     input.projectId !== null
       ? (db()
           .query(
-            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 1 AND (project_id = ? OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+            "SELECT 1 FROM knowledge WHERE tenant_id = ? AND is_current = 1 AND is_deleted = 1 AND (project_id = ? OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
           )
-          .get(input.projectId, input.title) as { 1: number } | null)
+          .get(tenantId, input.projectId, input.title) as { 1: number } | null)
       : (db()
           .query(
-            "SELECT 1 FROM knowledge WHERE is_current = 1 AND is_deleted = 1 AND (project_id IS NULL OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
+            "SELECT 1 FROM knowledge WHERE tenant_id = ? AND is_current = 1 AND is_deleted = 1 AND (project_id IS NULL OR cross_project = 1) AND LOWER(title) = LOWER(?) LIMIT 1",
           )
-          .get(input.title) as { 1: number } | null);
+          .get(tenantId, input.title) as { 1: number } | null);
   return deathCert != null;
 }
 
@@ -999,7 +1009,9 @@ export function findTombstonedByTitle(input: {
  * (re-)created with that exact UUID, so a future delete can tombstone it again.
  */
 export function clearTombstone(id: string): void {
-  db().query("DELETE FROM knowledge_tombstones WHERE id = ?").run(id);
+  db()
+    .query("DELETE FROM knowledge_tombstones WHERE tenant_id = ? AND id = ?")
+    .run(currentTenantId(), id);
 }
 
 // ---------------------------------------------------------------------------
@@ -1084,6 +1096,7 @@ export function findFuzzyDuplicate(input: {
   projectId: string | null;
   excludeId?: string;
 }): { id: string; title: string } | null {
+  const tenantId = currentTenantId();
   const q = ftsQueryOr(input.title);
   if (q === EMPTY_QUERY) return null;
 
@@ -1098,6 +1111,7 @@ export function findFuzzyDuplicate(input: {
          CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
          WHERE knowledge_fts MATCH ?
+         AND k.tenant_id = ?
          AND (k.project_id = ? OR k.cross_project = 1)
          AND COALESCE(m.confidence, 1.0) > 0.2
          ${excludeClause}
@@ -1106,6 +1120,7 @@ export function findFuzzyDuplicate(input: {
          CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
          WHERE knowledge_fts MATCH ?
+         AND k.tenant_id = ?
          AND (k.project_id IS NULL OR k.cross_project = 1)
          AND COALESCE(m.confidence, 1.0) > 0.2
          ${excludeClause}
@@ -1115,13 +1130,21 @@ export function findFuzzyDuplicate(input: {
       input.projectId !== null
         ? [
             q,
+            tenantId,
             input.projectId,
             ...(input.excludeId ? [input.excludeId] : []),
             tw,
             cw,
             catw,
           ]
-        : [q, ...(input.excludeId ? [input.excludeId] : []), tw, cw, catw];
+        : [
+            q,
+            tenantId,
+            ...(input.excludeId ? [input.excludeId] : []),
+            tw,
+            cw,
+            catw,
+          ];
 
     const candidates = db()
       .query(sql)
@@ -1189,9 +1212,9 @@ export async function findSemanticDuplicate(input: {
     const row = db()
       .query(
         `SELECT id FROM knowledge_current
-         WHERE id = ? AND (project_id = ? OR project_id IS NULL OR cross_project = 1)`,
+         WHERE tenant_id = ? AND id = ? AND (project_id = ? OR project_id IS NULL OR cross_project = 1)`,
       )
-      .get(hit.id, input.projectId) as { id: string } | null;
+      .get(currentTenantId(), hit.id, input.projectId) as { id: string } | null;
     if (row) return { id: row.id, similarity: hit.similarity };
   }
   return null;
@@ -1208,14 +1231,14 @@ function forProjectQuery(
 ): { sql: string; params: ReadParam[] } {
   const sql = includeCross
     ? `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-         WHERE (project_id = ? OR (project_id IS NULL) OR (cross_project = 1))
+         WHERE tenant_id = ? AND (project_id = ? OR (project_id IS NULL) OR (cross_project = 1))
          AND confidence > 0.2
          ORDER BY confidence DESC, updated_at DESC`
     : `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-         WHERE project_id = ?
+         WHERE tenant_id = ? AND project_id = ?
          AND confidence > 0.2
          ORDER BY confidence DESC, updated_at DESC`;
-  return { sql, params: [pid] };
+  return { sql, params: [currentTenantId(), pid] };
 }
 
 export function forProject(
@@ -1321,9 +1344,9 @@ export function pruneDeadEntriesAllProjects(limit = -1): KnowledgeEntry[] {
   const dead = db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-       WHERE cross_project = 0 AND confidence <= ? LIMIT ?`,
+       WHERE tenant_id = ? AND cross_project = 0 AND confidence <= ? LIMIT ?`,
     )
-    .all(DEAD_CONFIDENCE_FLOOR, limit)
+    .all(currentTenantId(), DEAD_CONFIDENCE_FLOOR, limit)
     .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
   for (const e of dead) remove(e.id);
   return dead;
@@ -1362,12 +1385,17 @@ export function compactKnowledgeVersions(limit = 500): number {
              SELECT id, updated_at,
                     ROW_NUMBER() OVER (PARTITION BY logical_id ORDER BY version DESC) AS rn
                FROM knowledge
-              WHERE is_current = 0
+              WHERE tenant_id = ? AND is_current = 0
            )
            WHERE rn > ? OR updated_at < ?
            LIMIT ?`,
         )
-        .all(COMPACTION_KEEP_SUPERSEDED, cutoff, limit) as Array<{ id: string }>
+        .all(
+          currentTenantId(),
+          COMPACTION_KEEP_SUPERSEDED,
+          cutoff,
+          limit,
+        ) as Array<{ id: string }>
     ).map((r) => r.id);
     if (ids.length === 0) return 0;
     // vec0 layout: superseded rows already have no vec entry (appendVersion drops it on
@@ -1502,9 +1530,9 @@ export function markInjected(ids: string[]): void {
   db()
     .query(
       `UPDATE knowledge_meta SET last_reinforced_at = ?
-        WHERE logical_id IN (SELECT logical_id FROM knowledge WHERE id IN (${placeholders}))`,
+        WHERE logical_id IN (SELECT logical_id FROM knowledge WHERE tenant_id = ? AND id IN (${placeholders}))`,
     )
-    .run(Date.now(), ...ids);
+    .run(Date.now(), currentTenantId(), ...ids);
 }
 
 /**
@@ -1519,6 +1547,7 @@ export function reinforce(id: string, delta: number = REINFORCE_STEP): void {
   // confidence). `id` may be any version id — resolve to the stable logical_id.
   const now = Date.now();
   const logicalId = logicalIdOf(id);
+  if (!getByLogical(logicalId)) return;
   applyConfidenceDelta(logicalId, delta, now);
   db()
     .query(
@@ -1542,6 +1571,7 @@ export function penalizeStaleReferences(
   logicalId: string,
   delta: number = REFERENCE_DRIFT_PENALTY,
 ): void {
+  if (!getByLogical(logicalId)) return;
   // confidence is a materialized cache over the PN-counter register (A2 3b-2):
   // a direct `UPDATE knowledge_meta SET confidence = …` would be WIPED by the next
   // rematerializeConfidence (any reinforce/decay/credit/update/prune). Record the
@@ -2012,12 +2042,18 @@ export function outcomeImpactMany(
     const placeholders = batch.map(() => "?").join(",");
     const rows = db()
       .query(
-        `SELECT logical_id, verdict, COUNT(*) AS n
-         FROM knowledge_session_injections
-         WHERE logical_id IN (${placeholders}) AND verdict IN ('pass','fail')
-         GROUP BY logical_id, verdict`,
+        `SELECT i.logical_id, i.verdict, COUNT(*) AS n
+         FROM knowledge_session_injections i
+         JOIN knowledge_current k ON k.logical_id = i.logical_id
+         WHERE k.tenant_id = ? AND i.logical_id IN (${placeholders})
+           AND i.verdict IN ('pass','fail')
+         GROUP BY i.logical_id, i.verdict`,
       )
-      .all(...batch) as { logical_id: string; verdict: string; n: number }[];
+      .all(currentTenantId(), ...batch) as {
+      logical_id: string;
+      verdict: string;
+      n: number;
+    }[];
     for (const r of rows) {
       let cur = out.get(r.logical_id);
       if (!cur) {
@@ -2057,6 +2093,7 @@ export type RefValidity = {
 /** Read the last reference-validity snapshot for an entry by logical_id. Read-only;
  *  surfaced by `lore data show`. */
 export function refValidity(logicalId: string): RefValidity | null {
+  if (!getByLogical(logicalId)) return null;
   const row = db()
     .query(
       "SELECT broken, total, checked_at FROM knowledge_ref_validity WHERE logical_id = ?",
@@ -2104,6 +2141,7 @@ export type KnowledgeFileRefs = {
  * session-context, not user knowledge; remote machines generate their own.
  */
 export function setFileRefs(logicalId: string, paths: string[]): string[] {
+  if (!getByLogical(logicalId)) return [];
   // Defensive normalization: drop empty strings, dedupe, sort for determinism,
   // cap at MAX_FILE_REFS_PER_ENTRY. Callers should already do this — the
   // re-cap here is a safety net against a buggy caller passing thousands.
@@ -2148,10 +2186,15 @@ export function knowledgeFileRefsBatch(
   const placeholders = logicalIds.map(() => "?").join(",");
   const rows = db()
     .query(
-      `SELECT logical_id, paths_json FROM knowledge_file_refs
-        WHERE logical_id IN (${placeholders})`,
+      `SELECT f.logical_id, f.paths_json
+         FROM knowledge_file_refs f
+         JOIN knowledge_current k ON k.logical_id = f.logical_id
+        WHERE k.tenant_id = ? AND f.logical_id IN (${placeholders})`,
     )
-    .all(...logicalIds) as Array<{ logical_id: string; paths_json: string }>;
+    .all(currentTenantId(), ...logicalIds) as Array<{
+    logical_id: string;
+    paths_json: string;
+  }>;
   for (const r of rows) {
     let parsed: unknown;
     try {
@@ -2189,11 +2232,13 @@ export function knowledgeRefAnchors(
   // stable secondary sort by anchor keeps output deterministic (cache-friendly).
   const rows = db()
     .query(
-      `SELECT logical_id, kind, anchor FROM knowledge_ref_anchor
-        WHERE logical_id IN (${placeholders})
-        ORDER BY logical_id, kind, anchor`,
+      `SELECT a.logical_id, a.kind, a.anchor
+         FROM knowledge_ref_anchor a
+         JOIN knowledge_current k ON k.logical_id = a.logical_id
+        WHERE k.tenant_id = ? AND a.logical_id IN (${placeholders})
+        ORDER BY a.logical_id, a.kind, a.anchor`,
     )
-    .all(...logicalIds) as Array<{
+    .all(currentTenantId(), ...logicalIds) as Array<{
     logical_id: string;
     kind: string;
     anchor: string;
@@ -2378,8 +2423,9 @@ async function scoreEntriesFTS(
           CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
           WHERE knowledge_fts MATCH ?
+          AND k.tenant_id = ?
           AND COALESCE(m.confidence, 1.0) > 0.2`,
-      [title, content, category, q],
+      [title, content, category, q, currentTenantId()],
     )) as Array<{
       id: string;
       rank: number;
@@ -2546,15 +2592,19 @@ export async function forSession(
   // free while a worker scans. Knowledge is not written on the hot per-message
   // path, so a worker's read-only snapshot is safe (staleness-tolerant). #966 B.
   const projectSql = `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-       WHERE project_id = ? AND cross_project = 0 AND confidence > 0.2${categoryClause}
+       WHERE tenant_id = ? AND project_id = ? AND cross_project = 0 AND confidence > 0.2${categoryClause}
        ORDER BY confidence DESC, updated_at DESC`;
   const crossSql = `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-       WHERE (project_id IS NULL OR cross_project = 1) AND confidence > 0.2${categoryClause}
+       WHERE tenant_id = ? AND (project_id IS NULL OR cross_project = 1) AND confidence > 0.2${categoryClause}
        ORDER BY confidence DESC, updated_at DESC`;
   const [projectRows, crossRows] = await timer.await(
     Promise.all([
-      offloadAllOrTimeout(projectSql, [pid, ...categoryParams]),
-      offloadAllOrTimeout(crossSql, [...categoryParams]),
+      offloadAllOrTimeout(projectSql, [
+        currentTenantId(),
+        pid,
+        ...categoryParams,
+      ]),
+      offloadAllOrTimeout(crossSql, [currentTenantId(), ...categoryParams]),
     ]),
   );
   // Symmetric degrade: if EITHER scan's worker wedged (timeout), drop the whole
@@ -2930,6 +2980,7 @@ export async function forSession(
       result.push({
         id: section.id,
         logical_id: section.id, // synthetic lat.md entry: its own logical identity
+        tenant_id: currentTenantId(),
         project_id: section.project_id,
         category: "lat.md",
         title: `[${section.file}] ${section.heading}`,
@@ -3068,6 +3119,7 @@ async function loadContextSourceCandidates(
   ): KnowledgeEntry => ({
     id,
     logical_id: id,
+    tenant_id: currentTenantId(),
     project_id: pid,
     category: RECALLED_CONTEXT_CATEGORY,
     title,
@@ -3344,9 +3396,9 @@ function scoreFTS(
 export function all(): KnowledgeEntry[] {
   return db()
     .query(
-      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE confidence > 0.2 ORDER BY confidence DESC, updated_at DESC`,
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND confidence > 0.2 ORDER BY confidence DESC, updated_at DESC`,
     )
-    .all()
+    .all(currentTenantId())
     .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
 }
 
@@ -3355,10 +3407,10 @@ export function crossProject(): KnowledgeEntry[] {
   return db()
     .query(
       `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current
-       WHERE (project_id IS NULL OR cross_project = 1) AND confidence > 0.2
+       WHERE tenant_id = ? AND (project_id IS NULL OR cross_project = 1) AND confidence > 0.2
        ORDER BY confidence DESC, updated_at DESC`,
     )
-    .all()
+    .all(currentTenantId())
     .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
 }
 
@@ -3379,9 +3431,9 @@ export function crossProject(): KnowledgeEntry[] {
 export function rerankPreferences(): number {
   const prefs = db()
     .query(
-      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE category = 'preference' AND confidence = 1.0`,
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND category = 'preference' AND confidence = 1.0`,
     )
-    .all()
+    .all(currentTenantId())
     .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
 
   // Strong unconditional directives
@@ -3431,16 +3483,16 @@ function searchLike(input: {
     const pid = ensureProject(input.projectPath);
     return db()
       .query(
-        `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE (project_id = ? OR project_id IS NULL OR cross_project = 1) AND confidence > 0.2 AND ${conditions} ORDER BY updated_at DESC LIMIT ?`,
+        `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND (project_id = ? OR project_id IS NULL OR cross_project = 1) AND confidence > 0.2 AND ${conditions} ORDER BY updated_at DESC LIMIT ?`,
       )
-      .all(pid, ...likeParams, input.limit)
+      .all(currentTenantId(), pid, ...likeParams, input.limit)
       .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
   }
   return db()
     .query(
-      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE confidence > 0.2 AND ${conditions} ORDER BY updated_at DESC LIMIT ?`,
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND confidence > 0.2 AND ${conditions} ORDER BY updated_at DESC LIMIT ?`,
     )
-    .all(...likeParams, input.limit)
+    .all(currentTenantId(), ...likeParams, input.limit)
     .map(hydrateKnowledgeEntry) as KnowledgeEntry[];
 }
 
@@ -3458,6 +3510,7 @@ export function search(input: {
        CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
        WHERE knowledge_fts MATCH ?
+       AND k.tenant_id = ?
        AND (k.project_id = ? OR k.project_id IS NULL OR k.cross_project = 1)
        AND COALESCE(m.confidence, 1.0) > 0.2
        ORDER BY bm25(knowledge_fts, ?, ?, ?) LIMIT ?`
@@ -3465,6 +3518,7 @@ export function search(input: {
        CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
        WHERE knowledge_fts MATCH ?
+       AND k.tenant_id = ?
        AND COALESCE(m.confidence, 1.0) > 0.2
        ORDER BY bm25(knowledge_fts, ?, ?, ?) LIMIT ?`;
 
@@ -3473,8 +3527,8 @@ export function search(input: {
   try {
     return runRelaxedSearch(input.query, (matchExpr) => {
       const params = pid
-        ? [matchExpr, pid, title, content, category, limit]
-        : [matchExpr, title, content, category, limit];
+        ? [matchExpr, currentTenantId(), pid, title, content, category, limit]
+        : [matchExpr, currentTenantId(), title, content, category, limit];
       return db()
         .query(ftsSQL)
         .all(...params)
@@ -3513,6 +3567,7 @@ export async function searchScored(input: {
        CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
        WHERE knowledge_fts MATCH ?
+       AND k.tenant_id = ?
        AND (k.project_id = ? OR k.project_id IS NULL OR k.cross_project = 1)
        AND COALESCE(m.confidence, 1.0) > 0.2
        ORDER BY rank LIMIT ?`
@@ -3520,6 +3575,7 @@ export async function searchScored(input: {
        CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
        WHERE knowledge_fts MATCH ?
+       AND k.tenant_id = ?
        AND COALESCE(m.confidence, 1.0) > 0.2
        ORDER BY rank LIMIT ?`;
 
@@ -3528,8 +3584,8 @@ export async function searchScored(input: {
       input.query,
       async (matchExpr) => {
         const params = pid
-          ? [title, content, category, matchExpr, pid, limit]
-          : [title, content, category, matchExpr, limit];
+          ? [title, content, category, matchExpr, currentTenantId(), pid, limit]
+          : [title, content, category, matchExpr, currentTenantId(), limit];
         // Staleness-tolerant knowledge FTS scan — offload off the event loop
         // (#966 B). KNOWLEDGE_COLS_K excludes the embedding BLOB, so the rows are
         // structured-clone-safe across the worker boundary.
@@ -3574,6 +3630,7 @@ export async function searchScoredOtherProjects(input: {
      CROSS JOIN knowledge k ON k.rowid = f.rowid
          LEFT JOIN knowledge_meta m ON m.logical_id = k.logical_id
      WHERE knowledge_fts MATCH ?
+     AND k.tenant_id = ?
      AND k.project_id IS NOT NULL
      AND k.project_id != ?
      AND k.cross_project = 0
@@ -3584,7 +3641,15 @@ export async function searchScoredOtherProjects(input: {
     return await runRelaxedSearchAsync(
       input.query,
       async (matchExpr) => {
-        const params = [title, content, category, matchExpr, excludePid, limit];
+        const params = [
+          title,
+          content,
+          category,
+          matchExpr,
+          currentTenantId(),
+          excludePid,
+          limit,
+        ];
         // Staleness-tolerant cross-project knowledge FTS scan — offload off the
         // event loop (#966 B). KNOWLEDGE_COLS_K excludes the embedding BLOB.
         const rows = await offloadAllOrTimeout(ftsSQL, params);
@@ -3603,8 +3668,10 @@ export async function searchScoredOtherProjects(input: {
 
 export function get(id: string): KnowledgeEntry | null {
   const row = db()
-    .query(`SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE id = ?`)
-    .get(id);
+    .query(
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND id = ?`,
+    )
+    .get(currentTenantId(), id);
   // Hydrate the `metadata` column like every `.all()` site does — without this
   // the single-row getters would return an unparsed JSON string, violating the
   // `KnowledgeEntry.metadata: KnowledgeMetadata | null` contract (#627 Phase 1).
@@ -3626,8 +3693,8 @@ export async function getManyOffloaded(
   if (!ids.length) return map;
   const placeholders = ids.map(() => "?").join(",");
   const rows = (await offloadAll(
-    `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE id IN (${placeholders})`,
-    ids,
+    `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND id IN (${placeholders})`,
+    [currentTenantId(), ...ids],
   )) as Record<string, unknown>[];
   for (const row of rows) {
     const entry = hydrateKnowledgeEntry(row) as KnowledgeEntry;
@@ -3646,9 +3713,9 @@ export async function getManyOffloaded(
 export function getByLogical(logicalId: string): KnowledgeEntry | null {
   const row = db()
     .query(
-      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE logical_id = ?`,
+      `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND logical_id = ?`,
     )
-    .get(logicalId);
+    .get(currentTenantId(), logicalId);
   // Hydrate `metadata` (#627 Phase 1) — see get() above.
   return row ? (hydrateKnowledgeEntry(row) as KnowledgeEntry) : null;
 }
@@ -3674,8 +3741,8 @@ export async function getManyByLogicalOffloaded(
   if (!logicalIds.length) return map;
   const placeholders = logicalIds.map(() => "?").join(",");
   const rows = (await offloadAll(
-    `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE logical_id IN (${placeholders})`,
-    logicalIds,
+    `SELECT ${KNOWLEDGE_COLS} FROM knowledge_current WHERE tenant_id = ? AND logical_id IN (${placeholders})`,
+    [currentTenantId(), ...logicalIds],
   )) as Record<string, unknown>[];
   for (const row of rows) {
     const entry = hydrateKnowledgeEntry(row) as KnowledgeEntry;
@@ -3693,8 +3760,8 @@ export async function getManyByLogicalOffloaded(
  */
 export function logicalIdOf(id: string): string {
   const row = db()
-    .query("SELECT logical_id FROM knowledge WHERE id = ?")
-    .get(id) as { logical_id: string } | null;
+    .query("SELECT logical_id FROM knowledge WHERE tenant_id = ? AND id = ?")
+    .get(currentTenantId(), id) as { logical_id: string } | null;
   return row?.logical_id ?? id;
 }
 
@@ -3730,9 +3797,9 @@ export function versionHistory(id: string): KnowledgeVersion[] {
   const logicalId = logicalIdOf(id);
   return db()
     .query(
-      `SELECT ${VERSION_COLS} FROM knowledge WHERE logical_id = ? ORDER BY version ASC`,
+      `SELECT ${VERSION_COLS} FROM knowledge WHERE tenant_id = ? AND logical_id = ? ORDER BY version ASC`,
     )
-    .all(logicalId) as KnowledgeVersion[];
+    .all(currentTenantId(), logicalId) as KnowledgeVersion[];
 }
 
 /**
@@ -3748,10 +3815,10 @@ export function recentKnowledgeChanges(
 ): KnowledgeVersion[] {
   return db()
     .query(
-      `SELECT ${VERSION_COLS} FROM knowledge WHERE project_id = ?
+      `SELECT ${VERSION_COLS} FROM knowledge WHERE tenant_id = ? AND project_id = ?
        ORDER BY updated_at DESC, version DESC LIMIT ?`,
     )
-    .all(projectId, limit) as KnowledgeVersion[];
+    .all(currentTenantId(), projectId, limit) as KnowledgeVersion[];
 }
 
 /**
@@ -3767,9 +3834,9 @@ export function getWorkerSource(
 ): { providerID: string; modelID: string } | null {
   const row = db()
     .query(
-      "SELECT worker_provider_id, worker_model_id FROM knowledge_current WHERE id = ?",
+      "SELECT worker_provider_id, worker_model_id FROM knowledge_current WHERE tenant_id = ? AND id = ?",
     )
-    .get(id) as {
+    .get(currentTenantId(), id) as {
     worker_provider_id: string | null;
     worker_model_id: string | null;
   } | null;
@@ -3813,10 +3880,13 @@ export function pruneOversized(maxLength: number): number {
               AS raw_confidence
          FROM knowledge k
          JOIN knowledge_meta m ON m.logical_id = k.logical_id
-         WHERE k.is_current = 1 AND k.is_deleted = 0
-           AND LENGTH(k.content) > ? AND m.confidence > 0`,
+          WHERE k.tenant_id = ? AND k.is_current = 1 AND k.is_deleted = 0
+            AND LENGTH(k.content) > ? AND m.confidence > 0`,
     )
-    .all(maxLength) as { logical_id: string; raw_confidence: number }[];
+    .all(currentTenantId(), maxLength) as {
+    logical_id: string;
+    raw_confidence: number;
+  }[];
   for (const e of oversized)
     applyConfidenceDelta(e.logical_id, -e.raw_confidence, now);
   return oversized.length;
@@ -4521,10 +4591,11 @@ export function recordDedupFeedback(input: {
   db()
     .query(
       `INSERT INTO dedup_feedback
-         (project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          (tenant_id, project_id, entry_a_title, entry_b_title, similarity, accepted, source, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
+      currentTenantId(),
       input.projectId,
       input.entryATitle,
       input.entryBTitle,
@@ -4547,9 +4618,12 @@ export function getDismissedKnowledgePairs(): Set<string> {
   const rows = db()
     .query(
       `SELECT entry_a_title, entry_b_title FROM dedup_feedback
-       WHERE kind = 'knowledge' AND accepted = 0 AND source = 'dashboard'`,
+       WHERE tenant_id = ? AND kind = 'knowledge' AND accepted = 0 AND source = 'dashboard'`,
     )
-    .all() as Array<{ entry_a_title: string; entry_b_title: string }>;
+    .all(currentTenantId()) as Array<{
+    entry_a_title: string;
+    entry_b_title: string;
+  }>;
   const dismissed = new Set<string>();
   for (const r of rows) {
     dismissed.add(`${r.entry_a_title}\x1f${r.entry_b_title}`);
@@ -4605,10 +4679,19 @@ export function recordContradiction(input: {
   const res = db()
     .query(
       `INSERT OR IGNORE INTO knowledge_contradictions
-         (logical_id_a, logical_id_b, project_id, similarity, rationale, status, detected_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, 'open', ?, ?)`,
+          (tenant_id, logical_id_a, logical_id_b, project_id, similarity, rationale, status, detected_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'open', ?, ?)`,
     )
-    .run(a, b, input.projectId, input.similarity, input.rationale, now, now);
+    .run(
+      currentTenantId(),
+      a,
+      b,
+      input.projectId,
+      input.similarity,
+      input.rationale,
+      now,
+      now,
+    );
   return res.changes > 0;
 }
 
@@ -4631,10 +4714,10 @@ export function recordContradictionCleared(input: {
   db()
     .query(
       `INSERT OR IGNORE INTO knowledge_contradictions
-         (logical_id_a, logical_id_b, project_id, similarity, rationale, status, detected_at, updated_at)
-       VALUES (?, ?, ?, ?, NULL, 'cleared', ?, ?)`,
+          (tenant_id, logical_id_a, logical_id_b, project_id, similarity, rationale, status, detected_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, NULL, 'cleared', ?, ?)`,
     )
-    .run(a, b, input.projectId, input.similarity, now, now);
+    .run(currentTenantId(), a, b, input.projectId, input.similarity, now, now);
 }
 
 /**
@@ -4647,9 +4730,9 @@ export function contradictionExists(a0: string, b0: string): boolean {
   const row = db()
     .query(
       `SELECT COUNT(*) AS n FROM knowledge_contradictions
-       WHERE logical_id_a = ? AND logical_id_b = ?`,
+       WHERE tenant_id = ? AND logical_id_a = ? AND logical_id_b = ?`,
     )
-    .get(a, b) as { n: number };
+    .get(currentTenantId(), a, b) as { n: number };
   return row.n > 0;
 }
 
@@ -4670,11 +4753,16 @@ export function listOpenContradictions(
          FROM knowledge_contradictions c
          JOIN knowledge_current ka ON ka.logical_id = c.logical_id_a
          JOIN knowledge_current kb ON kb.logical_id = c.logical_id_b
-        WHERE c.status = 'open'
+        WHERE c.tenant_id = ? AND ka.tenant_id = ? AND kb.tenant_id = ? AND c.status = 'open'
         ${pid ? "AND (c.project_id = ? OR c.project_id IS NULL)" : ""}
         ORDER BY c.detected_at DESC`,
     )
-    .all(...(pid ? [pid] : [])) as Array<{
+    .all(
+      currentTenantId(),
+      currentTenantId(),
+      currentTenantId(),
+      ...(pid ? [pid] : []),
+    ) as Array<{
     logical_id_a: string;
     logical_id_b: string;
     similarity: number;
@@ -4709,9 +4797,9 @@ export function setContradictionStatus(
   db()
     .query(
       `UPDATE knowledge_contradictions SET status = ?, updated_at = ?
-       WHERE logical_id_a = ? AND logical_id_b = ?`,
+       WHERE tenant_id = ? AND logical_id_a = ? AND logical_id_b = ?`,
     )
-    .run(status, Date.now(), a, b);
+    .run(status, Date.now(), currentTenantId(), a, b);
 }
 
 /**
@@ -4845,14 +4933,14 @@ export function getDedupFeedback(
     projectId !== null
       ? db()
           .query(
-            "SELECT similarity, accepted, source FROM dedup_feedback WHERE kind = 'knowledge' AND project_id = ? ORDER BY similarity",
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE tenant_id = ? AND kind = 'knowledge' AND project_id = ? ORDER BY similarity",
           )
-          .all(projectId)
+          .all(currentTenantId(), projectId)
       : db()
           .query(
-            "SELECT similarity, accepted, source FROM dedup_feedback WHERE kind = 'knowledge' AND project_id IS NULL ORDER BY similarity",
+            "SELECT similarity, accepted, source FROM dedup_feedback WHERE tenant_id = ? AND kind = 'knowledge' AND project_id IS NULL ORDER BY similarity",
           )
-          .all()
+          .all(currentTenantId())
   ) as Array<{ similarity: number; accepted: number; source: string }>;
   return rows.map((r) => ({
     similarity: r.similarity,
@@ -4867,14 +4955,14 @@ export function getDedupFeedbackCount(projectId: string | null): number {
     projectId !== null
       ? db()
           .query(
-            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE kind = 'knowledge' AND project_id = ?",
+            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE tenant_id = ? AND kind = 'knowledge' AND project_id = ?",
           )
-          .get(projectId)
+          .get(currentTenantId(), projectId)
       : db()
           .query(
-            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE kind = 'knowledge' AND project_id IS NULL",
+            "SELECT COUNT(*) as cnt FROM dedup_feedback WHERE tenant_id = ? AND kind = 'knowledge' AND project_id IS NULL",
           )
-          .get()
+          .get(currentTenantId())
   ) as { cnt: number } | null;
   return row?.cnt ?? 0;
 }
@@ -4896,20 +4984,20 @@ export function pruneDedupFeedback(projectId: string | null): void {
     db()
       .query(
         `DELETE FROM dedup_feedback WHERE id IN (
-           SELECT id FROM dedup_feedback WHERE kind = 'knowledge' AND project_id = ?
-           ORDER BY created_at ASC LIMIT ?
-         )`,
+            SELECT id FROM dedup_feedback WHERE tenant_id = ? AND kind = 'knowledge' AND project_id = ?
+            ORDER BY created_at ASC LIMIT ?
+          )`,
       )
-      .run(projectId, excess);
+      .run(currentTenantId(), projectId, excess);
   } else {
     db()
       .query(
         `DELETE FROM dedup_feedback WHERE id IN (
-           SELECT id FROM dedup_feedback WHERE kind = 'knowledge' AND project_id IS NULL
-           ORDER BY created_at ASC LIMIT ?
-         )`,
+            SELECT id FROM dedup_feedback WHERE tenant_id = ? AND kind = 'knowledge' AND project_id IS NULL
+            ORDER BY created_at ASC LIMIT ?
+          )`,
       )
-      .run(excess);
+      .run(currentTenantId(), excess);
   }
 }
 
@@ -4934,6 +5022,14 @@ export function recordTransfer(input: {
   recalledInProjectId: string;
 }): void {
   if (!input.recalledInProjectId) return;
+  if (!getByLogical(input.knowledgeId)) return;
+  if (
+    db()
+      .query("SELECT 1 FROM projects WHERE tenant_id = ? AND id = ?")
+      .get(currentTenantId(), input.recalledInProjectId) == null
+  ) {
+    return;
+  }
   const now = Date.now();
   db()
     .query(
@@ -4953,6 +5049,7 @@ export function recordTransfer(input: {
  * COUNT(*) suffices.
  */
 export function transferCount(knowledgeId: string): number {
+  if (!getByLogical(knowledgeId)) return 0;
   const row = db()
     .query(
       "SELECT COUNT(*) as cnt FROM knowledge_transfers WHERE knowledge_id = ?",
@@ -4968,9 +5065,12 @@ export function transferCount(knowledgeId: string): number {
 export function transferCounts(): Map<string, number> {
   const rows = db()
     .query(
-      "SELECT knowledge_id, COUNT(*) as cnt FROM knowledge_transfers GROUP BY knowledge_id",
+      `SELECT t.knowledge_id, COUNT(*) as cnt
+         FROM knowledge_transfers t
+         JOIN knowledge_current k ON k.logical_id = t.knowledge_id
+        WHERE k.tenant_id = ? GROUP BY t.knowledge_id`,
     )
-    .all() as Array<{ knowledge_id: string; cnt: number }>;
+    .all(currentTenantId()) as Array<{ knowledge_id: string; cnt: number }>;
   const m = new Map<string, number>();
   for (const r of rows) m.set(r.knowledge_id, r.cnt);
   return m;
@@ -4985,6 +5085,7 @@ export type KnowledgeTransfer = {
 
 /** Full per-foreign-project breakdown for one entry, newest activity first. */
 export function transfersFor(knowledgeId: string): KnowledgeTransfer[] {
+  if (!getByLogical(knowledgeId)) return [];
   return db()
     .query(
       `SELECT recalled_in_project_id, hit_count, first_recalled_at, last_recalled_at
@@ -5014,7 +5115,7 @@ function shouldRecordTransfer(
 ): boolean {
   // No session → stable synthetic key so we still throttle per (entry, project).
   const sid = sessionID ?? "__nosession__";
-  const key = `${sid}\x1f${knowledgeId}\x1f${recalledInProjectId}`;
+  const key = `${currentTenantId()}\x1f${sid}\x1f${knowledgeId}\x1f${recalledInProjectId}`;
   const now = Date.now();
   const last = transferDedup.get(key);
   if (last != null && now - last < TRANSFER_DEDUP_WINDOW_MS) return false;

--- a/packages/core/src/recall.ts
+++ b/packages/core/src/recall.ts
@@ -15,6 +15,7 @@ import * as temporal from "./temporal";
 import * as embedding from "./embedding";
 import { ReadPathTimer } from "./read-telemetry";
 import * as entities from "./entities";
+import { currentTenantId } from "./tenant";
 import * as toolTrace from "./tool-trace";
 import * as log from "./log";
 import { db, ensureProject, projectName } from "./db";
@@ -1659,9 +1660,12 @@ export function recallById(id: string): string {
     case "d": {
       const row = db()
         .query(
-          "SELECT id, observations, generation, created_at, session_id, c_norm, r_compression FROM distillations WHERE id = ?",
+          `SELECT d.id, d.observations, d.generation, d.created_at, d.session_id,
+                  d.c_norm, d.r_compression
+             FROM distillations d JOIN projects p ON p.id = d.project_id
+            WHERE p.tenant_id = ? AND d.id = ?`,
         )
-        .get(rawId) as Distillation | null;
+        .get(currentTenantId(), rawId) as Distillation | null;
       if (!row) return `No entry found for id: ${id}`;
       return [
         `## Recall Detail: ${id}`,
@@ -1673,9 +1677,12 @@ export function recallById(id: string): string {
     case "t": {
       const row = db()
         .query(
-          "SELECT id, project_id, session_id, role, content, tokens, distilled, created_at, metadata FROM temporal_messages WHERE id = ?",
+          `SELECT t.id, t.project_id, t.session_id, t.role, t.content, t.tokens,
+                  t.distilled, t.created_at, t.metadata
+             FROM temporal_messages t JOIN projects p ON p.id = t.project_id
+            WHERE p.tenant_id = ? AND t.id = ?`,
         )
-        .get(rawId) as temporal.TemporalMessage | null;
+        .get(currentTenantId(), rawId) as temporal.TemporalMessage | null;
       if (!row) return `No entry found for id: ${id}`;
       return [
         `## Recall Detail: ${id}`,
@@ -1689,9 +1696,12 @@ export function recallById(id: string): string {
     case "lat": {
       const row = db()
         .query(
-          "SELECT id, project_id, file, heading, depth, content, content_hash, first_paragraph, updated_at FROM lat_sections WHERE id = ?",
+          `SELECT l.id, l.project_id, l.file, l.heading, l.depth, l.content,
+                  l.content_hash, l.first_paragraph, l.updated_at
+             FROM lat_sections l JOIN projects p ON p.id = l.project_id
+            WHERE p.tenant_id = ? AND l.id = ?`,
         )
-        .get(rawId) as latReader.LatSection | null;
+        .get(currentTenantId(), rawId) as latReader.LatSection | null;
       if (!row) return `No entry found for id: ${id}`;
       return [
         `## Recall Detail: ${id}`,

--- a/packages/core/src/sync-data.ts
+++ b/packages/core/src/sync-data.ts
@@ -35,6 +35,7 @@ import {
   onKnowledgeTeamPromotionChanged,
   rematerializeConfidence,
 } from "./ltm";
+import { currentTenantId, LOCAL_TENANT_ID } from "./tenant";
 
 // The stable per-device id (also used by the confidence CRDT) doubles as the device id
 // for sync's server-side reaper watermark (#909). Re-exported so the gateway can report
@@ -47,6 +48,21 @@ export { replicaId } from "./ltm";
  * share one mechanism.
  */
 export const withApplying = withSyncApplying;
+
+/**
+ * Cloud sync is intentionally single-account and may only touch the historical
+ * local storage tenant. Request-owned remote/hosted tenants fail closed rather
+ * than sharing installation-global cursors, mirrors, or credentials.
+ */
+export function isLocalSyncContext(): boolean {
+  return currentTenantId() === LOCAL_TENANT_ID;
+}
+
+function assertLocalSyncContext(operation: string): void {
+  if (!isLocalSyncContext()) {
+    throw new Error(`${operation}: cloud sync is unavailable in tenant scope`);
+  }
+}
 
 export type SyncTier = "basic" | "pro" | "max";
 
@@ -556,6 +572,89 @@ export const SYNCED_TABLES: Record<SyncTier, SyncTableMeta[]> = {
   max: [],
 };
 
+export interface SyncTenantParentRef {
+  /** Incoming child column carrying the parent's durable identity. */
+  column: string;
+  /** Tenant-owned local table the reference resolves against. */
+  parentTable: "projects" | "entities" | "knowledge";
+  /** `knowledge.logical_id` is logical identity; all other parents use `id`. */
+  parentKey: "id" | "logical_id";
+  /** NULL means "no parent" and is valid for this child column. */
+  optional?: boolean;
+}
+
+/**
+ * Tenant-sensitive parent references for EVERY synced row shape. Empty entries
+ * are deliberate: those tables either have no parent or only reference
+ * installation-local cloud mirrors (which request tenants cannot own). Keeping
+ * this separate from remote FK assumptions is load-bearing: Supabase may accept
+ * orphan/cross-tenant children, while local SQLite FKs key only by id and cannot
+ * express `(tenant_id, id)` ownership.
+ */
+export const SYNC_TENANT_PARENT_REFS: Readonly<
+  Record<string, readonly SyncTenantParentRef[]>
+> = Object.freeze({
+  account_escrow: [],
+  scope_keys: [],
+  projects: [],
+  knowledge: [
+    {
+      column: "project_id",
+      parentTable: "projects",
+      parentKey: "id",
+      optional: true,
+    },
+  ],
+  knowledge_meta: [
+    {
+      column: "logical_id",
+      parentTable: "knowledge",
+      parentKey: "logical_id",
+    },
+  ],
+  knowledge_meta_crdt: [
+    {
+      column: "logical_id",
+      parentTable: "knowledge",
+      parentKey: "logical_id",
+    },
+  ],
+  entities: [
+    {
+      column: "project_id",
+      parentTable: "projects",
+      parentKey: "id",
+      optional: true,
+    },
+  ],
+  entity_aliases: [
+    { column: "entity_id", parentTable: "entities", parentKey: "id" },
+  ],
+  entity_relations: [
+    { column: "entity_a", parentTable: "entities", parentKey: "id" },
+    { column: "entity_b", parentTable: "entities", parentKey: "id" },
+  ],
+  knowledge_entity_refs: [
+    {
+      column: "knowledge_id",
+      parentTable: "knowledge",
+      parentKey: "logical_id",
+    },
+    { column: "entity_id", parentTable: "entities", parentKey: "id" },
+  ],
+  profiles: [],
+  orgs: [],
+  org_members: [],
+  scopes: [],
+  scope_members: [],
+  distillations: [
+    { column: "project_id", parentTable: "projects", parentKey: "id" },
+  ],
+  temporal_messages: [
+    { column: "project_id", parentTable: "projects", parentKey: "id" },
+  ],
+});
+
 // Every registered table across ALL tiers — so meta()/metaFor() resolve a table
 // regardless of the caller's current tier (a Pro table's shape is tier-independent;
 // tier only gates whether it is SYNCED, not whether its meta exists).
@@ -589,6 +688,7 @@ export function syncedTablesFor(tier: SyncTier): SyncTableMeta[] {
  * whose cumulative table set should sync. free → basic; pro → pro; max → max.
  */
 export function currentSyncTier(): SyncTier {
+  if (!isLocalSyncContext()) return "basic";
   const plan = currentTier();
   if (plan === "max") return "max";
   if (plan === "pro") return "pro";
@@ -611,6 +711,7 @@ export function metaFor(table: string): SyncTableMeta {
  * propagates here on the next pull (no bespoke "did I become pro?" path).
  */
 export function currentTier(): string {
+  if (!isLocalSyncContext()) return "free";
   // INVARIANT: the mirror holds AT MOST the currently-authenticated user's row.
   // `clearPullOnlyMirrors()` is called on logout and on account switch, so a stale
   // OR foreign account's tier can never linger here — making this unqualified
@@ -634,6 +735,7 @@ export function currentTier(): string {
  * mirror intact — callers gate on a user_id change.
  */
 export function clearPullOnlyMirrors(): void {
+  if (!isLocalSyncContext()) return;
   for (const m of [
     ...SYNCED_TABLES.basic,
     ...SYNCED_TABLES.pro,
@@ -641,7 +743,9 @@ export function clearPullOnlyMirrors(): void {
   ]) {
     if (!m.pullOnly) continue;
     db().exec(`DELETE FROM ${m.table}`);
-    db().query("DELETE FROM sync_state WHERE table_name = ?").run(m.table);
+    db()
+      .query("DELETE FROM sync_state WHERE tenant_id = ? AND table_name = ?")
+      .run(LOCAL_TENANT_ID, m.table);
     // Reset the pull cursor so the (new) account's rows are re-pulled from the
     // start rather than skipped by a cursor inherited from the previous account.
     setKV(`sync.pull.${m.table}`, "0|");
@@ -652,6 +756,62 @@ function meta(table: string): SyncTableMeta {
   const m = META_BY_TABLE.get(table);
   if (!m) throw new Error(`not a synced table: ${table}`);
   return m;
+}
+
+export class SyncParentConstraintError extends Error {
+  readonly code = "SQLITE_CONSTRAINT_FOREIGNKEY";
+  readonly errcode = 787;
+
+  constructor(
+    readonly table: string,
+    readonly column: string,
+    readonly reason: "missing" | "non-local",
+  ) {
+    super(
+      `sync parent constraint failed: ${table}.${column} has ${reason} parent`,
+    );
+    this.name = "SyncParentConstraintError";
+  }
+}
+
+/**
+ * Validate every tenant-sensitive parent reference before a pulled row can
+ * mutate local storage or receive sync_state. Missing parents follow the
+ * existing FK-orphan quarantine behavior for upserts; tombstones may outlive
+ * their parents, but still fail closed if a matching non-local parent exists.
+ */
+export function assertLocalSyncParents(
+  table: string,
+  row: Record<string, unknown>,
+  opts: { allowMissing?: boolean } = {},
+): void {
+  meta(table);
+  if (!Object.hasOwn(SYNC_TENANT_PARENT_REFS, table)) {
+    throw new Error(`missing sync parent registry entry: ${table}`);
+  }
+
+  for (const ref of SYNC_TENANT_PARENT_REFS[table]) {
+    const value = row[ref.column];
+    if (value === null || value === undefined) {
+      if (ref.optional || opts.allowMissing) continue;
+      throw new SyncParentConstraintError(table, ref.column, "missing");
+    }
+
+    const parentWhere =
+      ref.parentKey === "logical_id"
+        ? "COALESCE(logical_id, id) = ?"
+        : "id = ?";
+    const parents = db()
+      .query(`SELECT tenant_id FROM ${ref.parentTable} WHERE ${parentWhere}`)
+      .all(asString(value)) as Array<{ tenant_id: string }>;
+    if (parents.length === 0) {
+      if (opts.allowMissing) continue;
+      throw new SyncParentConstraintError(table, ref.column, "missing");
+    }
+    if (parents.some((parent) => parent.tenant_id !== LOCAL_TENANT_ID)) {
+      throw new SyncParentConstraintError(table, ref.column, "non-local");
+    }
+  }
 }
 
 /**
@@ -760,13 +920,72 @@ function hashRowColumns(
   return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
 }
 
+/**
+ * Ownership predicate for a live synced row. Tables with direct durable tenant
+ * ownership use it; child/register rows derive ownership from their parent.
+ * Installation-local key/mirror tables have no tenant column and are reachable
+ * only after the local-context guard above this DB boundary.
+ */
+function localRowGate(table: string): string {
+  switch (table) {
+    case "projects":
+    case "knowledge":
+    case "entities":
+    case "entity_aliases":
+      return `${table}.tenant_id = ''`;
+    case "knowledge_meta":
+    case "knowledge_meta_crdt":
+      return `EXISTS (SELECT 1 FROM knowledge k WHERE COALESCE(k.logical_id, k.id) = ${table}.logical_id AND k.tenant_id = '')`;
+    case "entity_relations":
+      return (
+        "EXISTS (SELECT 1 FROM entities e WHERE e.id = entity_relations.entity_a AND e.tenant_id = '') " +
+        "AND EXISTS (SELECT 1 FROM entities e WHERE e.id = entity_relations.entity_b AND e.tenant_id = '')"
+      );
+    case "knowledge_entity_refs":
+      return (
+        "EXISTS (SELECT 1 FROM knowledge k WHERE COALESCE(k.logical_id, k.id) = knowledge_entity_refs.knowledge_id AND k.tenant_id = '') " +
+        "AND EXISTS (SELECT 1 FROM entities e WHERE e.id = knowledge_entity_refs.entity_id AND e.tenant_id = '')"
+      );
+    case "distillations":
+    case "temporal_messages":
+      return `EXISTS (SELECT 1 FROM projects p WHERE p.id = ${table}.project_id AND p.tenant_id = '')`;
+    default:
+      return "1 = 1";
+  }
+}
+
+/** Refuse to update a same-primary-key row owned by a request tenant. */
+function assertNoNonLocalRowCollision(table: string, rowId: string): void {
+  const gate = localRowGate(table);
+  if (gate === "1 = 1") return;
+  const m = meta(table);
+  const idWhere = m.idColumns.map((c) => `${c} = ?`).join(" AND ");
+  const params = splitRowId(rowId);
+  const existing = db()
+    .query(`SELECT 1 FROM ${table} WHERE ${idWhere} LIMIT 1`)
+    .get(...params);
+  if (!existing) return;
+  const local = db()
+    .query(`SELECT 1 FROM ${table} WHERE ${idWhere} AND ${gate} LIMIT 1`)
+    .get(...params);
+  if (!local) {
+    throw new Error(
+      `cloud sync refused non-local row collision: ${table}/${rowId}`,
+    );
+  }
+}
+
 /** Read a synced row by its `row_id` (payload columns only). Null if absent. */
 export function getRowById(
   table: string,
   rowId: string,
 ): Record<string, unknown> | null {
+  if (!isLocalSyncContext()) return null;
   const m = meta(table);
-  const where = m.idColumns.map((c) => `${c} = ?`).join(" AND ");
+  const where = [
+    ...m.idColumns.map((c) => `${c} = ?`),
+    localRowGate(table),
+  ].join(" AND ");
   const cols = columns(table).filter((c) => !PAYLOAD_EXCLUDE.has(c));
   const row = db()
     .query(`SELECT ${cols.join(", ")} FROM ${table} WHERE ${where}`)
@@ -784,6 +1003,7 @@ export interface OutboxEntry {
   row_id: string;
   op: "upsert" | "delete";
   changed_at: number;
+  tenant_id: string;
 }
 
 /**
@@ -796,21 +1016,22 @@ export function readOutbox(
   limit = 500,
   table?: string,
 ): OutboxEntry[] {
+  if (!isLocalSyncContext()) return [];
   if (table) {
     return db()
       .query(
-        `SELECT seq, table_name, row_id, op, changed_at
-           FROM sync_outbox WHERE table_name = ? AND seq > ?
+        `SELECT seq, table_name, row_id, op, changed_at, tenant_id
+           FROM sync_outbox WHERE tenant_id = ? AND table_name = ? AND seq > ?
            ORDER BY seq LIMIT ?`,
       )
-      .all(table, sinceSeq, limit) as unknown as OutboxEntry[];
+      .all(LOCAL_TENANT_ID, table, sinceSeq, limit) as unknown as OutboxEntry[];
   }
   return db()
     .query(
-      `SELECT seq, table_name, row_id, op, changed_at
-         FROM sync_outbox WHERE seq > ? ORDER BY seq LIMIT ?`,
+      `SELECT seq, table_name, row_id, op, changed_at, tenant_id
+         FROM sync_outbox WHERE tenant_id = ? AND seq > ? ORDER BY seq LIMIT ?`,
     )
-    .all(sinceSeq, limit) as unknown as OutboxEntry[];
+    .all(LOCAL_TENANT_ID, sinceSeq, limit) as unknown as OutboxEntry[];
 }
 
 /**
@@ -819,9 +1040,10 @@ export function readOutbox(
  * `minCursor` is the lowest per-table push cursor the engine has persisted.
  */
 export function pruneOutbox(minCursor: number): number {
-  if (minCursor <= 0) return 0;
-  return db().query(`DELETE FROM sync_outbox WHERE seq <= ?`).run(minCursor)
-    .changes;
+  if (!isLocalSyncContext() || minCursor <= 0) return 0;
+  return db()
+    .query(`DELETE FROM sync_outbox WHERE tenant_id = ? AND seq <= ?`)
+    .run(LOCAL_TENANT_ID, minCursor).changes;
 }
 
 /**
@@ -834,12 +1056,13 @@ export function hasPendingChange(
   rowId: string,
   sinceSeq: number,
 ): boolean {
+  if (!isLocalSyncContext()) return false;
   const row = db()
     .query(
       `SELECT 1 FROM sync_outbox
-        WHERE table_name = ? AND row_id = ? AND seq > ? LIMIT 1`,
+        WHERE tenant_id = ? AND table_name = ? AND row_id = ? AND seq > ? LIMIT 1`,
     )
-    .get(table, rowId, sinceSeq);
+    .get(LOCAL_TENANT_ID, table, rowId, sinceSeq);
   return row != null;
 }
 
@@ -853,30 +1076,37 @@ export function hasPendingKnowledgeChange(
   logicalId: string,
   sinceSeq: number,
 ): boolean {
+  if (!isLocalSyncContext()) return false;
   const row = db()
     .query(
       `SELECT 1 FROM sync_outbox
-        WHERE table_name = 'knowledge' AND seq > ? AND row_id = ? LIMIT 1`,
+        WHERE tenant_id = ? AND table_name = 'knowledge' AND seq > ? AND row_id = ? LIMIT 1`,
     )
-    .get(sinceSeq, logicalId);
+    .get(LOCAL_TENANT_ID, sinceSeq, logicalId);
   return row != null;
 }
 
 /** True when the outbox has at least one entry for `table`. */
 export function hasOutboxEntries(table: string): boolean {
+  if (!isLocalSyncContext()) return false;
   return (
     db()
-      .query(`SELECT 1 FROM sync_outbox WHERE table_name = ? LIMIT 1`)
-      .get(table) != null
+      .query(
+        `SELECT 1 FROM sync_outbox WHERE tenant_id = ? AND table_name = ? LIMIT 1`,
+      )
+      .get(LOCAL_TENANT_ID, table) != null
   );
 }
 
 /** Highest outbox `seq` currently present (0 when empty). */
 export function maxOutboxSeq(): number {
+  if (!isLocalSyncContext()) return 0;
   return (
-    db().query(`SELECT COALESCE(MAX(seq), 0) AS m FROM sync_outbox`).get() as {
-      m: number;
-    }
+    db()
+      .query(
+        `SELECT COALESCE(MAX(seq), 0) AS m FROM sync_outbox WHERE tenant_id = ?`,
+      )
+      .get(LOCAL_TENANT_ID) as { m: number }
   ).m;
 }
 
@@ -929,8 +1159,9 @@ function rowIdExpr(m: SyncTableMeta): string {
 // trigger gate (db.ts installSyncCapture) — the two MUST stay in lockstep.
 function remoteBackedGate(prefix = ""): string {
   return (
-    `(${prefix}cross_project = 1 OR ${prefix}project_id IS NULL OR ` +
-    `${prefix}project_id IN (SELECT id FROM projects WHERE git_remote IS NOT NULL))`
+    `(${prefix}tenant_id = '' AND (` +
+    `${prefix}cross_project = 1 OR ${prefix}project_id IS NULL OR ` +
+    `${prefix}project_id IN (SELECT id FROM projects WHERE tenant_id = '' AND git_remote IS NOT NULL)))`
   );
 }
 
@@ -946,7 +1177,7 @@ function entityParentGate(idExpr: string): string {
 // P2c (#1246): the Pro tables are always project-scoped (project_id NOT NULL, no
 // cross_project) — they sync only when their project is remote-backed.
 function projectRemoteGate(idExpr: string): string {
-  return `EXISTS (SELECT 1 FROM projects p WHERE p.id = ${idExpr} AND p.git_remote IS NOT NULL)`;
+  return `EXISTS (SELECT 1 FROM projects p WHERE p.id = ${idExpr} AND p.tenant_id = '' AND p.git_remote IS NOT NULL)`;
 }
 
 function seedSelect(table: string): string {
@@ -1034,23 +1265,24 @@ function seedSelect(table: string): string {
     // Mirrors the capture trigger's git_remote gate. path is not synced (pickSyncColumns
     // drops it — not in syncColumns).
     case "projects":
-      return "SELECT * FROM projects WHERE git_remote IS NOT NULL ORDER BY created_at DESC, id";
+      return "SELECT * FROM projects WHERE tenant_id = '' AND git_remote IS NOT NULL ORDER BY created_at DESC, id";
     default:
       return `SELECT * FROM ${table}`;
   }
 }
 
 export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
+  if (!isLocalSyncContext()) return;
   const now = Date.now();
   const enqueue = db().query(
-    `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-     VALUES (?, ?, 'upsert', ?)`,
+    `INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+     VALUES (?, ?, 'upsert', ?, ?)`,
   );
   // Latest pending op for a row among entries the push hasn't consumed yet. An
   // already-pushed (seq <= cursor) entry is stale — never re-read — so excluded.
   const latestUnpushed = db().query(
     `SELECT op FROM sync_outbox
-      WHERE table_name = ? AND row_id = ? AND seq > ?
+      WHERE tenant_id = ? AND table_name = ? AND row_id = ? AND seq > ?
       ORDER BY seq DESC LIMIT 1`,
   );
   // One transaction for the whole seed: the per-row loop does N inserts, and
@@ -1075,7 +1307,7 @@ export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
       if (m.table === "knowledge") {
         const latestForLogical = db().query(
           `SELECT op FROM sync_outbox
-            WHERE table_name = 'knowledge' AND seq > ? AND row_id = ?
+            WHERE tenant_id = ? AND table_name = 'knowledge' AND seq > ? AND row_id = ?
             ORDER BY seq DESC LIMIT 1`,
         );
         // Value-ranked so a capped free tier syncs the MOST USEFUL entries first. The
@@ -1096,15 +1328,18 @@ export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
           .all() as { lid: string }[];
         for (const { lid } of lids) {
           const pending =
-            (latestForLogical.get(pushCursor, lid) as { op: string } | null)
-              ?.op ?? null;
+            (
+              latestForLogical.get(LOCAL_TENANT_ID, pushCursor, lid) as {
+                op: string;
+              } | null
+            )?.op ?? null;
           if (pending === "upsert") continue; // already queued
           if (pending === null) {
             const synced = getSyncState("knowledge", lid)?.content_hash ?? null;
             const row = currentKnowledgeRow(lid);
             if (row && contentHash("knowledge", row) === synced) continue;
           }
-          enqueue.run("knowledge", lid, now);
+          enqueue.run("knowledge", lid, now, LOCAL_TENANT_ID);
         }
         continue;
       }
@@ -1117,7 +1352,7 @@ export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
         const rowId = rowIdOf(m.table, row);
         const pending =
           (
-            latestUnpushed.get(m.table, rowId, pushCursor) as {
+            latestUnpushed.get(LOCAL_TENANT_ID, m.table, rowId, pushCursor) as {
               op: string;
             } | null
           )?.op ?? null;
@@ -1127,7 +1362,7 @@ export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
           const synced = getSyncState(m.table, rowId)?.content_hash ?? null;
           if (hashRowColumns(cols, row) === synced) continue;
         }
-        enqueue.run(m.table, rowId, now);
+        enqueue.run(m.table, rowId, now, LOCAL_TENANT_ID);
       }
     }
   });
@@ -1148,6 +1383,7 @@ export function seedOutbox(tier: SyncTier = currentSyncTier()): void {
  * while sync was disabled are not silently dropped from the push queue.
  */
 export function reconcile(tier: SyncTier = currentSyncTier()): void {
+  if (!isLocalSyncContext()) return;
   const now = Date.now();
   seedOutbox(tier);
   for (const m of syncedTablesFor(tier)) {
@@ -1176,19 +1412,21 @@ export function reconcile(tier: SyncTier = currentSyncTier()): void {
         : `NOT EXISTS (SELECT 1 FROM ${m.table} t WHERE ${rowIdExpr(m)} = s.row_id)`;
     db()
       .query(
-        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at)
-         SELECT s.table_name, s.row_id, 'delete', ?
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+         SELECT s.table_name, s.row_id, 'delete', ?, s.tenant_id
            FROM sync_state s
-          WHERE s.table_name = ?
+          WHERE s.tenant_id = ?
+            AND s.table_name = ?
             AND ${livenessNotExists}
             AND COALESCE(
               (SELECT o.op FROM sync_outbox o
-                WHERE o.table_name = s.table_name AND o.row_id = s.row_id
+                WHERE o.tenant_id = s.tenant_id
+                  AND o.table_name = s.table_name AND o.row_id = s.row_id
                 ORDER BY o.seq DESC LIMIT 1),
               'none'
             ) <> 'delete'`,
       )
-      .run(now, m.table);
+      .run(now, LOCAL_TENANT_ID, m.table);
   }
 }
 
@@ -1199,14 +1437,21 @@ export function reconcile(tier: SyncTier = currentSyncTier()): void {
 // BEGIN IMMEDIATE would nest). cross_project=0 only: global/cross-project rows were never
 // gated (they always sync) so they're already queued/synced. Only fires when sync is on.
 export function reseedProjectContent(projectId: string): void {
-  if (getTeamConfig(ENABLED_KEY) !== "1") return;
+  if (!isLocalSyncContext() || getTeamConfig(ENABLED_KEY) !== "1") return;
+  if (
+    db()
+      .query("SELECT 1 FROM projects WHERE id = ? AND tenant_id = ?")
+      .get(projectId, LOCAL_TENANT_ID) == null
+  )
+    return;
   const now = Date.now();
   const enqueue = (sql: string, ...params: unknown[]) =>
     db()
       .query(
-        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at) ${sql}`,
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+         SELECT queued.*, ? FROM (${sql}) queued`,
       )
-      .run(...params);
+      .run(LOCAL_TENANT_ID, ...params);
   // The project's own project-scoped rows (this project's cross_project=0 knowledge in
   // one sub-select, reused for the children so they align 1:1 with the seeded knowledge).
   // knowledge_current (live-only) so a deleted entry's lingering meta/refs aren't
@@ -1303,14 +1548,15 @@ onProjectRemoteBackfilled(reseedProjectContent);
  * Idempotent: an unchanged row short-circuits in the push (same content_hash AND scope).
  */
 export function reenqueueKnowledgeTeamGraph(logicalId: string): void {
-  if (getTeamConfig(ENABLED_KEY) !== "1") return;
+  if (!isLocalSyncContext() || getTeamConfig(ENABLED_KEY) !== "1") return;
   const now = Date.now();
   const enqueue = (sql: string, ...params: unknown[]) =>
     db()
       .query(
-        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at) ${sql}`,
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+         SELECT queued.*, ? FROM (${sql}) queued`,
       )
-      .run(...params);
+      .run(LOCAL_TENANT_ID, ...params);
   const linkedEntities =
     "SELECT entity_id FROM knowledge_entity_refs WHERE knowledge_id = ?";
   // The refs of this knowledge (they follow the knowledge → team).
@@ -1358,16 +1604,17 @@ onKnowledgeTeamPromotionChanged(reenqueueKnowledgeTeamGraph);
  * an unchanged row (same scope AND content_hash) short-circuits in the push.
  */
 export function reenqueueDeletedKnowledgeGraph(entityIds: string[]): void {
-  if (getTeamConfig(ENABLED_KEY) !== "1") return;
+  if (!isLocalSyncContext() || getTeamConfig(ENABLED_KEY) !== "1") return;
   if (entityIds.length === 0) return;
   const now = Date.now();
   const placeholders = entityIds.map(() => "?").join(", ");
   const enqueue = (sql: string, ...params: unknown[]) =>
     db()
       .query(
-        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at) ${sql}`,
+        `INSERT INTO sync_outbox (table_name, row_id, op, changed_at, tenant_id)
+         SELECT queued.*, ? FROM (${sql}) queued`,
       )
-      .run(...params);
+      .run(LOCAL_TENANT_ID, ...params);
   // The affected entities (their team-scope may have dropped now the referencing knowledge is gone).
   // NOTE: remove()'s recomputeEntityRank already UPDATEs each entity and trigger-enqueues it, so this
   // entity clause is redundant; the LOAD-BEARING part is the aliases + relations below (no trigger
@@ -1418,13 +1665,14 @@ export function getSyncState(
   table: string,
   rowId: string,
 ): SyncRowState | null {
+  if (!isLocalSyncContext()) return null;
   meta(table);
   const row = db()
     .query(
       `SELECT content_hash, revision, remote_updated_at, scope_id
-         FROM sync_state WHERE table_name = ? AND row_id = ?`,
+         FROM sync_state WHERE tenant_id = ? AND table_name = ? AND row_id = ?`,
     )
-    .get(table, rowId) as unknown as SyncRowState | undefined;
+    .get(LOCAL_TENANT_ID, table, rowId) as unknown as SyncRowState | undefined;
   return row ?? null;
 }
 
@@ -1433,16 +1681,18 @@ export function setSyncState(
   rowId: string,
   state: SyncRowState,
 ): void {
+  if (!isLocalSyncContext()) return;
   meta(table);
   db()
     .query(
-      `INSERT INTO sync_state (table_name, row_id, content_hash, revision, remote_updated_at, scope_id)
-       VALUES (?, ?, ?, ?, ?, ?)
+      `INSERT INTO sync_state (table_name, row_id, content_hash, revision, remote_updated_at, scope_id, tenant_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(table_name, row_id) DO UPDATE SET
-         content_hash = excluded.content_hash,
-         revision = excluded.revision,
-         remote_updated_at = excluded.remote_updated_at,
-         scope_id = excluded.scope_id`,
+          content_hash = excluded.content_hash,
+          revision = excluded.revision,
+          remote_updated_at = excluded.remote_updated_at,
+          scope_id = excluded.scope_id,
+          tenant_id = excluded.tenant_id`,
     )
     .run(
       table,
@@ -1451,14 +1701,18 @@ export function setSyncState(
       state.revision,
       state.remote_updated_at,
       state.scope_id ?? null,
+      LOCAL_TENANT_ID,
     );
 }
 
 export function clearSyncState(table: string, rowId: string): void {
+  if (!isLocalSyncContext()) return;
   meta(table);
   db()
-    .query(`DELETE FROM sync_state WHERE table_name = ? AND row_id = ?`)
-    .run(table, rowId);
+    .query(
+      `DELETE FROM sync_state WHERE tenant_id = ? AND table_name = ? AND row_id = ?`,
+    )
+    .run(LOCAL_TENANT_ID, table, rowId);
 }
 
 // ---------------------------------------------------------------------------
@@ -1478,7 +1732,8 @@ function knowledgeTeamScope(logicalId: string): string | null {
   const row = db()
     .query(
       `SELECT p.scope_id FROM knowledge_current k JOIN projects p ON p.id = k.project_id
-       WHERE k.logical_id = ? AND k.approval_status = 'approved' AND p.scope_id IS NOT NULL`,
+       WHERE k.tenant_id = '' AND p.tenant_id = '' AND k.logical_id = ?
+         AND k.approval_status = 'approved' AND p.scope_id IS NOT NULL`,
     )
     .get(logicalId) as { scope_id: string } | undefined;
   return row?.scope_id ?? null;
@@ -1496,7 +1751,8 @@ function entityTeamScope(entityId: string): string | null {
       `SELECT MIN(p.scope_id) AS scope_id FROM knowledge_entity_refs r
        JOIN knowledge_current k ON k.logical_id = r.knowledge_id
        JOIN projects p ON p.id = k.project_id
-       WHERE r.entity_id = ? AND k.approval_status = 'approved' AND p.scope_id IS NOT NULL`,
+       WHERE k.tenant_id = '' AND p.tenant_id = '' AND r.entity_id = ?
+         AND k.approval_status = 'approved' AND p.scope_id IS NOT NULL`,
     )
     .get(entityId) as { scope_id: string | null } | undefined;
   return row?.scope_id ?? null;
@@ -1517,6 +1773,7 @@ export function teamScopeForContent(
   table: string,
   rowId: string,
 ): string | null {
+  if (!isLocalSyncContext()) return null;
   switch (table) {
     case "knowledge":
       return knowledgeTeamScope(rowId);
@@ -1528,7 +1785,9 @@ export function teamScopeForContent(
     }
     case "entity_aliases": {
       const r = db()
-        .query("SELECT entity_id FROM entity_aliases WHERE id = ?")
+        .query(
+          "SELECT entity_id FROM entity_aliases WHERE tenant_id = '' AND id = ?",
+        )
         .get(rowId) as { entity_id: string } | undefined;
       return r ? entityTeamScope(r.entity_id) : null;
     }
@@ -1585,7 +1844,9 @@ export function applyRemoteUpsert(
   table: string,
   row: Record<string, unknown>,
 ): void {
+  assertLocalSyncContext("applyRemoteUpsert");
   const m = meta(table);
+  assertNoNonLocalRowCollision(table, rowIdOf(table, row));
   decodeBlobColumns(table, row);
   const cols = columns(table).filter(
     (c) => !PAYLOAD_EXCLUDE.has(c) && c in row,
@@ -1621,6 +1882,7 @@ export function replaceRegistryTable(
   table: string,
   remoteRows: Record<string, unknown>[],
 ): void {
+  assertLocalSyncContext("replaceRegistryTable");
   const m = meta(table);
   if (!m.mirrorSnapshot)
     throw new Error(
@@ -1687,22 +1949,26 @@ export function replaceRegistryTable(
  * convergeProjectsByRemote() pass merges them deterministically (min-id winner).
  */
 export function applyRemoteProject(row: Record<string, unknown>): void {
+  assertLocalSyncContext("applyRemoteProject");
   const id = String(row.id);
+  assertNoNonLocalRowCollision("projects", id);
   const gitRemote = typeof row.git_remote === "string" ? row.git_remote : null;
   const name = typeof row.name === "string" ? row.name : null;
   const createdAt = Number(row.created_at) || Date.now();
   withApplying(() => {
     const existing = db()
-      .query("SELECT id FROM projects WHERE id = ?")
-      .get(id) as { id: string } | null | undefined;
+      .query("SELECT id FROM projects WHERE tenant_id = ? AND id = ?")
+      .get(LOCAL_TENANT_ID, id) as { id: string } | null | undefined;
     if (existing) {
       // Update identity fields only; NEVER touch path (device-local). COALESCE keeps a
       // locally-known git_remote/name if the incoming row hasn't resolved one yet.
       db()
         .query(
-          "UPDATE projects SET git_remote = COALESCE(?, git_remote), name = COALESCE(?, name) WHERE id = ?",
+          `UPDATE projects
+              SET git_remote = COALESCE(?, git_remote), name = COALESCE(?, name)
+            WHERE tenant_id = ? AND id = ?`,
         )
-        .run(gitRemote, name, id);
+        .run(gitRemote, name, LOCAL_TENANT_ID, id);
     } else {
       db()
         .query(
@@ -1729,7 +1995,9 @@ function temporalLiveColumns(): Set<string> {
 }
 
 export function applyRemoteTemporal(row: Record<string, unknown>): void {
+  assertLocalSyncContext("applyRemoteTemporal");
   const table = "temporal_messages";
+  assertNoNonLocalRowCollision(table, rowIdOf(table, row));
   const m = meta(table);
   decodeBlobColumns(table, row);
   const insertRow: Record<string, unknown> = {
@@ -1764,8 +2032,12 @@ export function applyRemoteTemporal(row: Record<string, unknown>): void {
 
 /** Delete a pulled-as-removed row locally (under apply-suppression). */
 export function applyRemoteDelete(table: string, rowId: string): void {
+  assertLocalSyncContext("applyRemoteDelete");
   const m = meta(table);
-  const where = m.idColumns.map((c) => `${c} = ?`).join(" AND ");
+  const where = [
+    ...m.idColumns.map((c) => `${c} = ?`),
+    localRowGate(table),
+  ].join(" AND ");
   withApplying(() =>
     db()
       .query(`DELETE FROM ${table} WHERE ${where}`)
@@ -1783,7 +2055,9 @@ export function applyRemoteDelete(table: string, rowId: string): void {
  * `confidence = base`; re-materialize then folds in any counters already present.
  */
 export function applyRemoteMeta(row: Record<string, unknown>): void {
+  assertLocalSyncContext("applyRemoteMeta");
   const logicalId = String(row.logical_id);
+  assertNoNonLocalRowCollision("knowledge_meta", logicalId);
   const base = Number(row.base_confidence ?? 1.0);
   withApplying(() => {
     db()
@@ -1807,6 +2081,7 @@ export function applyRemoteMeta(row: Record<string, unknown>): void {
  * remote row (not stripped) because it needs `scope_id`.
  */
 export function applyRemoteScopeKey(remote: Record<string, unknown>): void {
+  assertLocalSyncContext("applyRemoteScopeKey");
   const scopeId = String(remote.scope_id);
   const memberUserId = String(remote.member_user_id);
   const wrapped =
@@ -1829,7 +2104,12 @@ export function applyRemoteScopeKey(remote: Record<string, unknown>): void {
  * not re-pushed (this device only ever pushes its OWN replica's rows).
  */
 export function applyRemoteMetaCrdt(row: Record<string, unknown>): void {
+  assertLocalSyncContext("applyRemoteMetaCrdt");
   const logicalId = String(row.logical_id);
+  assertNoNonLocalRowCollision(
+    "knowledge_meta_crdt",
+    rowIdOf("knowledge_meta_crdt", row),
+  );
   withApplying(() => {
     db()
       .query(
@@ -1924,7 +2204,9 @@ function insertKnowledgeVersion(
  * current content converges across devices.
  */
 export function applyRemoteKnowledge(row: Record<string, unknown>): void {
+  assertLocalSyncContext("applyRemoteKnowledge");
   const logicalId = String(row.id);
+  assertNoNonLocalRowCollision("knowledge", logicalId);
   const syncCols = columns("knowledge").filter(
     (c) => !PAYLOAD_EXCLUDE.has(c) && c in row,
   );
@@ -1932,14 +2214,17 @@ export function applyRemoteKnowledge(row: Record<string, unknown>): void {
     withTransaction(() => {
       const agg = db()
         .query(
-          "SELECT MAX(version) AS maxV, COUNT(*) AS n FROM knowledge WHERE COALESCE(logical_id, id) = ?",
+          "SELECT MAX(version) AS maxV, COUNT(*) AS n FROM knowledge WHERE tenant_id = ? AND COALESCE(logical_id, id) = ?",
         )
-        .get(logicalId) as { maxV: number | null; n: number };
+        .get(LOCAL_TENANT_ID, logicalId) as {
+        maxV: number | null;
+        n: number;
+      };
       const cur = db()
         .query(
-          "SELECT content FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+          "SELECT content FROM knowledge_current WHERE tenant_id = ? AND COALESCE(logical_id, id) = ?",
         )
-        .get(logicalId) as { content: string } | undefined;
+        .get(LOCAL_TENANT_ID, logicalId) as { content: string } | undefined;
 
       if (agg.n === 0) {
         // Brand-new entry: v1 carries the remote id AS the logical_id (id == logical_id).
@@ -1967,18 +2252,23 @@ export function applyRemoteKnowledge(row: Record<string, unknown>): void {
         if (setCols.length > 0) {
           db()
             .query(
-              `UPDATE knowledge SET ${setCols.map((c) => `${c} = ?`).join(", ")} WHERE COALESCE(logical_id, id) = ? AND is_current = 1`,
+              `UPDATE knowledge SET ${setCols.map((c) => `${c} = ?`).join(", ")}
+                WHERE tenant_id = ? AND COALESCE(logical_id, id) = ? AND is_current = 1`,
             )
-            .run(...setCols.map((c) => row[c] as never), logicalId);
+            .run(
+              ...setCols.map((c) => row[c] as never),
+              LOCAL_TENANT_ID,
+              logicalId,
+            );
         }
         return;
       }
       // Content differs (or no live current → revive) → append a new current version.
       db()
         .query(
-          "UPDATE knowledge SET is_current = 0 WHERE COALESCE(logical_id, id) = ? AND is_current = 1",
+          "UPDATE knowledge SET is_current = 0 WHERE tenant_id = ? AND COALESCE(logical_id, id) = ? AND is_current = 1",
         )
-        .run(logicalId);
+        .run(LOCAL_TENANT_ID, logicalId);
       insertKnowledgeVersion(row, syncCols, {
         id: uuidv7(),
         logicalId,
@@ -1996,26 +2286,27 @@ export function applyRemoteKnowledge(row: Record<string, unknown>): void {
  * + transactional (single-current invariant).
  */
 export function applyRemoteKnowledgeDelete(logicalId: string): void {
+  assertLocalSyncContext("applyRemoteKnowledgeDelete");
   withApplying(() =>
     withTransaction(() => {
       const cur = db()
         .query(
-          "SELECT * FROM knowledge_current WHERE COALESCE(logical_id, id) = ?",
+          "SELECT * FROM knowledge_current WHERE tenant_id = ? AND COALESCE(logical_id, id) = ?",
         )
-        .get(logicalId) as Record<string, unknown> | undefined;
+        .get(LOCAL_TENANT_ID, logicalId) as Record<string, unknown> | undefined;
       if (!cur) return; // already no live current — nothing to delete
       const maxV = (
         db()
           .query(
-            "SELECT MAX(version) AS m FROM knowledge WHERE COALESCE(logical_id, id) = ?",
+            "SELECT MAX(version) AS m FROM knowledge WHERE tenant_id = ? AND COALESCE(logical_id, id) = ?",
           )
-          .get(logicalId) as { m: number }
+          .get(LOCAL_TENANT_ID, logicalId) as { m: number }
       ).m;
       db()
         .query(
-          "UPDATE knowledge SET is_current = 0 WHERE COALESCE(logical_id, id) = ? AND is_current = 1",
+          "UPDATE knowledge SET is_current = 0 WHERE tenant_id = ? AND COALESCE(logical_id, id) = ? AND is_current = 1",
         )
-        .run(logicalId);
+        .run(LOCAL_TENANT_ID, logicalId);
       const syncCols = columns("knowledge").filter(
         (c) => !PAYLOAD_EXCLUDE.has(c) && c in cur,
       );
@@ -2060,12 +2351,14 @@ export type KnowledgePushPlan =
 export function currentKnowledgeRow(
   logicalId: string,
 ): Record<string, unknown> | null {
+  if (!isLocalSyncContext()) return null;
   const cols = columns("knowledge").filter((c) => !PAYLOAD_EXCLUDE.has(c));
   const row = db()
     .query(
-      `SELECT ${cols.join(", ")} FROM knowledge_current WHERE COALESCE(logical_id, id) = ?`,
+      `SELECT ${cols.join(", ")} FROM knowledge_current
+        WHERE tenant_id = ? AND COALESCE(logical_id, id) = ?`,
     )
-    .get(logicalId) as Record<string, unknown> | undefined;
+    .get(LOCAL_TENANT_ID, logicalId) as Record<string, unknown> | undefined;
   if (!row) return null;
   row.id = logicalId; // re-key on the stable logical_id (the remote row key)
   return row;
@@ -2083,6 +2376,7 @@ export function knowledgePushPlan(outboxRowId: string): KnowledgePushPlan {
 
 /** Rebuild an external-content FTS5 index after a batch of pulled changes. */
 export function rebuildFts(ftsTable: string): void {
+  assertLocalSyncContext("rebuildFts");
   if (ftsTable === "knowledge_fts") {
     // knowledge_fts is a PARTIAL mirror — only current, non-deleted versions are
     // indexed (A2, #823). FTS5 'rebuild' re-indexes EVERY physical row (incl.
@@ -2160,6 +2454,7 @@ export function recordConflict(
   resolution: string,
   localContent?: Record<string, unknown> | null,
 ): void {
+  assertLocalSyncContext("recordConflict");
   meta(table);
   db()
     .query(
@@ -2310,10 +2605,11 @@ export function resolveRelationUniqueConflict(
 // ---------------------------------------------------------------------------
 
 const ENABLED_KEY = "sync.enabled";
+const TENANT_ISOLATION_RECONCILE_KEY = "sync.tenantIsolationReconcile";
 
 /** True when local change-capture is active. */
 export function isSyncEnabled(): boolean {
-  return getTeamConfig(ENABLED_KEY) === "1";
+  return isLocalSyncContext() && getTeamConfig(ENABLED_KEY) === "1";
 }
 
 /**
@@ -2325,12 +2621,29 @@ export function isSyncEnabled(): boolean {
  * `seedOutbox`).
  */
 export function enableSync(tier: SyncTier = currentSyncTier()): void {
+  if (!isLocalSyncContext()) return;
   setTeamConfig(ENABLED_KEY, "1");
   reconcile(tier);
+  setKV(TENANT_ISOLATION_RECONCILE_KEY, "0");
+}
+
+/** Re-seed live local rows once after v81 quarantines legacy bookkeeping. */
+export function reconcileTenantIsolationMigration(
+  tier: SyncTier = currentSyncTier(),
+): void {
+  if (
+    !isLocalSyncContext() ||
+    !isSyncEnabled() ||
+    getKV(TENANT_ISOLATION_RECONCILE_KEY) !== "1"
+  )
+    return;
+  reconcile(tier);
+  setKV(TENANT_ISOLATION_RECONCILE_KEY, "0");
 }
 
 /** Disable change-capture. Leaves the outbox/state intact for re-enable. */
 export function disableSync(): void {
+  if (!isLocalSyncContext()) return;
   deleteTeamConfig(ENABLED_KEY);
 }
 
@@ -2357,8 +2670,10 @@ export function assertSyncInvariants(): void {
     if (!m.pullOnly) continue;
     const n = (
       db()
-        .query("SELECT COUNT(*) AS n FROM sync_outbox WHERE table_name = ?")
-        .get(m.table) as { n: number }
+        .query(
+          "SELECT COUNT(*) AS n FROM sync_outbox WHERE tenant_id = ? AND table_name = ?",
+        )
+        .get(LOCAL_TENANT_ID, m.table) as { n: number }
     ).n;
     if (n > 0) {
       violations.push(
@@ -2393,12 +2708,29 @@ export function assertSyncInvariants(): void {
   );
   for (const tbl of ["sync_outbox", "sync_state"] as const) {
     const names = db()
-      .query(`SELECT DISTINCT table_name FROM ${tbl}`)
-      .all() as Array<{ table_name: string }>;
+      .query(`SELECT DISTINCT table_name FROM ${tbl} WHERE tenant_id = ?`)
+      .all(LOCAL_TENANT_ID) as Array<{ table_name: string }>;
     for (const { table_name } of names) {
       if (!known.has(table_name)) {
         violations.push(`${tbl} references unregistered table "${table_name}"`);
       }
+    }
+
+    // Request-owned tenant provenance must never enter installation-global
+    // cloud-sync bookkeeping. NULL is the explicit quarantine marker for rows
+    // that predate tenant provenance; only the empty local tenant is active.
+    const foreign = (
+      db()
+        .query(
+          `SELECT COUNT(*) AS n FROM ${tbl}
+            WHERE tenant_id IS NOT NULL AND tenant_id <> ?`,
+        )
+        .get(LOCAL_TENANT_ID) as { n: number }
+    ).n;
+    if (foreign > 0) {
+      violations.push(
+        `${tbl} holds ${foreign} non-local tenant row${foreign === 1 ? "" : "s"}`,
+      );
     }
   }
 

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -1,4 +1,5 @@
-import { db, ensureProject, withSyncApplying } from "./db";
+import { createHash } from "node:crypto";
+import { db, ensureProject, projectId, withSyncApplying } from "./db";
 import { deleteEmbeddings } from "./db/vec-store";
 import { runRelaxedSearch, runRelaxedSearchAsync } from "./search";
 import { offloadAllOrTimeout, READ_JOB_TIMED_OUT } from "./read-offload";
@@ -14,6 +15,7 @@ import {
 import type { LoreMessage, LorePart, LoreToolState } from "./types";
 import { isTextPart, isReasoningPart, isToolPart } from "./types";
 import { estimateTokens } from "./tokenize";
+import { currentTenantId } from "./tenant";
 
 /**
  * Chunk-boundary terminator inserted between chunks by `partsToText`.
@@ -76,42 +78,152 @@ function messageMetadata(info: LoreMessage, parts: LorePart[]): string {
   return JSON.stringify(meta);
 }
 
+const TEMPORAL_ID_PREFIX = "lore_tm_v1_";
+
+/**
+ * Derive the globally unique storage key for a caller-supplied message ID.
+ *
+ * `source_id` remains the caller's opaque, request-stable identity. The primary
+ * key is always a domain-separated hash of its durable owner, so an input that
+ * happens to look like a Lore key is still hashed as input and can never be
+ * mistaken for a storage key.
+ */
+function derivedMessageId(
+  projectId: string,
+  sessionId: string,
+  sourceId: string,
+): string {
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify([
+        "lore-temporal-message-v1",
+        currentTenantId(),
+        projectId,
+        sessionId,
+        sourceId,
+      ]),
+    )
+    .digest("base64url");
+  return `${TEMPORAL_ID_PREFIX}${digest}`;
+}
+
+/** Resolve a source ID to an existing legacy/restored row or its v82 key. */
+function resolveMessageId(
+  projectId: string,
+  sessionId: string,
+  sourceId: string,
+  legacySourceId?: string,
+): string {
+  const derivedId = derivedMessageId(projectId, sessionId, sourceId);
+  const existing = db()
+    .query(
+      `SELECT t.id FROM temporal_messages t
+        JOIN projects p ON p.id = t.project_id
+        WHERE t.project_id = ? AND p.tenant_id = ? AND t.session_id = ?
+          AND (t.source_id = ?
+               OR (t.source_id = t.id AND t.source_id = ?)
+               OR (t.source_id IS NULL AND t.id = ?))
+        LIMIT 1`,
+    )
+    .get(
+      projectId,
+      currentTenantId(),
+      sessionId,
+      sourceId,
+      legacySourceId ?? sourceId,
+      derivedId,
+    ) as { id: string } | null;
+  return existing?.id ?? derivedId;
+}
+
+/**
+ * Return the recall/storage ID corresponding to a caller-supplied message ID.
+ * Existing pre-v82 rows retain their original IDs; new rows use a namespaced ID.
+ */
+export function storedMessageId(input: {
+  projectPath: string;
+  sessionID: string;
+  sourceID: string;
+  /** Pre-v82 gateway source ID, used only to resolve persisted local rows. */
+  legacySourceID?: string;
+}): string {
+  return resolveMessageId(
+    ensureProject(input.projectPath),
+    input.sessionID,
+    input.sourceID,
+    input.legacySourceID,
+  );
+}
+
+/** Read-only variant for no-store paths; never creates or backfills a project. */
+export function storedMessageIdIfProjectExists(input: {
+  projectPath: string;
+  sessionID: string;
+  sourceID: string;
+  legacySourceID?: string;
+}): string | undefined {
+  const pid = projectId(input.projectPath);
+  if (!pid) return undefined;
+  return resolveMessageId(
+    pid,
+    input.sessionID,
+    input.sourceID,
+    input.legacySourceID,
+  );
+}
+
 export function store(input: {
   projectPath: string;
   info: LoreMessage;
   parts: LorePart[];
-}) {
+  legacySourceID?: string;
+}): string | undefined {
   const pid = ensureProject(input.projectPath);
   const content = partsToText(input.parts);
   if (!content.trim()) return;
 
+  const storageId = resolveMessageId(
+    pid,
+    input.info.sessionID,
+    input.info.id,
+    input.legacySourceID,
+  );
   const existing = db()
-    .query("SELECT id FROM temporal_messages WHERE id = ?")
-    .get(input.info.id);
+    .query(
+      "SELECT id FROM temporal_messages WHERE id = ? AND project_id = ? AND session_id = ?",
+    )
+    .get(storageId, pid, input.info.sessionID);
   if (existing) {
     db()
       .query(
-        "UPDATE temporal_messages SET content = ?, tokens = ?, metadata = ? WHERE id = ?",
+        `UPDATE temporal_messages
+            SET content = ?, tokens = ?, metadata = ?,
+                source_id = ?
+          WHERE id = ? AND project_id = ? AND session_id = ?`,
       )
       .run(
         content,
         estimateTokens(content),
         messageMetadata(input.info, input.parts),
         input.info.id,
+        storageId,
+        pid,
+        input.info.sessionID,
       );
     // Re-embed on content update (fire-and-forget)
     if (embedding.isAvailable()) {
-      embedding.embedTemporalMessage(input.info.id, content);
+      embedding.embedTemporalMessage(storageId, content);
     }
-    return;
+    return storageId;
   }
 
   db()
     .query(
-      `INSERT INTO temporal_messages (id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
-       VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+      `INSERT INTO temporal_messages (id, source_id, project_id, session_id, role, content, tokens, distilled, created_at, metadata)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
     )
     .run(
+      storageId,
       input.info.id,
       pid,
       input.info.sessionID,
@@ -124,8 +236,9 @@ export function store(input: {
 
   // Embed new message for vector search (fire-and-forget)
   if (embedding.isAvailable()) {
-    embedding.embedTemporalMessage(input.info.id, content);
+    embedding.embedTemporalMessage(storageId, content);
   }
+  return storageId;
 }
 
 /**
@@ -138,7 +251,7 @@ export function store(input: {
  *     (state `completed` or `error`, after the gateway adapter resolves it)
  *     with the OUTCOME, keyed by the same `callID`.
  *
- * Both phases UPSERT on the globally-unique `call_id` primary key: the tool_use
+ * Both phases correlate on `(project_id, session_id, call_id)`: the tool_use
  * seeds the name + `pending`; the result updates status/error/duration in place.
  * The result branch deliberately does NOT overwrite the recorded tool name with
  * the synthetic `"result"` (it preserves the seeded name).
@@ -153,12 +266,19 @@ export function recordToolCalls(input: {
   projectPath: string;
   info: LoreMessage;
   parts: LorePart[];
+  legacySourceID?: string;
 }): void {
   const toolParts = input.parts.filter(isToolPart);
   if (!toolParts.length) return;
 
   const pid = ensureProject(input.projectPath);
   const createdAt = input.info.time.created;
+  const messageId = resolveMessageId(
+    pid,
+    input.info.sessionID,
+    input.info.id,
+    input.legacySourceID,
+  );
 
   // Split into the two phases up front so the seed (tool_use) phase can be
   // flattened into ONE multi-row upsert instead of one INSERT per part. The
@@ -200,7 +320,7 @@ export function recordToolCalls(input: {
         `INSERT INTO tool_calls
            (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at, verifier, input_paths_json)
          VALUES ${Array.from({ length: batch.length }, () => rowSql).join(", ")}
-         ON CONFLICT(call_id) DO UPDATE SET
+         ON CONFLICT(project_id, session_id, call_id) DO UPDATE SET
            status = CASE WHEN tool_calls.status = 'pending' THEN excluded.status ELSE tool_calls.status END,
            error_type = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_type ELSE tool_calls.error_type END,
            error_message = CASE WHEN tool_calls.status = 'pending' THEN excluded.error_message ELSE tool_calls.error_message END,
@@ -222,7 +342,7 @@ export function recordToolCalls(input: {
         const inputPathsJson = paths.length > 0 ? JSON.stringify(paths) : null;
         params.push(
           p.callID,
-          input.info.id,
+          messageId,
           pid,
           input.info.sessionID,
           p.tool,
@@ -239,13 +359,13 @@ export function recordToolCalls(input: {
     }
   }
 
-  // Phase B: user tool_result parts — update outcome by call_id, preserving
-  // the previously-seeded tool name and message_id.
+  // Phase B: user tool_result parts — update only the call owned by this
+  // project/session, preserving the previously-seeded tool name and message_id.
   if (resultParts.length) {
     const updateStmt = db().query(
       `UPDATE tool_calls
          SET status = ?, error_type = ?, error_message = ?, duration_ms = ?
-       WHERE call_id = ?`,
+       WHERE project_id = ? AND session_id = ? AND call_id = ?`,
     );
     for (const p of resultParts) {
       const outcome = toolOutcome(p.tool, p.state);
@@ -254,6 +374,8 @@ export function recordToolCalls(input: {
         outcome.errorType,
         outcome.errorMessage,
         outcome.duration,
+        pid,
+        input.info.sessionID,
         p.callID,
       );
     }
@@ -294,6 +416,7 @@ function toolOutcome(
 
 export type TemporalMessage = {
   id: string;
+  source_id?: string | null;
   project_id: string;
   session_id: string;
   role: string;
@@ -483,9 +606,11 @@ export function markDistilled(ids: string[]) {
   const placeholders = ids.map(() => "?").join(",");
   db()
     .query(
-      `UPDATE temporal_messages SET distilled = 1 WHERE id IN (${placeholders})`,
+      `UPDATE temporal_messages SET distilled = 1
+        WHERE id IN (${placeholders})
+          AND project_id IN (SELECT id FROM projects WHERE tenant_id = ?)`,
     )
-    .run(...ids);
+    .run(...ids, currentTenantId());
 }
 
 // Searches all temporal messages (including distilled). Distilled messages
@@ -579,14 +704,14 @@ export async function searchScored(input: {
   // is pure waste even in-process — `ScoredTemporalMessage` has no embedding
   // field. Mirrors the hydration SELECT in recall.ts.
   const ftsSQL = input.sessionID
-    ? `SELECT m.id, m.project_id, m.session_id, m.role, m.content, m.tokens,
-              m.distilled, m.created_at, m.metadata, rank
+    ? `SELECT m.id, m.source_id, m.project_id, m.session_id, m.role, m.content, m.tokens,
+               m.distilled, m.created_at, m.metadata, rank
        FROM temporal_fts f
        CROSS JOIN temporal_messages m ON m.rowid = f.rowid
        WHERE f.content MATCH ? AND m.project_id = ? AND m.session_id = ?
        ORDER BY rank LIMIT ?`
-    : `SELECT m.id, m.project_id, m.session_id, m.role, m.content, m.tokens,
-              m.distilled, m.created_at, m.metadata, rank
+    : `SELECT m.id, m.source_id, m.project_id, m.session_id, m.role, m.content, m.tokens,
+               m.distilled, m.created_at, m.metadata, rank
        FROM temporal_fts f
        CROSS JOIN temporal_messages m ON m.rowid = f.rowid
        WHERE f.content MATCH ? AND m.project_id = ?
@@ -755,7 +880,9 @@ function clearPrunedSyncState(
   if (ids.length === 0) return;
   const ph = ids.map(() => "?").join(",");
   database
-    .query(`DELETE FROM sync_state WHERE table_name = ? AND row_id IN (${ph})`)
+    .query(
+      `DELETE FROM sync_state WHERE tenant_id = '' AND table_name = ? AND row_id IN (${ph})`,
+    )
     .run(table, ...ids);
 }
 

--- a/packages/core/src/tenant.ts
+++ b/packages/core/src/tenant.ts
@@ -1,0 +1,20 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** Empty ownership is the historical, single-user local storage namespace. */
+export const LOCAL_TENANT_ID = "";
+
+const tenantStorage = new AsyncLocalStorage<string>();
+
+/** Opaque durable owner of storage touched by the current request/background job. */
+export function currentTenantId(): string {
+  return tenantStorage.getStore() ?? LOCAL_TENANT_ID;
+}
+
+/**
+ * Run work under an opaque tenant owner. AsyncLocalStorage propagates the owner
+ * through promises and fire-and-forget callbacks created by `fn`; delayed
+ * registries must still capture the value and re-enter this scope when invoked.
+ */
+export function withTenant<T>(tenantId: string, fn: () => T): T {
+  return tenantStorage.run(tenantId, fn);
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -195,6 +195,12 @@ export function isToolPart(p: LorePart): p is LoreToolPart {
 export type LoreMessageWithParts = {
   info: LoreMessage;
   parts: LorePart[];
+  /**
+   * Exact source ID produced by the gateway's pre-v82 identity algorithm.
+   * Transient migration metadata: storage may use it only to claim a migrated
+   * row under the same tenant/project/session, then persists the modern ID.
+   */
+  legacySourceID?: string;
   /** Transient provider bytes omitted from parts but counted by gradient. */
   hiddenInputTokens?: number;
 };

--- a/packages/core/src/vector-query.ts
+++ b/packages/core/src/vector-query.ts
@@ -37,9 +37,14 @@ export type DistillationVectorHit = {
  *  boundary (~3 KB for 768 dims) — never transferred: a transfer would detach
  *  the caller's buffer and corrupt the in-process fallback that reuses it. */
 export type VectorQuerySpec =
-  | { kind: "knowledge"; limit: number; excludeCategories?: string[] }
-  | { kind: "entities"; limit: number }
-  | { kind: "distillations"; limit: number }
+  | {
+      kind: "knowledge";
+      tenantId?: string;
+      limit: number;
+      excludeCategories?: string[];
+    }
+  | { kind: "entities"; tenantId?: string; limit: number }
+  | { kind: "distillations"; tenantId?: string; limit: number }
   | { kind: "allDistillations"; projectId: string; limit: number }
   | {
       kind: "temporal";
@@ -220,9 +225,21 @@ export function runVectorQuery(
     case "knowledge":
       return runKnowledge(conn, readMode, queryEmbedding, spec);
     case "entities":
-      return runEntities(conn, readMode, queryEmbedding, spec.limit);
+      return runEntities(
+        conn,
+        readMode,
+        queryEmbedding,
+        spec.tenantId,
+        spec.limit,
+      );
     case "distillations":
-      return runDistillations(conn, readMode, queryEmbedding, spec.limit);
+      return runDistillations(
+        conn,
+        readMode,
+        queryEmbedding,
+        spec.tenantId,
+        spec.limit,
+      );
     case "allDistillations":
       return runAllDistillations(
         conn,
@@ -264,10 +281,10 @@ function runKnowledge(
   conn: VectorQueryConn,
   readMode: VecReadMode,
   queryEmbedding: Float32Array,
-  spec: { limit: number; excludeCategories?: string[] },
+  spec: { tenantId?: string; limit: number; excludeCategories?: string[] },
 ): VectorHit[] {
   if (readMode === "degraded") return [];
-  const { limit, excludeCategories } = spec;
+  const { tenantId = "", limit, excludeCategories } = spec;
   if (readMode === "vec0") {
     // DiskANN-free FLAT vec0: exact KNN over the whole corpus (no recency cap).
     // Post-filter confidence/category (mutable / per-version) by joining the
@@ -277,8 +294,8 @@ function runKnowledge(
       let sql =
         "WITH knn AS (SELECT id, distance FROM knowledge_vec WHERE embedding MATCH ? AND k = ?) " +
         "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
-        "FROM knn JOIN knowledge_current c ON c.id = knn.id WHERE c.confidence > 0.2";
-      const params: unknown[] = [toBlob(queryEmbedding), k];
+        "FROM knn JOIN knowledge_current c ON c.id = knn.id WHERE c.tenant_id = ? AND c.confidence > 0.2";
+      const params: unknown[] = [toBlob(queryEmbedding), k, tenantId];
       if (excludeCategories?.length) {
         sql += ` AND c.category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
         params.push(...excludeCategories);
@@ -297,8 +314,8 @@ function runKnowledge(
   if (readMode === "blob-native") {
     try {
       let sql =
-        "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM knowledge_current WHERE embedding IS NOT NULL AND confidence > 0.2";
-      const params: unknown[] = [toBlob(queryEmbedding)];
+        "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM knowledge_current WHERE tenant_id = ? AND embedding IS NOT NULL AND confidence > 0.2";
+      const params: unknown[] = [toBlob(queryEmbedding), tenantId];
       if (excludeCategories?.length) {
         sql += ` AND category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
         params.push(...excludeCategories);
@@ -311,8 +328,8 @@ function runKnowledge(
     }
   }
   let sql =
-    "SELECT id, embedding FROM knowledge_current WHERE embedding IS NOT NULL AND confidence > 0.2";
-  const params: string[] = [];
+    "SELECT id, embedding FROM knowledge_current WHERE tenant_id = ? AND embedding IS NOT NULL AND confidence > 0.2";
+  const params: string[] = [tenantId];
   if (excludeCategories?.length) {
     sql += ` AND category NOT IN (${excludeCategories.map(() => "?").join(",")})`;
     params.push(...excludeCategories);
@@ -335,31 +352,41 @@ function runEntities(
   conn: VectorQueryConn,
   readMode: VecReadMode,
   queryEmbedding: Float32Array,
+  tenantId = "",
   limit: number,
 ): VectorHit[] {
   if (readMode === "degraded") return [];
   if (readMode === "vec0") {
-    return conn
-      .query(
-        "SELECT id, 1 - distance AS similarity FROM entity_vec WHERE embedding MATCH ? AND k = ? ORDER BY distance",
-      )
-      .all(toBlob(queryEmbedding), vecK(limit)) as VectorHit[];
+    const run = (k: number): VectorHit[] =>
+      conn
+        .query(
+          "WITH knn AS (SELECT id, distance FROM entity_vec WHERE embedding MATCH ? AND k = ?) " +
+            "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
+            "FROM knn JOIN entities e ON e.id = knn.id WHERE e.tenant_id = ? " +
+            "ORDER BY knn.distance LIMIT ?",
+        )
+        .all(toBlob(queryEmbedding), k, tenantId, limit) as VectorHit[];
+    const k0 = overfetchK(limit);
+    const hits = run(k0);
+    return hits.length >= limit || k0 >= VEC0_MAX_K ? hits : run(VEC0_MAX_K);
   }
   assertBlobReadMode(readMode);
   if (readMode === "blob-native") {
     try {
       return conn
         .query(
-          "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM entities WHERE embedding IS NOT NULL ORDER BY similarity DESC LIMIT ?",
+          "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM entities WHERE tenant_id = ? AND embedding IS NOT NULL ORDER BY similarity DESC LIMIT ?",
         )
-        .all(toBlob(queryEmbedding), limit) as VectorHit[];
+        .all(toBlob(queryEmbedding), tenantId, limit) as VectorHit[];
     } catch {
       // fall through to JS brute-force
     }
   }
   const rows = conn
-    .query("SELECT id, embedding FROM entities WHERE embedding IS NOT NULL")
-    .all() as Array<{ id: string; embedding: Buffer }>;
+    .query(
+      "SELECT id, embedding FROM entities WHERE tenant_id = ? AND embedding IS NOT NULL",
+    )
+    .all(tenantId) as Array<{ id: string; embedding: Buffer }>;
 
   const topK: VectorHit[] = [];
   for (const row of rows) {
@@ -374,6 +401,7 @@ function runDistillations(
   conn: VectorQueryConn,
   readMode: VecReadMode,
   queryEmbedding: Float32Array,
+  tenantId = "",
   limit: number,
 ): VectorHit[] {
   if (readMode === "degraded") return [];
@@ -386,10 +414,12 @@ function runDistillations(
         .query(
           "WITH knn AS (SELECT id, distance FROM distillation_vec WHERE embedding MATCH ? AND k = ?) " +
             "SELECT knn.id AS id, 1 - knn.distance AS similarity " +
-            "FROM knn JOIN distillations d ON d.id = knn.id WHERE d.archived = 0 " +
+            "FROM knn JOIN distillations d ON d.id = knn.id " +
+            "JOIN projects p ON p.id = d.project_id " +
+            "WHERE p.tenant_id = ? AND d.archived = 0 " +
             "ORDER BY knn.distance LIMIT ?",
         )
-        .all(toBlob(queryEmbedding), k, limit) as VectorHit[];
+        .all(toBlob(queryEmbedding), k, tenantId, limit) as VectorHit[];
     const k0 = overfetchK(limit);
     const hits = run(k0);
     return hits.length >= limit || k0 >= VEC0_MAX_K ? hits : run(VEC0_MAX_K);
@@ -399,18 +429,18 @@ function runDistillations(
     try {
       return conn
         .query(
-          "SELECT id, 1 - vec_distance_cosine(embedding, ?) AS similarity FROM distillations WHERE embedding IS NOT NULL AND archived = 0 ORDER BY similarity DESC LIMIT ?",
+          "SELECT d.id, 1 - vec_distance_cosine(d.embedding, ?) AS similarity FROM distillations d JOIN projects p ON p.id = d.project_id WHERE p.tenant_id = ? AND d.embedding IS NOT NULL AND d.archived = 0 ORDER BY similarity DESC LIMIT ?",
         )
-        .all(toBlob(queryEmbedding), limit) as VectorHit[];
+        .all(toBlob(queryEmbedding), tenantId, limit) as VectorHit[];
     } catch {
       // fall through to JS brute-force
     }
   }
   const rows = conn
     .query(
-      "SELECT id, embedding FROM distillations WHERE embedding IS NOT NULL AND archived = 0",
+      "SELECT d.id, d.embedding FROM distillations d JOIN projects p ON p.id = d.project_id WHERE p.tenant_id = ? AND d.embedding IS NOT NULL AND d.archived = 0",
     )
-    .all() as Array<{ id: string; embedding: Buffer }>;
+    .all(tenantId) as Array<{ id: string; embedding: Buffer }>;
 
   const topK: VectorHit[] = [];
   for (const row of rows) {

--- a/packages/core/test/curator-ensureproject-hoist.test.ts
+++ b/packages/core/test/curator-ensureproject-hoist.test.ts
@@ -9,7 +9,8 @@ const OTHER_PROJECT = "/tmp/lore-curator-ensureproject-hoist/other-project";
 
 // ensureProject()'s fast-path lookup. Counting this exact statement isolates
 // project-resolution calls from any other `projects` access.
-const ENSURE_PROJECT_SQL = "SELECT id, git_remote FROM projects WHERE path = ?";
+const ENSURE_PROJECT_SQL =
+  "SELECT id, git_remote FROM projects WHERE tenant_id = ? AND path = ?";
 
 function countingSink(counts: Record<string, number>): LogSink {
   return {

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -119,7 +119,155 @@ describe("db", () => {
     const row = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(row.version).toBe(79);
+    expect(row.version).toBe(82);
+  });
+
+  test("v81 quarantines sync bookkeeping that predates tenant provenance", () => {
+    const database = db();
+    database.exec("DELETE FROM sync_outbox; DELETE FROM sync_state;");
+    database
+      .query(
+        "INSERT INTO sync_outbox (table_name, row_id, op, changed_at) VALUES ('knowledge', 'legacy-outbox', 'delete', 1)",
+      )
+      .run();
+    database
+      .query(
+        `INSERT INTO sync_state
+           (table_name, row_id, content_hash, revision, remote_updated_at)
+         VALUES ('knowledge', 'legacy-state', NULL, 0, NULL)`,
+      )
+      .run();
+
+    // Reproduce an on-disk v80 database: the rows exist, but neither table can
+    // attribute them to a storage tenant. Re-open through the real migration.
+    database.exec("ALTER TABLE sync_outbox DROP COLUMN tenant_id");
+    database.exec("ALTER TABLE sync_state DROP COLUMN tenant_id");
+    database.exec("UPDATE schema_version SET version = 80");
+    close();
+
+    const migrated = db();
+    expect(
+      migrated.query("SELECT row_id, tenant_id FROM sync_outbox").all(),
+    ).toEqual([{ row_id: "legacy-outbox", tenant_id: null }]);
+    expect(
+      migrated.query("SELECT row_id, tenant_id FROM sync_state").all(),
+    ).toEqual([{ row_id: "legacy-state", tenant_id: null }]);
+    expect(migrated.query("SELECT version FROM schema_version").get()).toEqual({
+      version: 82,
+    });
+    expect(
+      migrated
+        .query("SELECT value FROM kv_meta WHERE key = ?")
+        .get("sync.tenantIsolationReconcile"),
+    ).toEqual({ value: "1" });
+
+    migrated.exec(
+      "DELETE FROM sync_outbox; DELETE FROM sync_state; UPDATE kv_meta SET value = '0' WHERE key = 'sync.tenantIsolationReconcile';",
+    );
+  });
+
+  test("v82 preserves existing temporal/tool data while adding owned identities", () => {
+    const database = db();
+    const projectID = ensureProject(
+      `/tmp/v82-existing-data-${crypto.randomUUID()}`,
+    );
+    const messageID = `legacy-message-${crypto.randomUUID()}`;
+    const callID = `legacy-call-${crypto.randomUUID()}`;
+    database
+      .query(
+        `INSERT INTO temporal_messages
+           (id, source_id, project_id, session_id, role, content, tokens,
+            distilled, created_at, metadata)
+         VALUES (?, ?, ?, 'legacy-session', 'user', 'legacy zircon content',
+                 3, 0, 1000, '{}')`,
+      )
+      .run(messageID, messageID, projectID);
+    database.exec("DELETE FROM tool_calls;");
+    database
+      .query(
+        `INSERT INTO tool_calls
+           (call_id, message_id, project_id, session_id, tool, status,
+            created_at, verifier, input_paths_json)
+         VALUES (?, ?, ?, 'legacy-session', 'read', 'completed', 1000, 0,
+                 '["legacy.ts"]')`,
+      )
+      .run(callID, messageID, projectID);
+
+    // Reproduce the v81 layouts exactly: no temporal source_id and a globally
+    // primary-keyed tool call. Existing IDs and payloads must survive v82.
+    database.exec(`
+      DROP INDEX idx_temporal_source_identity;
+      ALTER TABLE temporal_messages DROP COLUMN source_id;
+      CREATE TABLE tool_calls_v81 (
+        call_id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        project_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        tool TEXT NOT NULL,
+        status TEXT NOT NULL,
+        error_type TEXT,
+        error_message TEXT,
+        duration_ms INTEGER,
+        created_at INTEGER NOT NULL,
+        verifier INTEGER,
+        input_paths_json TEXT
+      );
+      INSERT INTO tool_calls_v81 SELECT * FROM tool_calls;
+      DROP TABLE tool_calls;
+      ALTER TABLE tool_calls_v81 RENAME TO tool_calls;
+      CREATE INDEX idx_tool_calls_project_tool_status
+        ON tool_calls (project_id, tool, status);
+      CREATE INDEX idx_tool_calls_project_session
+        ON tool_calls (project_id, session_id);
+      UPDATE schema_version SET version = 81;
+    `);
+    close();
+
+    const migrated = db();
+    expect(migrated.query("SELECT version FROM schema_version").get()).toEqual({
+      version: 82,
+    });
+    expect(
+      migrated
+        .query(
+          "SELECT id, source_id, content FROM temporal_messages WHERE id = ?",
+        )
+        .get(messageID),
+    ).toEqual({
+      id: messageID,
+      source_id: messageID,
+      content: "legacy zircon content",
+    });
+    expect(
+      migrated
+        .query(
+          `SELECT m.id FROM temporal_fts f
+             JOIN temporal_messages m ON m.rowid = f.rowid
+            WHERE temporal_fts MATCH 'zircon' AND m.id = ?`,
+        )
+        .get(messageID),
+    ).toEqual({ id: messageID });
+    expect(
+      migrated
+        .query(
+          "SELECT call_id, status, input_paths_json FROM tool_calls WHERE call_id = ?",
+        )
+        .get(callID),
+    ).toEqual({
+      call_id: callID,
+      status: "completed",
+      input_paths_json: '["legacy.ts"]',
+    });
+    const pk = (
+      migrated.query("PRAGMA table_info(tool_calls)").all() as Array<{
+        name: string;
+        pk: number;
+      }>
+    )
+      .filter((column) => column.pk > 0)
+      .sort((a, b) => a.pk - b.pk)
+      .map((column) => column.name);
+    expect(pk).toEqual(["project_id", "session_id", "call_id"]);
   });
 
   test("v55: confidence/last_reinforced_at moved to knowledge_meta, exposed via view", () => {
@@ -176,7 +324,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(79);
+    expect(ver.version).toBe(82);
     // Register + JOIN view were rebuilt and are queryable (confidence exposed).
     expect(
       fresh
@@ -213,7 +361,7 @@ describe("db", () => {
     const ver = fresh.query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(ver.version).toBe(79);
+    expect(ver.version).toBe(82);
   });
 
   test("v56: knowledge_ref_validity table + projects.last_refcheck_at exist after recovery", () => {
@@ -1931,14 +2079,14 @@ describe("db", () => {
       expect(names).toContain("idx_tool_calls_project_session");
     });
 
-    test("call_id PK upserts in place", () => {
+    test("owned call_id PK upserts in place", () => {
       const pid = ensureProject("/tmp/tool-calls-pk-test");
       const insert = () =>
         db().query(
           `INSERT INTO tool_calls
                (call_id, message_id, project_id, session_id, tool, status, error_type, error_message, duration_ms, created_at)
              VALUES ('c1', 'm1', ?, 's1', 'bash', ?, ?, ?, ?, 1000)
-             ON CONFLICT(call_id) DO UPDATE SET
+              ON CONFLICT(project_id, session_id, call_id) DO UPDATE SET
                status = excluded.status,
                error_type = excluded.error_type,
                error_message = excluded.error_message,
@@ -2157,10 +2305,10 @@ describe("db", () => {
         db()
           .query(
             `INSERT INTO temporal_messages
-               (id, project_id, session_id, role, content, tokens, distilled, created_at)
-             VALUES (?, ?, ?, 'user', 'x', 1, 0, 1000)`,
+                (id, source_id, project_id, session_id, role, content, tokens, distilled, created_at)
+              VALUES (?, ?, ?, ?, 'user', 'x', 1, 0, 1000)`,
           )
-          .run(id, pid, sid);
+          .run(id, id, pid, sid);
       ins(pidA, sess, "m1");
       ins(pidA, sess, "m2");
       ins(pidA, sess, "m3");
@@ -2189,10 +2337,10 @@ describe("db", () => {
         db()
           .query(
             `INSERT INTO temporal_messages
-               (id, project_id, session_id, role, content, tokens, distilled, created_at)
-             VALUES (?, ?, ?, 'user', 'x', 1, 0, 1000)`,
+                (id, source_id, project_id, session_id, role, content, tokens, distilled, created_at)
+              VALUES (?, ?, ?, ?, 'user', 'x', 1, 0, 1000)`,
           )
-          .run(id, pid, sess);
+          .run(id, id, pid, sess);
       }
       // 1200 ids (>999 SQLite bound-variable limit) — must not throw and must
       // count only the 5 that exist.

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, test, expect, beforeEach } from "vitest";
+import { afterEach, describe, test, expect, beforeEach, vi } from "vitest";
 import { existsSync } from "node:fs";
 import { db, ensureProject } from "../src/db";
 import { LOCAL_MODEL_PATH_ENV } from "../src/embedding-vendor";
@@ -425,10 +425,12 @@ describe("local provider unavailable — no auto-fallback (remote is opt-in)", (
 describe("pickRemoteFallback", () => {
   let savedVoyage: string | undefined;
   let savedOpenAI: string | undefined;
+  let savedFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     savedVoyage = process.env.VOYAGE_API_KEY;
     savedOpenAI = process.env.OPENAI_API_KEY;
+    savedFetch = globalThis.fetch;
     delete process.env.VOYAGE_API_KEY;
     delete process.env.OPENAI_API_KEY;
   });
@@ -438,6 +440,7 @@ describe("pickRemoteFallback", () => {
     else delete process.env.VOYAGE_API_KEY;
     if (savedOpenAI !== undefined) process.env.OPENAI_API_KEY = savedOpenAI;
     else delete process.env.OPENAI_API_KEY;
+    globalThis.fetch = savedFetch;
   });
 
   test("returns null when neither key is set", () => {
@@ -466,6 +469,67 @@ describe("pickRemoteFallback", () => {
   test("rejects placeholder API keys (e.g. 'nokey')", () => {
     process.env.OPENAI_API_KEY = "nokey";
     expect(pickRemoteFallback()).toBeNull();
+  });
+
+  test("Voyage failures expose status but never the response body or statusText", async () => {
+    const bodyMarker = "PRIVATE_VOYAGE_RESPONSE_BODY_MARKER";
+    const reasonMarker = "PRIVATE_VOYAGE_REASON_MARKER";
+    process.env.VOYAGE_API_KEY = "vk-test-key-that-is-long-enough";
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(bodyMarker, {
+          status: 503,
+          statusText: reasonMarker,
+        }),
+    );
+    const fallback = pickRemoteFallback();
+    expect(fallback?.name).toBe("voyage");
+    if (!fallback) throw new Error("expected Voyage fallback");
+
+    const promise = fallback.provider.embed(["query"], "query");
+    await expect(promise).rejects.toThrow("503");
+    await expect(promise).rejects.not.toThrow(bodyMarker);
+    await expect(promise).rejects.not.toThrow(reasonMarker);
+  });
+
+  test("Voyage malformed JSON errors do not retain the response prefix", async () => {
+    const bodyMarker = "PRIVATE_VOYAGE_MALFORMED_PREFIX";
+    process.env.VOYAGE_API_KEY = "vk-test-key-that-is-long-enough";
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(`${bodyMarker} not-json`, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const fallback = pickRemoteFallback();
+    if (!fallback) throw new Error("expected Voyage fallback");
+
+    const promise = fallback.provider.embed(["query"], "query");
+    await expect(promise).rejects.toThrow("malformed JSON");
+    await expect(promise).rejects.not.toThrow(bodyMarker);
+  });
+
+  test("Voyage request failures do not retain thrown URL secrets", async () => {
+    const userinfoMarker = "PRIVATE_VOYAGE_THROWN_USERINFO";
+    const queryMarker = "PRIVATE_VOYAGE_THROWN_QUERY";
+    const fragmentMarker = "PRIVATE_VOYAGE_THROWN_FRAGMENT";
+    process.env.VOYAGE_API_KEY = "vk-test-key-that-is-long-enough";
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error(
+        `fetch https://user:${userinfoMarker}@example.com/embed?token=${queryMarker}#${fragmentMarker} failed`,
+      );
+    });
+    const fallback = pickRemoteFallback();
+    if (!fallback) throw new Error("expected Voyage fallback");
+
+    const promise = fallback.provider.embed(["query"], "query");
+    await expect(promise).rejects.toThrow(
+      "Voyage embeddings API request failed",
+    );
+    await expect(promise).rejects.not.toThrow(userinfoMarker);
+    await expect(promise).rejects.not.toThrow(queryMarker);
+    await expect(promise).rejects.not.toThrow(fragmentMarker);
   });
 });
 

--- a/packages/core/test/entities-offloaded-chunk.test.ts
+++ b/packages/core/test/entities-offloaded-chunk.test.ts
@@ -131,7 +131,7 @@ describe("getManyWithAliasesOffloaded chunks unbounded IN (#1022)", () => {
 
     // Both scans must actually have split into multiple chunks.
     const entityScans = RecordingReadWorker.specs.filter((s) =>
-      /FROM entities WHERE id IN/.test(s.sql),
+      /FROM entities WHERE tenant_id = .*id IN/.test(s.sql),
     );
     const aliasScans = RecordingReadWorker.specs.filter((s) =>
       /FROM entity_aliases WHERE entity_id IN/.test(s.sql),
@@ -140,7 +140,9 @@ describe("getManyWithAliasesOffloaded chunks unbounded IN (#1022)", () => {
     expect(aliasScans.length).toBe(Math.ceil(1801 / CHUNK)); // 3
 
     // Chunks must partition the id set: union of entity-scan params === all ids.
-    const scanned = new Set(entityScans.flatMap((s) => s.params as string[]));
+    const scanned = new Set(
+      entityScans.flatMap((s) => (s.params as string[]).slice(1)),
+    );
     expect(scanned.size).toBe(1801);
     for (const id of ids) expect(scanned.has(id)).toBe(true);
   });

--- a/packages/core/test/log.test.ts
+++ b/packages/core/test/log.test.ts
@@ -1,4 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /**
  * Import a fresh copy of the log module with a controlled `LORE_DEBUG` value.
@@ -138,3 +150,304 @@ describe("log stderr silencing (embedded/TUI mode)", () => {
     expect(stderr).toHaveBeenCalledWith("[lore]", "now visible");
   });
 });
+
+describe("local log credential redaction", () => {
+  it("redacts credential assignments, headers, tokens, and private keys", async () => {
+    const log = await freshLog(undefined);
+    const redacted = log.redactSensitiveLogText(
+      "operation failed clientSecret=client-secret-value " +
+        'payload={"apiKey":"json-api-key-value"}\n' +
+        "Authorization: Bearer bearer-value\n" +
+        "ocp-apim-subscription-key=azure-subscription-secret\n" +
+        "cf-access-client-id: cloudflare-client-secret\n" +
+        "Cookie: session=cookie-value; refresh=refresh-cookie-value\n" +
+        "token=plain-token-value\n" +
+        "-----BEGIN PRIVATE KEY-----\nprivate-key-bytes\n-----END PRIVATE KEY-----",
+    );
+
+    expect(redacted).toContain("operation failed");
+    for (const secret of [
+      "client-secret-value",
+      "json-api-key-value",
+      "bearer-value",
+      "azure-subscription-secret",
+      "cloudflare-client-secret",
+      "cookie-value",
+      "refresh-cookie-value",
+      "plain-token-value",
+      "private-key-bytes",
+    ]) {
+      expect(redacted).not.toContain(secret);
+    }
+    expect(redacted).toContain("[Filtered]");
+  });
+
+  it.each([
+    {
+      name: "a quoted scalar containing whitespace",
+      input: 'request failed: token = "quoted secret value" status=401',
+      secrets: ["quoted secret value"],
+      expected: 'request failed: token = "[Filtered]" status=401',
+    },
+    {
+      name: "an unquoted scalar containing whitespace",
+      input: "request failed: token = unquoted secret value status=401",
+      secrets: ["unquoted secret value"],
+      expected: "request failed: token = [Filtered] status=401",
+    },
+    {
+      name: "an unquoted JSON scalar",
+      input: 'request failed: {"token":12345,"status":401}',
+      secrets: ["12345"],
+      expected: 'request failed: {"token":[Filtered],"status":401}',
+    },
+    {
+      name: "a boolean JSON scalar",
+      input: 'request failed: {"token":true,"status":401}',
+      secrets: ["true"],
+      expected: 'request failed: {"token":[Filtered],"status":401}',
+    },
+    {
+      name: "a null JSON scalar",
+      input: 'request failed: {"token":null,"status":401}',
+      secrets: ["null"],
+      expected: 'request failed: {"token":[Filtered],"status":401}',
+    },
+    {
+      name: "a JSON array",
+      input:
+        'request failed: credentials=["array-secret",{"nested":"object-secret"}] status=401',
+      secrets: ["array-secret", "object-secret"],
+      expected: "request failed: credentials=[Filtered] status=401",
+    },
+    {
+      name: "a JSON object",
+      input:
+        'request failed: credentials={"refreshToken":"refresh-secret","nested":["nested-secret"]} status=401',
+      secrets: ["refresh-secret", "nested-secret"],
+      expected: "request failed: credentials=[Filtered] status=401",
+    },
+    {
+      name: "a Cookie compound value",
+      input:
+        "request failed: Cookie: session=cookie-secret; refresh=refresh-secret, oauth=oauth-secret status=401",
+      secrets: ["cookie-secret", "refresh-secret", "oauth-secret"],
+      expected: "request failed: Cookie: [Filtered] status=401",
+    },
+    {
+      name: "a Cookie2 compound value",
+      input:
+        "request failed: Cookie2: session=cookie-secret; refresh=refresh-secret, oauth=oauth-secret status=401",
+      secrets: ["cookie-secret", "refresh-secret", "oauth-secret"],
+      expected: "request failed: Cookie2: [Filtered] status=401",
+    },
+    {
+      name: "a non-cookie compound header value",
+      input:
+        "request failed: x-auth-token: foo=first-secret; bar=second-secret status=401",
+      secrets: ["first-secret", "second-secret"],
+      expected: "request failed: x-auth-token: [Filtered] status=401",
+    },
+  ])(
+    "redacts the complete value of $name after arbitrary text",
+    async (testCase) => {
+      const log = await freshLog(undefined);
+      const redacted = log.redactSensitiveLogText(testCase.input);
+
+      for (const secret of testCase.secrets) {
+        expect(redacted).not.toContain(secret);
+      }
+      expect(redacted).toBe(testCase.expected);
+    },
+  );
+
+  it.each([
+    "xapikey",
+    "x-authsessionid",
+    "x-oauthsessionid",
+    "x-secretsessionid",
+    "x-tokensessionid",
+    "x-keysessionid",
+  ])(
+    "redacts collapsed credential alias %s in local free text",
+    async (name) => {
+      const log = await freshLog(undefined);
+      const secret = "collapsed-alias-secret";
+
+      expect(
+        log.redactSensitiveLogText(`request failed: ${name}=${secret}`),
+      ).toBe(`request failed: ${name}=[Filtered]`);
+    },
+  );
+
+  it("preserves bearer scheme diagnostics", async () => {
+    const log = await freshLog(undefined);
+
+    for (const diagnostic of [
+      "routing decision scheme=bearer provider=anthropic",
+      "routing decision scheme=bearer selected upstream",
+    ]) {
+      expect(log.redactSensitiveLogText(diagnostic)).toBe(diagnostic);
+    }
+  });
+});
+
+describe.skipIf(process.platform === "win32")(
+  "persistent log filesystem security",
+  () => {
+    let base: string;
+    let savedNodeEnv: string | undefined;
+    let savedXdg: string | undefined;
+
+    beforeEach(() => {
+      savedNodeEnv = process.env.NODE_ENV;
+      savedXdg = process.env.XDG_DATA_HOME;
+      base = mkdtempSync(join(tmpdir(), "lore-log-test-"));
+      process.env.NODE_ENV = "production";
+      process.env.XDG_DATA_HOME = base;
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = savedNodeEnv;
+      if (savedXdg === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = savedXdg;
+      vi.resetModules();
+      rmSync(base, { recursive: true, force: true });
+    });
+
+    async function freshPersistentLog() {
+      vi.resetModules();
+      return import("../src/log");
+    }
+
+    it("creates the data directory and log as owner-only", async () => {
+      const log = await freshPersistentLog();
+      log.info("owner-only");
+
+      const dir = join(base, "lore");
+      const path = join(dir, "lore.log");
+      expect(lstatSync(dir).mode & 0o777).toBe(0o700);
+      expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    });
+
+    it("redacts credentials before writing persistent log bytes", async () => {
+      const log = await freshPersistentLog();
+      log.error(
+        "request failed",
+        "clientSecret=persistent-client-secret",
+        "Authorization: Bearer persistent-bearer-secret",
+        'payload={"refreshToken":"persistent-refresh-token"}',
+      );
+
+      const content = readFileSync(join(base, "lore", "lore.log"), "utf8");
+      expect(content).toContain("request failed");
+      expect(content).toContain("[Filtered]");
+      expect(content).not.toContain("persistent-client-secret");
+      expect(content).not.toContain("persistent-bearer-secret");
+      expect(content).not.toContain("persistent-refresh-token");
+    });
+
+    it("tightens existing directory and log permissions before appending", async () => {
+      const dir = join(base, "lore");
+      const path = join(dir, "lore.log");
+      mkdirSync(dir, { mode: 0o777 });
+      chmodSync(dir, 0o777);
+      writeFileSync(path, "before\n", { mode: 0o666 });
+      chmodSync(path, 0o666);
+
+      const log = await freshPersistentLog();
+      log.info("after");
+
+      expect(readFileSync(path, "utf8")).toContain("after");
+      expect(lstatSync(dir).mode & 0o777).toBe(0o700);
+      expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    });
+
+    it("clears special and group bits while tightening the data directory", async () => {
+      const dir = join(base, "lore");
+      mkdirSync(dir, { mode: 0o700 });
+      chmodSync(dir, 0o2770);
+
+      const log = await freshPersistentLog();
+      log.info("preserve setgid");
+
+      expect(lstatSync(dir).mode & 0o7777).toBe(0o700);
+      expect(lstatSync(join(dir, "lore.log")).mode & 0o777).toBe(0o600);
+    });
+
+    it("tightens a legacy rotated log immediately", async () => {
+      const dir = join(base, "lore");
+      const backup = join(dir, "lore.log.1");
+      mkdirSync(dir, { mode: 0o700 });
+      writeFileSync(backup, "old sensitive logs", { mode: 0o666 });
+      chmodSync(backup, 0o666);
+
+      const log = await freshPersistentLog();
+      log.info("new log");
+
+      expect(readFileSync(backup, "utf8")).toBe("old sensitive logs");
+      expect(lstatSync(backup).mode & 0o777).toBe(0o600);
+    });
+
+    it("rotates an oversized legacy log into an owner-only backup", async () => {
+      const dir = join(base, "lore");
+      const path = join(dir, "lore.log");
+      const backup = `${path}.1`;
+      mkdirSync(dir, { mode: 0o700 });
+      writeFileSync(path, Buffer.alloc(5 * 1024 * 1024 + 1), { mode: 0o666 });
+      chmodSync(path, 0o666);
+
+      const log = await freshPersistentLog();
+      for (let i = 0; i < 1_000; i++) log.info("rotation check");
+
+      expect(lstatSync(backup).mode & 0o777).toBe(0o600);
+      expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    });
+
+    it("does not replace a symlink used as the rotation backup", async () => {
+      const dir = join(base, "lore");
+      const path = join(dir, "lore.log");
+      const target = join(base, "victim-backup.log");
+      mkdirSync(dir, { mode: 0o700 });
+      writeFileSync(path, Buffer.alloc(5 * 1024 * 1024 + 1), { mode: 0o600 });
+      writeFileSync(target, "do not replace");
+      symlinkSync(target, `${path}.1`);
+
+      const log = await freshPersistentLog();
+      for (let i = 0; i < 1_000; i++) log.info("rotation check");
+
+      expect(readFileSync(target, "utf8")).toBe("do not replace");
+      expect(lstatSync(`${path}.1`).isSymbolicLink()).toBe(true);
+    });
+
+    it("does not follow a symlink used as the persistent log", async () => {
+      const dir = join(base, "lore");
+      const target = join(base, "victim.log");
+      mkdirSync(dir, { mode: 0o700 });
+      writeFileSync(target, "do not append");
+      symlinkSync(target, join(dir, "lore.log"));
+
+      const log = await freshPersistentLog();
+      log.info("credential-bearing message");
+
+      expect(readFileSync(target, "utf8")).toBe("do not append");
+    });
+
+    it("does not write through a data path reported as another owner", async () => {
+      if (typeof process.getuid !== "function") return;
+      const dir = join(base, "lore");
+      const path = join(dir, "lore.log");
+      mkdirSync(dir, { mode: 0o700 });
+      writeFileSync(path, "before");
+      const uid = process.getuid();
+      vi.spyOn(process, "getuid").mockReturnValue(uid + 1);
+
+      const log = await freshPersistentLog();
+      log.info("must not append");
+
+      expect(readFileSync(path, "utf8")).toBe("before");
+    });
+  },
+);

--- a/packages/core/test/ltm-versioning.test.ts
+++ b/packages/core/test/ltm-versioning.test.ts
@@ -39,11 +39,11 @@ function ftsHits(token: string): number {
 }
 
 describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
-  test("schema version is 79", () => {
+  test("schema version is 81", () => {
     const v = db().query("SELECT version FROM schema_version").get() as {
       version: number;
     };
-    expect(v.version).toBe(79);
+    expect(v.version).toBe(82);
   });
 
   test("create() defaults logical_id = id, version 1, current, not deleted", () => {
@@ -87,8 +87,9 @@ describe("A2 sub-PR 1: append-only knowledge scaffolding", () => {
 
     const v = versions(id);
     expect(v).toHaveLength(2); // append-only: both physically present
-    const v1 = v.find((x) => x.version === 1)!;
-    const v2 = v.find((x) => x.version === 2)!;
+    const v1 = v.find((x) => x.version === 1);
+    const v2 = v.find((x) => x.version === 2);
+    if (!v1 || !v2) throw new Error("expected both knowledge versions");
     expect(v1.is_current).toBe(0); // demoted
     expect(v2.is_current).toBe(1);
     expect(v2.logical_id).toBe(id); // same logical entry

--- a/packages/core/test/sync-registry-contract.test.ts
+++ b/packages/core/test/sync-registry-contract.test.ts
@@ -22,6 +22,7 @@ import {
   enableSync,
   readOutbox,
   SYNCED_TABLES,
+  SYNC_TENANT_PARENT_REFS,
   seedOutbox,
 } from "../src/sync-data";
 
@@ -190,6 +191,94 @@ describe("SYNCED_TABLES registry contract", () => {
           enableSync();
           expect(outboxFor(m.table)).toHaveLength(0);
         });
+      }
+    });
+  }
+});
+
+describe("SYNC_TENANT_PARENT_REFS registry contract", () => {
+  const EXPECTED: Record<
+    string,
+    Array<{
+      column: string;
+      parentTable: "projects" | "entities" | "knowledge";
+      parentKey: "id" | "logical_id";
+      optional?: boolean;
+    }>
+  > = {
+    knowledge: [
+      {
+        column: "project_id",
+        parentTable: "projects",
+        parentKey: "id",
+        optional: true,
+      },
+    ],
+    knowledge_meta: [
+      {
+        column: "logical_id",
+        parentTable: "knowledge",
+        parentKey: "logical_id",
+      },
+    ],
+    knowledge_meta_crdt: [
+      {
+        column: "logical_id",
+        parentTable: "knowledge",
+        parentKey: "logical_id",
+      },
+    ],
+    entities: [
+      {
+        column: "project_id",
+        parentTable: "projects",
+        parentKey: "id",
+        optional: true,
+      },
+    ],
+    entity_aliases: [
+      { column: "entity_id", parentTable: "entities", parentKey: "id" },
+    ],
+    entity_relations: [
+      { column: "entity_a", parentTable: "entities", parentKey: "id" },
+      { column: "entity_b", parentTable: "entities", parentKey: "id" },
+    ],
+    knowledge_entity_refs: [
+      {
+        column: "knowledge_id",
+        parentTable: "knowledge",
+        parentKey: "logical_id",
+      },
+      { column: "entity_id", parentTable: "entities", parentKey: "id" },
+    ],
+    distillations: [
+      { column: "project_id", parentTable: "projects", parentKey: "id" },
+    ],
+    temporal_messages: [
+      { column: "project_id", parentTable: "projects", parentKey: "id" },
+    ],
+  };
+
+  test("has an explicit entry for every synced table", () => {
+    expect(Object.keys(SYNC_TENANT_PARENT_REFS).sort()).toEqual(
+      ALL_REGISTERED.map((m) => m.table).sort(),
+    );
+  });
+
+  for (const m of ALL_REGISTERED) {
+    test(`${m.table}: tenant-sensitive parent mapping is complete and schema-valid`, () => {
+      expect(SYNC_TENANT_PARENT_REFS[m.table]).toEqual(EXPECTED[m.table] ?? []);
+      for (const ref of SYNC_TENANT_PARENT_REFS[m.table]) {
+        expect(m.syncColumns).toContain(ref.column);
+        const parentColumns = (
+          db().query(`PRAGMA table_info(${ref.parentTable})`).all() as Array<{
+            name: string;
+          }>
+        ).map((column) => column.name);
+        expect(parentColumns).toContain("tenant_id");
+        expect(parentColumns).toContain(
+          ref.parentKey === "logical_id" ? "logical_id" : "id",
+        );
       }
     });
   }

--- a/packages/core/test/temporal-identity.test.ts
+++ b/packages/core/test/temporal-identity.test.ts
@@ -1,0 +1,488 @@
+import { describe, expect, test } from "vitest";
+import { close, db, ensureProject } from "../src/db";
+import { withTenant } from "../src/tenant";
+import * as temporal from "../src/temporal";
+import type { LoreMessage, LorePart } from "../src/types";
+
+const TENANT_A = "a".repeat(64);
+const TENANT_B = "b".repeat(64);
+
+function message(
+  sourceID: string,
+  sessionID: string,
+  role: "user" | "assistant" = "user",
+): LoreMessage {
+  if (role === "user") {
+    return {
+      id: sourceID,
+      sessionID,
+      role,
+      time: { created: 1_000 },
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "test" },
+    };
+  }
+  return {
+    id: sourceID,
+    sessionID,
+    role,
+    time: { created: 1_000 },
+    parentID: "parent",
+    modelID: "test",
+    providerID: "anthropic",
+    mode: "build",
+    path: { cwd: "/tmp", root: "/tmp" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+  };
+}
+
+function textPart(sourceID: string, sessionID: string, text: string): LorePart {
+  return {
+    id: `part-${sourceID}-${sessionID}`,
+    sessionID,
+    messageID: sourceID,
+    type: "text",
+    text,
+  };
+}
+
+function toolPart(
+  sourceID: string,
+  sessionID: string,
+  callID: string,
+  tool: string,
+  state: Record<string, unknown>,
+): LorePart {
+  return {
+    id: `tool-${sourceID}-${sessionID}`,
+    sessionID,
+    messageID: sourceID,
+    type: "tool",
+    tool,
+    callID,
+    state,
+  };
+}
+
+function storeText(input: {
+  tenantID: string;
+  projectPath: string;
+  sessionID: string;
+  sourceID: string;
+  text: string;
+}): string {
+  return withTenant(input.tenantID, () => {
+    const id = temporal.store({
+      projectPath: input.projectPath,
+      info: message(input.sourceID, input.sessionID),
+      parts: [textPart(input.sourceID, input.sessionID, input.text)],
+    });
+    if (!id) throw new Error("expected temporal row");
+    return id;
+  });
+}
+
+function recordTool(input: {
+  tenantID: string;
+  projectPath: string;
+  sessionID: string;
+  sourceID: string;
+  callID: string;
+  tool: string;
+  state: Record<string, unknown>;
+  role: "user" | "assistant";
+}): void {
+  withTenant(input.tenantID, () =>
+    temporal.recordToolCalls({
+      projectPath: input.projectPath,
+      info: message(input.sourceID, input.sessionID, input.role),
+      parts: [
+        toolPart(
+          input.sourceID,
+          input.sessionID,
+          input.callID,
+          input.tool,
+          input.state,
+        ),
+      ],
+    }),
+  );
+}
+
+function toolRows(tenantID: string, projectPath: string) {
+  return withTenant(tenantID, () => {
+    const projectID = ensureProject(projectPath);
+    return db()
+      .query(
+        `SELECT session_id, call_id, tool, status, error_type
+           FROM tool_calls WHERE project_id = ? ORDER BY session_id`,
+      )
+      .all(projectID) as Array<{
+      session_id: string;
+      call_id: string;
+      tool: string;
+      status: string;
+      error_type: string | null;
+    }>;
+  });
+}
+
+describe("temporal tenant/session identity", () => {
+  test.each([
+    [TENANT_A, TENANT_B],
+    [TENANT_B, TENANT_A],
+  ])(
+    "keeps the same source message isolated in tenant order %# and after restart",
+    (firstTenant, secondTenant) => {
+      const projectPath = `/test/temporal-identity/order-${firstTenant[0]}`;
+      const sourceID = "caller-message-id";
+      const sessionID = "shared-session-id";
+      const text = "tenant isolated zircon temporal memory";
+
+      const firstID = storeText({
+        tenantID: firstTenant,
+        projectPath,
+        sessionID,
+        sourceID,
+        text,
+      });
+      const secondID = storeText({
+        tenantID: secondTenant,
+        projectPath,
+        sessionID,
+        sourceID,
+        text,
+      });
+
+      expect(firstID).not.toBe(secondID);
+      expect(firstID).toMatch(/^lore_tm_v1_/);
+      expect(secondID).toMatch(/^lore_tm_v1_/);
+
+      // Even a known storage ID cannot be mutated from the other tenant.
+      withTenant(secondTenant, () => temporal.markDistilled([firstID]));
+      expect(
+        withTenant(firstTenant, () =>
+          temporal.undistilled(projectPath, sessionID).map((row) => row.id),
+        ),
+      ).toEqual([firstID]);
+
+      withTenant(firstTenant, () => temporal.markDistilled([firstID]));
+      expect(
+        withTenant(firstTenant, () =>
+          temporal.undistilled(projectPath, sessionID),
+        ),
+      ).toEqual([]);
+      expect(
+        withTenant(secondTenant, () =>
+          temporal.undistilled(projectPath, sessionID).map((row) => row.id),
+        ),
+      ).toEqual([secondID]);
+
+      for (const [tenantID, expectedID] of [
+        [firstTenant, firstID],
+        [secondTenant, secondID],
+      ] as const) {
+        expect(
+          withTenant(tenantID, () =>
+            temporal.search({
+              projectPath,
+              sessionID,
+              query: "zircon memory",
+            }),
+          ).map((row) => row.id),
+        ).toEqual([expectedID]);
+      }
+
+      withTenant(secondTenant, () => temporal.markDistilled([secondID]));
+      close();
+
+      for (const [tenantID, expectedID] of [
+        [firstTenant, firstID],
+        [secondTenant, secondID],
+      ] as const) {
+        const rows = withTenant(tenantID, () =>
+          temporal.bySession(projectPath, sessionID),
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+          id: expectedID,
+          source_id: sourceID,
+          distilled: 1,
+        });
+      }
+    },
+  );
+
+  test("does not collapse the same source ID and content across sessions", () => {
+    const projectPath = "/test/temporal-identity/two-sessions";
+    const sourceID = "same-caller-id";
+    const firstID = storeText({
+      tenantID: TENANT_A,
+      projectPath,
+      sessionID: "session-one",
+      sourceID,
+      text: "repeated assistant answer",
+    });
+    const secondID = storeText({
+      tenantID: TENANT_A,
+      projectPath,
+      sessionID: "session-two",
+      sourceID,
+      text: "repeated assistant answer",
+    });
+
+    expect(firstID).not.toBe(secondID);
+    expect(withTenant(TENANT_A, () => temporal.count(projectPath))).toBe(2);
+
+    storeText({
+      tenantID: TENANT_A,
+      projectPath,
+      sessionID: "session-one",
+      sourceID,
+      text: "updated only in session one",
+    });
+    expect(
+      withTenant(
+        TENANT_A,
+        () => temporal.bySession(projectPath, "session-one")[0]?.content,
+      ),
+    ).toContain("updated only");
+    expect(
+      withTenant(
+        TENANT_A,
+        () => temporal.bySession(projectPath, "session-two")[0]?.content,
+      ),
+    ).toBe("repeated assistant answer");
+  });
+
+  test("never accepts a caller-supplied value as an internal storage ID", () => {
+    const sourceID = "lore_tm_v1_caller-controlled";
+    const storedID = storeText({
+      tenantID: TENANT_A,
+      projectPath: "/test/temporal-identity/reserved-prefix",
+      sessionID: "reserved-prefix-session",
+      sourceID,
+      text: "reserved prefix input",
+    });
+
+    expect(storedID).toMatch(/^lore_tm_v1_/);
+    expect(storedID).not.toBe(sourceID);
+    expect(
+      withTenant(TENANT_A, () =>
+        temporal.bySession(
+          "/test/temporal-identity/reserved-prefix",
+          "reserved-prefix-session",
+        ),
+      )[0]?.source_id,
+    ).toBe(sourceID);
+  });
+
+  test("resolves a persisted pre-v82 source ID without re-keying it", () => {
+    const projectPath = "/test/temporal-identity/legacy-source";
+    const sessionID = "legacy-source-session";
+    const legacyID = "pre-v82-gateway-hash";
+    withTenant(TENANT_A, () => {
+      const projectID = ensureProject(projectPath);
+      db()
+        .query(
+          `INSERT INTO temporal_messages
+             (id, source_id, project_id, session_id, role, content, tokens,
+              distilled, created_at, metadata)
+           VALUES (?, ?, ?, ?, 'user', 'legacy', 1, 0, 1, '{}')`,
+        )
+        .run(legacyID, legacyID, projectID, sessionID);
+    });
+
+    expect(
+      withTenant(TENANT_A, () =>
+        temporal.storedMessageId({
+          projectPath,
+          sessionID,
+          sourceID: "v82-session-aware-hash",
+          legacySourceID: legacyID,
+        }),
+      ),
+    ).toBe(legacyID);
+  });
+
+  test("does not treat a fresh v82 row as an unclaimed legacy row", () => {
+    const projectPath = "/test/temporal-identity/unambiguous-legacy";
+    const sessionID = "unambiguous-legacy-session";
+    const legacySourceID = "legacy-shaped-source";
+    const freshID = storeText({
+      tenantID: TENANT_A,
+      projectPath,
+      sessionID,
+      sourceID: legacySourceID,
+      text: "fresh v82 content",
+    });
+
+    const resolved = withTenant(TENANT_A, () =>
+      temporal.storedMessageId({
+        projectPath,
+        sessionID,
+        sourceID: "different-modern-source",
+        legacySourceID,
+      }),
+    );
+    expect(resolved).not.toBe(freshID);
+    expect(resolved).toMatch(/^lore_tm_v1_/);
+  });
+
+  test("reuses a restored sync row whose local-only source ID is null", () => {
+    const projectPath = "/test/temporal-identity/restored-row";
+    const sessionID = "restored-session";
+    const sourceID = "restored-source";
+    withTenant(TENANT_A, () => {
+      const projectID = ensureProject(projectPath);
+      const restoredID = temporal.storedMessageId({
+        projectPath,
+        sessionID,
+        sourceID,
+      });
+      db()
+        .query(
+          `INSERT INTO temporal_messages
+             (id, source_id, project_id, session_id, role, content, tokens,
+              distilled, created_at, metadata)
+           VALUES (?, NULL, ?, ?, 'user', 'restored content', 1, 1, 1, '{}')`,
+        )
+        .run(restoredID, projectID, sessionID);
+    });
+
+    const storedID = storeText({
+      tenantID: TENANT_A,
+      projectPath,
+      sessionID,
+      sourceID,
+      text: "updated restored content",
+    });
+    expect(
+      withTenant(TENANT_A, () => temporal.bySession(projectPath, sessionID)),
+    ).toEqual([
+      expect.objectContaining({
+        id: storedID,
+        source_id: sourceID,
+        content: "updated restored content",
+      }),
+    ]);
+  });
+
+  test("correlates duplicate raw tool call IDs only within project and session", () => {
+    const sharedPath = "/test/temporal-identity/tool-shared";
+    const otherPath = "/test/temporal-identity/tool-other-project";
+    const callID = "provider-call-id";
+    const seed = (
+      tenantID: string,
+      projectPath: string,
+      sessionID: string,
+      tool: string,
+    ) =>
+      recordTool({
+        tenantID,
+        projectPath,
+        sessionID,
+        sourceID: `assistant-${sessionID}`,
+        callID,
+        tool,
+        state: { status: "pending", input: {} },
+        role: "assistant",
+      });
+    const result = (
+      tenantID: string,
+      projectPath: string,
+      sessionID: string,
+      targetCallID: string,
+      state: Record<string, unknown>,
+    ) =>
+      recordTool({
+        tenantID,
+        projectPath,
+        sessionID,
+        sourceID: `result-${sessionID}`,
+        callID: targetCallID,
+        tool: "result",
+        state,
+        role: "user",
+      });
+
+    seed(TENANT_A, sharedPath, "main", "read");
+    seed(TENANT_A, sharedPath, "other-session", "edit");
+    seed(TENANT_A, otherPath, "main", "bash");
+    seed(TENANT_B, sharedPath, "main", "write");
+
+    // Unknown/malformed ownership combinations are no-ops even though the raw
+    // call ID exists under another tenant/project/session.
+    result(TENANT_B, sharedPath, "missing-session", callID, {
+      status: "error",
+      input: null,
+      error: "malformed cross-session result",
+    });
+    result(TENANT_A, sharedPath, "main", "unknown-call", {
+      status: "completed",
+      input: null,
+      output: "unknown",
+    });
+
+    // Resolve tenants in the opposite order from their seeds.
+    result(TENANT_B, sharedPath, "main", callID, {
+      status: "error",
+      input: null,
+      error: "permission denied",
+    });
+    result(TENANT_A, sharedPath, "main", callID, {
+      status: "completed",
+      input: null,
+      output: "ok",
+    });
+
+    expect(toolRows(TENANT_A, sharedPath)).toEqual([
+      {
+        session_id: "main",
+        call_id: callID,
+        tool: "read",
+        status: "completed",
+        error_type: null,
+      },
+      {
+        session_id: "other-session",
+        call_id: callID,
+        tool: "edit",
+        status: "pending",
+        error_type: null,
+      },
+    ]);
+    expect(toolRows(TENANT_B, sharedPath)).toEqual([
+      {
+        session_id: "main",
+        call_id: callID,
+        tool: "write",
+        status: "error",
+        error_type: "permission",
+      },
+    ]);
+    expect(toolRows(TENANT_A, otherPath)[0]?.status).toBe("pending");
+
+    close();
+
+    // A post-restart result for the second session must not rewrite main, the
+    // other project, or tenant B despite sharing the same raw call ID.
+    result(TENANT_A, sharedPath, "other-session", callID, {
+      status: "error",
+      input: null,
+      error: "timed out",
+    });
+    expect(toolRows(TENANT_A, sharedPath).map((row) => row.status)).toEqual([
+      "completed",
+      "error",
+    ]);
+    expect(toolRows(TENANT_A, otherPath)[0]?.status).toBe("pending");
+    expect(toolRows(TENANT_B, sharedPath)[0]?.status).toBe("error");
+  });
+});

--- a/packages/core/test/temporal-prune-race.test.ts
+++ b/packages/core/test/temporal-prune-race.test.ts
@@ -171,7 +171,7 @@ describe("temporal.prune resilience to a db()-swap missing-table race (#1001)", 
     // no-such-table *before* any pass runs. The whole tick must no-op, not abort.
     registerSink(
       throwingSink(
-        /FROM projects WHERE path/,
+        /FROM projects WHERE .*path/,
         new Error("no such table: projects"),
       ),
     );

--- a/packages/core/test/temporal.test.ts
+++ b/packages/core/test/temporal.test.ts
@@ -132,30 +132,32 @@ describe("temporal", () => {
     // Use a DEDICATED project so this seeded row never perturbs the cumulative
     // count/order-sensitive tests that share PROJECT.
     const LEAN_PROJECT = "/test/temporal/lean-cols";
-    temporal.store({
+    const storedId = temporal.store({
       projectPath: LEAN_PROJECT,
       info: makeMessage("msg-lean", "user", "sess-lean"),
       parts: makeParts("msg-lean", "lean offload columns probe"),
     });
+    if (!storedId) throw new Error("expected stored message id");
     // Give the row a non-null embedding BLOB. `SELECT m.*` would marshal this
     // BLOB across the read-worker boundary (forbidden by the read-job contract)
     // and waste bytes even in-process; the lean column list must drop it.
     db()
       .query("UPDATE temporal_messages SET embedding = ? WHERE id = ?")
-      .run(new Uint8Array([1, 2, 3, 4]), "msg-lean");
+      .run(new Uint8Array([1, 2, 3, 4]), storedId);
 
     const results = await temporal.searchScored({
       projectPath: LEAN_PROJECT,
       query: "offload columns probe",
     });
-    const hit = results.find((r) => r.id === "msg-lean");
+    const hit = results.find((r) => r.source_id === "msg-lean");
     expect(hit).toBeDefined();
+    if (!hit) throw new Error("expected lean temporal search hit");
     // The fix: the SELECT enumerates lean columns and omits `embedding`.
     // Reverting to `SELECT m.*` re-introduces the key and fails this.
-    expect("embedding" in hit!).toBe(false);
+    expect("embedding" in hit).toBe(false);
     // The columns recall actually consumes survive.
-    expect(hit!.content).toContain("offload");
-    expect(typeof hit!.rank).toBe("number");
+    expect(hit.content).toContain("offload");
+    expect(typeof hit.rank).toBe("number");
   });
 
   test("search respects session scope", () => {
@@ -186,11 +188,17 @@ describe("temporal", () => {
     const pending = temporal.undistilled(PROJECT, "sess-1");
     expect(pending.length).toBe(3);
 
-    temporal.markDistilled(["msg-1", "msg-2"]);
+    temporal.markDistilled(
+      pending
+        .filter((message) =>
+          ["msg-1", "msg-2"].includes(message.source_id ?? ""),
+        )
+        .map((message) => message.id),
+    );
 
     const after = temporal.undistilled(PROJECT, "sess-1");
     expect(after.length).toBe(1);
-    expect(after[0].id).toBe("msg-3");
+    expect(after[0].source_id).toBe("msg-3");
   });
 
   test("search finds distilled messages", () => {
@@ -201,7 +209,7 @@ describe("temporal", () => {
     });
     expect(results.length).toBeGreaterThan(0);
     // msg-2 contains "OAuth2" and is distilled — must still appear
-    expect(results.some((r) => r.id === "msg-2")).toBe(true);
+    expect(results.some((r) => r.source_id === "msg-2")).toBe(true);
   });
 
   test("count and undistilledCount", () => {
@@ -505,7 +513,7 @@ describe("temporal", () => {
       expect(errored.duration_ms).toBe(60);
     });
 
-    test("is idempotent on re-store (UPSERT on call_id)", () => {
+    test("is idempotent on re-store (UPSERT on owned call_id)", () => {
       const pid = ensureProject(TOOL_PROJECT);
       const info = makeMessage("tm-2", "assistant", "sess-tool");
       const parts: LorePart[] = [
@@ -699,7 +707,7 @@ describe("temporal", () => {
       expect(r.find((x) => x.call_id === "v0")?.verifier).toBe(1);
       expect(r.find((x) => x.call_id === "v1")?.verifier).toBe(0);
       // message_id seeded from the assistant message on every batched row.
-      expect(r.every((x) => x.message_id === "tm-vf")).toBe(true);
+      expect(r.every((x) => x.message_id.startsWith("lore_tm_v1_"))).toBe(true);
     });
 
     test("result update preserves the batched seed's message_id", () => {
@@ -730,7 +738,13 @@ describe("temporal", () => {
       });
       const r = rows(pid);
       expect(r.length).toBe(1);
-      expect(r[0].message_id).toBe("tm-mid-asst"); // seed's id, not the result's
+      expect(r[0].message_id).toBe(
+        temporal.storedMessageId({
+          projectPath: TOOL_PROJECT,
+          sessionID: "sess-tool",
+          sourceID: "tm-mid-asst",
+        }),
+      ); // seed's storage id, not the result's
       expect(r[0].status).toBe("completed");
     });
 

--- a/packages/core/test/tenant-isolation.test.ts
+++ b/packages/core/test/tenant-isolation.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { close, db, ensureProject, invalidateProjectIdCache } from "../src/db";
+import { withTenant } from "../src/tenant";
+import * as entities from "../src/entities";
+import * as ltm from "../src/ltm";
+import * as temporal from "../src/temporal";
+import { recallById, runRecall } from "../src/recall";
+import { config } from "../src/config";
+import { isVecAvailable } from "../src/db/vec";
+import {
+  readStorageMode,
+  resolveReadMode,
+  storeEmbedding,
+} from "../src/db/vec-store";
+import { runVectorQuery } from "../src/vector-query";
+
+const TENANT_A = "a".repeat(64);
+const TENANT_B = "b".repeat(64);
+
+afterEach(() => {
+  invalidateProjectIdCache();
+});
+
+describe("durable remote tenant storage isolation", () => {
+  test.each([
+    [TENANT_A, TENANT_B],
+    [TENANT_B, TENANT_A],
+  ])(
+    "same client path resolves independently in adversarial order %#",
+    async (firstTenant, secondTenant) => {
+      const path = `/test/tenant-isolation/order-${firstTenant[0]}`;
+      const firstId = withTenant(firstTenant, () => ensureProject(path));
+      const secondId = withTenant(secondTenant, () => ensureProject(path));
+
+      expect(firstId).not.toBe(secondId);
+      expect(
+        db()
+          .query(
+            "SELECT tenant_id, path FROM projects WHERE id IN (?, ?) ORDER BY tenant_id",
+          )
+          .all(firstId, secondId),
+      ).toEqual([
+        { tenant_id: TENANT_A, path },
+        { tenant_id: TENANT_B, path },
+      ]);
+
+      close();
+      const firstAfterRestart = withTenant(firstTenant, () =>
+        ensureProject(path),
+      );
+      const secondAfterRestart = withTenant(secondTenant, () =>
+        ensureProject(path),
+      );
+      expect(firstAfterRestart).toBe(firstId);
+      expect(secondAfterRestart).toBe(secondId);
+    },
+  );
+
+  test("isolates project/global memory, entities, recall, point reads, and background sweeps after restart", async () => {
+    const path = "/test/tenant-isolation/shared-client-path";
+    const secret = "alpha-tenant-zircon-memory";
+    let projectKnowledgeId = "";
+    let globalKnowledgeId = "";
+    let entityId = "";
+    let temporalId = "";
+    let projectA = "";
+
+    await withTenant(TENANT_A, async () => {
+      projectA = ensureProject(path, undefined, "github.com/shared/repo");
+      projectKnowledgeId = ltm.create({
+        projectPath: path,
+        scope: "project",
+        category: "architecture",
+        title: "Tenant A zircon architecture",
+        content: `${secret} belongs only to tenant A`,
+        crossProject: true,
+      });
+      globalKnowledgeId = ltm.create({
+        projectPath: path,
+        scope: "global",
+        category: "preference",
+        title: "Tenant A zircon preference",
+        content: `Always preserve ${secret}`,
+        crossProject: true,
+      });
+      entityId = entities.create({
+        projectPath: path,
+        entityType: "service",
+        canonicalName: "ZirconTenantAService",
+        aliases: [{ type: "name", value: "zircon-a-service" }],
+        crossProject: true,
+      }).id;
+      temporalId = crypto.randomUUID();
+      const storedTemporalId = temporal.store({
+        projectPath: path,
+        info: {
+          id: temporalId,
+          sessionID: "tenant-a-session",
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: "anthropic", modelID: "test-model" },
+        },
+        parts: [
+          {
+            id: crypto.randomUUID(),
+            sessionID: "tenant-a-session",
+            messageID: temporalId,
+            type: "text",
+            text: `recall ${secret}`,
+          },
+        ],
+      });
+      if (!storedTemporalId) throw new Error("expected stored temporal row");
+      temporalId = storedTemporalId;
+      db()
+        .query(
+          `INSERT INTO distillations
+             (id, project_id, session_id, narrative, facts, source_ids,
+              observations, generation, token_count, created_at, archived)
+           VALUES (?, ?, ?, '', '', '[]', ?, 0, 10, ?, 0)`,
+        )
+        .run(
+          crypto.randomUUID(),
+          projectA,
+          "tenant-a-session",
+          `distilled ${secret}`,
+          Date.now(),
+        );
+      ltm.recordContradiction({
+        logicalIdA: projectKnowledgeId,
+        logicalIdB: globalKnowledgeId,
+        projectId: projectA,
+        similarity: 0.9,
+        rationale: "tenant A only",
+      });
+      ltm.recordDedupFeedback({
+        projectId: null,
+        entryATitle: "tenant A feedback one",
+        entryBTitle: "tenant A feedback two",
+        similarity: 0.91,
+        accepted: false,
+        source: "dashboard",
+      });
+      entities.recordEntityDedupFeedback({
+        projectId: null,
+        entryATitle: "tenant A entity one",
+        entryBTitle: "tenant A entity two",
+        similarity: 0.92,
+        accepted: false,
+        source: "dashboard",
+      });
+    });
+
+    // A real restart drops connection-keyed project caches before the adversary
+    // arrives and forces ownership to be recovered from durable rows.
+    close();
+    invalidateProjectIdCache();
+
+    await withTenant(TENANT_B, async () => {
+      const projectB = ensureProject(path, undefined, "github.com/shared/repo");
+      expect(projectB).not.toBe(projectA);
+      expect(ltm.forProject(path, true)).toEqual([]);
+      expect(entities.forProject(path, true)).toEqual([]);
+      expect(ltm.get(projectKnowledgeId)).toBeNull();
+      expect(ltm.get(globalKnowledgeId)).toBeNull();
+      expect(entities.get(entityId)).toBeNull();
+      expect(recallById(`k:${projectKnowledgeId}`)).toContain("No entry found");
+      expect(recallById(`e:${entityId}`)).toContain("No entry found");
+      expect(recallById(`t:${temporalId}`)).toContain("No entry found");
+
+      const recall = await runRecall({
+        query: secret,
+        projectPath: path,
+        sessionID: "tenant-b-session",
+        scope: "all",
+      });
+      expect(recall).not.toContain(secret);
+      expect(recall).not.toContain("ZirconTenantAService");
+
+      // These installation-wide background/catalog passes must operate on the
+      // active tenant only, not fan out over tenant A's global rows.
+      expect(ltm.pruneDeadEntriesAllProjects()).toEqual([]);
+      expect(ltm.rerankPreferences()).toBe(0);
+      expect(entities.listAll()).toEqual([]);
+      expect(
+        ltm.contradictionExists(projectKnowledgeId, globalKnowledgeId),
+      ).toBe(false);
+      expect(ltm.getDedupFeedback(null)).toEqual([]);
+      expect(entities.getEntityDedupFeedback(null)).toEqual([]);
+    });
+
+    close();
+    invalidateProjectIdCache();
+
+    await withTenant(TENANT_A, async () => {
+      expect(ensureProject(path)).toBe(projectA);
+      expect(
+        ltm.forProject(path, true).map((entry) => entry.logical_id),
+      ).toEqual(
+        expect.arrayContaining([projectKnowledgeId, globalKnowledgeId]),
+      );
+      expect(
+        entities.forProject(path, true).map((entity) => entity.id),
+      ).toContain(entityId);
+      const recall = await runRecall({
+        query: secret,
+        projectPath: path,
+        sessionID: "tenant-a-session",
+        scope: "all",
+      });
+      expect(recall).toContain(secret);
+      expect(recallById(`t:${temporalId}`)).toContain(secret);
+      expect(
+        ltm.contradictionExists(projectKnowledgeId, globalKnowledgeId),
+      ).toBe(true);
+      expect(ltm.getDedupFeedback(null)).toHaveLength(1);
+      expect(entities.getEntityDedupFeedback(null)).toHaveLength(1);
+    });
+  });
+
+  test("filters vector candidate pools before ranking across worker-safe query specs", async () => {
+    const path = "/test/tenant-isolation/vector-shared-path";
+    const dimensions = config().search.embeddings.dimensions;
+    const vector = (axis: number) => {
+      const value = new Float32Array(dimensions);
+      value[axis] = 1;
+      return value;
+    };
+    const ids: Record<
+      string,
+      { knowledge: string; entity: string; distillation: string }
+    > = {};
+
+    for (const [tenantId, axis] of [
+      [TENANT_A, 0],
+      [TENANT_B, 1],
+    ] as const) {
+      withTenant(tenantId, () => {
+        const projectId = ensureProject(path);
+        const knowledge = ltm.create({
+          projectPath: path,
+          scope: "project",
+          category: "architecture",
+          title: `Vector knowledge ${tenantId[0]}`,
+          content: `private vector content ${tenantId[0]}`,
+        });
+        const entity = entities.create({
+          projectPath: path,
+          entityType: "service",
+          canonicalName: `VectorService${tenantId[0]}`,
+        }).id;
+        const distillation = crypto.randomUUID();
+        db()
+          .query(
+            `INSERT INTO distillations
+               (id, project_id, session_id, narrative, facts, source_ids,
+                observations, generation, token_count, created_at, archived)
+             VALUES (?, ?, ?, '', '', '[]', ?, 0, 10, ?, 0)`,
+          )
+          .run(
+            distillation,
+            projectId,
+            `vector-session-${tenantId[0]}`,
+            `private distillation ${tenantId[0]}`,
+            Date.now(),
+          );
+        storeEmbedding(db(), "knowledge", knowledge, vector(axis));
+        storeEmbedding(db(), "entities", entity, vector(axis));
+        storeEmbedding(db(), "distillations", distillation, vector(axis));
+        ids[tenantId] = { knowledge, entity, distillation };
+      });
+    }
+
+    const mode = resolveReadMode(readStorageMode(db()), isVecAvailable());
+    const query = vector(0);
+    const tenantB = ids[TENANT_B];
+    const knowledgeHits = runVectorQuery(db(), mode, query, {
+      kind: "knowledge",
+      tenantId: TENANT_B,
+      limit: 10,
+    });
+    const entityHits = runVectorQuery(db(), mode, query, {
+      kind: "entities",
+      tenantId: TENANT_B,
+      limit: 10,
+    });
+    const distillationHits = runVectorQuery(db(), mode, query, {
+      kind: "distillations",
+      tenantId: TENANT_B,
+      limit: 10,
+    });
+
+    expect(knowledgeHits.map((hit) => hit.id)).toEqual([tenantB.knowledge]);
+    expect(entityHits.map((hit) => hit.id)).toEqual([tenantB.entity]);
+    expect(distillationHits.map((hit) => hit.id)).toEqual([
+      tenantB.distillation,
+    ]);
+  });
+});

--- a/packages/gateway/instrument.ts
+++ b/packages/gateway/instrument.ts
@@ -45,10 +45,13 @@ setMaxListeners(15);
 import * as Sentry from "@sentry/bun";
 import { log } from "@loreai/core";
 import { VERSION } from "./src/cli/version";
+import { eventHasTransientError } from "./src/transient-errors";
 import {
-  eventHasTransientError,
-  isTransientErrorMessage,
-} from "./src/transient-errors";
+  SENTRY_DATA_COLLECTION,
+  scrubTelemetryEvent,
+  scrubTelemetryValue,
+  wrapTelemetryTransport,
+} from "./src/telemetry-privacy";
 
 /**
  * Build-time debug ID for sourcemap resolution, injected by esbuild.
@@ -118,20 +121,27 @@ const sentryEnabled = isTestRunner
         : !isDev
     : false;
 
-if (sentryEnabled && !Sentry.isInitialized()) {
-  Sentry.init({
+/** Build the complete Sentry configuration. Exported for privacy regressions. */
+export function buildSentryOptions(
+  makeTransport: typeof Sentry.makeNodeTransport = Sentry.makeNodeTransport,
+): Sentry.BunOptions {
+  return {
     dsn: "https://0282201d6a3df3bc46423e61012ae62b@o275100.ingest.us.sentry.io/4511355222622208",
 
     release: VERSION,
     environment: isDev ? "development" : "production",
 
-    // Adds request headers and IP for users, for more info visit:
-    // https://docs.sentry.io/platforms/javascript/guides/bun/configuration/options/#sendDefaultPii
-    sendDefaultPii: true,
+    // Lore proxies private prompts and provider credentials. Collection is
+    // default-deny, and the hooks/transport below provide defense in depth for
+    // SDK integrations that construct telemetry outside these defaults.
+    sendDefaultPii: false,
+    dataCollection: SENTRY_DATA_COLLECTION,
 
-    // Capture 100% of transactions and logs
+    // Capture transactions, but never export the application's free-form logs.
+    // Explicit metrics and fixed-message error telemetry are emitted at their
+    // designed call sites instead.
     tracesSampleRate: 1.0,
-    enableLogs: true,
+    enableLogs: false,
 
     // Disable the NodeFetch integration. In the esbuild CJS bundle, the
     // vendored undici code inside @sentry/node has 100+ `let` declarations
@@ -144,36 +154,59 @@ if (sentryEnabled && !Sentry.isInitialized()) {
     // The gateway does its own upstream fetch tracing, so no functionality is lost.
     integrations: (defaults) => defaults.filter((i) => i.name !== "NodeFetch"),
 
+    beforeBreadcrumb() {
+      return null;
+    },
+
+    // Defense in depth if a future integration creates logs despite enableLogs.
+    beforeSendLog() {
+      return null;
+    },
+
+    beforeSendSpan(span) {
+      return scrubTelemetryValue(span);
+    },
+
+    beforeSendTransaction(event) {
+      return scrubTelemetryEvent(event);
+    },
+
     // Drop transient network errors that are not actionable bugs.
     // Each exception in the chain is tested independently so a real bug
     // wrapping a transient cause isn't accidentally silenced.
     beforeSend(event) {
-      return eventHasTransientError(event) ? null : event;
+      return eventHasTransientError(event) ? null : scrubTelemetryEvent(event);
     },
-  });
 
-  // Bridge core's log.* calls → Sentry structured logs + error capture.
-  // Error-level logs are filtered against the same TRANSIENT_ERROR_PATTERNS
-  // used by beforeSend — structured logs bypass beforeSend entirely, so
-  // without this gate transient worker errors flood the Sentry Logs product.
-  log.registerSink({
-    info: (message, attrs) => Sentry.logger.info(message, attrs),
-    warn: (message, attrs) => Sentry.logger.warn(message, attrs),
-    error: (message, attrs) => {
-      if (!isTransientErrorMessage(message)) {
-        Sentry.logger.error(message, attrs);
-      }
+    // Final boundary: sanitize every envelope item, including payload types
+    // added by future SDK integrations that do not pass through hooks above.
+    transport(options) {
+      return wrapTelemetryTransport(makeTransport(options));
     },
-    captureException: (err) => Sentry.captureException(err),
+  };
+}
+
+if (sentryEnabled && !Sentry.isInitialized()) {
+  Sentry.init(buildSentryOptions());
+
+  // Keep only the DB tracing seam. Core log messages and Error objects are
+  // intentionally NOT bridged: they can contain prompts, paths, entity names,
+  // commands, or provider response bodies. Sentry receives only the explicit
+  // metrics/fixed-message error telemetry defined at reviewed call sites.
+  log.registerSink({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    captureException: () => {},
     // Per-query DB tracing. `onlyIfParent: true` means a span is only created
     // when there is an active parent (e.g. an in-flight request transaction),
     // so background/idle DB churn adds no orphan transactions or cost.
-    withDbSpan: (sql, fn) =>
+    withDbSpan: (_sql, fn) =>
       Sentry.startSpan(
         {
-          name: sql,
+          name: "sqlite query",
           op: "db",
-          attributes: { "db.system": "sqlite", "db.statement": sql },
+          attributes: { "db.system": "sqlite" },
           onlyIfParent: true,
         },
         fn,

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -31,6 +31,7 @@
     "@stricli/core": "1.2.8",
     "@supabase/supabase-js": "^2.58.0",
     "google-auth-library": "^10.9.0",
+    "jsonc-parser": "3.3.1",
     "p-limit": "7",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.7.3",

--- a/packages/gateway/script/build-binary-sea.ts
+++ b/packages/gateway/script/build-binary-sea.ts
@@ -48,6 +48,7 @@ import { parseArgs } from "node:util";
 import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
 import { MODEL_DIR_NAME, MODEL_FILES } from "./vendor-paths";
 import { ortNativePlugin } from "./ort-native-plugin";
+import { jsoncParserEsmPlugin } from "./jsonc-parser-plugin";
 import { ensureVecBinaries, vecAssetKey } from "./vendor-sqlite-vec";
 import { ortNativeAssets } from "./vendor-ort-native";
 import { fossilize } from "fossilize";
@@ -525,6 +526,7 @@ async function buildBinary() {
     plugins: [
       binaryExternalsPlugin(),
       sentryBunToNodePlugin(),
+      jsoncParserEsmPlugin(packageDir),
       stubSqliteVecPlugin(),
     ],
     inject: [

--- a/packages/gateway/script/bundle.ts
+++ b/packages/gateway/script/bundle.ts
@@ -32,6 +32,7 @@ import { dirname, join } from "node:path";
 import { PLACEHOLDER_DEBUG_ID, injectDebugId } from "./debug-id";
 import { findOrtWebDir } from "./ort-web-plugin";
 import { ortNpmDualPlugin } from "./ort-npm-plugin";
+import { jsoncParserEsmPlugin } from "./jsonc-parser-plugin";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageDir = dirname(here);
@@ -106,7 +107,7 @@ await esbuild.build({
   minify: true,
   logLevel: "info",
   legalComments: "none",
-  plugins: [sentryNodePlugin],
+  plugins: [sentryNodePlugin, jsoncParserEsmPlugin(packageDir)],
   // Inject ESM/CJS interop shim so `import.meta.url` can be rewritten
   // via `define` (the static `import.meta` token would otherwise be
   // dropped to empty in CJS output, triggering esbuild's
@@ -171,7 +172,7 @@ await esbuild.build({
   minify: true,
   logLevel: "info",
   legalComments: "none",
-  plugins: [sentryNodePlugin],
+  plugins: [sentryNodePlugin, jsoncParserEsmPlugin(packageDir)],
   define: {
     LORE_CLI_VERSION: JSON.stringify(pkg.version),
     __SENTRY_DEBUG_ID__: JSON.stringify(PLACEHOLDER_DEBUG_ID),
@@ -493,7 +494,7 @@ export declare function loadConfig(): GatewayConfig;
  * port file management, and existing-instance reuse automatically.
  */
 export declare function startServer(config: GatewayConfig): Promise<{
-  stop: () => void;
+  stop: () => Promise<void>;
   port: number;
   hosts: string[];
   /** Resolves when all bound servers are listening. */

--- a/packages/gateway/script/jsonc-parser-plugin.ts
+++ b/packages/gateway/script/jsonc-parser-plugin.ts
@@ -1,0 +1,25 @@
+import type * as esbuild from "esbuild";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+/**
+ * Bundle jsonc-parser through its static ESM entry.
+ *
+ * The package's default UMD entry performs factory-scoped relative requires
+ * such as `./impl/format`. Esbuild cannot discover those calls, leaving broken
+ * runtime lookups in otherwise self-contained npm and SEA bundles.
+ */
+export function jsoncParserEsmPlugin(packageDir: string): esbuild.Plugin {
+  const jsoncParserEsmEntry = createRequire(
+    join(packageDir, "package.json"),
+  ).resolve("jsonc-parser/lib/esm/main.js");
+
+  return {
+    name: "jsonc-parser-esm",
+    setup(build) {
+      build.onResolve({ filter: /^jsonc-parser$/ }, () => ({
+        path: jsoncParserEsmEntry,
+      }));
+    },
+  };
+}

--- a/packages/gateway/script/record-session.ts
+++ b/packages/gateway/script/record-session.ts
@@ -100,15 +100,14 @@ console.error("[record] Press Ctrl+C to stop recording.");
 // SIGINT handler — print stats and exit
 // ---------------------------------------------------------------------------
 
-process.on("SIGINT", () => {
+async function shutdown(): Promise<void> {
   // stopRecording() clears the module-level path; seqCounter stays at its
   // final value, which equals the number of turns captured.
   // We import stopRecording lazily to read seqCounter after all turns.
-  void import("../src/recorder").then(({ stopRecording }) => {
-    stopRecording();
-  });
+  const { stopRecording } = await import("../src/recorder");
+  stopRecording();
 
-  server.stop();
+  await server.stop();
 
   // Re-read the fixture file to count lines (most reliable turn count)
   try {
@@ -124,4 +123,11 @@ process.on("SIGINT", () => {
   }
 
   process.exit(0);
+}
+
+process.on("SIGINT", () => {
+  void shutdown().catch((error: unknown) => {
+    console.error("[record] Failed to stop recording cleanly:", error);
+    process.exit(1);
+  });
 });

--- a/packages/gateway/script/smoke-test.ts
+++ b/packages/gateway/script/smoke-test.ts
@@ -500,7 +500,7 @@ try {
   // Cleanup
   // -----------------------------------------------------------------------
   console.log("[smoke] Stopping server...");
-  server.stop();
+  await server.stop();
 
   // Clean up temp DB and related files
   for (const suffix of ["", "-shm", "-wal"]) {

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -44,35 +44,99 @@ export function workerKeyScheme(providerID?: string): AuthCredential["scheme"] {
 // Header extraction / formatting
 // ---------------------------------------------------------------------------
 
+export const PROVIDER_AUTH_HEADER_NAMES = [
+  "x-api-key",
+  "x-goog-api-key",
+  "authorization",
+] as const;
+type AuthHeaderName = (typeof PROVIDER_AUTH_HEADER_NAMES)[number];
+
+function isAuthHeaderName(name: string): name is AuthHeaderName {
+  return PROVIDER_AUTH_HEADER_NAMES.some((candidate) => candidate === name);
+}
+
+function getHeaderValue(
+  headers: Record<string, string>,
+  target: AuthHeaderName,
+): string | undefined {
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === target) {
+      return typeof value === "string" ? value : undefined;
+    }
+  }
+  return undefined;
+}
+
+function isValidApiKey(value: string | undefined): value is string {
+  return value !== undefined && /^\S+$/.test(value);
+}
+
 /**
  * Extract auth from request headers.
  *
- * Prefers `x-api-key` (Anthropic SDK default), falls back to
- * `Authorization: Bearer` (OAuth / Claude Code subscriptions).
- * Returns `null` if neither is present.
+ * Accepts one of `x-api-key` (Anthropic SDK default), `x-goog-api-key`
+ * (Gemini), or `Authorization: Bearer` (OAuth / Claude Code subscriptions).
+ * Returns `null` when no valid credential is present or when multiple auth
+ * mechanisms are present. Rejecting ambiguity here prevents fingerprint and
+ * upstream-routing callers from silently selecting one credential by priority.
  */
 export function extractAuth(
   headers: Record<string, string> | null | undefined,
 ): AuthCredential | null {
-  if (!headers) return null;
+  if (!headers || hasConflictingAuthHeaders(headers)) return null;
 
-  const apiKey = headers["x-api-key"] || headers["X-Api-Key"];
-  if (apiKey) return { scheme: "api-key", value: apiKey };
+  const apiKey = getHeaderValue(headers, "x-api-key");
+  if (isValidApiKey(apiKey)) return { scheme: "api-key", value: apiKey };
 
   // Google Gemini's native API authenticates with `x-goog-api-key`. Capture it
   // as an api-key credential so gemini sessions get a stable identity and their
   // background workers can resolve auth (worker builders emit it as
   // `x-goog-api-key`, not the generic `x-api-key`, via buildGeminiWorkerRequest).
-  const googKey = headers["x-goog-api-key"] || headers["X-Goog-Api-Key"];
-  if (googKey) return { scheme: "api-key", value: googKey };
+  const googKey = getHeaderValue(headers, "x-goog-api-key");
+  if (isValidApiKey(googKey)) return { scheme: "api-key", value: googKey };
 
-  const authHeader = headers.authorization || headers.Authorization;
+  const authHeader = getHeaderValue(headers, "authorization");
   if (authHeader) {
     const match = /^Bearer\s+(\S+)$/i.exec(authHeader);
     if (match) return { scheme: "bearer", value: match[1] };
   }
 
   return null;
+}
+
+/**
+ * Whether more than one recognized authentication mechanism was supplied.
+ *
+ * Header names are matched case-insensitively because direct module callers do
+ * not necessarily pass a Web `Headers`-normalized record. Presence is enough:
+ * two auth mechanisms are ambiguous even when either value is empty or both
+ * happen to contain the same bytes.
+ */
+export function hasConflictingAuthHeaders(
+  headers: Record<string, string> | null | undefined,
+): boolean {
+  if (!headers) return false;
+  const present = new Set<AuthHeaderName>();
+  for (const name of Object.keys(headers)) {
+    const lower = name.toLowerCase();
+    if (!isAuthHeaderName(lower)) continue;
+    present.add(lower);
+    if (present.size > 1) return true;
+  }
+  return false;
+}
+
+/** Copy the one provider-auth variant without changing its header scheme. */
+export function copyProviderAuthHeaders(
+  headers: Record<string, string> | null | undefined,
+): Record<string, string> {
+  if (!headers || hasConflictingAuthHeaders(headers)) return {};
+  const copied: Record<string, string> = {};
+  for (const name of PROVIDER_AUTH_HEADER_NAMES) {
+    const value = getHeaderValue(headers, name);
+    if (value !== undefined) copied[name] = value;
+  }
+  return copied;
 }
 
 /**
@@ -94,15 +158,34 @@ export function authHeaders(cred: AuthCredential): Record<string, string> {
  * Privacy-safe credential fingerprint — SHA-256 of scheme + value, truncated
  * to 16 hex chars (64 bits).
  *
- * Used to differentiate sessions that share the same first message but use
- * different API keys or OAuth tokens. The scheme prefix prevents collisions
- * between an API key and a bearer token with the same value. Not reversible.
+ * Used for local fallback session correlation, telemetry, quotas, and batching.
+ * Remote session identity uses `credentialTenantFingerprint()` below so its
+ * persisted tenant boundary retains the full SHA-256 output. The scheme prefix
+ * prevents collisions between an API key and bearer token with equal bytes.
  */
 export function authFingerprint(cred: AuthCredential): string {
   return createHash("sha256")
     .update(`${cred.scheme}|${cred.value}`)
     .digest("hex")
     .slice(0, 16);
+}
+
+/**
+ * Server-derived tenant identity for remote session binding.
+ *
+ * Unlike the short diagnostic/quota fingerprint above, this uses the full
+ * SHA-256 output and a versioned domain separator. It is safe to persist as a
+ * one-way tenant identifier; the credential itself is never stored. The auth
+ * scheme is part of the material, so equal API-key and bearer bytes remain
+ * distinct tenants.
+ */
+export function credentialTenantFingerprint(cred: AuthCredential): string {
+  return createHash("sha256")
+    .update("lore.remote-session-tenant.v1\0")
+    .update(cred.scheme)
+    .update("\0")
+    .update(cred.value)
+    .digest("hex");
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +199,12 @@ export function authFingerprint(cred: AuthCredential): string {
  * within the same OpenCode session.
  */
 const sessionAuth = new Map<string, Map<string, AuthCredential>>();
+
+/** Credential/provider observed on the session's most recent authenticated turn. */
+const currentSessionAuth = new Map<
+  string,
+  { providerID?: string; credential: AuthCredential }
+>();
 
 /**
  * Store a credential for a specific (session, provider) pair.
@@ -136,6 +225,7 @@ export function setSessionAuth(
   }
   const key = providerID || "_default";
   byProvider.set(key, cred);
+  currentSessionAuth.set(sessionID, { providerID, credential: cred });
   // Only set _default when no explicit providerID was given (legacy callers).
   // When a named provider stores its credential (e.g. "minimax"), do NOT
   // overwrite _default — that causes cross-contamination: a MiniMax API key
@@ -177,6 +267,13 @@ export function getSessionAuth(
   return byProvider.get("_default") ?? null;
 }
 
+/** Return the credential/provider from a session's latest authenticated turn. */
+export function getCurrentSessionAuth(
+  sessionID: string,
+): { providerID?: string; credential: AuthCredential } | null {
+  return currentSessionAuth.get(sessionID) ?? null;
+}
+
 /** Dedup guard so the mismatch warning fires once per session+lookup-key. */
 const warnedAuthKeyMismatch = new Set<string>();
 
@@ -201,6 +298,7 @@ function warnAuthKeyMismatch(
 /** Delete a session's credentials (for eviction). */
 export function deleteSessionAuth(sessionID: string): void {
   sessionAuth.delete(sessionID);
+  currentSessionAuth.delete(sessionID);
   clearAuthStale(sessionID);
   // Drop this session's mismatch-warning dedup entries so the set doesn't grow
   // unbounded over a long-lived gateway (keys are `${sessionID}:${lookupKey}`).
@@ -384,71 +482,52 @@ export function isGlobalAuthStale(): boolean {
 /**
  * Resolve auth credentials for a given session (and optionally a specific provider).
  *
- * 1. If `sessionID` is provided, check the per-session registry first.
- *    When `providerID` is also given, returns the credential stored for
- *    that specific provider — preventing cross-contamination when a session
- *    uses multiple providers (e.g. Anthropic + MiniMax).
- *    Skips credentials whose specific provider is marked stale (401/403)
- *    so the global fallback can provide a potentially-refreshed token.
- * 2. Fall back to the global `lastSeenAuth` (for cold-start or callers
- *    that don't pass a session ID).
- * 3. If the global fallback holds the same value as the stale session
- *    credential, return `null` — the token is expired everywhere and
- *    retrying would just generate another 401. This prevents the
- *    background worker 401 storm in single-session OAuth setups where
- *    session and global credentials are the same expired token.
+ * 1. If `sessionID` is provided, resolve ONLY from that session.
+ *    Provider-agnostic callers use the credential from that session's most
+ *    recent authenticated turn, not a historical `_default` slot.
+ *    When `providerID` is also given, returns the credential stored for that
+ *    specific provider — preventing cross-contamination when a session uses
+ *    multiple providers (e.g. Anthropic + MiniMax). A cold or stale session
+ *    never inherits another client's process-global credential.
+ * 2. The process-global fallback is available only to callers that omit a
+ *    session ID. Runtime callers should additionally gate that legacy path to
+ *    local, configured direct-provider routes.
  */
 export function resolveAuth(
   sessionID?: string,
   providerID?: string,
 ): AuthCredential | null {
   if (sessionID) {
-    const cred = getSessionAuth(sessionID, providerID);
-    // Check staleness for the specific provider being requested.
-    // A stale MiniMax credential should NOT cause the Anthropic credential
-    // to be skipped (or vice versa).
-    const staleKey = providerID || "_default";
-    if (cred && !isAuthStale(sessionID, staleKey)) return cred;
-
-    // CROSS-PROVIDER GUARD: when a SPECIFIC providerID is requested and this
-    // session has no credential for it, do NOT borrow the global fallback —
-    // it belongs to whatever provider the session authenticated with, NOT the
-    // requested one. Returning it produces the exact production bug: a worker
-    // configured for `minimax` borrows the session's Anthropic key and gets
-    // sent off as a doomed cross-provider request (401 "invalid x-api-key"
-    // loop). The global fallback is only safe for provider-agnostic callers
-    // (no providerID) and for cold-start when the session genuinely has no
-    // provider-specific store yet.
-    if (providerID && !cred && sessionHasProviderStore(sessionID)) {
+    if (!providerID) {
+      const current = currentSessionAuth.get(sessionID);
+      if (current) {
+        const staleKey = current.providerID || "_default";
+        if (!isAuthStale(sessionID, staleKey)) return current.credential;
+      }
       return null;
     }
-
-    // Global fallback — provider-aware (never borrows a different provider's
-    // credential, #829) — and guarded against returning the same stale token.
-    // In single-session OAuth setups, session and global hold the exact
-    // same expired bearer token. Returning it would cause callers to make
-    // a request that immediately 401s again.
-    const global = getLastSeenAuth(providerID);
-    if (cred && global && global.value === cred.value) return null;
-    return global;
+    return resolveSessionProviderAuth(sessionID, providerID);
   }
   return getLastSeenAuth(providerID);
 }
 
 /**
- * Whether a session has any provider-specific credential stored (i.e. the
- * gateway has observed at least one real authenticated turn for it). Used by
- * `resolveAuth` to decide that a missing credential for a SPECIFIC provider is
- * a genuine "this provider isn't authenticated here" signal — not a cold-start
- * — so the global (foreign-provider) fallback must be suppressed.
+ * Resolve a credential only from one session for one provider.
+ *
+ * Unlike `resolveAuth`, this never consults the process-global fallback. That
+ * distinction is required for provider-owned account endpoints and background
+ * workers: the last credential observed anywhere in the process is not evidence
+ * that it belongs to this session or provider.
  */
-function sessionHasProviderStore(sessionID: string): boolean {
+export function resolveSessionProviderAuth(
+  sessionID: string,
+  providerID: string,
+): AuthCredential | null {
   const byProvider = sessionAuth.get(sessionID);
-  if (!byProvider) return false;
-  for (const key of byProvider.keys()) {
-    if (key !== "_default") return true;
-  }
-  return false;
+  if (!byProvider) return null;
+  const credential = byProvider.get(providerID);
+  if (!credential || isAuthStale(sessionID, providerID)) return null;
+  return credential;
 }
 
 // ---------------------------------------------------------------------------
@@ -458,6 +537,7 @@ function sessionHasProviderStore(sessionID: string): boolean {
 /** Reset all auth state — test-only. */
 export function _resetAuthForTest(): void {
   sessionAuth.clear();
+  currentSessionAuth.clear();
   staleSessionAuth.clear();
   warnedAuthKeyMismatch.clear();
   lastSeenAuth = null;

--- a/packages/gateway/src/batch-queue.ts
+++ b/packages/gateway/src/batch-queue.ts
@@ -54,6 +54,10 @@ export interface BatchResult {
   text: string | null;
   usage: AnthropicUsage | null;
   model: string | null;
+  /** Non-content provider status for diagnostics. */
+  statusCode?: number;
+  /** Body-derived capability signal retained without retaining response text. */
+  temperatureUnsupported?: boolean;
   error?: string;
 }
 
@@ -193,17 +197,10 @@ function groupKey(cred: AuthCredential, providerID: string): string {
 }
 
 /**
- * Extract a human-readable error string from an Anthropic batch errored result.
- *
- * Anthropic's `MessageBatchErroredResult.error` is an `ErrorResponse` envelope:
- * `{ type: "error", request_id, error: { type, message } }`. The real cause is
- * the nested `error.error` object; the envelope's own `type` is always the
- * literal "error" and it carries no `message`. Reading the envelope directly is
- * what produced the unhelpful `error: undefined` log lines.
- *
- * Falls back to a flattened `{ type, message }` shape (some proxies flatten the
- * envelope) and finally to the outcome string, so the result is never
- * `undefined`.
+ * Return a body-independent Anthropic batch error label. Upstream messages are
+ * intentionally ignored because BatchResult values flow through diagnostics.
+ * The body is inspected in-place for bounded capability classification before
+ * it is discarded.
  */
 export function extractAnthropicError(
   error:
@@ -216,10 +213,7 @@ export function extractAnthropicError(
     | undefined,
   fallbackOutcome: string,
 ): string {
-  const inner = error?.error;
-  if (inner?.message) return `${inner.type ?? "error"}: ${inner.message}`;
-  // Tolerate a flattened envelope where the message sits at the top level.
-  if (error?.message) return `${error.type ?? "error"}: ${error.message}`;
+  void error;
   return fallbackOutcome;
 }
 
@@ -263,9 +257,8 @@ export function createAnthropicBatchProvider(
       });
 
       if (!response.ok) {
-        const text = await response.text().catch(() => "(no body)");
         if (response.status === 401 || response.status === 403) {
-          log.warn(`anthropic batch auth error (${response.status}): ${text}`);
+          log.warn(`anthropic batch auth error (${response.status})`);
           return "auth-error";
         }
         if (response.status === 404) {
@@ -274,13 +267,17 @@ export function createAnthropicBatchProvider(
           );
           return "not-found";
         }
-        log.error(
-          `anthropic batch create failed: ${response.status} ${response.statusText} — ${text}`,
-        );
+        log.error(`anthropic batch create failed: ${response.status}`);
         return null;
       }
 
-      const data = (await response.json()) as { id: string };
+      const data = (await response.json().catch(() => null)) as {
+        id?: string;
+      } | null;
+      if (!data || typeof data.id !== "string") {
+        log.error("anthropic batch create returned malformed JSON");
+        return null;
+      }
       return data.id;
     },
 
@@ -294,16 +291,18 @@ export function createAnthropicBatchProvider(
       });
 
       if (!response.ok) {
-        log.error(
-          `anthropic batch poll failed for ${batchId}: ${response.status}`,
-        );
+        log.error(`anthropic batch poll failed: ${response.status}`);
         return { status: "pending" }; // Retry on next poll
       }
 
-      const data = (await response.json()) as {
+      const data = (await response.json().catch(() => null)) as {
         processing_status: string;
         results_url: string | null;
-      };
+      } | null;
+      if (!data) {
+        log.error("anthropic batch poll returned malformed JSON");
+        return { status: "pending" };
+      }
 
       if (data.processing_status !== "ended") return { status: "pending" };
 
@@ -319,7 +318,7 @@ export function createAnthropicBatchProvider(
 
       if (!resultsResponse.ok) {
         log.error(
-          `anthropic batch results fetch failed for ${batchId}: ${resultsResponse.status}`,
+          `anthropic batch results fetch failed: ${resultsResponse.status}`,
         );
         return { status: "pending" }; // Retry on next poll
       }
@@ -368,19 +367,29 @@ export function createAnthropicBatchProvider(
               model: msg?.model ?? null,
             });
           } else {
+            const outcome: BatchResult["outcome"] = [
+              "errored",
+              "canceled",
+              "expired",
+            ].includes(row.result.type)
+              ? row.result.type
+              : "errored";
+            const errorMessage =
+              row.result.error?.error?.message ?? row.result.error?.message;
             results.push({
               customId: row.custom_id,
-              outcome: row.result.type,
+              outcome,
               text: null,
               usage: null,
               model: null,
-              error: extractAnthropicError(row.result.error, row.result.type),
+              temperatureUnsupported:
+                typeof errorMessage === "string" &&
+                isTemperatureUnsupported400(errorMessage),
+              error: extractAnthropicError(row.result.error, outcome),
             });
           }
         } catch {
-          log.error(
-            `failed to parse anthropic batch result line: ${line.slice(0, 200)}`,
-          );
+          log.error("failed to parse anthropic batch result line");
         }
       }
 
@@ -417,24 +426,27 @@ async function uploadOpenAIBatchFile(
   });
 
   if (!response.ok) {
-    const text = await response.text().catch(() => "(no body)");
     if (response.status === 401 || response.status === 403) {
-      log.warn(`openai file upload auth error (${response.status}): ${text}`);
+      log.warn(`openai file upload auth error (${response.status})`);
       return "auth-error";
     }
     // 404/405 means the upstream doesn't support the batch/files API at all
     // (e.g. vLLM, local models, MiniMax). Treat as permanent provider-level failure.
     if (response.status === 404 || response.status === 405) {
-      log.warn(
-        `openai file upload not supported (${response.status}): ${text}`,
-      );
+      log.warn(`openai file upload not supported (${response.status})`);
       return "not-found";
     }
-    log.error(`openai file upload failed: ${response.status} — ${text}`);
+    log.error(`openai file upload failed: ${response.status}`);
     return null;
   }
 
-  const data = (await response.json()) as { id: string };
+  const data = (await response.json().catch(() => null)) as {
+    id?: string;
+  } | null;
+  if (!data || typeof data.id !== "string") {
+    log.error("openai file upload returned malformed JSON");
+    return null;
+  }
   return data.id;
 }
 
@@ -483,7 +495,12 @@ async function downloadOpenAIResults(
         };
       };
 
-      if (row.response.status_code === 200) {
+      const statusCode =
+        typeof row.response.status_code === "number" &&
+        Number.isFinite(row.response.status_code)
+          ? Math.trunc(row.response.status_code)
+          : undefined;
+      if (statusCode === 200) {
         const body = row.response.body;
         results.push({
           customId: row.custom_id,
@@ -494,21 +511,22 @@ async function downloadOpenAIResults(
         });
       } else {
         const errBody = row.response.body?.error;
+        const errorMessage = errBody?.message;
         results.push({
           customId: row.custom_id,
           outcome: "errored",
           text: null,
           usage: null,
           model: null,
-          error: errBody?.message
-            ? `HTTP ${row.response.status_code} ${errBody.type ?? ""}: ${errBody.message}`.trim()
-            : `HTTP ${row.response.status_code}`,
+          statusCode,
+          temperatureUnsupported:
+            typeof errorMessage === "string" &&
+            isTemperatureUnsupported400(errorMessage),
+          error: statusCode == null ? "HTTP error" : `HTTP ${statusCode}`,
         });
       }
     } catch {
-      log.error(
-        `failed to parse openai batch result line: ${line.slice(0, 200)}`,
-      );
+      log.error("failed to parse openai batch result line");
     }
   }
 
@@ -627,24 +645,27 @@ export function createOpenAIBatchProvider(upstreamUrl: string): BatchProvider {
       });
 
       if (!response.ok) {
-        const text = await response.text().catch(() => "(no body)");
         if (response.status === 401 || response.status === 403) {
-          log.warn(`openai batch auth error (${response.status}): ${text}`);
+          log.warn(`openai batch auth error (${response.status})`);
           return "auth-error";
         }
         // 404/405 means the upstream doesn't support the batch API at all
         // (e.g. vLLM, local models, MiniMax). Treat as permanent provider-level failure.
         if (response.status === 404 || response.status === 405) {
-          log.warn(`openai batch not supported (${response.status}): ${text}`);
+          log.warn(`openai batch not supported (${response.status})`);
           return "not-found";
         }
-        log.error(
-          `openai batch create failed: ${response.status} ${response.statusText} — ${text}`,
-        );
+        log.error(`openai batch create failed: ${response.status}`);
         return null;
       }
 
-      const data = (await response.json()) as { id: string };
+      const data = (await response.json().catch(() => null)) as {
+        id?: string;
+      } | null;
+      if (!data || typeof data.id !== "string") {
+        log.error("openai batch create returned malformed JSON");
+        return null;
+      }
       return data.id;
     },
 
@@ -654,17 +675,19 @@ export function createOpenAIBatchProvider(upstreamUrl: string): BatchProvider {
       });
 
       if (!response.ok) {
-        log.error(
-          `openai batch poll failed for ${batchId}: ${response.status}`,
-        );
+        log.error(`openai batch poll failed: ${response.status}`);
         return { status: "pending" }; // Retry on next poll
       }
 
-      const data = (await response.json()) as {
+      const data = (await response.json().catch(() => null)) as {
         status: string;
         output_file_id?: string;
         error_file_id?: string;
-      };
+      } | null;
+      if (!data) {
+        log.error("openai batch poll returned malformed JSON");
+        return { status: "pending" };
+      }
 
       if (data.status === "completed" && data.output_file_id) {
         const results = await downloadOpenAIResults(
@@ -869,8 +892,8 @@ export function createBatchLLMClient(
 
       const pollTimer = setInterval(
         () =>
-          void pollBatch(batchId).catch((e) =>
-            log.error("batch poll error:", e),
+          void pollBatch(batchId).catch(() =>
+            log.error("batch poll failed unexpectedly"),
           ),
         pollIntervalMs,
       );
@@ -885,10 +908,10 @@ export function createBatchLLMClient(
       });
 
       log.info(
-        `batch created (${provider.name}): ${batchId} with ${items.length} requests`,
+        `batch created (${provider.name}) with ${items.length} requests`,
       );
-    } catch (e) {
-      log.error(`batch create error (${provider.name}):`, e);
+    } catch {
+      log.error(`batch create error (${provider.name})`);
       await fallbackAll(items);
     }
   }
@@ -964,7 +987,7 @@ export function createBatchLLMClient(
     // Uses provider-specific max age (1h Anthropic, 4h OpenAI)
     if (Date.now() - batch.submittedAt > batch.provider.maxBatchAgeMs) {
       log.warn(
-        `batch ${batchId} (${batch.provider.name}) exceeded max age — falling back to synchronous`,
+        `batch (${batch.provider.name}) exceeded max age — falling back to synchronous`,
       );
       clearInterval(batch.pollTimer);
       inflight.delete(batchId);
@@ -978,9 +1001,7 @@ export function createBatchLLMClient(
       if (pollResult.status === "pending") return;
 
       if (pollResult.status === "failed") {
-        log.error(
-          `batch ${batchId} (${batch.provider.name}) failed: ${pollResult.error}`,
-        );
+        log.error(`batch (${batch.provider.name}) failed`);
         clearInterval(batch.pollTimer);
         inflight.delete(batchId);
         await fallbackAll([...batch.requests.values()]);
@@ -989,7 +1010,7 @@ export function createBatchLLMClient(
 
       // status === "done" — resolve all results
       log.info(
-        `batch ${batchId} (${batch.provider.name}) completed — resolving ${pollResult.results.length} results`,
+        `batch (${batch.provider.name}) completed — resolving ${pollResult.results.length} results`,
       );
 
       for (const result of pollResult.results) {
@@ -1041,7 +1062,7 @@ export function createBatchLLMClient(
             // submits (batch AND single-request) omit `temperature` upfront for
             // this model instead of re-erroring every item. Feeds the same
             // shared set consulted by paramsWithSupportedTemperature().
-            if (result.error && isTemperatureUnsupported400(result.error)) {
+            if (result.temperatureUnsupported) {
               markTemperatureUnsupported({
                 providerID: pending.providerID,
                 modelID: pending.params.model,
@@ -1050,37 +1071,33 @@ export function createBatchLLMClient(
             pending.resolve(null); // Match inner client behavior (null on error)
             totalFailed++;
             log.error(
-              `batch item ${result.customId} errored: ${result.error ?? "unknown"}`,
+              `batch item failed (${batch.provider.name}` +
+                `${result.statusCode == null ? "" : `, HTTP ${result.statusCode}`}` +
+                ")",
             );
             // These are background jobs (distillation/curation/embeddings) that
             // fail silently to the caller (resolved null). Capture so the real
             // cause is tracked, not just logged. Grouped by provider to keep
-            // noise bounded; the actual error text is in `extra`.
+            // noise bounded; no provider response text is attached.
             if (Sentry.isInitialized()) {
-              Sentry.captureException(
-                new Error(`batch item errored: ${result.error ?? "unknown"}`),
-                {
-                  fingerprint: [
-                    "LOREAI-GATEWAY",
-                    "batch-item-errored",
-                    batch.provider.name,
-                  ],
-                  extra: {
-                    provider: batch.provider.name,
-                    customId: result.customId,
-                    model: pending.params.model,
-                    workerID: pending.workerID,
-                    error: result.error ?? "unknown",
-                  },
+              Sentry.captureException(new Error("Batch item failed"), {
+                fingerprint: [
+                  "LOREAI-GATEWAY",
+                  "batch-item-errored",
+                  batch.provider.name,
+                ],
+                extra: {
+                  provider: batch.provider.name,
+                  status: result.statusCode,
                 },
-              );
+              });
             }
             break;
           case "canceled":
           case "expired":
             pending.resolve(null);
             totalFailed++;
-            log.warn(`batch item ${result.customId} ${result.outcome}`);
+            log.warn(`batch item ${result.outcome}`);
             break;
         }
 
@@ -1097,10 +1114,10 @@ export function createBatchLLMClient(
       clearInterval(batch.pollTimer);
       inflight.delete(batchId);
       log.info(
-        `batch ${batchId} fully resolved (${totalResolved} ok, ${totalFailed} failed total)`,
+        `batch (${batch.provider.name}) fully resolved (${totalResolved} ok, ${totalFailed} failed total)`,
       );
-    } catch (e) {
-      log.error(`batch poll error for ${batchId} (${batch.provider.name}):`, e);
+    } catch {
+      log.error(`batch poll error (${batch.provider.name})`);
     }
   }
 
@@ -1151,8 +1168,8 @@ export function createBatchLLMClient(
               }),
             });
             item.resolve(result);
-          } catch (e) {
-            log.error(`batch fallback error for ${item.customId}:`, e);
+          } catch {
+            log.error("batch fallback error");
             item.resolve(null);
           }
         }),
@@ -1165,7 +1182,7 @@ export function createBatchLLMClient(
   // -------------------------------------------------------------------------
 
   flushTimer = setInterval(() => {
-    flush().catch((e) => log.error("batch flush timer error:", e));
+    flush().catch(() => log.error("batch flush timer error"));
   }, flushIntervalMs);
 
   // -------------------------------------------------------------------------
@@ -1255,7 +1272,7 @@ export function createBatchLLMClient(
 
       // Auto-flush if queue is full
       if (queue.length >= maxQueueSize) {
-        flush().catch((e) => log.error("batch auto-flush error:", e));
+        flush().catch(() => log.error("batch auto-flush error"));
       }
 
       return promise;
@@ -1298,13 +1315,15 @@ export function createBatchLLMClient(
       }
 
       // Clean up inflight poll timers (batches will expire naturally)
-      for (const [batchId, batch] of inflight) {
+      for (const batch of inflight.values()) {
         clearInterval(batch.pollTimer);
         // Resolve all pending promises with null (callers handle null gracefully)
         for (const [, pending] of batch.requests) {
           pending.resolve(null);
         }
-        log.warn(`batch shutdown: abandoned inflight batch ${batchId}`);
+        log.warn(
+          `batch shutdown: abandoned inflight batch (${batch.provider.name})`,
+        );
       }
       inflight.clear();
     },

--- a/packages/gateway/src/cache-warmer.ts
+++ b/packages/gateway/src/cache-warmer.ts
@@ -39,11 +39,12 @@ import {
   getPrefixChurnRate,
   PREFIX_CHURN_WARM_BLOCK,
 } from "@loreai/core";
-import type {
-  InterTurnHistogram,
-  WarmupResult,
-  SessionState,
-  WarmupState,
+import {
+  applyUpstreamExtraHeaders,
+  type InterTurnHistogram,
+  type WarmupResult,
+  type SessionState,
+  type WarmupState,
 } from "./translate/types";
 import {
   cacheSegmentDigest,
@@ -54,7 +55,12 @@ import {
 import { resolveAuth, authHeaders, markAuthStale } from "./auth";
 import { recordWorkerFailure, recordWorkerSuccess } from "./worker-health";
 import { resignBody } from "./cch";
-import { loadConfig, resolveUpstreamRoute } from "./config";
+import {
+  extraHeadersForUpstream,
+  loadConfig,
+  resolveUpstreamRoute,
+  type GatewayConfig,
+} from "./config";
 import { isBedrockMantleHost } from "./translate/bedrock";
 import {
   isVertexHost,
@@ -296,8 +302,21 @@ const CB_KV_KEY = "warmup_circuit_breaker";
  */
 export function warmupBucketKey(state: SessionState): string {
   const model = state.lastUpstream?.model ?? "unknown";
-  const url = state.lastUpstream?.url ?? "unknown";
+  const url = state.lastUpstream?.url
+    ? warmupUrlForLog(state.lastUpstream.url)
+    : "unknown";
   return `${state.sessionID}\x1f${model}\x1f${url}`;
+}
+
+/** Strip credential-bearing URL components while retaining endpoint routing. */
+function warmupUrlForLog(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "invalid";
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "invalid";
+  }
 }
 
 /** Load tripped buckets from DB on first access (only tripped buckets persist). */
@@ -2046,6 +2065,13 @@ function extractFirstUserText(bodyJson: string): string {
   return "";
 }
 
+/** Accept only real token counts from an upstream usage object. */
+function responseTokenCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : 0;
+}
+
 /**
  * Execute a cache warmup for a session.
  *
@@ -2058,7 +2084,7 @@ function extractFirstUserText(bodyJson: string): string {
 export async function executeWarmup(
   state: SessionState,
   profile: CacheWarmingProfile,
-  upstreamExtraHeaders: Record<string, string> = {},
+  config: GatewayConfig = loadConfig(),
 ): Promise<WarmupResult> {
   const noResult: WarmupResult = {
     ok: false,
@@ -2127,21 +2153,17 @@ export async function executeWarmup(
         toVertexModelId(model),
         false,
       );
-    } catch (err) {
+    } catch {
       // ADC unavailable / token mint failed — skip this tick rather than
       // crashing the warmer loop. Telemetry must never break the idle loop.
       log.warn(
-        `cache-warmer: vertex auth failed for session=${state.sessionID.slice(0, 16)}: ${(err as Error).message}`,
+        `cache-warmer: vertex auth failed for session=${state.sessionID.slice(0, 16)}`,
       );
       recordWorkerFailure(state.sessionID, "cache-warmer", "no-auth");
       return noResult;
     }
     // No cch re-sign for Vertex (no billing header) — send the warmup as-is.
     signedBody = warmupBody;
-    // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS as the final overlay.
-    for (const [key, value] of Object.entries(upstreamExtraHeaders)) {
-      headers[key] = value;
-    }
   } else {
     // Resolve auth for this session — use the provider from lastUpstream
     // to avoid cross-contamination when the session uses multiple providers.
@@ -2163,13 +2185,6 @@ export async function executeWarmup(
       headers["anthropic-beta"] = betaHeader;
     }
 
-    // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS as the final overlay so
-    // corporate-proxy / LiteLLM / Cloudflare AI Gateway / service-account
-    // scenarios work for cache-warming calls too.
-    for (const [key, value] of Object.entries(upstreamExtraHeaders)) {
-      headers[key] = value;
-    }
-
     // Re-sign the cch billing header. The cch hash covers the entire
     // serialized body, and we changed max_tokens/stream. The cch is
     // billing verification only — NOT part of the cache key.
@@ -2177,6 +2192,14 @@ export async function executeWarmup(
     signedBody = resignBody(warmupBody, firstUserText);
     requestUrl = profile.upstreamUrl;
   }
+
+  // Apply gateway-admin headers only after the final warmup URL is known. This
+  // keeps cache warming under the same exact configured-base policy as normal
+  // foreground and compact dispatches.
+  applyUpstreamExtraHeaders(
+    headers,
+    extraHeadersForUpstream(config, requestUrl),
+  );
 
   log.info(
     `cache-warmer: sending warmup for session=${state.sessionID.slice(0, 16)} ` +
@@ -2191,10 +2214,9 @@ export async function executeWarmup(
     });
 
     if (!response.ok) {
-      const errorBody = await response.text().catch(() => "");
       log.error(
         `cache-warmer: upstream error ${response.status} for ` +
-          `session=${state.sessionID.slice(0, 16)}: ${errorBody.slice(0, 300)}`,
+          `session=${state.sessionID.slice(0, 16)}`,
       );
       // On auth error, disable future warmups for this session until
       // a fresh credential arrives. Prevents unbounded 401 spam every 30s.
@@ -2211,18 +2233,31 @@ export async function executeWarmup(
     }
 
     // Parse the response to extract usage
-    const resp = (await response.json()) as {
+    let resp: {
       usage?: {
-        cache_read_input_tokens?: number;
-        cache_creation_input_tokens?: number;
-        input_tokens?: number;
+        cache_read_input_tokens?: unknown;
+        cache_creation_input_tokens?: unknown;
+        input_tokens?: unknown;
       };
       stop_reason?: string;
     };
+    try {
+      resp = (await response.json()) as typeof resp;
+    } catch {
+      log.error(
+        `cache-warmer: upstream returned malformed JSON with status ${response.status} for ` +
+          `session=${state.sessionID.slice(0, 16)}`,
+      );
+      return noResult;
+    }
 
-    const inputTokens = resp.usage?.input_tokens ?? 0;
-    const cacheReadTokens = resp.usage?.cache_read_input_tokens ?? 0;
-    const cacheCreationTokens = resp.usage?.cache_creation_input_tokens ?? 0;
+    const inputTokens = responseTokenCount(resp.usage?.input_tokens);
+    const cacheReadTokens = responseTokenCount(
+      resp.usage?.cache_read_input_tokens,
+    );
+    const cacheCreationTokens = responseTokenCount(
+      resp.usage?.cache_creation_input_tokens,
+    );
     const totalInput = inputTokens + cacheReadTokens + cacheCreationTokens;
 
     const result: WarmupResult = {
@@ -2403,10 +2438,11 @@ export async function executeWarmup(
     recordWorkerSuccess(state.sessionID);
 
     return result;
-  } catch (e) {
+  } catch {
+    // Network errors can include credential-bearing request URLs. Keep the
+    // session diagnostic, but never the thrown details.
     log.error(
-      `cache-warmer: fetch error for session=${state.sessionID.slice(0, 16)}:`,
-      e,
+      `cache-warmer: fetch failed for session=${state.sessionID.slice(0, 16)}`,
     );
     return noResult;
   }

--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -6,7 +6,8 @@
  *  - How to detect it (binary name on PATH)
  *  - What env vars to set so it talks through the gateway
  */
-import { getGitRemote } from "@loreai/core";
+import { GATEWAY_AUTH_HEADER, getGitRemote } from "@loreai/core";
+import { PROVIDER_AUTH_HEADER_NAMES } from "../auth";
 import { CLAUDE_CODE_FIRST_PARTY_ENV } from "../cch";
 import { whichSync } from "./lib/which";
 
@@ -261,6 +262,27 @@ export function appendCustomHeader(
   env[envKey] = existing ? `${existing}\n${header}` : header;
 }
 
+/** Set exactly one custom-header line, replacing case-insensitive duplicates. */
+export function setCustomHeader(
+  env: Record<string, string>,
+  envKey: string,
+  name: string,
+  value: string,
+): void {
+  // oxlint-disable-next-line no-control-regex -- intentional control-character sanitization
+  const clean = (s: string) => s.replace(/[\x00-\x1f\x7f]/g, "");
+  const cleanName = clean(name);
+  const target = cleanName.toLowerCase();
+  const existing = env[envKey] ?? process.env[envKey] ?? "";
+  const retained = existing.split(/\r?\n/).filter((line) => {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex < 0) return line.trim() !== "";
+    return line.slice(0, colonIndex).trim().toLowerCase() !== target;
+  });
+  retained.push(`${cleanName}: ${clean(value)}`);
+  env[envKey] = retained.join("\n");
+}
+
 /**
  * Partial opencode config injected via `OPENCODE_CONFIG_CONTENT` when
  * launching opencode through `lore run`. Ensures the @loreai/opencode
@@ -405,6 +427,13 @@ export const AGENTS: AgentDef[] = [
           if (colonIdx <= 0) continue;
           const name = line.slice(0, colonIdx).trim();
           const value = line.slice(colonIdx + 1).trim();
+          const lower = name.toLowerCase();
+          if (
+            lower === GATEWAY_AUTH_HEADER ||
+            PROVIDER_AUTH_HEADER_NAMES.some((candidate) => candidate === lower)
+          ) {
+            continue;
+          }
           if (name) pairs.push(`${name} = ${tomlQuote(value)}`);
         }
         if (pairs.length) {

--- a/packages/gateway/src/cli/app.ts
+++ b/packages/gateway/src/cli/app.ts
@@ -31,6 +31,7 @@ import { importCommand } from "./commands/import";
 import { entityCommand } from "./commands/entity";
 import { dataCommand } from "./commands/data";
 import { recallCommand } from "./commands/recall";
+import { uninstallCommand } from "./commands/uninstall";
 
 /**
  * Routes that are still served by the legacy dispatcher.
@@ -127,6 +128,7 @@ export const routes = buildRouteMap({
     entity: entityCommand,
     data: dataCommand,
     recall: recallCommand,
+    uninstall: uninstallCommand,
   },
 });
 

--- a/packages/gateway/src/cli/commands/uninstall.ts
+++ b/packages/gateway/src/cli/commands/uninstall.ts
@@ -1,0 +1,46 @@
+/** `lore uninstall` — reverse persistent setup and remove the standalone CLI. */
+import { buildCommand } from "../lib/command";
+import { commandUninstall } from "../uninstall";
+
+type UninstallFlags = {
+  purge: boolean;
+  yes: boolean;
+  "dry-run": boolean;
+};
+
+export const uninstallCommand = buildCommand<UninstallFlags, []>({
+  brief: "Undo persistent setup and remove the standalone Lore CLI",
+  fullDescription:
+    "Restores setup-managed configuration and removes standalone install " +
+    "artifacts. Local data and project files are preserved unless --purge " +
+    "is explicitly confirmed. Package-managed CLIs must still be removed " +
+    "with their package manager.",
+  parameters: {
+    aliases: { y: "yes" },
+    flags: {
+      purge: {
+        kind: "boolean",
+        brief:
+          "Also delete default local data, logs, credentials, and runtime state",
+        default: false,
+      },
+      yes: {
+        kind: "boolean",
+        brief: "Skip the --purge confirmation prompt (alias: -y)",
+        default: false,
+      },
+      "dry-run": {
+        kind: "boolean",
+        brief: "Show the cleanup plan without changing anything",
+        default: false,
+      },
+    },
+  },
+  async handler(flags) {
+    await commandUninstall([], {
+      purge: flags.purge,
+      yes: flags.yes,
+      "dry-run": flags["dry-run"],
+    });
+  },
+});

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -45,6 +45,9 @@ Commands:
   entity <subcommand> Manage the entity registry (list, show, add, merge)
   upgrade [version]   Update lore to the latest (or specified) version
                        Flags: --check, --force, --offline, --channel <ch>
+  uninstall           Undo persistent setup and remove standalone Lore
+                       Preserves local data by default; --purge deletes default
+                       data, logs, credentials, and runtime state after confirmation
   help                Show this help text
 
 Options:
@@ -162,6 +165,9 @@ Examples:
   lore upgrade stable           # Switch back to stable channel
   lore upgrade 0.14.0           # Install a specific version
   lore upgrade --offline        # Upgrade from cached patches (no network)
+  lore uninstall                # Undo setup and remove standalone install artifacts
+  lore uninstall --dry-run      # Preview cleanup without changing anything
+  lore uninstall --purge        # Also delete default local data after confirmation
   lore data list projects       # List all tracked projects
   lore data list knowledge      # List knowledge entries for current project
   lore data clear --project .   # Clear all data for the current project
@@ -193,6 +199,7 @@ Environment variables:
   LORE_UPSTREAM_ANTHROPIC       Upstream Anthropic API URL
   LORE_UPSTREAM_OPENAI          Upstream OpenAI API URL
   LORE_REMOTE_URL               Remote gateway URL for \`lore run\` (overridden by --remote)
+  LORE_GATEWAY_AUTH_TOKEN       Access token required by remote/hosted data-plane routes
   LORE_HOSTED_MODE              Hosted mode — disables FS ops on client-controlled paths
                                 ON by default for \`lore start\`; set to 0 to disable
   LORE_REMOTE_GATEWAY           Remote-gateway mode — bucket path-less sessions per-session

--- a/packages/gateway/src/cli/inventory.ts
+++ b/packages/gateway/src/cli/inventory.ts
@@ -20,7 +20,7 @@ import {
 import { getPath, readLegacyJsonBackup } from "./setup-backup";
 import { getEnvValue, getTomlTopLevelValue } from "./setup-backup";
 import { readPortFile } from "../portfile";
-import { probeGateway } from "./start";
+import { internalProbeFetch, probeGateway } from "./start";
 import { VERSION } from "./version";
 
 // ---------------------------------------------------------------------------
@@ -640,7 +640,7 @@ export async function fetchMemoryHealth(base: string): Promise<{
   worker?: { ok: boolean; detail: string };
 } | null> {
   try {
-    const res = await fetch(`${base}/health`, {
+    const res = await internalProbeFetch(`${base}/health`, {
       signal: AbortSignal.timeout(2000),
     });
     if (!res.ok) return null;

--- a/packages/gateway/src/cli/json-config.ts
+++ b/packages/gateway/src/cli/json-config.ts
@@ -1,0 +1,1160 @@
+import { randomBytes } from "node:crypto";
+import { Buffer } from "node:buffer";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  basename,
+  dirname,
+  join,
+  parse as parsePath,
+  resolve,
+} from "node:path";
+import {
+  applyEdits,
+  modify,
+  parse,
+  printParseErrorCode,
+  type FormattingOptions,
+  type ParseError,
+} from "jsonc-parser";
+
+const formatting: FormattingOptions = {
+  insertSpaces: true,
+  tabSize: 2,
+  eol: "\n",
+};
+
+export interface TrustedFileIdentity {
+  dev: bigint;
+  ino: bigint;
+  mode: bigint;
+  uid: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+  birthtimeNs: bigint;
+}
+
+export interface TrustedTextFile {
+  text: string;
+  bytes: Buffer;
+  identity: TrustedFileIdentity;
+}
+
+export interface TrustedFileSnapshot {
+  bytes: Buffer | null;
+  identity: TrustedFileIdentity | null;
+  mode: number | null;
+}
+
+export interface TrustedFileTransaction {
+  snapshot(file: string): TrustedFileSnapshot;
+  assertSnapshotIdentity(
+    file: string,
+    expectedIdentity: TrustedFileIdentity | null,
+  ): void;
+  assertCurrentIdentity(file: string): void;
+  write(
+    file: string,
+    text: string,
+    options?: { mode?: number },
+  ): TrustedFileIdentity;
+  remove(file: string): void;
+}
+
+export interface StagedTrustedFileMutation<T> {
+  result: T;
+  prepareCommit: () => void;
+  commit: () => void;
+  rollback: () => void;
+}
+
+interface TrustedFileArtifact {
+  path: string;
+  identity: TrustedFileIdentity;
+}
+
+type TrustedFileCommitHook = (file: string, commit: number) => void;
+type TrustedFilePublishHook = (
+  operation: "write" | "remove",
+  file: string,
+) => void;
+type TrustedFileRollbackHook = (
+  file: string,
+  target: "present" | "absent",
+  phase: "after-stage" | "after-publication",
+) => void;
+type StagedTrustedFileCommitHook = () => void;
+
+let trustedFileCommitHook: TrustedFileCommitHook | null = null;
+let trustedFilePublishHook: TrustedFilePublishHook | null = null;
+let trustedFileRollbackHook: TrustedFileRollbackHook | null = null;
+let trustedDirectoryFsyncHook: ((directory: string) => void) | null = null;
+let stagedTrustedFileCommitHook: StagedTrustedFileCommitHook | null = null;
+
+export class CommittedAtomicWriteError extends Error {
+  constructor(
+    cause: unknown,
+    readonly identity: TrustedFileIdentity,
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
+class CommittedAtomicRemoveError extends Error {}
+
+/** Test-only failure injection after a transaction commit. */
+export function _setTrustedFileCommitHookForTest(
+  hook: TrustedFileCommitHook | null,
+): void {
+  trustedFileCommitHook = hook;
+}
+
+/** Test-only adversarial hook immediately before path publication/removal. */
+export function _setTrustedFilePublishHookForTest(
+  hook: TrustedFilePublishHook | null,
+): void {
+  trustedFilePublishHook = hook;
+}
+
+/** Test-only adversarial hook after rollback stages the current generation. */
+export function _setTrustedFileRollbackHookForTest(
+  hook: TrustedFileRollbackHook | null,
+): void {
+  trustedFileRollbackHook = hook;
+}
+
+/** Test-only observation of durable directory publication. */
+export function _setTrustedDirectoryFsyncHookForTest(
+  hook: ((directory: string) => void) | null,
+): void {
+  trustedDirectoryFsyncHook = hook;
+}
+
+/** Test-only failure injection before a staged mutation releases rollback data. */
+export function _setStagedTrustedFileCommitHookForTest(
+  hook: StagedTrustedFileCommitHook | null,
+): void {
+  stagedTrustedFileCommitHook = hook;
+}
+
+interface TrustedDirectoryIdentity {
+  dev: bigint;
+  ino: bigint;
+  mode: bigint;
+  uid: bigint;
+}
+
+function currentUid(): bigint | null {
+  return typeof process.getuid === "function" ? BigInt(process.getuid()) : null;
+}
+
+function unsafePath(file: string, reason: string): Error {
+  return new Error(`Unsafe setup path ${file}: ${reason}.`);
+}
+
+function assertOwned(file: string, uid: bigint): void {
+  const expected = currentUid();
+  if (expected !== null && uid !== expected) {
+    throw unsafePath(file, `owned by uid ${uid}, expected uid ${expected}`);
+  }
+}
+
+function fileIdentity(
+  stats: ReturnType<typeof lstatBigInt>,
+): TrustedFileIdentity {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    uid: stats.uid,
+    size: stats.size,
+    mtimeNs: stats.mtimeNs,
+    ctimeNs: stats.ctimeNs,
+    birthtimeNs: stats.birthtimeNs,
+  };
+}
+
+function directoryIdentity(
+  stats: ReturnType<typeof lstatBigInt>,
+): TrustedDirectoryIdentity {
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    uid: stats.uid,
+  };
+}
+
+function lstatBigInt(file: string) {
+  return lstatSync(file, { bigint: true });
+}
+
+function sameFileIdentity(
+  left: TrustedFileIdentity | null,
+  right: TrustedFileIdentity | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.birthtimeNs === right.birthtimeNs
+  );
+}
+
+function sameFileGeneration(
+  left: TrustedFileIdentity | null,
+  right: TrustedFileIdentity | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs
+  );
+}
+
+function sameDirectoryIdentity(
+  left: TrustedDirectoryIdentity,
+  right: TrustedDirectoryIdentity,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.uid === right.uid
+  );
+}
+
+function inspectTrustedDirectory(
+  directory: string,
+  allowMissing = false,
+): TrustedDirectoryIdentity | null {
+  let stats: ReturnType<typeof lstatBigInt>;
+  try {
+    stats = lstatBigInt(directory);
+  } catch (error: unknown) {
+    if (allowMissing && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+  if (stats.isSymbolicLink()) {
+    throw unsafePath(directory, "symbolic-link directories are not allowed");
+  }
+  if (!stats.isDirectory()) {
+    throw unsafePath(directory, "expected a directory");
+  }
+  assertOwned(directory, stats.uid);
+  return directoryIdentity(stats);
+}
+
+function inspectTrustedFile(file: string): TrustedFileIdentity | null {
+  let stats: ReturnType<typeof lstatBigInt>;
+  try {
+    stats = lstatBigInt(file);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (stats.isSymbolicLink()) {
+    throw unsafePath(file, "symbolic links are not allowed");
+  }
+  if (!stats.isFile()) {
+    throw unsafePath(file, "expected a regular file");
+  }
+  assertOwned(file, stats.uid);
+  return fileIdentity(stats);
+}
+
+function fsyncDirectory(directory: string): void {
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(
+      directory,
+      constants.O_RDONLY |
+        (constants.O_DIRECTORY ?? 0) |
+        (constants.O_NOFOLLOW ?? 0),
+    );
+    fsyncSync(descriptor);
+    trustedDirectoryFsyncHook?.(directory);
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    const unsupported =
+      code === "EINVAL" ||
+      code === "ENOTSUP" ||
+      code === "ENOSYS" ||
+      (process.platform === "win32" &&
+        (code === "EACCES" || code === "EISDIR" || code === "EPERM"));
+    if (!unsupported) throw error;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+/**
+ * Reject existing symlink components in an explicit custom config root. Missing
+ * suffixes are allowed so setup can create a new custom directory.
+ */
+export function assertNoSymlinkPathComponents(
+  directory: string,
+  source: string,
+): void {
+  const absolute = resolve(directory);
+  const root = parsePath(absolute).root;
+  let current = root;
+  for (const part of absolute
+    .slice(root.length)
+    .split(/[\\/]+/)
+    .filter(Boolean)) {
+    current = join(current, part);
+    let stats: ReturnType<typeof lstatBigInt>;
+    try {
+      stats = lstatBigInt(current);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    if (stats.isSymbolicLink()) {
+      throw unsafePath(source, `path component ${current} is a symbolic link`);
+    }
+    if (!stats.isDirectory()) {
+      throw unsafePath(source, `path component ${current} is not a directory`);
+    }
+  }
+}
+
+/** Create a config directory, then verify its final component and ownership. */
+export function ensureTrustedDirectory(directory: string): void {
+  if (inspectTrustedDirectory(directory, true)) return;
+  const absolute = resolve(directory);
+  const root = parsePath(absolute).root;
+  let current = root;
+  for (const part of absolute
+    .slice(root.length)
+    .split(/[\\/]+/)
+    .filter(Boolean)) {
+    const parent = current;
+    current = join(current, part);
+    try {
+      const existing = lstatBigInt(current);
+      if (existing.isSymbolicLink() || !existing.isDirectory()) {
+        throw unsafePath(current, "expected a non-symbolic-link directory");
+      }
+      continue;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    try {
+      mkdirSync(current, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    if (!inspectTrustedDirectory(current)) {
+      throw unsafePath(current, "directory creation failed");
+    }
+    // Persist every newly published component before creating its child.
+    fsyncDirectory(parent);
+  }
+  if (!inspectTrustedDirectory(directory)) {
+    throw unsafePath(directory, "directory creation failed");
+  }
+}
+
+/** Return whether a trusted regular file exists, without following it. */
+export function trustedFileExists(file: string): boolean {
+  if (!inspectTrustedDirectory(dirname(file), true)) return false;
+  return inspectTrustedFile(file) !== null;
+}
+
+/**
+ * Read an owner-controlled regular file without following its final component.
+ * The path and descriptor identities must agree before and after the read.
+ */
+export function readTrustedTextFile(
+  file: string,
+  options: { allowMissing?: boolean } = {},
+): TrustedTextFile | null {
+  const parent = inspectTrustedDirectory(dirname(file), options.allowMissing);
+  if (!parent) return null;
+  const before = inspectTrustedFile(file);
+  if (!before) {
+    if (options.allowMissing) return null;
+    const error = new Error(
+      `ENOENT: no such file or directory, open '${file}'`,
+    );
+    (error as NodeJS.ErrnoException).code = "ENOENT";
+    throw error;
+  }
+
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(file, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const openedStats = fstatSync(descriptor, { bigint: true });
+    if (!openedStats.isFile()) {
+      throw unsafePath(file, "expected a regular file");
+    }
+    assertOwned(file, openedStats.uid);
+    const opened = fileIdentity(openedStats);
+    if (!sameFileIdentity(before, opened)) {
+      throw unsafePath(file, "file identity changed before it could be read");
+    }
+    const bytes = readFileSync(descriptor);
+    const after = fileIdentity(fstatSync(descriptor, { bigint: true }));
+    if (!sameFileIdentity(opened, after)) {
+      throw unsafePath(file, "file changed while it was being read");
+    }
+    if (!sameFileIdentity(inspectTrustedFile(file), after)) {
+      throw unsafePath(file, "file path changed while it was being read");
+    }
+    const parentAfter = inspectTrustedDirectory(dirname(file));
+    if (!parentAfter || !sameDirectoryIdentity(parent, parentAfter)) {
+      throw unsafePath(
+        file,
+        "parent directory changed while it was being read",
+      );
+    }
+    return { text: bytes.toString("utf8"), bytes, identity: after };
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+/** Capture the exact text, existence, identity, and permission bits of a file. */
+export function snapshotTrustedFile(file: string): TrustedFileSnapshot {
+  const current = readTrustedTextFile(file, { allowMissing: true });
+  if (!current) return { bytes: null, identity: null, mode: null };
+  return {
+    bytes: current.bytes,
+    identity: current.identity,
+    mode: Number(current.identity.mode & 0o7777n),
+  };
+}
+
+/**
+ * Atomically replace a trusted file using an exclusive 0600 temporary file in
+ * the same directory. Existing config permissions are preserved.
+ */
+export function atomicWriteTrustedFile(
+  file: string,
+  content: string | Uint8Array,
+  options: {
+    expectedIdentity?: TrustedFileIdentity | null;
+    mode?: number;
+    preserveDisplaced?: (artifact: TrustedFileArtifact) => void;
+  } = {},
+): TrustedFileIdentity {
+  const parent = inspectTrustedDirectory(dirname(file));
+  if (!parent) throw unsafePath(file, "parent directory does not exist");
+  const current = inspectTrustedFile(file);
+  const expected =
+    options.expectedIdentity === undefined ? current : options.expectedIdentity;
+  if (!sameFileIdentity(current, expected)) {
+    throw unsafePath(file, "file changed after it was read");
+  }
+
+  const temp = join(
+    dirname(file),
+    `.${basename(file)}.lore-tmp-${process.pid}-${randomBytes(12).toString("hex")}`,
+  );
+  let descriptor: number | undefined;
+  let published = false;
+  let tempPresent = true;
+  let tempIdentity: TrustedFileIdentity | null = null;
+  let displaced: string | null = null;
+  try {
+    descriptor = openSync(
+      temp,
+      constants.O_WRONLY |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        constants.O_NOFOLLOW,
+      0o600,
+    );
+    const mode =
+      options.mode ??
+      (expected === null ? 0o600 : Number(expected.mode & 0o7777n));
+    writeFileSync(descriptor, content);
+    // Install the final permission bits while the inode still has only its
+    // unpredictable temporary name. Publication must never expose the wrong
+    // mode, even briefly.
+    fchmodSync(descriptor, mode);
+    fsyncSync(descriptor);
+    tempIdentity = fileIdentity(fstatSync(descriptor, { bigint: true }));
+
+    const parentBeforeRename = inspectTrustedDirectory(dirname(file));
+    if (
+      !parentBeforeRename ||
+      !sameDirectoryIdentity(parent, parentBeforeRename)
+    ) {
+      throw unsafePath(file, "parent directory changed before atomic replace");
+    }
+    if (!sameFileIdentity(inspectTrustedFile(file), expected)) {
+      throw unsafePath(file, "file changed before atomic replace");
+    }
+    trustedFilePublishHook?.("write", file);
+    if (!sameFileIdentity(inspectTrustedFile(file), expected)) {
+      throw unsafePath(file, "file changed immediately before publication");
+    }
+    if (expected !== null) {
+      displaced = join(
+        dirname(file),
+        `.${basename(file)}.lore-displaced-${process.pid}-${randomBytes(12).toString("hex")}`,
+      );
+      renameSync(file, displaced);
+      const moved = inspectTrustedFile(displaced);
+      if (
+        !moved ||
+        moved.dev !== expected.dev ||
+        moved.ino !== expected.ino ||
+        moved.uid !== expected.uid ||
+        moved.size !== expected.size ||
+        moved.mtimeNs !== expected.mtimeNs
+      ) {
+        if (inspectTrustedFile(file) === null) renameSync(displaced, file);
+        displaced = null;
+        throw unsafePath(file, "file changed while staging atomic replace");
+      }
+      if (!moved) throw unsafePath(file, "displaced generation is missing");
+    }
+    try {
+      // link(2) is an atomic no-clobber publication. A concurrent creator wins
+      // with EEXIST and is preserved; Lore's old generation remains displaced
+      // for explicit recovery rather than being silently overwritten.
+      linkSync(temp, file);
+      published = true;
+      if (displaced && options.preserveDisplaced) {
+        const artifactIdentity = inspectTrustedFile(displaced);
+        if (!artifactIdentity) {
+          throw unsafePath(file, "displaced generation is missing");
+        }
+        options.preserveDisplaced({
+          path: displaced,
+          identity: artifactIdentity,
+        });
+        displaced = null;
+      }
+    } catch (error) {
+      if (displaced && inspectTrustedFile(file) === null) {
+        renameSync(displaced, file);
+        displaced = null;
+      }
+      throw error;
+    }
+    unlinkSync(temp);
+    tempPresent = false;
+    const installed = inspectTrustedFile(file);
+    if (
+      !installed ||
+      installed.dev !== tempIdentity.dev ||
+      installed.ino !== tempIdentity.ino
+    ) {
+      throw unsafePath(file, "atomic replace installed an unexpected file");
+    }
+    if (displaced) {
+      const artifactIdentity = inspectTrustedFile(displaced);
+      if (!artifactIdentity) {
+        throw unsafePath(file, "displaced generation is missing");
+      }
+      unlinkSync(displaced);
+      displaced = null;
+    }
+    // The file inode was synced before publication; sync the complete
+    // publication/displacement cleanup as one durable directory state.
+    fsyncDirectory(dirname(file));
+    return installed;
+  } catch (error) {
+    if (published && tempIdentity) {
+      let committed = tempIdentity;
+      if (descriptor !== undefined) {
+        try {
+          committed = fileIdentity(fstatSync(descriptor, { bigint: true }));
+        } catch {
+          // Keep the last trusted descriptor identity and preserve the original
+          // post-rename failure as the transaction's cause.
+        }
+      }
+      throw new CommittedAtomicWriteError(error, committed);
+    }
+    throw error;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+    if (tempPresent) {
+      try {
+        unlinkSync(temp);
+      } catch {
+        // Best effort only: a cleanup failure must not replace the trust-boundary
+        // error that prevented the atomic install.
+      }
+    }
+  }
+}
+
+/** Remove a trusted regular file without following its final component. */
+export function removeTrustedFile(
+  file: string,
+  expectedIdentity?: TrustedFileIdentity | null,
+  preserveRemoved?: (artifact: TrustedFileArtifact) => void,
+): boolean {
+  const parent = inspectTrustedDirectory(dirname(file), true);
+  if (!parent) return false;
+  const current = inspectTrustedFile(file);
+  const expected = expectedIdentity === undefined ? current : expectedIdentity;
+  if (!sameFileIdentity(current, expected)) {
+    throw unsafePath(file, "file changed before removal");
+  }
+  if (!current) return false;
+  const parentBeforeUnlink = inspectTrustedDirectory(dirname(file));
+  if (
+    !parentBeforeUnlink ||
+    !sameDirectoryIdentity(parent, parentBeforeUnlink)
+  ) {
+    throw unsafePath(file, "parent directory changed before removal");
+  }
+  if (!sameFileIdentity(inspectTrustedFile(file), current)) {
+    throw unsafePath(file, "file changed before removal");
+  }
+  trustedFilePublishHook?.("remove", file);
+  if (!sameFileIdentity(inspectTrustedFile(file), current)) {
+    throw unsafePath(file, "file changed immediately before removal");
+  }
+  const displaced = join(
+    dirname(file),
+    `.${basename(file)}.lore-removing-${process.pid}-${randomBytes(12).toString("hex")}`,
+  );
+  renameSync(file, displaced);
+  const moved = inspectTrustedFile(displaced);
+  if (!sameFileGeneration(moved, current)) {
+    if (inspectTrustedFile(file) === null) renameSync(displaced, file);
+    throw unsafePath(file, "file changed while staging removal");
+  }
+  if (!moved) throw unsafePath(file, "staged removal generation is missing");
+  try {
+    if (preserveRemoved) {
+      preserveRemoved({ path: displaced, identity: moved });
+    } else {
+      unlinkSync(displaced);
+    }
+    fsyncDirectory(dirname(file));
+  } catch (error) {
+    throw new CommittedAtomicRemoveError(
+      error instanceof Error ? error.message : String(error),
+      { cause: error },
+    );
+  }
+  return true;
+}
+
+function cleanupTrustedArtifact(artifact: TrustedFileArtifact): void {
+  removeTrustedFile(artifact.path, artifact.identity);
+}
+
+function cleanupTrustedArtifacts(
+  artifacts: readonly TrustedFileArtifact[],
+): void {
+  for (const artifact of artifacts) {
+    try {
+      cleanupTrustedArtifact(artifact);
+    } catch {
+      // Canonical config + journal state has already committed or rolled back.
+      // Preserve an artifact that cannot be identified and removed exactly.
+    }
+  }
+}
+
+function restoreTrustedFileSnapshot(
+  file: string,
+  snapshot: TrustedFileSnapshot,
+  expectedIdentity: TrustedFileIdentity | null,
+  artifacts: TrustedFileArtifact[],
+): void {
+  const current = readTrustedTextFile(file, { allowMissing: true });
+  if (!sameFileIdentity(current?.identity ?? null, expectedIdentity)) {
+    throw unsafePath(file, "file changed before transaction rollback");
+  }
+  if (snapshot.bytes === null) {
+    if (current) {
+      try {
+        removeTrustedFile(file, current.identity, (artifact) =>
+          artifacts.push(artifact),
+        );
+      } catch (error) {
+        if (!readTrustedTextFile(file, { allowMissing: true })) return;
+        throw error;
+      }
+    }
+    trustedFileRollbackHook?.(file, "absent", "after-stage");
+    if (inspectTrustedFile(file) !== null) {
+      throw unsafePath(
+        file,
+        "replacement appeared during transaction rollback",
+      );
+    }
+    return;
+  }
+
+  const originalArtifact = artifacts.find(
+    (artifact) =>
+      snapshot.identity !== null &&
+      sameFileGeneration(artifact.identity, snapshot.identity),
+  );
+  if (originalArtifact) {
+    if (current) {
+      removeTrustedFile(file, current.identity, (artifact) =>
+        artifacts.push(artifact),
+      );
+    }
+    trustedFileRollbackHook?.(file, "present", "after-stage");
+    try {
+      linkSync(originalArtifact.path, file);
+    } catch (error) {
+      throw unsafePath(
+        file,
+        `could not republish the exact rollback generation: ${String(error)}`,
+      );
+    }
+    const restored = inspectTrustedFile(file);
+    if (!sameFileGeneration(restored, snapshot.identity)) {
+      throw unsafePath(file, "rollback installed an unexpected generation");
+    }
+    trustedFileRollbackHook?.(file, "present", "after-publication");
+    fsyncDirectory(dirname(file));
+    if (!sameFileGeneration(inspectTrustedFile(file), snapshot.identity)) {
+      throw unsafePath(file, "rollback generation changed before completion");
+    }
+    const refreshedArtifact = inspectTrustedFile(originalArtifact.path);
+    if (
+      refreshedArtifact &&
+      sameFileGeneration(refreshedArtifact, snapshot.identity)
+    ) {
+      originalArtifact.identity = refreshedArtifact;
+    }
+    return;
+  }
+
+  if (
+    current?.bytes.equals(snapshot.bytes) &&
+    Number(current.identity.mode & 0o7777n) === snapshot.mode
+  ) {
+    return;
+  }
+  try {
+    atomicWriteTrustedFile(file, snapshot.bytes, {
+      expectedIdentity: current?.identity ?? null,
+      mode: snapshot.mode ?? 0o600,
+    });
+  } catch (error) {
+    const restored = readTrustedTextFile(file, { allowMissing: true });
+    if (
+      restored?.bytes.equals(snapshot.bytes) &&
+      Number(restored.identity.mode & 0o7777n) === snapshot.mode
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Run a synchronous group of trusted atomic file writes as a small transaction.
+ * If the action throws, every attempted path is restored to its pre-action
+ * bytes, existence, and permission bits. Rollback uses the same trusted atomic
+ * IO and attempts every path even if restoring an earlier path fails.
+ */
+export function withTrustedFileTransaction<T>(
+  files: readonly string[],
+  action: (transaction: TrustedFileTransaction) => T,
+): T {
+  if (files.length === 0) {
+    throw new Error("Trusted file transaction requires at least one file.");
+  }
+  const paths = [...new Set(files)];
+  const directory = dirname(paths[0]);
+  if (paths.some((file) => dirname(file) !== directory)) {
+    throw new Error("Trusted file transaction paths must share a directory.");
+  }
+  const snapshots = new Map(
+    paths.map((file) => [file, snapshotTrustedFile(file)] as const),
+  );
+  const currentIdentities = new Map(
+    paths.map((file) => [file, snapshots.get(file)?.identity ?? null] as const),
+  );
+  const committed: string[] = [];
+  const artifacts: TrustedFileArtifact[] = [];
+  let commit = 0;
+
+  const requireSnapshot = (file: string): TrustedFileSnapshot => {
+    const snapshot = snapshots.get(file);
+    if (!snapshot) {
+      throw new Error(`File ${file} is not part of this trusted transaction.`);
+    }
+    return snapshot;
+  };
+
+  const transaction: TrustedFileTransaction = {
+    snapshot: requireSnapshot,
+    assertSnapshotIdentity: (file, expectedIdentity) => {
+      if (!sameFileIdentity(requireSnapshot(file).identity, expectedIdentity)) {
+        throw unsafePath(file, "file changed after it was read");
+      }
+    },
+    assertCurrentIdentity: (file) => {
+      requireSnapshot(file);
+      if (
+        !sameFileIdentity(
+          inspectTrustedFile(file),
+          currentIdentities.get(file) ?? null,
+        )
+      ) {
+        throw unsafePath(file, "file changed during trusted transaction");
+      }
+    },
+    write: (file, text, options = {}) => {
+      requireSnapshot(file);
+      const expectedIdentity = currentIdentities.get(file) ?? null;
+      let identity: TrustedFileIdentity;
+      try {
+        identity = atomicWriteTrustedFile(file, text, {
+          expectedIdentity,
+          mode: options.mode,
+          preserveDisplaced: (artifact) => artifacts.push(artifact),
+        });
+      } catch (error) {
+        if (error instanceof CommittedAtomicWriteError) {
+          // The atomic rename committed, but a later chmod/fsync/verification
+          // step failed. Track that visible write so the outer catch restores
+          // it rather than leaving a half-committed transaction.
+          currentIdentities.set(file, error.identity);
+          committed.push(file);
+        }
+        throw error;
+      }
+      currentIdentities.set(file, identity);
+      committed.push(file);
+      commit += 1;
+      trustedFileCommitHook?.(file, commit);
+      return identity;
+    },
+    remove: (file) => {
+      requireSnapshot(file);
+      const expectedIdentity = currentIdentities.get(file) ?? null;
+      let removed = false;
+      try {
+        removed = removeTrustedFile(file, expectedIdentity, (artifact) =>
+          artifacts.push(artifact),
+        );
+      } catch (error) {
+        if (error instanceof CommittedAtomicRemoveError) {
+          currentIdentities.set(file, null);
+          committed.push(file);
+        }
+        throw error;
+      }
+      if (!removed) return;
+      currentIdentities.set(file, null);
+      committed.push(file);
+      commit += 1;
+      trustedFileCommitHook?.(file, commit);
+    },
+  };
+
+  try {
+    const result = action(transaction);
+    cleanupTrustedArtifacts(artifacts);
+    return result;
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    // Restore the primary config before its recovery sidecar. If config CAS
+    // fails, the untouched journal is the only durable path to recovery.
+    const committedSet = new Set(committed);
+    const rollbackPaths = paths.filter((file) => committedSet.has(file));
+    for (const file of rollbackPaths) {
+      try {
+        restoreTrustedFileSnapshot(
+          file,
+          requireSnapshot(file),
+          currentIdentities.get(file) ?? null,
+          artifacts,
+        );
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+        break;
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        "Trusted file transaction failed and could not be fully rolled back.",
+      );
+    }
+    cleanupTrustedArtifacts(artifacts);
+    throw error;
+  }
+}
+
+/**
+ * Run an arbitrary synchronous trusted-file mutation while retaining hard-link
+ * claims for every original generation. The caller must either commit those
+ * claims after all other fallible work is prepared, or roll the mutation back.
+ *
+ * This outer transaction intentionally complements `withTrustedFileTransaction`:
+ * setup operations keep their per-config crash journals, while uninstall can
+ * still restore several already-completed setup undos if a later phase fails.
+ */
+export function stageTrustedFileMutation<T>(
+  files: readonly string[],
+  action: () => T,
+): StagedTrustedFileMutation<T> {
+  if (files.length === 0) {
+    throw new Error("Staged trusted file mutation requires at least one file.");
+  }
+  const paths = [...new Set(files)];
+  const snapshots = new Map(
+    paths.map((file) => [file, snapshotTrustedFile(file)] as const),
+  );
+  const artifacts: TrustedFileArtifact[] = [];
+
+  const refreshArtifacts = (): void => {
+    for (const artifact of artifacts) {
+      const current = inspectTrustedFile(artifact.path);
+      if (current && sameFileGeneration(current, artifact.identity)) {
+        artifact.identity = current;
+      }
+    }
+  };
+  const cleanupArtifacts = (): void => {
+    refreshArtifacts();
+    cleanupTrustedArtifacts(artifacts);
+    artifacts.length = 0;
+  };
+
+  try {
+    for (const file of paths) {
+      const snapshot = snapshots.get(file);
+      if (!snapshot?.identity) continue;
+      if (!sameFileIdentity(inspectTrustedFile(file), snapshot.identity)) {
+        throw unsafePath(file, "file changed before uninstall staging");
+      }
+      const artifactPath = join(
+        dirname(file),
+        `.${basename(file)}.lore-uninstall-original-${process.pid}-${randomBytes(12).toString("hex")}`,
+      );
+      linkSync(file, artifactPath);
+      const artifactIdentity = inspectTrustedFile(artifactPath);
+      if (artifactIdentity) {
+        artifacts.push({ path: artifactPath, identity: artifactIdentity });
+      }
+      const current = inspectTrustedFile(file);
+      if (
+        !artifactIdentity ||
+        !sameFileGeneration(artifactIdentity, snapshot.identity) ||
+        !sameFileGeneration(current, snapshot.identity)
+      ) {
+        throw unsafePath(file, "file changed while staging uninstall rollback");
+      }
+      fsyncDirectory(dirname(file));
+    }
+  } catch (error) {
+    cleanupArtifacts();
+    throw error;
+  }
+
+  let result: T;
+  try {
+    result = action();
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    refreshArtifacts();
+    for (const file of paths) {
+      const snapshot = snapshots.get(file);
+      if (!snapshot) continue;
+      const current = inspectTrustedFile(file);
+      if (sameFileGeneration(current, snapshot.identity)) continue;
+      try {
+        restoreTrustedFileSnapshot(file, snapshot, current, artifacts);
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+        break;
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        "Staged trusted file mutation failed and could not be fully rolled back.",
+      );
+    }
+    cleanupArtifacts();
+    throw error;
+  }
+
+  const currentIdentities = new Map(
+    paths.map((file) => [file, inspectTrustedFile(file)] as const),
+  );
+  let active = true;
+  let prepared = false;
+
+  return {
+    result,
+    prepareCommit: () => {
+      if (!active) return;
+      refreshArtifacts();
+      for (const file of paths) {
+        if (
+          !sameFileIdentity(
+            inspectTrustedFile(file),
+            currentIdentities.get(file) ?? null,
+          )
+        ) {
+          throw unsafePath(file, "file changed before uninstall commit");
+        }
+        const snapshot = snapshots.get(file);
+        if (!snapshot?.identity) continue;
+        const original = artifacts.find((artifact) =>
+          sameFileGeneration(artifact.identity, snapshot.identity),
+        );
+        if (!original) {
+          throw unsafePath(file, "uninstall rollback generation is missing");
+        }
+      }
+      stagedTrustedFileCommitHook?.();
+      prepared = true;
+    },
+    commit: () => {
+      if (!active) return;
+      if (!prepared) {
+        throw new Error("Staged trusted file mutation was not prepared.");
+      }
+      cleanupArtifacts();
+      active = false;
+    },
+    rollback: () => {
+      if (!active) return;
+      const rollbackErrors: unknown[] = [];
+      refreshArtifacts();
+      for (const file of paths) {
+        const snapshot = snapshots.get(file);
+        if (!snapshot) continue;
+        const expected = currentIdentities.get(file) ?? null;
+        if (sameFileGeneration(expected, snapshot.identity)) continue;
+        try {
+          restoreTrustedFileSnapshot(file, snapshot, expected, artifacts);
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError);
+          break;
+        }
+      }
+      if (rollbackErrors.length > 0) {
+        throw new AggregateError(
+          rollbackErrors,
+          "Staged trusted file mutation could not be fully rolled back.",
+        );
+      }
+      cleanupArtifacts();
+      active = false;
+    },
+  };
+}
+
+export function parseJsonConfigText(
+  text: string,
+  file: string,
+): Record<string, unknown> {
+  const errors: ParseError[] = [];
+  const value = parse(text, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  }) as unknown;
+  if (
+    errors.length > 0 ||
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value)
+  ) {
+    const detail = errors[0]
+      ? printParseErrorCode(errors[0].error)
+      : "root must be an object";
+    throw new Error(`Could not parse ${file} as JSON/JSONC (${detail}).`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function readJsonConfigFile(file: string): {
+  text: string;
+  config: Record<string, unknown>;
+  identity: TrustedFileIdentity;
+} {
+  const trusted = readTrustedTextFile(file);
+  if (!trusted) throw new Error(`Could not read ${file}.`);
+  return {
+    text: trusted.text,
+    config: parseJsonConfigText(trusted.text, file),
+    identity: trusted.identity,
+  };
+}
+
+export function readJsonConfigFileIfExists(file: string): {
+  text: string;
+  config: Record<string, unknown>;
+  identity: TrustedFileIdentity;
+} | null {
+  const trusted = readTrustedTextFile(file, { allowMissing: true });
+  if (!trusted) return null;
+  return {
+    text: trusted.text,
+    config: parseJsonConfigText(trusted.text, file),
+    identity: trusted.identity,
+  };
+}
+
+export function setJsonConfigValue(
+  text: string,
+  path: string[],
+  value: unknown,
+): string {
+  return applyEdits(
+    text,
+    modify(text, path, value, { formattingOptions: formatting }),
+  );
+}
+
+export function deleteJsonConfigValue(text: string, path: string[]): string {
+  return applyEdits(
+    text,
+    modify(text, path, undefined, { formattingOptions: formatting }),
+  );
+}
+
+export function resolveOpencodeConfigPath(defaultJsonPath: string): string {
+  for (const candidate of opencodeConfigPaths(defaultJsonPath)) {
+    if (trustedFileExists(candidate)) return candidate;
+  }
+  return defaultJsonPath;
+}
+
+export function opencodeConfigPaths(defaultJsonPath: string): string[] {
+  const dir = dirname(defaultJsonPath);
+  return ["opencode.jsonc", "opencode.json", "config.json"].map((name) =>
+    join(dir, name),
+  );
+}

--- a/packages/gateway/src/cli/lib/argv.ts
+++ b/packages/gateway/src/cli/lib/argv.ts
@@ -42,6 +42,7 @@ export const STRICLI_ROUTES: ReadonlySet<string> = new Set([
   "entity",
   "data",
   "recall",
+  "uninstall",
 ]);
 
 export interface PreprocessResult {
@@ -96,6 +97,7 @@ export const KNOWN_ROOT_COMMANDS: ReadonlySet<string> = new Set([
   "import",
   "entity",
   "upgrade",
+  "uninstall",
   "help",
   "version",
 ]);

--- a/packages/gateway/src/cli/lib/binary.ts
+++ b/packages/gateway/src/cli/lib/binary.ts
@@ -13,17 +13,21 @@
 
 import {
   existsSync,
+  linkSync,
+  lstatSync,
   readFileSync,
   renameSync,
+  rmSync,
   unlinkSync,
-  writeFileSync,
 } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
 import { chmod, copyFile, mkdir, unlink } from "node:fs/promises";
 import { delimiter, join, resolve } from "node:path";
 import { compare as semverCompare } from "semver";
 import { makeCache, type PatchCache } from "binpatch";
 import { VERSION } from "../version";
 import { stringifyUnknown, UpgradeError } from "./errors";
+import type { LifecycleLock } from "../../lifecycle-lock";
 
 /** GitHub owner/repo for Lore releases */
 const GITHUB_OWNER = "BYK";
@@ -103,13 +107,11 @@ export function getBinaryPaths(installPath: string): {
   installPath: string;
   tempPath: string;
   oldPath: string;
-  lockPath: string;
 } {
   return {
     installPath,
     tempPath: `${installPath}.download`,
     oldPath: `${installPath}.old`,
-    lockPath: `${installPath}.lock`,
   };
 }
 
@@ -192,25 +194,52 @@ export async function fetchWithUpgradeError(
  * Intentionally synchronous: the multi-step rename sequence must be
  * uninterruptible to avoid leaving the install path in a broken state.
  *
- * - Unix: Atomic rename overwrites the target
- * - Windows: Rename old binary to .old first, then rename temp into place
+ * All platforms quarantine the current path, verify the displaced generation,
+ * then hard-link the staged binary into the empty canonical path. link(2) is
+ * deliberately no-clobber if an external successor appears in that window.
  */
-export function replaceBinarySync(tempPath: string, installPath: string): void {
-  if (process.platform === "win32") {
-    const oldPath = `${installPath}.old`;
-    try {
-      renameSync(installPath, oldPath);
-    } catch {
+export function replaceBinarySync(
+  tempPath: string,
+  installPath: string,
+  hooks: {
+    beforeQuarantine?: () => void;
+    beforePublish?: () => void;
+    expectedInstallIdentity?: BinaryIdentity;
+  } = {},
+): void {
+  const displaced = `${installPath}.upgrade-displaced-${process.pid}-${randomBytes(8).toString("hex")}`;
+  let hadInstall = false;
+  try {
+    hooks.beforeQuarantine?.();
+    renameSync(installPath, displaced);
+    hadInstall = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  try {
+    if (
+      hooks.expectedInstallIdentity &&
+      !binaryIdentityMatches(displaced, hooks.expectedInstallIdentity)
+    ) {
+      throw new Error(
+        `Install binary changed during publication quarantine: ${installPath}`,
+      );
+    }
+    hooks.beforePublish?.();
+    linkSync(tempPath, installPath);
+    unlinkSync(tempPath);
+    if (hadInstall && process.platform !== "win32") {
+      rmSync(displaced, { force: true });
+    }
+  } catch (error) {
+    if (hadInstall) {
       try {
-        unlinkSync(oldPath);
-        renameSync(installPath, oldPath);
+        if (!existsSync(installPath)) linkSync(displaced, installPath);
       } catch {
-        // Current binary might not exist — that's fine
+        // Keep displaced as a recovery artifact.
       }
     }
-    renameSync(tempPath, installPath);
-  } else {
-    renameSync(tempPath, installPath);
+    throw error;
   }
 }
 
@@ -224,128 +253,71 @@ export function cleanupOldBinary(oldPath: string): void {
   });
 }
 
-// Lock Management
-
-/**
- * Check if a process with the given PID is still running.
- */
-export function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EPERM") {
-      return true;
-    }
-    return false;
-  }
-}
-
-/**
- * Acquire an exclusive lock for binary installation/upgrade.
- * Uses atomic file creation with 'wx' flag to prevent race conditions.
- */
-export function acquireLock(lockPath: string): void {
-  try {
-    writeFileSync(lockPath, String(process.pid), { flag: "wx" });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-      throw error;
-    }
-    handleExistingLock(lockPath);
-  }
-}
-
-function handleExistingLock(lockPath: string): void {
-  let content: string;
-  try {
-    content = readFileSync(lockPath, "utf-8").trim();
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      acquireLock(lockPath);
-      return;
-    }
-    throw error;
-  }
-
-  const existingPid = Number.parseInt(content, 10);
-
-  if (!Number.isNaN(existingPid) && isProcessRunning(existingPid)) {
-    // Allow re-entry from the same process (e.g. downloadBinaryToTemp
-    // acquires the lock, then installBinary tries to acquire the same lock
-    // when source and target directories are identical).
-    if (existingPid === process.pid) {
-      return;
-    }
-    // Allow child process to take over parent's lock (exec-based restart).
-    if (existingPid === process.ppid) {
-      writeFileSync(lockPath, String(process.pid));
-      return;
-    }
-    throw new UpgradeError(
-      "execution_failed",
-      "Another upgrade is already in progress",
-    );
-  }
-
-  // Stale lock from dead process — remove and retry
-  try {
-    unlinkSync(lockPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  acquireLock(lockPath);
-}
-
-/**
- * Release the binary lock.
- */
-export function releaseLock(lockPath: string): void {
-  try {
-    unlinkSync(lockPath);
-  } catch {
-    // Ignore — file might already be gone
-  }
-}
-
 /**
  * Install a binary to the target directory.
  */
 export async function installBinary(
   sourcePath: string,
   installDir: string,
+  lifecycleLock: LifecycleLock,
+  hooks: Parameters<typeof replaceBinarySync>[2] = {},
 ): Promise<string> {
+  lifecycleLock.assertOwned();
   await mkdir(installDir, { recursive: true, mode: 0o755 });
 
   const installPath = join(installDir, getBinaryFilename());
-  const { tempPath, lockPath } = getBinaryPaths(installPath);
+  const { tempPath } = getBinaryPaths(installPath);
 
-  acquireLock(lockPath);
-
-  try {
-    if (resolve(sourcePath) !== resolve(tempPath)) {
-      try {
-        await unlink(tempPath);
-      } catch {
-        // Ignore if doesn't exist
-      }
-
-      await copyFile(sourcePath, tempPath);
-
-      if (process.platform !== "win32") {
-        await chmod(tempPath, 0o755);
-      }
+  if (resolve(sourcePath) !== resolve(tempPath)) {
+    lifecycleLock.assertOwned();
+    try {
+      await unlink(tempPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     }
 
-    replaceBinarySync(tempPath, installPath);
-  } finally {
-    releaseLock(lockPath);
+    lifecycleLock.assertOwned();
+    await copyFile(sourcePath, tempPath);
+
+    if (process.platform !== "win32") {
+      lifecycleLock.assertOwned();
+      await chmod(tempPath, 0o755);
+    }
   }
 
+  lifecycleLock.assertOwned();
+  replaceBinarySync(tempPath, installPath, hooks);
+
   return installPath;
+}
+
+interface BinaryIdentity {
+  device: bigint;
+  inode: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  sha256: string;
+}
+
+function binaryIdentityMatches(
+  path: string,
+  expected: BinaryIdentity,
+): boolean {
+  try {
+    const info = lstatSync(path, { bigint: true });
+    return (
+      info.isFile() &&
+      !info.isSymbolicLink() &&
+      info.dev === expected.device &&
+      info.ino === expected.inode &&
+      info.size === expected.size &&
+      info.mtimeNs === expected.mtimeNs &&
+      createHash("sha256").update(readFileSync(path)).digest("hex") ===
+        expected.sha256
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/gateway/src/cli/lib/ghcr.ts
+++ b/packages/gateway/src/cli/lib/ghcr.ts
@@ -18,6 +18,7 @@
  * Adapted from Sentry CLI's ghcr.ts for Lore.
  */
 
+import { createHash } from "node:crypto";
 import { getUserAgent } from "./binary";
 import { UpgradeError } from "./errors";
 
@@ -29,6 +30,8 @@ const GHCR_MAX_RETRIES = 1;
 
 /** Timeout for large blob downloads (30 seconds) */
 const GHCR_BLOB_TIMEOUT = 30_000;
+
+const SHA256_OCI_DIGEST = /^sha256:([a-f0-9]{64})$/;
 
 function isRetryableError(error: Error): boolean {
   if (error.name === "TimeoutError" || error.name === "AbortError") {
@@ -242,6 +245,13 @@ export async function downloadNightlyBlob(
   digest: string,
   signal?: AbortSignal,
 ): Promise<Response> {
+  const expectedDigest = SHA256_OCI_DIGEST.exec(digest)?.[1];
+  if (!expectedDigest) {
+    throw new UpgradeError(
+      "execution_failed",
+      `Invalid OCI blob digest: ${digest}`,
+    );
+  }
   const blobUrl = `${GHCR_REGISTRY}/v2/${GHCR_REPO}/blobs/${digest}`;
 
   let blobResponse: Response;
@@ -263,7 +273,7 @@ export async function downloadNightlyBlob(
   }
 
   if (blobResponse.status === 200) {
-    return blobResponse;
+    return verifyBlobResponse(blobResponse, expectedDigest);
   }
 
   if (
@@ -279,12 +289,31 @@ export async function downloadNightlyBlob(
         `GHCR blob redirect (${blobResponse.status}) had no Location header`,
       );
     }
+    let parsedRedirect: URL;
+    try {
+      parsedRedirect = new URL(redirectUrl);
+    } catch {
+      throw new UpgradeError(
+        "network_error",
+        "GHCR blob redirect had an invalid Location URL",
+      );
+    }
+    if (
+      parsedRedirect.protocol !== "https:" ||
+      parsedRedirect.username !== "" ||
+      parsedRedirect.password !== ""
+    ) {
+      throw new UpgradeError(
+        "network_error",
+        "GHCR blob redirect was not an authenticated HTTPS URL",
+      );
+    }
 
     let redirectResponse: Response;
     try {
-      redirectResponse = await fetch(redirectUrl, {
+      redirectResponse = await fetch(parsedRedirect, {
         headers: { "User-Agent": getUserAgent() },
-        signal,
+        signal: buildSignal(GHCR_BLOB_TIMEOUT, signal),
       });
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -301,13 +330,39 @@ export async function downloadNightlyBlob(
       );
     }
 
-    return redirectResponse;
+    return verifyBlobResponse(redirectResponse, expectedDigest);
   }
 
   throw new UpgradeError(
     "network_error",
     `Unexpected GHCR blob response: HTTP ${blobResponse.status}`,
   );
+}
+
+/**
+ * Materialize and verify a blob before exposing any bytes to a decompressor or
+ * patch consumer. The manifest digest is the OCI content-addressing boundary;
+ * GHCR package write access remains the publisher-identity trust boundary.
+ */
+async function verifyBlobResponse(
+  response: Response,
+  expectedDigest: string,
+): Promise<Response> {
+  const bytes = await response.arrayBuffer();
+  const actualDigest = createHash("sha256")
+    .update(new Uint8Array(bytes))
+    .digest("hex");
+  if (actualDigest !== expectedDigest) {
+    throw new UpgradeError(
+      "execution_failed",
+      `OCI blob digest mismatch: got sha256:${actualDigest}, expected sha256:${expectedDigest}`,
+    );
+  }
+  return new Response(bytes, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
 }
 
 /** Page size for tag listing pagination */

--- a/packages/gateway/src/cli/lib/release-integrity.ts
+++ b/packages/gateway/src/cli/lib/release-integrity.ts
@@ -1,0 +1,210 @@
+/**
+ * Stable release integrity metadata.
+ *
+ * Trust boundary: GitHub's HTTPS Releases API authenticates repository release
+ * metadata and supplies a server-computed digest for the checksum asset. The
+ * checksum asset then authenticates the decompressed platform binary. This is
+ * not an offline publisher signature: compromise of GitHub or release-publish
+ * credentials can still publish a self-consistent malicious release.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  compareVersions,
+  fetchWithUpgradeError,
+  getGitHubHeaders,
+  getPlatformBinaryName,
+  GITHUB_RELEASES_URL,
+} from "./binary";
+import { UpgradeError } from "./errors";
+
+export const RELEASE_CHECKSUMS_ASSET = "lore-checksums.txt";
+
+/** Last stable release published before checksum assets became mandatory. */
+export const LAST_LEGACY_STABLE_RELEASE = "0.40.0";
+
+const SHA256_ASSET_DIGEST = /^sha256:([a-f0-9]{64})$/;
+const CHECKSUM_LINE = /^([a-f0-9]{64})  ([A-Za-z0-9][A-Za-z0-9._-]*)$/;
+const MAX_CHECKSUM_METADATA_BYTES = 64 * 1024;
+
+type GitHubReleaseAsset = {
+  name?: string;
+  browser_download_url?: string;
+  digest?: string;
+};
+
+type GitHubRelease = {
+  tag_name?: string;
+  assets?: GitHubReleaseAsset[];
+};
+
+function isExpectedChecksumAssetUrl(url: string, tag: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "https:" &&
+      parsed.username === "" &&
+      parsed.password === "" &&
+      parsed.hostname === "github.com" &&
+      parsed.port === "" &&
+      parsed.search === "" &&
+      parsed.hash === "" &&
+      parsed.pathname ===
+        `/BYK/loreai/releases/download/${encodeURIComponent(tag)}/${RELEASE_CHECKSUMS_ASSET}`
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function stableReleaseRequiresChecksums(version: string): boolean {
+  try {
+    return compareVersions(version, LAST_LEGACY_STABLE_RELEASE) === 1;
+  } catch {
+    // Unknown stable tag shapes receive the strict policy, not a compatibility
+    // bypass. Historical Lore releases all use semver.
+    return true;
+  }
+}
+
+function integrityError(message: string): UpgradeError {
+  return new UpgradeError("execution_failed", message);
+}
+
+function parseExpectedChecksum(metadata: string, filename: string): string {
+  if (!metadata.endsWith("\n")) {
+    throw integrityError("Stable release checksum metadata is not canonical");
+  }
+
+  const entries = new Map<string, string>();
+  for (const line of metadata.slice(0, -1).split("\n")) {
+    const match = CHECKSUM_LINE.exec(line);
+    if (!match?.[1] || !match[2]) {
+      throw integrityError("Stable release checksum metadata is malformed");
+    }
+    if (entries.has(match[2])) {
+      throw integrityError(
+        `Stable release checksum metadata contains duplicate entry ${match[2]}`,
+      );
+    }
+    entries.set(match[2], match[1]);
+  }
+
+  const checksum = entries.get(filename);
+  if (!checksum) {
+    throw integrityError(
+      `Stable release checksum metadata has no entry for ${filename}`,
+    );
+  }
+  return checksum;
+}
+
+/**
+ * Fetch and authenticate the expected SHA-256 for this platform's stable
+ * binary. Missing metadata is tolerated only for releases that predate the
+ * checksum rollout.
+ */
+export async function fetchStableBinaryChecksum(
+  version: string,
+): Promise<string | null> {
+  const required = stableReleaseRequiresChecksums(version);
+  let response: Response;
+  try {
+    response = await fetchWithUpgradeError(
+      `${GITHUB_RELEASES_URL}/tags/${encodeURIComponent(version)}`,
+      { headers: getGitHubHeaders() },
+      "GitHub",
+    );
+  } catch (error) {
+    if (!required) return null;
+    throw error;
+  }
+
+  if (!response.ok) {
+    if (!required) return null;
+    throw integrityError(
+      `Could not fetch checksum metadata for stable release ${version}: HTTP ${response.status}`,
+    );
+  }
+
+  let release: GitHubRelease;
+  try {
+    release = (await response.json()) as GitHubRelease;
+  } catch {
+    throw integrityError("Stable release metadata is not valid JSON");
+  }
+  if (release.tag_name !== version && release.tag_name !== `v${version}`) {
+    throw integrityError(
+      `Stable release metadata tag does not match requested version ${version}`,
+    );
+  }
+
+  const asset = release.assets?.find(
+    (candidate) => candidate.name === RELEASE_CHECKSUMS_ASSET,
+  );
+  if (!asset) {
+    if (!required) return null;
+    throw integrityError(
+      `Stable release ${version} is missing required checksum metadata`,
+    );
+  }
+  if (!asset.browser_download_url) {
+    throw integrityError(
+      "Stable release checksum metadata has no download URL",
+    );
+  }
+  if (
+    !release.tag_name ||
+    !isExpectedChecksumAssetUrl(asset.browser_download_url, release.tag_name)
+  ) {
+    throw integrityError(
+      "Stable release checksum metadata has an invalid download URL",
+    );
+  }
+  const expectedMetadataDigest = SHA256_ASSET_DIGEST.exec(
+    asset.digest ?? "",
+  )?.[1];
+  if (!expectedMetadataDigest) {
+    throw integrityError(
+      "Stable release checksum metadata has no authenticated SHA-256 asset digest",
+    );
+  }
+
+  const metadataResponse = await fetchWithUpgradeError(
+    asset.browser_download_url,
+    { headers: getGitHubHeaders() },
+    "GitHub",
+  );
+  if (!metadataResponse.ok) {
+    throw integrityError(
+      `Failed to download stable release checksum metadata: HTTP ${metadataResponse.status}`,
+    );
+  }
+  const declaredLength = Number(metadataResponse.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_CHECKSUM_METADATA_BYTES
+  ) {
+    throw integrityError("Stable release checksum metadata is too large");
+  }
+  const metadataBytes = new Uint8Array(await metadataResponse.arrayBuffer());
+  if (metadataBytes.byteLength > MAX_CHECKSUM_METADATA_BYTES) {
+    throw integrityError("Stable release checksum metadata is too large");
+  }
+  const actualMetadataDigest = createHash("sha256")
+    .update(metadataBytes)
+    .digest("hex");
+  if (actualMetadataDigest !== expectedMetadataDigest) {
+    throw integrityError(
+      `Stable release checksum metadata digest mismatch: got ${actualMetadataDigest}, expected ${expectedMetadataDigest}`,
+    );
+  }
+
+  let metadata: string;
+  try {
+    metadata = new TextDecoder("utf-8", { fatal: true }).decode(metadataBytes);
+  } catch {
+    throw integrityError("Stable release checksum metadata is not valid UTF-8");
+  }
+  return parseExpectedChecksum(metadata, getPlatformBinaryName());
+}

--- a/packages/gateway/src/cli/lib/upgrade.ts
+++ b/packages/gateway/src/cli/lib/upgrade.ts
@@ -16,7 +16,14 @@
  * detection, setup spawning, and Sentry SDK telemetry.
  */
 
-import { chmodSync, createWriteStream, statSync, unlinkSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  createWriteStream,
+  readFileSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -26,7 +33,6 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { getMeta, setMeta } from "@loreai/core";
 
 import {
-  acquireLock,
   cleanupOldBinary,
   fetchWithUpgradeError,
   getBinaryFilename,
@@ -39,11 +45,15 @@ import {
   getBinaryDownloadUrl,
   isNightlyVersion,
   KNOWN_CURL_DIRS,
-  releaseLock,
 } from "./binary";
+import type { LifecycleLock } from "../../lifecycle-lock";
 import { attemptDeltaUpgrade } from "./delta-upgrade";
 import { UpgradeError } from "./errors";
 import { makeByteProgress } from "./progress";
+import {
+  fetchStableBinaryChecksum,
+  stableReleaseRequiresChecksums,
+} from "./release-integrity";
 import {
   downloadNightlyBlob,
   fetchManifest,
@@ -158,7 +168,6 @@ export function getCurlInstallPaths(): {
   installPath: string;
   tempPath: string;
   oldPath: string;
-  lockPath: string;
 } {
   // Check if we're running from a known curl install location
   for (const dir of KNOWN_CURL_PATHS) {
@@ -282,7 +291,6 @@ export async function versionExists(
 
 export type DownloadResult = {
   tempBinaryPath: string;
-  lockPath: string;
   patchBytes?: number;
 };
 
@@ -333,6 +341,7 @@ function getNightlyGzFilename(): string {
  */
 async function downloadNightlyToPath(
   destPath: string,
+  lifecycleLock: LifecycleLock,
   version?: string,
 ): Promise<void> {
   const token = await getAnonymousToken();
@@ -349,6 +358,7 @@ async function downloadNightlyToPath(
       "GHCR blob response had no body",
     );
   }
+  lifecycleLock.assertOwned();
   await streamDecompressToFile(response.body, destPath);
 }
 
@@ -359,6 +369,7 @@ async function downloadNightlyToPath(
 async function downloadStableToPath(
   version: string,
   destPath: string,
+  lifecycleLock: LifecycleLock,
 ): Promise<void> {
   const url = getBinaryDownloadUrl(version);
   const headers = getGitHubHeaders();
@@ -371,6 +382,7 @@ async function downloadStableToPath(
       "GitHub",
     );
     if (gzResponse.ok && gzResponse.body) {
+      lifecycleLock.assertOwned();
       await streamDecompressToFile(gzResponse.body, destPath);
       return;
     }
@@ -388,6 +400,7 @@ async function downloadStableToPath(
   }
 
   const body = await response.arrayBuffer();
+  lifecycleLock.assertOwned();
   await writeFile(destPath, Buffer.from(body));
 }
 
@@ -430,92 +443,142 @@ function formatBytes(bytes: number): string {
  * Download the new binary to a temporary path and return its location.
  *
  * Tries delta upgrade first, falls back to full download.
- * The lock is held on success so concurrent upgrades are blocked.
+ * The caller holds the per-user lifecycle lock for the complete upgrade.
  */
 export async function downloadBinaryToTemp(
   version: string,
+  lifecycleLock: LifecycleLock,
   downloadTag?: string,
   offline?: OfflineMode,
+  currentExecutable: string = process.execPath,
 ): Promise<DownloadResult> {
-  const { tempPath, lockPath } = getCurlInstallPaths();
+  const tempPath = getBinaryPaths(currentExecutable).tempPath;
+  const nightly = isNightlyVersion(version);
+  let expectedStableSha256: string | null = null;
 
-  acquireLock(lockPath);
-
-  try {
-    // Clean up leftover temp file
-    try {
-      unlinkSync(tempPath);
-    } catch {
-      // Ignore
-    }
-
-    // Try delta upgrade first
-    const deltaStart = Date.now();
-    const deltaResult = await attemptDeltaUpgrade(
-      version,
-      process.execPath,
-      tempPath,
-      !!offline,
-    );
-
-    let patchBytes: number | undefined;
-    if (deltaResult) {
-      patchBytes = deltaResult.patchBytes;
-      const elapsed = ((Date.now() - deltaStart) / 1000).toFixed(1);
-      console.error(
-        `[lore] Applied delta patch (${formatBytes(patchBytes)} downloaded, ${deltaResult.chainLength} link(s)) in ${elapsed}s`,
-      );
-    } else if (offline) {
-      throw new UpgradeError(
-        "offline_cache_miss",
-        offline === "explicit"
-          ? `Cannot upgrade to ${version} in offline mode — no pre-downloaded update is available. ` +
-              "Run `lore upgrade` without `--offline` to download the update directly."
-          : `Cannot upgrade to ${version} — the network is unavailable and no pre-downloaded update was found. ` +
-              "Check your internet connection and try again.",
-      );
-    } else {
-      // Full download
-      const fullStart = Date.now();
-      if (isNightlyVersion(version)) {
-        await downloadNightlyToPath(tempPath, version);
-      } else {
-        await downloadStableToPath(downloadTag ?? version, tempPath);
+  // Authenticate stable publisher metadata before downloading, patching, or
+  // exposing a candidate binary. Historical releases remain installable, but
+  // every release after the checksum rollout fails closed when metadata is
+  // unavailable. Offline upgrades to those releases cannot establish this
+  // GitHub-backed trust boundary and are therefore rejected.
+  if (!nightly) {
+    if (offline) {
+      if (stableReleaseRequiresChecksums(version)) {
+        throw new UpgradeError(
+          "offline_cache_miss",
+          `Cannot authenticate stable release ${version} in offline mode because its publisher checksum metadata is unavailable`,
+        );
       }
-      const elapsed = ((Date.now() - fullStart) / 1000).toFixed(1);
-      console.error(`[lore] Downloaded full binary in ${elapsed}s`);
+    } else {
+      expectedStableSha256 = await fetchStableBinaryChecksum(version);
     }
-
-    const verifiedSize = await waitForBinaryVisible(tempPath);
-    console.error(`[lore] Binary verified (${formatBytes(verifiedSize)})`);
-
-    // Clear consumed patch cache
-    getPatchCache()
-      .clear()
-      .catch(() => {});
-
-    // Set executable permission (Unix only)
-    if (process.platform !== "win32") {
-      chmodSync(tempPath, 0o755);
-    }
-
-    return { tempBinaryPath: tempPath, lockPath, patchBytes };
-  } catch (error) {
-    releaseLock(lockPath);
-    throw error;
   }
+
+  // Clean up leftover temp file
+  lifecycleLock.assertOwned();
+  try {
+    unlinkSync(tempPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  // Try delta upgrade first
+  lifecycleLock.assertOwned();
+  const deltaStart = Date.now();
+  const deltaResult = await attemptDeltaUpgrade(
+    version,
+    currentExecutable,
+    tempPath,
+    !!offline,
+  );
+
+  let patchBytes: number | undefined;
+  if (deltaResult) {
+    patchBytes = deltaResult.patchBytes;
+    const elapsed = ((Date.now() - deltaStart) / 1000).toFixed(1);
+    console.error(
+      `[lore] Applied delta patch (${formatBytes(patchBytes)} downloaded, ${deltaResult.chainLength} link(s)) in ${elapsed}s`,
+    );
+  } else if (offline) {
+    throw new UpgradeError(
+      "offline_cache_miss",
+      offline === "explicit"
+        ? `Cannot upgrade to ${version} in offline mode — no pre-downloaded update is available. ` +
+            "Run `lore upgrade` without `--offline` to download the update directly."
+        : `Cannot upgrade to ${version} — the network is unavailable and no pre-downloaded update was found. ` +
+            "Check your internet connection and try again.",
+    );
+  } else {
+    // Full download
+    const fullStart = Date.now();
+    if (nightly) {
+      await downloadNightlyToPath(tempPath, lifecycleLock, version);
+    } else {
+      await downloadStableToPath(
+        downloadTag ?? version,
+        tempPath,
+        lifecycleLock,
+      );
+    }
+    const elapsed = ((Date.now() - fullStart) / 1000).toFixed(1);
+    console.error(`[lore] Downloaded full binary in ${elapsed}s`);
+  }
+
+  const verifiedSize = await waitForBinaryVisible(tempPath);
+  if (expectedStableSha256) {
+    const actualSha256 = createHash("sha256")
+      .update(readFileSync(tempPath))
+      .digest("hex");
+    if (actualSha256 !== expectedStableSha256) {
+      lifecycleLock.assertOwned();
+      try {
+        unlinkSync(tempPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      throw new UpgradeError(
+        "execution_failed",
+        `Downloaded binary checksum mismatch: got ${actualSha256}, expected ${expectedStableSha256}`,
+      );
+    }
+    console.error(
+      `[lore] Binary verified (SHA-256, ${formatBytes(verifiedSize)})`,
+    );
+  } else {
+    console.error(`[lore] Binary verified (${formatBytes(verifiedSize)})`);
+  }
+
+  // This mutation belongs to the upgrade transition too; wait for it instead
+  // of allowing it to escape beyond lifecycle-lock release.
+  lifecycleLock.assertOwned();
+  await getPatchCache().clear();
+
+  // Set executable permission (Unix only)
+  if (process.platform !== "win32") {
+    lifecycleLock.assertOwned();
+    chmodSync(tempPath, 0o755);
+  }
+
+  return { tempBinaryPath: tempPath, patchBytes };
 }
 
 /**
  * Execute the full upgrade: download binary, replace self.
  *
- * Returns the download result with paths for the caller to
- * handle lock release.
+ * The caller retains lifecycle-lock ownership through binary installation.
  */
 export async function executeUpgrade(
   version: string,
+  lifecycleLock: LifecycleLock,
   downloadTag?: string,
   offline?: OfflineMode,
+  currentExecutable?: string,
 ): Promise<DownloadResult> {
-  return downloadBinaryToTemp(version, downloadTag, offline);
+  return downloadBinaryToTemp(
+    version,
+    lifecycleLock,
+    downloadTag,
+    offline,
+    currentExecutable,
+  );
 }

--- a/packages/gateway/src/cli/lib/version-check.ts
+++ b/packages/gateway/src/cli/lib/version-check.ts
@@ -47,6 +47,7 @@ const JITTER_FACTOR = 0.2;
 /** Commands/flags that should not show update notifications */
 const SUPPRESSED_ARGS = new Set([
   "upgrade",
+  "uninstall",
   "--version",
   "-v",
   "--json",

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -10,6 +10,7 @@
  *   data           → inspect and manage stored data
  *   recall         → search project memory from the terminal
  *   upgrade        → self-update
+ *   uninstall      → undo persistent setup and remove standalone Lore
  *   help           → print usage
  */
 import { parseArgs } from "node:util";
@@ -116,6 +117,7 @@ const OPTIONS = {
   "import-lore-md": { type: "boolean" as const },
   gate: { type: "boolean" as const },
   "dry-run": { type: "boolean" as const },
+  purge: { type: "boolean" as const },
   "no-children": { type: "boolean" as const },
   // `lore import` flag — restrict detection to the current directory only
   // (skip sibling git worktrees / clone paths of the same repo).
@@ -588,6 +590,12 @@ export async function _cli(): Promise<void> {
         break;
       }
 
+      case "uninstall": {
+        const { commandUninstall } = await import("./uninstall");
+        await commandUninstall(rest, values);
+        break;
+      }
+
       case "help":
         printHelp();
         break;
@@ -621,6 +629,7 @@ export async function _cli(): Promise<void> {
               "import",
               "entity",
               "upgrade",
+              "uninstall",
               "help",
               ...knownBinaries,
             ];

--- a/packages/gateway/src/cli/run.ts
+++ b/packages/gateway/src/cli/run.ts
@@ -14,20 +14,22 @@ import {
   detectAgents,
   AGENTS,
   appendCustomHeader,
+  setCustomHeader,
   captureUserUpstream,
   type AgentDef,
   type DetectedAgent,
 } from "./agents";
 import { providerForUpstreamOrigin } from "../config";
-import { safeExit, forcedExit } from "./exit";
+import { safeExit } from "./exit";
 import {
   installSignalShutdown,
   installChildSignalForwarding,
-  runShutdownWithDeadline,
+  makeProcessShutdownController,
   signalExitCode,
+  type ProcessShutdownController,
 } from "./shutdown";
 import { maybeAutoImport } from "./import-auto";
-import { discoverWorkspaceRoot, log } from "@loreai/core";
+import { discoverWorkspaceRoot, GATEWAY_AUTH_HEADER, log } from "@loreai/core";
 
 // ---------------------------------------------------------------------------
 // Interactive agent picker (TTY only)
@@ -200,6 +202,26 @@ export function injectAdoptionHeaders(
 }
 
 /**
+ * Gateway access credential required for remote/hosted data-plane requests.
+ * It is sent as `x-lore-gateway-token` and remains separate from provider API
+ * keys/bearer tokens. Remote/hosted startup fails closed unless it is 32-256
+ * visible ASCII characters without commas. OpenCode/Pi consume
+ * LORE_REMOTE_URL + LORE_GATEWAY_AUTH_TOKEN in their adapters; Claude Code
+ * supports a per-request custom header directly. Never place it in a URL or
+ * CLI argument. Env: LORE_GATEWAY_AUTH_TOKEN.
+ */
+export function injectRemoteGatewayAccess(
+  agent: AgentDef | null,
+  env: Record<string, string>,
+  gatewayUrl: string,
+): void {
+  env.LORE_REMOTE_URL = gatewayUrl;
+  const token = process.env.LORE_GATEWAY_AUTH_TOKEN;
+  if (!token || agent?.name !== "claude-code") return;
+  setCustomHeader(env, "ANTHROPIC_CUSTOM_HEADERS", GATEWAY_AUTH_HEADER, token);
+}
+
+/**
  * The agent that `lore run` will actually launch, resolved BEFORE the gateway
  * starts so we can adopt the user's upstream (which requires setting gateway
  * env before `loadConfig`). `command` is the binary/command to exec; `def` is
@@ -265,6 +287,7 @@ export function resolveLaunchTarget(
   cmdArgs: string[],
   extraArgs: string[],
   adopted: AdoptedUpstream | null,
+  remoteGateway = false,
 ): LaunchTarget {
   // Resolve workspace root once — walks up from cwd looking for monorepo
   // markers (.lore.json with workspaces, .git, pnpm-workspace.yaml, etc.)
@@ -290,6 +313,9 @@ export function resolveLaunchTarget(
     if (selection.def && adopted) {
       injectAdoptionHeaders(selection.def, env, adopted);
     }
+    if (remoteGateway) {
+      injectRemoteGatewayAccess(selection.def, env, gatewayUrl);
+    }
     return {
       command: cmdArgs[0],
       args: [...prependArgs, ...cmdArgs.slice(1), ...extraArgs],
@@ -312,6 +338,7 @@ export function resolveLaunchTarget(
   const agentCliArgs = def.cliArgs?.(gatewayUrl, projectDir) ?? [];
   const env = def.envVars(gatewayUrl, projectDir);
   if (adopted) injectAdoptionHeaders(def, env, adopted);
+  if (remoteGateway) injectRemoteGatewayAccess(def, env, gatewayUrl);
   return {
     command: def.binary,
     args: [...agentCliArgs, ...extraArgs],
@@ -353,6 +380,7 @@ export async function commandRun(
   let gatewayUrl: string;
   let owned: boolean;
   let shutdown: () => Promise<void>;
+  let processShutdown: ProcessShutdownController | undefined;
   // The config actually in effect for the running gateway. In local mode
   // startGateway() re-runs loadConfig() AFTER upstream adoption has set
   // LORE_UPSTREAM_*, so handle.config reflects the adopted upstream while the
@@ -360,6 +388,7 @@ export async function commandRun(
   // the effective config or its worker calls route to the pre-adoption default
   // upstream (e.g. api.anthropic.com) and fail auth against the adopted key.
   let effectiveConfig = config;
+  let remoteGateway = false;
 
   // 2. Adopt the user's existing upstream (local mode only — a remote gateway
   //    owns its own config; header injection below still routes it there).
@@ -398,8 +427,10 @@ export async function commandRun(
       return safeExit(1);
     }
     gatewayUrl = remoteUrl;
+    remoteGateway = true;
     owned = false;
     shutdown = async () => {};
+    processShutdown = undefined;
     console.log(`[lore] Using remote gateway at ${gatewayUrl}`);
     // In remote mode, adopt via header injection only (no local gateway env).
     if (selection?.def) {
@@ -408,10 +439,15 @@ export async function commandRun(
   } else {
     // Local mode: start (or reuse) a local gateway.
     // `lore run` always runs locally — agent is on the same machine.
-    const handle = await startGateway({ ...opts, local: true });
+    const handle = await startGateway({
+      ...opts,
+      local: true,
+      processBoundary: true,
+    });
     gatewayUrl = `http://${bracketHost(handle.config.hosts[0])}:${handle.port}`;
     owned = handle.owned;
     shutdown = handle.shutdown;
+    processShutdown = handle.processShutdown;
     // Post-adoption config (LORE_UPSTREAM_* now reflected). Used for autoImport.
     effectiveConfig = handle.config;
 
@@ -430,7 +466,14 @@ export async function commandRun(
 
   // 4. Build the launch target (env + args) now that we have the URL.
   const target = selection
-    ? resolveLaunchTarget(selection, gatewayUrl, cmdArgs, extraArgs, adopted)
+    ? resolveLaunchTarget(
+        selection,
+        gatewayUrl,
+        cmdArgs,
+        extraArgs,
+        adopted,
+        remoteGateway,
+      )
     : null;
 
   if (!target) {
@@ -441,7 +484,7 @@ export async function commandRun(
     console.log(`[lore]   export ANTHROPIC_BASE_URL=${gatewayUrl}`);
 
     if (owned) {
-      installSignalShutdown(shutdown);
+      installSignalShutdown(shutdown, processShutdown);
     }
 
     // Block forever
@@ -465,27 +508,31 @@ export async function commandRun(
     log.silenceStderr();
   }
 
+  const childProcessShutdown =
+    processShutdown ?? makeProcessShutdownController(shutdown);
+
+  // Authenticated shutdown may have started while auto-import was awaited.
+  // This check, spawn, and attachment are deliberately one synchronous section:
+  // no timer, signal, or HTTP callback can interleave on the JS event loop.
+  if (childProcessShutdown.isShutdownStarted()) {
+    return childProcessShutdown(0);
+  }
   const child = launchChild(target);
 
-  // Forward the first signal to the child (its `exit` handler then drives
-  // gateway teardown); a second interrupt forces an immediate exit so the user
-  // is never stuck waiting on a hung child or shutdown.
-  installChildSignalForwarding(child);
+  // The first signal starts the one shared child + gateway teardown deadline
+  // immediately. Attachment is synchronous with spawn, before callbacks run.
+  installChildSignalForwarding(child, childProcessShutdown);
 
-  // Wait for child to exit, then tear down gateway (only if we own it)
+  // Child completion joins (or starts) the same coordinated teardown.
   return new Promise<void>((_resolve) => {
     child.on("exit", (code, signal) => {
       void (async () => {
-        // Deadline-bounded so a slow shutdown step can't hang the process.
-        // Use forcedExit on this path: the bounded shutdown may have timed out
-        // (4000ms) and the embedding worker may still be mid-inference in a
-        // native call — safeExit → process.exit() would walk NAPI destructors
-        // under it and SIGABRT (the "💣 Program crashed" report).
-        if (owned) await runShutdownWithDeadline(shutdown);
-        if (signal) {
-          forcedExit(signalExitCode(signal));
-        }
-        forcedExit(code ?? 0);
+        // Use the same one-shot whole-teardown controller as authenticated
+        // process control. It exits normally after safe closure and force-exits
+        // if teardown rejects or exceeds SHUTDOWN_DEADLINE_MS.
+        await childProcessShutdown.childExited(
+          signal ? signalExitCode(signal) : (code ?? 0),
+        );
       })();
     });
 
@@ -494,8 +541,12 @@ export async function commandRun(
         console.error(
           `[lore] Failed to launch ${target.command}: ${err.message}`,
         );
-        if (owned) await runShutdownWithDeadline(shutdown);
-        forcedExit(1);
+        // A spawn failure has no child to reap. Other ChildProcess `error`
+        // events (including signal-delivery failures) do not prove a spawned
+        // child exited, so preserve the failure outcome but keep waiting for
+        // its exit event within the shared deadline.
+        if (child.pid === undefined) await childProcessShutdown.childExited(1);
+        else await childProcessShutdown(1);
       })();
     });
   });

--- a/packages/gateway/src/cli/setup-backup.ts
+++ b/packages/gateway/src/cli/setup-backup.ts
@@ -22,6 +22,8 @@
  * logic is unit-testable without touching the filesystem.
  */
 
+import { createHash } from "node:crypto";
+
 export const LORE_BACKUP_KEY = "_loreBackup";
 
 // ---------------------------------------------------------------------------
@@ -29,16 +31,35 @@ export const LORE_BACKUP_KEY = "_loreBackup";
 // ---------------------------------------------------------------------------
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+  const prototype = Object.getPrototypeOf(v);
+  return prototype === Object.prototype || prototype === null;
+}
+
+const DANGEROUS_PATH_SEGMENTS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+function pathParts(path: string): string[] {
+  const parts = path.split(".");
+  if (
+    parts.length === 0 ||
+    parts.some((part) => part.length === 0 || DANGEROUS_PATH_SEGMENTS.has(part))
+  ) {
+    throw new Error(`Invalid JSON backup path: ${path}`);
+  }
+  return parts;
 }
 
 /** Read a dot-path (e.g. `env.ANTHROPIC_BASE_URL`). Returns undefined if any
  * segment is missing. */
 export function getPath(obj: Record<string, unknown>, path: string): unknown {
-  const parts = path.split(".");
+  const parts = pathParts(path);
   let cur: unknown = obj;
   for (const p of parts) {
-    if (!isPlainObject(cur)) return undefined;
+    if (!isPlainObject(cur) || !Object.hasOwn(cur, p)) return undefined;
     cur = cur[p];
   }
   return cur;
@@ -50,11 +71,11 @@ export function setPath(
   path: string,
   value: unknown,
 ): void {
-  const parts = path.split(".");
+  const parts = pathParts(path);
   let cur: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const p = parts[i];
-    if (!isPlainObject(cur[p])) cur[p] = {};
+    if (!Object.hasOwn(cur, p) || !isPlainObject(cur[p])) cur[p] = {};
     cur = cur[p] as Record<string, unknown>;
   }
   cur[parts[parts.length - 1]] = value;
@@ -62,11 +83,12 @@ export function setPath(
 
 /** Delete a dot-path leaf, then prune any parent objects left empty. */
 export function deletePath(obj: Record<string, unknown>, path: string): void {
-  const parts = path.split(".");
+  const parts = pathParts(path);
   // Walk down, remembering the chain so we can prune empties on the way back.
   const chain: Record<string, unknown>[] = [obj];
   let cur: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
+    if (!Object.hasOwn(cur, parts[i])) return;
     const next = cur[parts[i]];
     if (!isPlainObject(next)) return; // path doesn't exist — nothing to delete
     cur = next;
@@ -87,6 +109,27 @@ function jsonEqual(a: unknown, b: unknown): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+function cloneJson<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function hashJson(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
 // ---------------------------------------------------------------------------
 // JSON backup (Claude Code, OpenCode)
 // ---------------------------------------------------------------------------
@@ -98,12 +141,761 @@ export interface JsonBackupEntry {
   priorValue?: unknown;
 }
 
-export interface JsonBackup {
+export interface LegacyJsonBackup {
   version: 1;
   savedAt: string;
   entries: JsonBackupEntry[];
   /** OpenCode only: lore appended `@loreai/opencode` to the `plugin` array. */
   pluginAdded?: boolean;
+}
+
+export interface JsonBackupGeneration {
+  device: string;
+  inode: string;
+  birthtimeNs: string;
+  size: string;
+  mtimeNs: string;
+}
+
+/**
+ * Stable crash-safe provenance. Version 2 remains reserved for a pending
+ * journal; version 3 binds the committed backup to the installed config
+ * generation and its managed/unmanaged semantic state.
+ */
+export interface BoundJsonBackup {
+  version: 3;
+  savedAt: string;
+  entries: JsonBackupEntry[];
+  pluginAdded?: boolean;
+  originalExists: boolean;
+  createdAncestors: string[];
+  managedHash: string;
+  unmanagedHash: string;
+  generation: JsonBackupGeneration | null;
+}
+
+export type JsonBackup = LegacyJsonBackup | BoundJsonBackup;
+
+export interface JsonSetupJournalProjectionEntry {
+  path: string;
+  present: boolean;
+  value?: unknown;
+}
+
+export interface JsonSetupJournalConfigState {
+  hash: string | null;
+  projection: JsonSetupJournalProjectionEntry[];
+}
+
+/**
+ * A prepared config/sidecar transaction. Stable sidecars are strict v1/v3
+ * JsonBackup values; version 2 exists only while a replacement is pending.
+ */
+export interface JsonSetupJournal {
+  version: 2;
+  state: "prepared";
+  preparedAt: string;
+  oldBackup: JsonBackup | null;
+  newBackup: JsonBackup | null;
+  beforeConfig: JsonSetupJournalConfigState;
+  afterConfig: JsonSetupJournalConfigState;
+}
+
+const JSON_BACKUP_ENV_PATHS = new Set([
+  "env.ANTHROPIC_BASE_URL",
+  "env.DISABLE_AUTO_COMPACT",
+  "env._CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL",
+]);
+const JSON_BACKUP_PROVIDER_PATH =
+  /^provider\.([a-z0-9][a-z0-9-]*)\.options\.baseURL$/;
+const JSON_BACKUP_PI_PROVIDER_PATH =
+  /^providers\.([a-z0-9][a-z0-9-]*)\.baseUrl$/;
+const JSON_BACKUP_PROVIDER_CONTAINER_PATH =
+  /^provider\.([a-z0-9][a-z0-9-]*)(?:\.options)?$/;
+const JSON_BACKUP_PI_PROVIDER_CONTAINER_PATH =
+  /^providers\.([a-z0-9][a-z0-9-]*)$/;
+const JSON_BACKUP_CONTAINER_PATHS = new Set([
+  "env",
+  "provider",
+  "providers",
+  "compaction",
+  "plugin",
+]);
+const JSON_BACKUP_CREATED_ANCESTOR =
+  /^(?:env|compaction|provider(?:\.[a-z0-9][a-z0-9-]*(?:\.options)?)?|providers(?:\.[a-z0-9][a-z0-9-]*)?)$/;
+
+function isManagedJsonBackupPath(path: string): boolean {
+  pathParts(path);
+  return (
+    JSON_BACKUP_ENV_PATHS.has(path) ||
+    JSON_BACKUP_CONTAINER_PATHS.has(path) ||
+    JSON_BACKUP_PROVIDER_CONTAINER_PATH.test(path) ||
+    JSON_BACKUP_PI_PROVIDER_CONTAINER_PATH.test(path) ||
+    path === "compaction.auto" ||
+    JSON_BACKUP_PROVIDER_PATH.test(path) ||
+    JSON_BACKUP_PI_PROVIDER_PATH.test(path)
+  );
+}
+
+function isManagedJsonJournalPath(path: string): boolean {
+  return (
+    path === "plugin" ||
+    path === LORE_BACKUP_KEY ||
+    isManagedJsonBackupPath(path)
+  );
+}
+
+function isJsonValue(value: unknown, seen = new Set<object>()): boolean {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return true;
+  }
+  if (typeof value === "number") return Number.isFinite(value);
+  if (typeof value !== "object") return false;
+  if (seen.has(value)) return false;
+  seen.add(value);
+  const valid = Array.isArray(value)
+    ? value.every((item) => isJsonValue(item, seen))
+    : isPlainObject(value) &&
+      Object.keys(value).every(
+        (key) =>
+          !DANGEROUS_PATH_SEGMENTS.has(key) && isJsonValue(value[key], seen),
+      );
+  seen.delete(value);
+  return valid;
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  required: string[],
+  optional: string[] = [],
+): boolean {
+  const keys = Object.keys(value);
+  return (
+    required.every((key) => Object.hasOwn(value, key)) &&
+    keys.every((key) => required.includes(key) || optional.includes(key))
+  );
+}
+
+function hasExpectedLoreValue(path: string, value: unknown): boolean {
+  if (path === "compaction.auto") return value === false;
+  if (
+    JSON_BACKUP_CONTAINER_PATHS.has(path) ||
+    JSON_BACKUP_PROVIDER_CONTAINER_PATH.test(path) ||
+    JSON_BACKUP_PI_PROVIDER_CONTAINER_PATH.test(path)
+  ) {
+    return isJsonValue(value);
+  }
+  return typeof value === "string";
+}
+
+function validIsoTimestamp(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    Number.isFinite(Date.parse(value)) &&
+    new Date(value).toISOString() === value
+  );
+}
+
+function validateJsonBackupEntries(value: Record<string, unknown>): void {
+  if (!Array.isArray(value.entries)) {
+    throw new Error("Invalid JSON setup backup metadata.");
+  }
+  const seenPaths = new Set<string>();
+  for (const rawEntry of value.entries) {
+    if (!isPlainObject(rawEntry) || typeof rawEntry.hadPrior !== "boolean") {
+      throw new Error("Invalid JSON setup backup entry.");
+    }
+    const required = rawEntry.hadPrior
+      ? ["path", "loreValue", "hadPrior", "priorValue"]
+      : ["path", "loreValue", "hadPrior"];
+    const entryPath = rawEntry.path;
+    if (
+      !hasExactKeys(rawEntry, required) ||
+      typeof entryPath !== "string" ||
+      !isManagedJsonBackupPath(entryPath) ||
+      seenPaths.has(entryPath) ||
+      !hasExpectedLoreValue(entryPath, rawEntry.loreValue) ||
+      !isJsonValue(rawEntry.loreValue) ||
+      (rawEntry.hadPrior && !isJsonValue(rawEntry.priorValue)) ||
+      [...seenPaths].some(
+        (path) =>
+          path.startsWith(`${entryPath}.`) || entryPath.startsWith(`${path}.`),
+      )
+    ) {
+      throw new Error("Invalid JSON setup backup entry.");
+    }
+    seenPaths.add(entryPath);
+  }
+}
+
+function parseJsonBackupGeneration(
+  value: unknown,
+): JsonBackupGeneration | null {
+  if (value === null) return null;
+  if (
+    !isPlainObject(value) ||
+    !hasExactKeys(value, [
+      "device",
+      "inode",
+      "birthtimeNs",
+      "size",
+      "mtimeNs",
+    ]) ||
+    typeof value.device !== "string" ||
+    typeof value.inode !== "string" ||
+    typeof value.birthtimeNs !== "string" ||
+    typeof value.size !== "string" ||
+    typeof value.mtimeNs !== "string" ||
+    !/^\d+$/.test(value.device) ||
+    !/^\d+$/.test(value.inode) ||
+    !/^\d+$/.test(value.birthtimeNs) ||
+    !/^\d+$/.test(value.size) ||
+    !/^\d+$/.test(value.mtimeNs)
+  ) {
+    throw new Error("Invalid JSON setup backup generation.");
+  }
+  return value as unknown as JsonBackupGeneration;
+}
+
+/** Strictly validate untrusted JSON backup metadata. */
+export function parseJsonBackup(value: unknown): JsonBackup {
+  if (
+    !isPlainObject(value) ||
+    (value.version !== 1 && value.version !== 3) ||
+    !validIsoTimestamp(value.savedAt) ||
+    (Object.hasOwn(value, "pluginAdded") &&
+      typeof value.pluginAdded !== "boolean")
+  ) {
+    throw new Error("Invalid JSON setup backup metadata.");
+  }
+  if (value.version === 1) {
+    if (
+      !hasExactKeys(value, ["version", "savedAt", "entries"], ["pluginAdded"])
+    ) {
+      throw new Error("Invalid JSON setup backup metadata.");
+    }
+    validateJsonBackupEntries(value);
+    return value as unknown as LegacyJsonBackup;
+  }
+
+  if (
+    !hasExactKeys(
+      value,
+      [
+        "version",
+        "savedAt",
+        "entries",
+        "originalExists",
+        "createdAncestors",
+        "managedHash",
+        "unmanagedHash",
+        "generation",
+      ],
+      ["pluginAdded"],
+    ) ||
+    typeof value.originalExists !== "boolean" ||
+    !Array.isArray(value.createdAncestors) ||
+    typeof value.managedHash !== "string" ||
+    typeof value.unmanagedHash !== "string" ||
+    !/^[a-f0-9]{64}$/.test(value.managedHash) ||
+    !/^[a-f0-9]{64}$/.test(value.unmanagedHash)
+  ) {
+    throw new Error("Invalid JSON setup backup metadata.");
+  }
+  validateJsonBackupEntries(value);
+  parseJsonBackupGeneration(value.generation);
+  const seenAncestors = new Set<string>();
+  let previousAncestor: string | null = null;
+  for (const ancestor of value.createdAncestors) {
+    if (
+      typeof ancestor !== "string" ||
+      !JSON_BACKUP_CREATED_ANCESTOR.test(ancestor) ||
+      seenAncestors.has(ancestor) ||
+      (previousAncestor !== null && ancestor < previousAncestor) ||
+      !(value.entries as JsonBackupEntry[]).some((entry) =>
+        entry.path.startsWith(`${ancestor}.`),
+      )
+    ) {
+      throw new Error("Invalid JSON setup backup created ancestors.");
+    }
+    seenAncestors.add(ancestor);
+    previousAncestor = ancestor;
+  }
+  return value as unknown as BoundJsonBackup;
+}
+
+/** Stable sidecars must never contain an unbound v3 draft. */
+export function parseStableJsonBackup(value: unknown): JsonBackup {
+  const backup = parseJsonBackup(value);
+  if (backup.version === 3 && backup.generation === null) {
+    throw new Error("Unbound JSON setup backup generation.");
+  }
+  return backup;
+}
+
+function parseJsonSetupJournalConfigState(
+  value: unknown,
+): JsonSetupJournalConfigState {
+  if (
+    !isPlainObject(value) ||
+    !hasExactKeys(value, ["hash", "projection"]) ||
+    (value.hash !== null &&
+      (typeof value.hash !== "string" || !/^[a-f0-9]{64}$/.test(value.hash))) ||
+    !Array.isArray(value.projection)
+  ) {
+    throw new Error("Invalid JSON setup journal config state.");
+  }
+
+  const seenPaths = new Set<string>();
+  let previousPath: string | null = null;
+  for (const rawEntry of value.projection) {
+    if (!isPlainObject(rawEntry) || typeof rawEntry.present !== "boolean") {
+      throw new Error("Invalid JSON setup journal projection.");
+    }
+    const required = rawEntry.present
+      ? ["path", "present", "value"]
+      : ["path", "present"];
+    if (
+      !hasExactKeys(rawEntry, required) ||
+      typeof rawEntry.path !== "string" ||
+      !isManagedJsonJournalPath(rawEntry.path) ||
+      seenPaths.has(rawEntry.path) ||
+      (previousPath !== null && rawEntry.path < previousPath) ||
+      (rawEntry.present && !isJsonValue(rawEntry.value)) ||
+      (rawEntry.path === LORE_BACKUP_KEY &&
+        rawEntry.present &&
+        !isValidJsonBackup(rawEntry.value))
+    ) {
+      throw new Error("Invalid JSON setup journal projection.");
+    }
+    seenPaths.add(rawEntry.path);
+    previousPath = rawEntry.path;
+  }
+  if (value.hash === null && value.projection.some((entry) => entry.present)) {
+    throw new Error("Invalid JSON setup journal config state.");
+  }
+  return value as unknown as JsonSetupJournalConfigState;
+}
+
+function isValidJsonBackup(value: unknown): boolean {
+  try {
+    parseJsonBackup(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Strictly validate a pending v2 sidecar journal. */
+export function parseJsonSetupJournal(value: unknown): JsonSetupJournal {
+  if (
+    !isPlainObject(value) ||
+    !hasExactKeys(value, [
+      "version",
+      "state",
+      "preparedAt",
+      "oldBackup",
+      "newBackup",
+      "beforeConfig",
+      "afterConfig",
+    ]) ||
+    value.version !== 2 ||
+    value.state !== "prepared" ||
+    typeof value.preparedAt !== "string" ||
+    !Number.isFinite(Date.parse(value.preparedAt)) ||
+    new Date(value.preparedAt).toISOString() !== value.preparedAt
+  ) {
+    throw new Error("Invalid JSON setup journal metadata.");
+  }
+
+  const oldBackup =
+    value.oldBackup === null ? null : parseJsonBackup(value.oldBackup);
+  const newBackup =
+    value.newBackup === null ? null : parseJsonBackup(value.newBackup);
+  const beforeConfig = parseJsonSetupJournalConfigState(value.beforeConfig);
+  const afterConfig = parseJsonSetupJournalConfigState(value.afterConfig);
+  const projectionPaths = new Set(
+    beforeConfig.projection.map((entry) => entry.path),
+  );
+  const requiredPaths = [oldBackup, newBackup].flatMap(
+    (backup) => backup?.entries.map((entry) => entry.path) ?? [],
+  );
+  if (oldBackup?.pluginAdded || newBackup?.pluginAdded) {
+    requiredPaths.push("plugin");
+  }
+  if (
+    beforeConfig.projection.length !== afterConfig.projection.length ||
+    beforeConfig.projection.some(
+      (entry, index) => entry.path !== afterConfig.projection[index]?.path,
+    ) ||
+    requiredPaths.some((path) => !projectionPaths.has(path))
+  ) {
+    throw new Error("Invalid JSON setup journal projections.");
+  }
+
+  return {
+    version: 2,
+    state: "prepared",
+    preparedAt: value.preparedAt,
+    oldBackup,
+    newBackup,
+    beforeConfig,
+    afterConfig,
+  };
+}
+
+function jsonConfigHash(text: string | null): string | null {
+  return text === null ? null : createHash("sha256").update(text).digest("hex");
+}
+
+function captureJsonSetupProjection(
+  config: Record<string, unknown>,
+  paths: readonly string[],
+  configExists = true,
+): JsonSetupJournalProjectionEntry[] {
+  if (!configExists) {
+    return paths.map((path) => ({ path, present: false }));
+  }
+  return paths.map((path) => {
+    const value = getPath(config, path);
+    return value === undefined
+      ? { path, present: false }
+      : { path, present: true, value };
+  });
+}
+
+/** Build the strict prepared journal written before the config commit. */
+export function prepareJsonSetupJournal(input: {
+  oldBackup: JsonBackup | null;
+  newBackup: JsonBackup | null;
+  beforeText: string | null;
+  beforeConfig: Record<string, unknown>;
+  afterText: string | null;
+  afterConfig: Record<string, unknown>;
+  projectionPaths?: readonly string[];
+  now?: () => Date;
+}): JsonSetupJournal {
+  if (input.oldBackup) parseJsonBackup(input.oldBackup);
+  if (input.newBackup) parseJsonBackup(input.newBackup);
+  const paths = [
+    ...new Set(
+      [input.oldBackup, input.newBackup]
+        .flatMap((backup) => backup?.entries.map((entry) => entry.path) ?? [])
+        .concat(
+          input.oldBackup?.pluginAdded || input.newBackup?.pluginAdded
+            ? ["plugin"]
+            : [],
+          Object.hasOwn(input.beforeConfig, LORE_BACKUP_KEY) ||
+            Object.hasOwn(input.afterConfig, LORE_BACKUP_KEY)
+            ? [LORE_BACKUP_KEY]
+            : [],
+          input.projectionPaths ?? [],
+        ),
+    ),
+  ].sort();
+  if (paths.some((path) => !isManagedJsonJournalPath(path))) {
+    throw new Error("Invalid JSON setup journal projection path.");
+  }
+  const journal: JsonSetupJournal = {
+    version: 2,
+    state: "prepared",
+    preparedAt: (input.now?.() ?? new Date()).toISOString(),
+    oldBackup: input.oldBackup,
+    newBackup: input.newBackup,
+    beforeConfig: {
+      hash: jsonConfigHash(input.beforeText),
+      projection: captureJsonSetupProjection(
+        input.beforeConfig,
+        paths,
+        input.beforeText !== null,
+      ),
+    },
+    afterConfig: {
+      hash: jsonConfigHash(input.afterText),
+      projection: captureJsonSetupProjection(
+        input.afterConfig,
+        paths,
+        input.afterText !== null,
+      ),
+    },
+  };
+  return parseJsonSetupJournal(journal);
+}
+
+function sameProjection(
+  left: JsonSetupJournalProjectionEntry[],
+  right: JsonSetupJournalProjectionEntry[],
+): boolean {
+  return jsonEqual(left, right);
+}
+
+/**
+ * Select the stable sidecar state for a pending journal without changing the
+ * config. Exact bytes win; if unrelated config bytes changed after a crash,
+ * the managed projection must identify exactly one side.
+ */
+export function selectJsonSetupJournalState(
+  rawJournal: JsonSetupJournal,
+  currentText: string | null,
+  currentConfig: Record<string, unknown>,
+): "old" | "new" {
+  const journal = parseJsonSetupJournal(rawJournal);
+  const currentHash = jsonConfigHash(currentText);
+  const exact = (["old", "new"] as const).filter((state) => {
+    const config = state === "old" ? journal.beforeConfig : journal.afterConfig;
+    return config.hash === currentHash;
+  });
+  if (exact.length === 1) return exact[0];
+  if (exact.length === 2) {
+    throw new Error("Ambiguous Lore setup journal config state.");
+  }
+
+  const paths = journal.beforeConfig.projection.map((entry) => entry.path);
+  const currentProjection = captureJsonSetupProjection(
+    currentConfig,
+    paths,
+    currentText !== null,
+  );
+  const projected = (["old", "new"] as const).filter((state) => {
+    const config = state === "old" ? journal.beforeConfig : journal.afterConfig;
+    return sameProjection(config.projection, currentProjection);
+  });
+  if (projected.length === 1) return projected[0];
+  throw new Error(
+    projected.length === 2
+      ? "Ambiguous Lore setup journal config state."
+      : "Unknown Lore setup journal config state.",
+  );
+}
+
+function captureJsonEntry(
+  existing: Record<string, unknown>,
+  path: string,
+  loreValue: unknown,
+): JsonBackupEntry {
+  if (
+    !isManagedJsonBackupPath(path) ||
+    !hasExpectedLoreValue(path, loreValue)
+  ) {
+    throw new Error(`Invalid JSON backup path or Lore value: ${path}`);
+  }
+  const prior = getPath(existing, path);
+  return prior === undefined
+    ? { path, loreValue, hadPrior: false }
+    : { path, loreValue, hadPrior: true, priorValue: prior };
+}
+
+function deriveAfterConfig(
+  existing: Record<string, unknown>,
+  loreValues: Record<string, unknown>,
+): Record<string, unknown> {
+  const after = cloneJson(existing);
+  for (const [path, value] of Object.entries(loreValues)) {
+    setPath(after, path, cloneJson(value));
+  }
+  return after;
+}
+
+function blockingPath(
+  existing: Record<string, unknown>,
+  path: string,
+): string | null {
+  const parts = pathParts(path);
+  let current: unknown = existing;
+  const traversed: string[] = [];
+  for (const part of parts.slice(0, -1)) {
+    if (!isPlainObject(current) || !Object.hasOwn(current, part)) return null;
+    traversed.push(part);
+    current = current[part];
+    if (!isPlainObject(current)) return traversed.join(".");
+  }
+  return null;
+}
+
+function captureBackupEntries(
+  existing: Record<string, unknown>,
+  after: Record<string, unknown>,
+  loreValues: Record<string, unknown>,
+): JsonBackupEntry[] {
+  const captured = new Map<string, JsonBackupEntry>();
+  for (const [path, loreValue] of Object.entries(loreValues)) {
+    const blocker = blockingPath(existing, path);
+    const entryPath = blocker ?? path;
+    if (captured.has(entryPath)) continue;
+    const installedValue = blocker ? getPath(after, blocker) : loreValue;
+    captured.set(
+      entryPath,
+      captureJsonEntry(existing, entryPath, cloneJson(installedValue)),
+    );
+  }
+  return [...captured.values()];
+}
+
+function captureCreatedAncestors(
+  existing: Record<string, unknown>,
+  entries: readonly JsonBackupEntry[],
+): string[] {
+  const created = new Set<string>();
+  for (const entry of entries) {
+    const parts = pathParts(entry.path);
+    let current: unknown = existing;
+    const traversed: string[] = [];
+    for (const part of parts.slice(0, -1)) {
+      traversed.push(part);
+      const present = isPlainObject(current) && Object.hasOwn(current, part);
+      if (!present) created.add(traversed.join("."));
+      current = present && isPlainObject(current) ? current[part] : undefined;
+    }
+  }
+  return [...created].sort();
+}
+
+function deleteLeaf(obj: Record<string, unknown>, path: string): void {
+  const parts = pathParts(path);
+  let current: unknown = obj;
+  for (const part of parts.slice(0, -1)) {
+    if (!isPlainObject(current) || !Object.hasOwn(current, part)) return;
+    current = current[part];
+  }
+  if (isPlainObject(current)) delete current[parts.at(-1) as string];
+}
+
+function pruneCreatedAncestors(
+  obj: Record<string, unknown>,
+  ancestors: readonly string[],
+): void {
+  for (const path of [...ancestors].sort(
+    (left, right) => pathParts(right).length - pathParts(left).length,
+  )) {
+    const value = getPath(obj, path);
+    if (isPlainObject(value) && Object.keys(value).length === 0) {
+      deleteLeaf(obj, path);
+    }
+  }
+}
+
+function managedProjection(
+  config: Record<string, unknown>,
+  backup: Pick<JsonBackup, "entries" | "pluginAdded">,
+): unknown[] {
+  const projection = backup.entries.map((entry) => {
+    const value = getPath(config, entry.path);
+    return value === undefined
+      ? { path: entry.path, present: false }
+      : { path: entry.path, present: true, value };
+  });
+  if (
+    Object.hasOwn(backup, "pluginAdded") &&
+    !backup.entries.some((entry) => entry.path === "plugin")
+  ) {
+    projection.push({
+      path: "plugin[@loreai/opencode]",
+      present:
+        Array.isArray(config.plugin) &&
+        config.plugin.includes("@loreai/opencode"),
+    });
+  }
+  return projection;
+}
+
+function unmanagedProjection(
+  config: Record<string, unknown>,
+  backup: Pick<BoundJsonBackup, "entries" | "pluginAdded" | "createdAncestors">,
+): Record<string, unknown> {
+  const unmanaged = cloneJson(config);
+  for (const entry of backup.entries) deleteLeaf(unmanaged, entry.path);
+  if (
+    Object.hasOwn(backup, "pluginAdded") &&
+    !backup.entries.some((entry) => entry.path === "plugin") &&
+    Array.isArray(unmanaged.plugin)
+  ) {
+    const plugins = unmanaged.plugin;
+    unmanaged.plugin = plugins.filter((item) => item !== "@loreai/opencode");
+    if ((unmanaged.plugin as unknown[]).length === 0) delete unmanaged.plugin;
+  }
+  pruneCreatedAncestors(unmanaged, backup.createdAncestors);
+  return unmanaged;
+}
+
+export function jsonBackupConfigHashes(
+  config: Record<string, unknown>,
+  backup: JsonBackup,
+): { managedHash: string; unmanagedHash: string } {
+  const createdAncestors = backup.version === 3 ? backup.createdAncestors : [];
+  return {
+    managedHash: hashJson(managedProjection(config, backup)),
+    unmanagedHash: hashJson(
+      unmanagedProjection(config, { ...backup, createdAncestors }),
+    ),
+  };
+}
+
+function boundBackupDraft(input: {
+  savedAt: string;
+  entries: JsonBackupEntry[];
+  pluginAdded?: boolean;
+  originalExists: boolean;
+  createdAncestors: string[];
+  afterConfig: Record<string, unknown>;
+}): BoundJsonBackup {
+  const draft: BoundJsonBackup = {
+    version: 3,
+    savedAt: input.savedAt,
+    entries: input.entries,
+    originalExists: input.originalExists,
+    createdAncestors: input.createdAncestors,
+    managedHash: "0".repeat(64),
+    unmanagedHash: "0".repeat(64),
+    generation: null,
+  };
+  if (input.pluginAdded !== undefined) draft.pluginAdded = input.pluginAdded;
+  Object.assign(draft, jsonBackupConfigHashes(input.afterConfig, draft));
+  return draft;
+}
+
+export function bindJsonBackupGeneration(
+  backup: JsonBackup,
+  generation: JsonBackupGeneration,
+): JsonBackup {
+  parseJsonBackup(backup);
+  if (backup.version === 1) return backup;
+  return parseStableJsonBackup({ ...backup, generation });
+}
+
+/** Verify that a stable sidecar still belongs to the current config. */
+export function assertJsonBackupConfigState(
+  backup: JsonBackup,
+  config: Record<string, unknown>,
+  generation: JsonBackupGeneration,
+): void {
+  parseJsonBackup(backup);
+  if (backup.version === 1) return;
+  if (!backup.generation) {
+    throw new Error("Unbound JSON setup backup generation.");
+  }
+  const current = jsonBackupConfigHashes(config, backup);
+  const sameGeneration =
+    backup.generation.device === generation.device &&
+    backup.generation.inode === generation.inode &&
+    (backup.generation.birthtimeNs !== "0"
+      ? backup.generation.birthtimeNs === generation.birthtimeNs
+      : backup.generation.size === generation.size &&
+        backup.generation.mtimeNs === generation.mtimeNs);
+  if (sameGeneration) return;
+  if (current.unmanagedHash !== backup.unmanagedHash) {
+    throw new Error(
+      "Current unmanaged config state does not match Lore setup provenance.",
+    );
+  }
+  if (current.managedHash === backup.managedHash) {
+    throw new Error(
+      "Current config generation was replaced without a distinguishable managed-key edit.",
+    );
+  }
 }
 
 /**
@@ -114,24 +906,113 @@ export interface JsonBackup {
 export function captureJsonBackup(
   existing: Record<string, unknown>,
   loreValues: Record<string, unknown>,
-  opts: { pluginAdded?: boolean; now?: () => Date } = {},
+  opts: {
+    pluginAdded?: boolean;
+    now?: () => Date;
+    originalExists?: boolean;
+    afterConfig?: Record<string, unknown>;
+  } = {},
 ): JsonBackup {
-  const entries: JsonBackupEntry[] = [];
-  for (const [path, loreValue] of Object.entries(loreValues)) {
-    const prior = getPath(existing, path);
-    entries.push(
-      prior === undefined
-        ? { path, loreValue, hadPrior: false }
-        : { path, loreValue, hadPrior: true, priorValue: prior },
-    );
-  }
-  const backup: JsonBackup = {
-    version: 1,
+  const afterConfig =
+    opts.afterConfig ?? deriveAfterConfig(existing, loreValues);
+  const entries = captureBackupEntries(existing, afterConfig, loreValues);
+  return boundBackupDraft({
     savedAt: (opts.now?.() ?? new Date()).toISOString(),
     entries,
-  };
-  if (opts.pluginAdded !== undefined) backup.pluginAdded = opts.pluginAdded;
-  return backup;
+    pluginAdded: opts.pluginAdded,
+    originalExists: opts.originalExists ?? true,
+    createdAncestors: captureCreatedAncestors(existing, entries),
+    afterConfig,
+  });
+}
+
+/** Refresh provenance for a repeated setup while retaining the true prior. */
+export function refreshJsonBackup(
+  existing: Record<string, unknown>,
+  loreValues: Record<string, unknown>,
+  previous: JsonBackup | null,
+  opts: {
+    pluginAdded?: boolean;
+    now?: () => Date;
+    originalExists?: boolean;
+    afterConfig?: Record<string, unknown>;
+  } = {},
+): JsonBackup {
+  if (!previous) return captureJsonBackup(existing, loreValues, opts);
+  parseJsonBackup(previous);
+
+  const afterConfig =
+    opts.afterConfig ?? deriveAfterConfig(existing, loreValues);
+  let desiredEntries = captureBackupEntries(existing, afterConfig, loreValues);
+  for (const previousEntry of previous.entries) {
+    if (
+      (!JSON_BACKUP_CONTAINER_PATHS.has(previousEntry.path) &&
+        !JSON_BACKUP_PROVIDER_CONTAINER_PATH.test(previousEntry.path) &&
+        !JSON_BACKUP_PI_PROVIDER_CONTAINER_PATH.test(previousEntry.path)) ||
+      !Object.keys(loreValues).some(
+        (path) =>
+          path === previousEntry.path ||
+          path.startsWith(`${previousEntry.path}.`),
+      )
+    ) {
+      continue;
+    }
+    desiredEntries = desiredEntries.filter(
+      (entry) =>
+        entry.path === previousEntry.path ||
+        !entry.path.startsWith(`${previousEntry.path}.`),
+    );
+    const current = getPath(existing, previousEntry.path);
+    const loreValue = getPath(afterConfig, previousEntry.path);
+    desiredEntries.push(
+      jsonEqual(current, previousEntry.loreValue)
+        ? { ...previousEntry, loreValue: cloneJson(loreValue) }
+        : captureJsonEntry(existing, previousEntry.path, cloneJson(loreValue)),
+    );
+  }
+  const previousByPath = new Map(
+    previous.entries.map((entry) => [entry.path, entry]),
+  );
+  const entries: JsonBackupEntry[] = [];
+  for (const desired of desiredEntries) {
+    const priorEntry = previousByPath.get(desired.path);
+    if (
+      priorEntry &&
+      jsonEqual(getPath(existing, desired.path), priorEntry.loreValue)
+    ) {
+      entries.push({ ...priorEntry, loreValue: desired.loreValue });
+    } else {
+      entries.push(desired);
+    }
+    previousByPath.delete(desired.path);
+    for (const previousPath of previousByPath.keys()) {
+      if (previousPath.startsWith(`${desired.path}.`)) {
+        previousByPath.delete(previousPath);
+      }
+    }
+  }
+  entries.push(...previousByPath.values());
+
+  const pluginAdded = previous.pluginAdded || opts.pluginAdded;
+  return boundBackupDraft({
+    savedAt: previous.savedAt,
+    entries,
+    pluginAdded,
+    originalExists:
+      previous.version === 3
+        ? previous.originalExists
+        : (opts.originalExists ?? true),
+    createdAncestors:
+      previous.version === 3
+        ? [
+            ...new Set([
+              ...previous.createdAncestors,
+              ...captureCreatedAncestors(existing, desiredEntries),
+            ]),
+          ].sort()
+        : captureCreatedAncestors(existing, desiredEntries),
+    afterConfig,
+  });
 }
 
 export interface RestoreSummary {
@@ -154,9 +1035,25 @@ export interface RestoreSummary {
 export function readLegacyJsonBackup(
   config: Record<string, unknown>,
 ): JsonBackup | null {
-  const raw = config[LORE_BACKUP_KEY];
-  if (!isPlainObject(raw) || !Array.isArray(raw.entries)) return null;
-  return raw as unknown as JsonBackup;
+  try {
+    return requireLegacyJsonBackup(config);
+  } catch {
+    return null;
+  }
+}
+
+/** Strict legacy reader for setup/undo paths that may overwrite config. */
+export function requireLegacyJsonBackup(
+  config: Record<string, unknown>,
+): JsonBackup | null {
+  if (!Object.hasOwn(config, LORE_BACKUP_KEY)) return null;
+  try {
+    return parseJsonBackup(config[LORE_BACKUP_KEY]);
+  } catch (error) {
+    throw new Error("Invalid legacy Lore setup backup metadata.", {
+      cause: error,
+    });
+  }
 }
 
 /**
@@ -173,12 +1070,17 @@ export function applyJsonBackup(
   config: Record<string, unknown>,
   backup: JsonBackup,
 ): RestoreSummary {
+  parseJsonBackup(backup);
   const restored: string[] = [];
   const skipped: string[] = [];
 
   for (const entry of backup.entries) {
     const current = getPath(config, entry.path);
     if (!jsonEqual(current, entry.loreValue)) {
+      const alreadyRestored = entry.hadPrior
+        ? jsonEqual(current, entry.priorValue)
+        : current === undefined;
+      if (alreadyRestored) continue;
       // The user changed (or removed) this value after setup — leave it.
       skipped.push(entry.path);
       continue;
@@ -186,13 +1088,21 @@ export function applyJsonBackup(
     if (entry.hadPrior) {
       setPath(config, entry.path, entry.priorValue);
     } else {
-      deletePath(config, entry.path);
+      deleteLeaf(config, entry.path);
     }
     restored.push(entry.path);
   }
 
+  if (backup.version === 3) {
+    pruneCreatedAncestors(config, backup.createdAncestors);
+  }
+
   // OpenCode: drop the plugin lore appended (only if still present).
-  if (backup.pluginAdded && Array.isArray(config.plugin)) {
+  if (
+    backup.pluginAdded &&
+    !backup.entries.some((entry) => entry.path === "plugin") &&
+    Array.isArray(config.plugin)
+  ) {
     const arr = config.plugin as unknown[];
     const idx = arr.indexOf("@loreai/opencode");
     if (idx !== -1) {
@@ -203,6 +1113,41 @@ export function applyJsonBackup(
   }
 
   return { hadBackup: true, restored, skipped };
+}
+
+/** Keep only provenance that a partial restore still needs. */
+export function retainSkippedJsonBackup(
+  backup: JsonBackup,
+  skipped: string[],
+  currentConfig?: Record<string, unknown>,
+): JsonBackup | null {
+  parseJsonBackup(backup);
+  const skippedPaths = new Set(skipped);
+  const entries = backup.entries.filter((entry) =>
+    skippedPaths.has(entry.path),
+  );
+  if (entries.length === 0) return null;
+  if (backup.version === 1) {
+    return { version: 1, savedAt: backup.savedAt, entries };
+  }
+  if (!currentConfig) {
+    currentConfig = {};
+    for (const entry of entries) {
+      setPath(currentConfig, entry.path, cloneJson(entry.loreValue));
+    }
+  }
+  return boundBackupDraft({
+    savedAt: backup.savedAt,
+    entries,
+    originalExists: backup.originalExists,
+    createdAncestors: backup.createdAncestors.filter((ancestor) =>
+      entries.some(
+        (entry) =>
+          entry.path === ancestor || entry.path.startsWith(`${ancestor}.`),
+      ),
+    ),
+    afterConfig: currentConfig,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -217,6 +1162,99 @@ const TOML_UNSET = "(was unset)";
 // compares the current value against the lore-set value and only reverts when
 // they still match — mirroring the JSON "revert-only-if-unchanged" guarantee.
 const TOML_LORE_SET = " # lore-set ";
+const TOML_BACKUP_KEYS = new Set([
+  "openai_base_url",
+  "model_auto_compact_token_limit",
+]);
+
+interface TextBackupEntry {
+  key: string;
+  priorValue: string | null;
+  loreValue: string;
+}
+
+function stripBackupBlock(content: string, start: number, end: number): string {
+  const lines = content.split("\n");
+  return [...lines.slice(0, start), ...lines.slice(end + 1)].join("\n");
+}
+
+function readTomlBackupBlock(content: string): {
+  content: string;
+  entries: TextBackupEntry[];
+} | null {
+  const lines = content.split("\n");
+  const starts = lines.flatMap((line, index) =>
+    line.trim() === TOML_BACKUP_HEADER ? [index] : [],
+  );
+  if (starts.length === 0) {
+    if (lines.some((line) => line.trim() === TOML_BACKUP_FOOTER)) {
+      throw new Error("Invalid Codex Lore backup block.");
+    }
+    return null;
+  }
+  if (starts.length !== 1) throw new Error("Invalid Codex Lore backup block.");
+  const start = starts[0];
+  const end = lines.findIndex(
+    (line, index) => index > start && line.trim() === TOML_BACKUP_FOOTER,
+  );
+  if (
+    end === -1 ||
+    lines.some(
+      (line, index) => index !== end && line.trim() === TOML_BACKUP_FOOTER,
+    )
+  ) {
+    throw new Error("Invalid Codex Lore backup block.");
+  }
+
+  const entries: TextBackupEntry[] = [];
+  const seen = new Set<string>();
+  for (const raw of lines.slice(start + 1, end)) {
+    const body = raw.replace(/^#\s*/, "");
+    const sepIdx = body.lastIndexOf(TOML_LORE_SET);
+    if (!/^#\s+/.test(raw) || sepIdx === -1) {
+      throw new Error("Invalid Codex Lore backup entry.");
+    }
+    const priorPart = body.slice(0, sepIdx).trim();
+    const loreValue = body.slice(sepIdx + TOML_LORE_SET.length).trim();
+    let key: string;
+    let priorValue: string | null;
+    const eq = priorPart.indexOf("=");
+    if (eq > 0) {
+      key = priorPart.slice(0, eq).trim();
+      priorValue = priorPart.slice(eq + 1).trim();
+    } else if (priorPart.endsWith(TOML_UNSET)) {
+      key = priorPart.slice(0, -TOML_UNSET.length).trim();
+      priorValue = null;
+    } else {
+      throw new Error("Invalid Codex Lore backup entry.");
+    }
+    if (
+      !TOML_BACKUP_KEYS.has(key) ||
+      seen.has(key) ||
+      loreValue.length === 0 ||
+      (priorValue !== null && priorValue.length === 0)
+    ) {
+      throw new Error("Invalid Codex Lore backup entry.");
+    }
+    seen.add(key);
+    entries.push({ key, priorValue, loreValue });
+  }
+  if (entries.length === 0) throw new Error("Empty Codex Lore backup block.");
+  return { content: stripBackupBlock(content, start, end), entries };
+}
+
+function formatTomlBackupBlock(entries: TextBackupEntry[]): string {
+  const lines = [TOML_BACKUP_HEADER];
+  for (const entry of entries) {
+    const priorPart =
+      entry.priorValue === null
+        ? `${entry.key} ${TOML_UNSET}`
+        : `${entry.key} = ${entry.priorValue}`;
+    lines.push(`#   ${priorPart}${TOML_LORE_SET}${entry.loreValue}`);
+  }
+  lines.push(TOML_BACKUP_FOOTER);
+  return lines.join("\n");
+}
 
 /** Extract the raw value text of a top-level TOML key, or null if absent. */
 export function getTomlTopLevelValue(
@@ -288,6 +1326,35 @@ export function buildTomlBackupBlock(
   return lines.join("\n");
 }
 
+/** Prepare a backup block for a repeated Codex setup. */
+export function refreshTomlBackupBlock(
+  content: string,
+  loreValues: Record<string, string>,
+): { content: string; block: string } {
+  const previous = readTomlBackupBlock(content);
+  const config = previous?.content ?? content;
+  const previousByKey = new Map(
+    previous?.entries.map((entry) => [entry.key, entry]) ?? [],
+  );
+  const entries: TextBackupEntry[] = [];
+  for (const [key, loreValue] of Object.entries(loreValues)) {
+    if (!TOML_BACKUP_KEYS.has(key) || loreValue.length === 0) {
+      throw new Error(`Invalid Codex Lore backup key or value: ${key}`);
+    }
+    const old = previousByKey.get(key);
+    const current = getTomlTopLevelValue(config, key);
+    entries.push({
+      key,
+      priorValue: old && current === old.loreValue ? old.priorValue : current,
+      loreValue,
+    });
+    previousByKey.delete(key);
+  }
+  entries.push(...previousByKey.values());
+  if (entries.length === 0) throw new Error("Empty Codex Lore backup block.");
+  return { content: config, block: formatTomlBackupBlock(entries) };
+}
+
 /** Prepend a backup block to the content (block already includes no trailing newline). */
 export function prependTomlBackupBlock(content: string, block: string): string {
   return content ? `${block}\n${content}` : `${block}\n`;
@@ -305,19 +1372,8 @@ export function restoreTomlBackup(content: string): {
   content: string;
   summary: RestoreSummary;
 } {
-  const lines = content.split("\n");
-  const start = lines.findIndex((l) => l.trim() === TOML_BACKUP_HEADER);
-  if (start === -1) {
-    return {
-      content,
-      summary: { hadBackup: false, restored: [], skipped: [] },
-    };
-  }
-  let end = start;
-  while (end < lines.length && lines[end].trim() !== TOML_BACKUP_FOOTER) end++;
-  if (end >= lines.length) {
-    // Footer missing (block hand-edited/corrupted). Refuse to touch the file —
-    // otherwise we'd treat the entire remainder as the block and delete it.
+  const backup = readTomlBackupBlock(content);
+  if (!backup) {
     return {
       content,
       summary: { hadBackup: false, restored: [], skipped: [] },
@@ -326,34 +1382,15 @@ export function restoreTomlBackup(content: string): {
 
   const restored: string[] = [];
   const skipped: string[] = [];
-  const entryLines = lines.slice(start + 1, end);
-  // Restore against the FULL content — the block lines are comments, so they
-  // never match a top-level key pattern. The block is stripped afterwards, but
-  // only when nothing was skipped (see below).
-  let result = content;
+  const skippedEntries: TextBackupEntry[] = [];
+  let result = backup.content;
 
-  for (const raw of entryLines) {
-    const body = raw.replace(/^#\s*/, "");
-    const sepIdx = body.indexOf(TOML_LORE_SET);
-    if (sepIdx === -1) continue; // not a recognized entry line
-    const priorPart = body.slice(0, sepIdx).trim();
-    const loreValue = body.slice(sepIdx + TOML_LORE_SET.length).trim();
-
-    let key: string;
-    let priorValue: string | null;
-    if (priorPart.endsWith(TOML_UNSET)) {
-      key = priorPart.slice(0, -TOML_UNSET.length).trim();
-      priorValue = null; // was unset → undo should delete it
-    } else {
-      const eq = priorPart.indexOf("=");
-      if (eq <= 0) continue;
-      key = priorPart.slice(0, eq).trim();
-      priorValue = priorPart.slice(eq + 1).trim();
-    }
-
+  for (const entry of backup.entries) {
+    const { key, loreValue, priorValue } = entry;
     // Revert-only-if-unchanged: skip if the user changed the value after setup.
     if (getTomlTopLevelValue(result, key) !== loreValue) {
       skipped.push(key);
+      skippedEntries.push(entry);
       continue;
     }
     result =
@@ -363,15 +1400,11 @@ export function restoreTomlBackup(content: string): {
     restored.push(key);
   }
 
-  // Strip the backup block only when everything was reverted. If some keys were
-  // skipped (the user changed them), keep the block so their original values
-  // remain recoverable — never silently drop that metadata.
-  if (skipped.length === 0) {
-    const out = result.split("\n");
-    const s = out.findIndex((l) => l.trim() === TOML_BACKUP_HEADER);
-    let e = s;
-    while (e < out.length && out[e].trim() !== TOML_BACKUP_FOOTER) e++;
-    result = [...out.slice(0, s), ...out.slice(e + 1)].join("\n");
+  if (skippedEntries.length > 0) {
+    result = prependTomlBackupBlock(
+      result,
+      formatTomlBackupBlock(skippedEntries),
+    );
   }
 
   return {
@@ -432,6 +1465,84 @@ const ENV_BACKUP_HEADER =
 const ENV_BACKUP_FOOTER = "# end lore setup backup";
 const ENV_UNSET = "(was unset)";
 const ENV_LORE_SET = " # lore-set ";
+const ENV_BACKUP_KEYS = new Set([
+  "OPENAI_BASE_URL",
+  "HERMES_INFERENCE_PROVIDER",
+  "GOOGLE_GEMINI_BASE_URL",
+]);
+
+function readEnvBackupBlock(content: string): {
+  content: string;
+  entries: TextBackupEntry[];
+} | null {
+  const lines = content.split("\n");
+  const starts = lines.flatMap((line, index) =>
+    line.trim() === ENV_BACKUP_HEADER ? [index] : [],
+  );
+  if (starts.length === 0) {
+    if (lines.some((line) => line.trim() === ENV_BACKUP_FOOTER)) {
+      throw new Error("Invalid Lore env backup block.");
+    }
+    return null;
+  }
+  if (starts.length !== 1) throw new Error("Invalid Lore env backup block.");
+  const start = starts[0];
+  const end = lines.findIndex(
+    (line, index) => index > start && line.trim() === ENV_BACKUP_FOOTER,
+  );
+  if (
+    end === -1 ||
+    lines.some(
+      (line, index) => index !== end && line.trim() === ENV_BACKUP_FOOTER,
+    )
+  ) {
+    throw new Error("Invalid Lore env backup block.");
+  }
+
+  const entries: TextBackupEntry[] = [];
+  const seen = new Set<string>();
+  for (const raw of lines.slice(start + 1, end)) {
+    const body = raw.replace(/^#\s*/, "");
+    const sepIdx = body.lastIndexOf(ENV_LORE_SET);
+    if (!/^#\s+/.test(raw) || sepIdx === -1) {
+      throw new Error("Invalid Lore env backup entry.");
+    }
+    const priorPart = body.slice(0, sepIdx).trim();
+    const loreValue = body.slice(sepIdx + ENV_LORE_SET.length).trim();
+    let key: string;
+    let priorValue: string | null;
+    const eq = priorPart.indexOf("=");
+    if (eq > 0) {
+      key = priorPart.slice(0, eq).trim();
+      priorValue = priorPart.slice(eq + 1).trim();
+    } else if (priorPart.endsWith(ENV_UNSET)) {
+      key = priorPart.slice(0, -ENV_UNSET.length).trim();
+      priorValue = null;
+    } else {
+      throw new Error("Invalid Lore env backup entry.");
+    }
+    if (!ENV_BACKUP_KEYS.has(key) || seen.has(key) || loreValue.length === 0) {
+      throw new Error("Invalid Lore env backup entry.");
+    }
+    seen.add(key);
+    entries.push({ key, priorValue, loreValue });
+  }
+  if (entries.length === 0) throw new Error("Empty Lore env backup block.");
+  return { content: stripBackupBlock(content, start, end), entries };
+}
+
+function formatEnvBackupBlock(entries: TextBackupEntry[]): string {
+  const lines = [ENV_BACKUP_HEADER];
+  for (const entry of entries) {
+    const priorPart =
+      entry.priorValue === null
+        ? `${entry.key} ${ENV_UNSET}`
+        : `${entry.key}=${entry.priorValue}`;
+    lines.push(`#   ${priorPart}${ENV_LORE_SET}${entry.loreValue}`);
+  }
+  lines.push(ENV_BACKUP_FOOTER);
+  return lines.join("\n");
+}
 
 /** Match `KEY=`, `KEY =`, or `export KEY=` (dotenv-style), capturing nothing. */
 function envAssignPattern(key: string): RegExp {
@@ -451,20 +1562,21 @@ function envJoin(lines: string[]): string {
   return lines.length ? `${lines.join("\n")}\n` : "";
 }
 
-/** Read a dotenv key's raw value (trimmed), or null if absent/commented. */
+/** Read the effective final live dotenv value, or null if absent. */
 export function getEnvValue(content: string, key: string): string | null {
   const valuePattern = new RegExp(
     `^\\s*(?:export\\s+)?${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=\\s*(.*?)\\s*$`,
   );
+  let value: string | null = null;
   for (const line of envLines(content)) {
     if (/^\s*#/.test(line)) continue;
     const m = valuePattern.exec(line);
-    if (m) return m[1];
+    if (m) value = m[1];
   }
-  return null;
+  return value;
 }
 
-/** Upsert `KEY=value` (replaces the first live occurrence, else appends). */
+/** Upsert one canonical `KEY=value`, removing shadowing live duplicates. */
 export function setEnvValueRaw(
   content: string,
   key: string,
@@ -472,15 +1584,20 @@ export function setEnvValueRaw(
 ): string {
   const lines = envLines(content);
   const pattern = envAssignPattern(key);
-  for (let i = 0; i < lines.length; i++) {
-    if (/^\s*#/.test(lines[i])) continue;
-    if (pattern.test(lines[i])) {
-      lines[i] = `${key}=${value}`;
-      return envJoin(lines);
+  const out: string[] = [];
+  let replaced = false;
+  for (const line of lines) {
+    if (!/^\s*#/.test(line) && pattern.test(line)) {
+      if (!replaced) {
+        out.push(`${key}=${value}`);
+        replaced = true;
+      }
+      continue;
     }
+    out.push(line);
   }
-  lines.push(`${key}=${value}`);
-  return envJoin(lines);
+  if (!replaced) out.push(`${key}=${value}`);
+  return envJoin(out);
 }
 
 /** Delete every live (non-comment) assignment of `key`. */
@@ -515,6 +1632,35 @@ export function buildEnvBackupBlock(
   return lines.join("\n");
 }
 
+/** Refresh a Hermes/Gemini backup block for another setup write. */
+export function refreshEnvBackupBlock(
+  content: string,
+  loreValues: Record<string, string>,
+): { content: string; block: string } {
+  const previous = readEnvBackupBlock(content);
+  const config = previous?.content ?? content;
+  const previousByKey = new Map(
+    previous?.entries.map((entry) => [entry.key, entry]) ?? [],
+  );
+  const entries: TextBackupEntry[] = [];
+  for (const [key, loreValue] of Object.entries(loreValues)) {
+    if (!ENV_BACKUP_KEYS.has(key) || loreValue.length === 0) {
+      throw new Error(`Invalid Lore env backup key or value: ${key}`);
+    }
+    const old = previousByKey.get(key);
+    const current = getEnvValue(config, key);
+    entries.push({
+      key,
+      priorValue: old && current === old.loreValue ? old.priorValue : current,
+      loreValue,
+    });
+    previousByKey.delete(key);
+  }
+  entries.push(...previousByKey.values());
+  if (entries.length === 0) throw new Error("Empty Lore env backup block.");
+  return { content: config, block: formatEnvBackupBlock(entries) };
+}
+
 /** Prepend a backup block to the content (block carries no trailing newline). */
 export function prependEnvBackupBlock(content: string, block: string): string {
   return content ? `${block}\n${content}` : `${block}\n`;
@@ -531,18 +1677,8 @@ export function restoreEnvBackup(content: string): {
   content: string;
   summary: RestoreSummary;
 } {
-  const lines = content.split("\n");
-  const start = lines.findIndex((l) => l.trim() === ENV_BACKUP_HEADER);
-  if (start === -1) {
-    return {
-      content,
-      summary: { hadBackup: false, restored: [], skipped: [] },
-    };
-  }
-  let end = start;
-  while (end < lines.length && lines[end].trim() !== ENV_BACKUP_FOOTER) end++;
-  if (end >= lines.length) {
-    // Footer missing (block hand-edited/corrupted). Refuse to touch the file.
+  const backup = readEnvBackupBlock(content);
+  if (!backup) {
     return {
       content,
       summary: { hadBackup: false, restored: [], skipped: [] },
@@ -551,31 +1687,15 @@ export function restoreEnvBackup(content: string): {
 
   const restored: string[] = [];
   const skipped: string[] = [];
-  const entryLines = lines.slice(start + 1, end);
-  let result = content;
+  const skippedEntries: TextBackupEntry[] = [];
+  let result = backup.content;
 
-  for (const raw of entryLines) {
-    const body = raw.replace(/^#\s*/, "");
-    const sepIdx = body.indexOf(ENV_LORE_SET);
-    if (sepIdx === -1) continue; // not a recognized entry line
-    const priorPart = body.slice(0, sepIdx).trim();
-    const loreValue = body.slice(sepIdx + ENV_LORE_SET.length).trim();
-
-    let key: string;
-    let priorValue: string | null;
-    if (priorPart.endsWith(ENV_UNSET)) {
-      key = priorPart.slice(0, -ENV_UNSET.length).trim();
-      priorValue = null; // was unset → undo should delete it
-    } else {
-      const eq = priorPart.indexOf("=");
-      if (eq <= 0) continue;
-      key = priorPart.slice(0, eq).trim();
-      priorValue = priorPart.slice(eq + 1).trim();
-    }
-
+  for (const entry of backup.entries) {
+    const { key, loreValue, priorValue } = entry;
     // Revert-only-if-unchanged: skip if the user changed the value after setup.
     if (getEnvValue(result, key) !== loreValue) {
       skipped.push(key);
+      skippedEntries.push(entry);
       continue;
     }
     result =
@@ -585,13 +1705,11 @@ export function restoreEnvBackup(content: string): {
     restored.push(key);
   }
 
-  // Strip the backup block only when everything was reverted.
-  if (skipped.length === 0) {
-    const out = result.split("\n");
-    const s = out.findIndex((l) => l.trim() === ENV_BACKUP_HEADER);
-    let e = s;
-    while (e < out.length && out[e].trim() !== ENV_BACKUP_FOOTER) e++;
-    result = [...out.slice(0, s), ...out.slice(e + 1)].join("\n");
+  if (skippedEntries.length > 0) {
+    result = prependEnvBackupBlock(
+      result,
+      formatEnvBackupBlock(skippedEntries),
+    );
   }
 
   return { content: result, summary: { hadBackup: true, restored, skipped } };

--- a/packages/gateway/src/cli/setup.ts
+++ b/packages/gateway/src/cli/setup.ts
@@ -13,34 +13,62 @@
  * The command auto-detects installed apps when no argument is given,
  * or accepts an explicit app name (e.g. `lore setup codex`).
  */
-import { execFileSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { dirname, join } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { lstatSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { homedir } from "node:os";
-import { CLAUDE_CODE_FIRST_PARTY_ENV } from "../cch";
-import { readPortFile } from "../portfile";
-import { detectAgents } from "./agents";
-import { probeGateway } from "./start";
 import {
-  captureJsonBackup,
+  assertNoSymlinkPathComponents,
+  atomicWriteTrustedFile,
+  CommittedAtomicWriteError,
+  deleteJsonConfigValue,
+  ensureTrustedDirectory,
+  opencodeConfigPaths,
+  parseJsonConfigText,
+  readJsonConfigFile,
+  readJsonConfigFileIfExists,
+  readTrustedTextFile,
+  removeTrustedFile,
+  resolveOpencodeConfigPath,
+  setJsonConfigValue,
+  stageTrustedFileMutation,
+  trustedFileExists,
+  withTrustedFileTransaction,
+  type StagedTrustedFileMutation,
+  type TrustedFileIdentity,
+  type TrustedFileTransaction,
+} from "./json-config";
+import { CLAUDE_CODE_FIRST_PARTY_ENV } from "../cch";
+import {
+  LifecycleLockLostError,
+  withLifecycleLock,
+  type LifecycleLock,
+} from "../lifecycle-lock";
+import { readGatewayProcessFile } from "../pidfile";
+import { detectAgents } from "./agents";
+import {
+  refreshJsonBackup,
+  parseStableJsonBackup,
+  parseJsonSetupJournal,
+  prepareJsonSetupJournal,
+  selectJsonSetupJournalState,
   applyJsonBackup,
-  readLegacyJsonBackup,
+  requireLegacyJsonBackup,
   LORE_BACKUP_KEY,
-  buildTomlBackupBlock,
+  refreshTomlBackupBlock,
   prependTomlBackupBlock,
   restoreTomlBackup,
-  buildEnvBackupBlock,
+  refreshEnvBackupBlock,
   prependEnvBackupBlock,
   restoreEnvBackup,
   setEnvValueRaw,
+  retainSkippedJsonBackup,
+  bindJsonBackupGeneration,
+  assertJsonBackupConfigState,
+  getPath,
   type RestoreSummary,
   type JsonBackup,
+  type JsonSetupJournal,
 } from "./setup-backup";
 
 // ---------------------------------------------------------------------------
@@ -62,17 +90,149 @@ interface PluginSpec {
   apply: (config: Record<string, unknown>) => boolean;
 }
 
+class PluginInstallFailure extends Error {}
+
+type SetupGuard = LifecycleLock;
+
+interface SetupExternalEffect {
+  apply: (guard: LifecycleLock) => boolean;
+  prepareCommit: (guard: LifecycleLock) => void;
+  establishCommitPoint: (guard: LifecycleLock) => boolean;
+  commit: (guard: LifecycleLock) => void;
+  rollback: (guard: LifecycleLock) => void;
+}
+
+class PublishedSetupCommitError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
+class SetupExternalTransaction {
+  private readonly effects: SetupExternalEffect[] = [];
+  private readonly commitReports: Array<() => void> = [];
+  private active = true;
+  private durableCommitPoint = false;
+
+  constructor(private readonly guard: LifecycleLock) {}
+
+  apply(effect: SetupExternalEffect): boolean {
+    if (!this.active) throw new Error("Setup external transaction is closed.");
+    this.effects.push(effect);
+    return effect.apply(this.guard);
+  }
+
+  onCommit(report: () => void): void {
+    if (!this.active) throw new Error("Setup external transaction is closed.");
+    this.commitReports.push(report);
+  }
+
+  prepareCommit(): void {
+    if (!this.active) return;
+    for (const effect of this.effects) {
+      this.guard.assertOwned();
+      effect.prepareCommit(this.guard);
+    }
+  }
+
+  establishCommitPoint(): void {
+    if (!this.active) return;
+    for (const effect of this.effects) {
+      this.guard.assertOwned();
+      try {
+        if (effect.establishCommitPoint(this.guard)) {
+          this.durableCommitPoint = true;
+        }
+      } catch (error) {
+        if (error instanceof PublishedSetupCommitError) {
+          this.durableCommitPoint = true;
+        }
+        throw error;
+      }
+    }
+  }
+
+  hasDurableCommitPoint(): boolean {
+    return this.durableCommitPoint;
+  }
+
+  commit(): void {
+    if (!this.active) return;
+    for (const effect of this.effects) {
+      this.guard.assertOwned();
+      effect.commit(this.guard);
+    }
+    this.active = false;
+    for (const report of this.commitReports) report();
+  }
+
+  rollback(): void {
+    if (!this.active) return;
+    if (this.durableCommitPoint) {
+      throw new Error(
+        "Setup external transaction crossed its durable commit point and cannot be rolled back.",
+      );
+    }
+    const rollbackErrors: unknown[] = [];
+    for (const effect of [...this.effects].reverse()) {
+      try {
+        this.guard.assertOwned();
+        effect.rollback(this.guard);
+      } catch (error) {
+        rollbackErrors.push(error);
+      }
+    }
+    this.active = false;
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        rollbackErrors,
+        "Setup external side effects could not be fully rolled back.",
+      );
+    }
+  }
+
+  abandon(): void {
+    this.active = false;
+  }
+}
+
+type SetupExternalEffectTestPhase =
+  | "after-installed-journal"
+  | "before-prepare"
+  | "before-install-mutation"
+  | "before-rollback-mutation"
+  | "before-journal-cleanup";
+let setupExternalEffectHook:
+  | ((phase: SetupExternalEffectTestPhase) => void)
+  | null = null;
+
+/** Test-only interruption/failure injection around external-effect commit. */
+export function _setSetupExternalEffectHookForTest(
+  hook: ((phase: SetupExternalEffectTestPhase) => void) | null,
+): void {
+  setupExternalEffectHook = hook;
+}
+
 interface AppSetup {
   /** Internal identifier matching AgentDef.name */
   agentName: string;
   /** Human-readable name */
   displayName: string;
-  /** Run the setup for this app. `noPlugin` is true when the user passed --no-plugin. */
-  run: (baseUrl: string, noPlugin: boolean) => void;
+  /** Run setup. Returns false only when setup stops without succeeding. */
+  run: (
+    baseUrl: string,
+    noPlugin: boolean,
+    guard: SetupGuard,
+    external: SetupExternalTransaction,
+  ) => boolean | void;
   /** Optional plugin install + registration */
   plugin?: PluginSpec;
+  /** Validate every file/backup this undo may read without mutating anything. */
+  prevalidateUndo: (stagedPaths?: readonly string[]) => void;
+  /** Every persistent file this app's setup or undo may mutate. */
+  undoPaths: () => string[];
   /** Undo a previous `lore setup` for this app, restoring the saved backup. */
-  undo: () => RestoreSummary;
+  undo: (guard: SetupGuard, stagedPaths?: readonly string[]) => RestoreSummary;
 }
 
 /**
@@ -102,7 +262,9 @@ const SUPPORTED_APPS: AppSetup[] = [
   {
     agentName: "codex",
     displayName: "Codex",
-    run: (baseUrl) => setupCodex(baseUrl),
+    run: (baseUrl, _noPlugin, guard) => setupCodex(baseUrl, guard),
+    prevalidateUndo: prevalidateCodexUndo,
+    undoPaths: () => [codexConfigPath()],
     undo: undoCodex,
     // No Lore plugin for Codex — the gateway URL + DISABLE_AUTO_COMPACT in
     // the TOML is the full integration. There's no plugin host in Codex.
@@ -110,14 +272,31 @@ const SUPPORTED_APPS: AppSetup[] = [
   {
     agentName: "opencode",
     displayName: "OpenCode",
-    run: (baseUrl, noPlugin) => setupOpencode(baseUrl, noPlugin),
+    run: (baseUrl, noPlugin, guard, external) =>
+      setupOpencode(baseUrl, noPlugin, guard, external),
     plugin: opencodePluginSpec,
-    undo: undoOpencode,
+    prevalidateUndo: (paths) =>
+      prevalidateOpencodeUndo(paths?.filter((_path, index) => index % 2 === 0)),
+    undoPaths: () =>
+      opencodeConfigPaths(opencodeConfigPath()).flatMap((path) => [
+        path,
+        jsonBackupPath(path),
+      ]),
+    undo: (guard, paths) =>
+      undoOpencode(
+        guard,
+        paths?.filter((_path, index) => index % 2 === 0),
+      ),
   },
   {
     agentName: "claude-code",
     displayName: "Claude Code",
-    run: (baseUrl) => setupClaudeCode(baseUrl),
+    run: (baseUrl, _noPlugin, guard) => setupClaudeCode(baseUrl, guard),
+    prevalidateUndo: () => prevalidateJsonUndo(claudeCodeSettingsPath()),
+    undoPaths: () => [
+      claudeCodeSettingsPath(),
+      jsonBackupPath(claudeCodeSettingsPath()),
+    ],
     undo: undoClaudeCode,
     // No Lore plugin for Claude Code — Anthropic controls the API surface
     // and there's no plugin host. The ANTHROPIC_BASE_URL env var is the
@@ -126,7 +305,9 @@ const SUPPORTED_APPS: AppSetup[] = [
   {
     agentName: "hermes",
     displayName: "Hermes Agent",
-    run: (baseUrl) => setupHermes(baseUrl),
+    run: (baseUrl, _noPlugin, guard) => setupHermes(baseUrl, guard),
+    prevalidateUndo: prevalidateHermesUndo,
+    undoPaths: () => [hermesEnvPath()],
     undo: undoHermes,
     // No Lore plugin registered here — Hermes reads `OPENAI_BASE_URL` +
     // `HERMES_INFERENCE_PROVIDER` from `~/.hermes/.env` (python-dotenv) at
@@ -136,7 +317,12 @@ const SUPPORTED_APPS: AppSetup[] = [
   {
     agentName: "pi",
     displayName: "Pi",
-    run: (baseUrl) => setupPi(baseUrl),
+    run: (baseUrl, _noPlugin, guard) => setupPi(baseUrl, guard),
+    prevalidateUndo: () => prevalidateJsonUndo(piModelsConfigPath()),
+    undoPaths: () => [
+      piModelsConfigPath(),
+      jsonBackupPath(piModelsConfigPath()),
+    ],
     undo: undoPi,
     // The `@loreai/pi` extension is the richer path (dynamic per-provider
     // routing + attribution headers), but it's installed via Pi's own
@@ -148,7 +334,9 @@ const SUPPORTED_APPS: AppSetup[] = [
   {
     agentName: "copilot",
     displayName: "GitHub Copilot CLI",
-    run: (baseUrl) => setupCopilot(baseUrl),
+    run: (baseUrl, _noPlugin, guard) => setupCopilot(baseUrl, guard),
+    prevalidateUndo: () => {},
+    undoPaths: () => [],
     undo: undoCopilot,
     // Copilot CLI has NO config-file endpoint override — interception is only
     // via the COPILOT_API_URL env var. `run` prints the required `lore run
@@ -158,7 +346,9 @@ const SUPPORTED_APPS: AppSetup[] = [
   {
     agentName: "gemini",
     displayName: "Gemini CLI",
-    run: (baseUrl) => setupGemini(baseUrl),
+    run: (baseUrl, _noPlugin, guard) => setupGemini(baseUrl, guard),
+    prevalidateUndo: prevalidateGeminiUndo,
+    undoPaths: () => [geminiEnvPath()],
     undo: undoGemini,
     // Gemini CLI reads GOOGLE_GEMINI_BASE_URL from ~/.gemini/.env (dotenv), so
     // this persists the base URL there — the native generateContent equivalent
@@ -170,39 +360,184 @@ const SUPPORTED_APPS: AppSetup[] = [
 // Plugin install + registration
 // ---------------------------------------------------------------------------
 
-/**
- * Check whether an npm package is already installed globally.
- * Uses `npm ls -g --json` and looks for the package in the dependency tree.
- * Returns true if installed at any version, false otherwise.
- */
-function isNpmPackageInstalled(npmPackage: string): boolean {
+interface NpmPackageGeneration {
+  path: string;
+  device: string;
+  inode: string;
+  mode: string;
+  uid: string;
+  gid: string;
+  size: string;
+  mtimeNs: string;
+  ctimeNs: string;
+  birthtimeNs: string;
+  manifestDevice: string;
+  manifestInode: string;
+  manifestMode: string;
+  manifestUid: string;
+  manifestGid: string;
+  manifestSize: string;
+  manifestMtimeNs: string;
+  manifestCtimeNs: string;
+  manifestBirthtimeNs: string;
+}
+
+type NpmPackageSnapshot =
+  | { state: "absent" }
+  | {
+      state: "installed";
+      version: string | null;
+      source: string | null;
+      generation: NpmPackageGeneration;
+    }
+  | { state: "unknown" };
+
+type KnownNpmPackageSnapshot = Exclude<
+  NpmPackageSnapshot,
+  { state: "unknown" }
+>;
+
+function inspectPackageGeneration(path: string): NpmPackageGeneration | null {
   try {
-    const out = execFileSync(
-      "npm",
-      ["ls", "-g", npmPackage, "--json", "--depth=0"],
-      {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      },
-    );
-    const parsed = JSON.parse(out) as {
-      dependencies?: Record<string, unknown>;
+    const stats = lstatSync(path, { bigint: true });
+    const manifest = lstatSync(join(path, "package.json"), { bigint: true });
+    if (!manifest.isFile() || manifest.isSymbolicLink()) return null;
+    return {
+      path,
+      device: stats.dev.toString(),
+      inode: stats.ino.toString(),
+      mode: stats.mode.toString(),
+      uid: stats.uid.toString(),
+      gid: stats.gid.toString(),
+      size: stats.size.toString(),
+      mtimeNs: stats.mtimeNs.toString(),
+      ctimeNs: stats.ctimeNs.toString(),
+      birthtimeNs: stats.birthtimeNs.toString(),
+      manifestDevice: manifest.dev.toString(),
+      manifestInode: manifest.ino.toString(),
+      manifestMode: manifest.mode.toString(),
+      manifestUid: manifest.uid.toString(),
+      manifestGid: manifest.gid.toString(),
+      manifestSize: manifest.size.toString(),
+      manifestMtimeNs: manifest.mtimeNs.toString(),
+      manifestCtimeNs: manifest.ctimeNs.toString(),
+      manifestBirthtimeNs: manifest.birthtimeNs.toString(),
     };
-    return Boolean(parsed.dependencies?.[npmPackage]);
   } catch {
-    // `npm ls` exits non-zero when the package isn't found. That's the
-    // common case here, so we treat any error as "not installed."
-    return false;
+    return null;
   }
+}
+
+function npmGlobalRoot(): string | null {
+  const result = spawnSync("npm", ["root", "-g"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.error || result.status !== 0) return null;
+  const root = result.stdout.trim();
+  return root && isAbsolute(root) ? resolve(root) : null;
+}
+
+function npmPackagePath(
+  npmPackage: string,
+  record: Record<string, unknown>,
+): string | null {
+  if (typeof record.path === "string" && isAbsolute(record.path)) {
+    return resolve(record.path);
+  }
+  const root = npmGlobalRoot();
+  if (!root) return null;
+  return resolve(root, ...npmPackage.split("/"));
+}
+
+/** Capture enough global npm state to restore a package without guessing. */
+function inspectNpmPackage(npmPackage: string): NpmPackageSnapshot {
+  const result = spawnSync(
+    "npm",
+    ["ls", "-g", npmPackage, "--json", "--depth=0", "--long"],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+  if (result.error || result.status === null) return { state: "unknown" };
+  try {
+    const parsed = JSON.parse(result.stdout) as {
+      dependencies?: Record<string, unknown>;
+      error?: unknown;
+    };
+    if (parsed.error !== undefined) return { state: "unknown" };
+    if (parsed.dependencies !== undefined) {
+      if (
+        typeof parsed.dependencies !== "object" ||
+        parsed.dependencies === null ||
+        Array.isArray(parsed.dependencies)
+      ) {
+        return { state: "unknown" };
+      }
+      if (Object.hasOwn(parsed.dependencies, npmPackage)) {
+        const dependency = parsed.dependencies[npmPackage];
+        const record =
+          typeof dependency === "object" &&
+          dependency !== null &&
+          !Array.isArray(dependency)
+            ? (dependency as Record<string, unknown>)
+            : {};
+        const version =
+          typeof record.version === "string" ? record.version : null;
+        let source: string | null = null;
+        for (const key of ["resolved", "_resolved", "from", "_from"]) {
+          if (typeof record[key] === "string") {
+            source = record[key];
+            break;
+          }
+        }
+        const packagePath = npmPackagePath(npmPackage, record);
+        const generation = packagePath
+          ? inspectPackageGeneration(packagePath)
+          : null;
+        return generation
+          ? { state: "installed", version, source, generation }
+          : { state: "unknown" };
+      }
+    }
+    return result.status === 0 || result.status === 1
+      ? { state: "absent" }
+      : { state: "unknown" };
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+function sameNpmPackageSnapshot(
+  left: KnownNpmPackageSnapshot,
+  right: KnownNpmPackageSnapshot,
+): boolean {
+  if (left.state !== right.state) return false;
+  if (left.state === "absent" || right.state === "absent") return true;
+  return (
+    left.version === right.version &&
+    left.source === right.source &&
+    Object.keys(left.generation).every(
+      (key) =>
+        left.generation[key as keyof NpmPackageGeneration] ===
+        right.generation[key as keyof NpmPackageGeneration],
+    )
+  );
 }
 
 /**
  * Run `npm install -g <package>` and stream stdout/stderr to the user.
  * Returns true on success, false on failure (with a helpful error message
- * already printed). Never throws.
+ * already printed). A pre-mutation validator may throw before npm starts.
  */
-function runNpmInstall(npmPackage: string): boolean {
-  console.log(`[lore] Running: npm install -g ${npmPackage}`);
+function runNpmInstall(
+  npmPackage: string,
+  display = npmPackage,
+  immediatelyBeforeMutation?: () => void,
+): boolean {
+  console.log(`[lore] Running: npm install -g ${display}`);
+  immediatelyBeforeMutation?.();
   try {
     execFileSync("npm", ["install", "-g", npmPackage], {
       stdio: "inherit",
@@ -225,24 +560,630 @@ function runNpmInstall(npmPackage: string): boolean {
   }
 }
 
+function runNpmUninstall(
+  npmPackage: string,
+  immediatelyBeforeMutation?: () => void,
+): boolean {
+  console.log(`[lore] Running: npm uninstall -g ${npmPackage}`);
+  immediatelyBeforeMutation?.();
+  try {
+    execFileSync("npm", ["uninstall", "-g", npmPackage], {
+      stdio: "inherit",
+    });
+    return true;
+  } catch {
+    console.error(
+      `[lore] npm uninstall failed while rolling back ${npmPackage}.`,
+    );
+    return false;
+  }
+}
+
+const SETUP_EXTERNAL_EFFECT_JOURNAL = "setup-external-effect.json";
+
+interface NpmExternalEffectJournal {
+  version: 1;
+  ownerToken: string;
+  npmPackage: string;
+  phase: "prepared" | "installed" | "commit-prepared" | "committed";
+  priorState: KnownNpmPackageSnapshot;
+  installedState?: KnownNpmPackageSnapshot;
+}
+
+interface NpmExternalEffectJournalFile {
+  journal: NpmExternalEffectJournal;
+  identity: TrustedFileIdentity;
+}
+
+export function setupExternalEffectJournalPath(lockPath: string): string {
+  return join(dirname(lockPath), SETUP_EXTERNAL_EFFECT_JOURNAL);
+}
+
+function parsePackageGeneration(value: unknown): NpmPackageGeneration {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Invalid setup external-effect package generation.");
+  }
+  const record = value as Record<string, unknown>;
+  const fields: Array<keyof NpmPackageGeneration> = [
+    "path",
+    "device",
+    "inode",
+    "mode",
+    "uid",
+    "gid",
+    "size",
+    "mtimeNs",
+    "ctimeNs",
+    "birthtimeNs",
+    "manifestDevice",
+    "manifestInode",
+    "manifestMode",
+    "manifestUid",
+    "manifestGid",
+    "manifestSize",
+    "manifestMtimeNs",
+    "manifestCtimeNs",
+    "manifestBirthtimeNs",
+  ];
+  for (const field of fields) {
+    if (typeof record[field] !== "string" || record[field].length === 0) {
+      throw new Error("Invalid setup external-effect package generation.");
+    }
+  }
+  if (!isAbsolute(record.path as string)) {
+    throw new Error("Invalid setup external-effect package path.");
+  }
+  return Object.fromEntries(
+    fields.map((field) => [field, record[field]]),
+  ) as unknown as NpmPackageGeneration;
+}
+
+function parseKnownNpmPackageSnapshot(value: unknown): KnownNpmPackageSnapshot {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Invalid setup external-effect package state.");
+  }
+  const record = value as Record<string, unknown>;
+  if (record.state === "absent") return { state: "absent" };
+  if (
+    record.state !== "installed" ||
+    (record.version !== null && typeof record.version !== "string") ||
+    (record.source !== null && typeof record.source !== "string")
+  ) {
+    throw new Error("Invalid setup external-effect package state.");
+  }
+  return {
+    state: "installed",
+    version: record.version,
+    source: record.source,
+    generation: parsePackageGeneration(record.generation),
+  };
+}
+
+function parseNpmExternalEffectJournal(
+  value: unknown,
+): NpmExternalEffectJournal {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Invalid setup external-effect journal.");
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.version !== 1 ||
+    typeof record.ownerToken !== "string" ||
+    record.ownerToken.length === 0 ||
+    record.npmPackage !== opencodePluginSpec.npmPackage ||
+    !["prepared", "installed", "commit-prepared", "committed"].includes(
+      record.phase as string,
+    )
+  ) {
+    throw new Error("Invalid setup external-effect journal.");
+  }
+  const phase = record.phase as NpmExternalEffectJournal["phase"];
+  const installedState =
+    record.installedState === undefined
+      ? undefined
+      : parseKnownNpmPackageSnapshot(record.installedState);
+  if (phase !== "prepared" && !installedState) {
+    throw new Error("Invalid setup external-effect journal.");
+  }
+  return {
+    version: 1,
+    ownerToken: record.ownerToken,
+    npmPackage: opencodePluginSpec.npmPackage,
+    phase,
+    priorState: parseKnownNpmPackageSnapshot(record.priorState),
+    installedState,
+  };
+}
+
+function readNpmExternalEffectJournal(
+  guard: LifecycleLock,
+): NpmExternalEffectJournalFile | null {
+  const path = setupExternalEffectJournalPath(guard.path);
+  const file = readTrustedTextFile(path, { allowMissing: true });
+  if (!file) return null;
+  try {
+    return {
+      journal: parseNpmExternalEffectJournal(JSON.parse(file.text) as unknown),
+      identity: file.identity,
+    };
+  } catch (error) {
+    throw new Error(
+      `Invalid setup external-effect journal ${path}; it was preserved.`,
+      { cause: error },
+    );
+  }
+}
+
+function writeNpmExternalEffectJournal(
+  guard: LifecycleLock,
+  journal: NpmExternalEffectJournal,
+  expectedIdentity: TrustedFileIdentity | null,
+): TrustedFileIdentity {
+  guard.assertOwned();
+  return atomicWriteTrustedFile(
+    setupExternalEffectJournalPath(guard.path),
+    `${JSON.stringify(journal, null, 2)}\n`,
+    { expectedIdentity, mode: 0o600 },
+  );
+}
+
+function removeNpmExternalEffectJournal(
+  guard: LifecycleLock,
+  identity: TrustedFileIdentity,
+): void {
+  guard.assertOwned();
+  removeTrustedFile(setupExternalEffectJournalPath(guard.path), identity);
+}
+
+function sameNpmPackageMetadata(
+  left: KnownNpmPackageSnapshot,
+  right: KnownNpmPackageSnapshot,
+): boolean {
+  if (left.state !== right.state) return false;
+  if (left.state === "absent" || right.state === "absent") return true;
+  return left.version === right.version && left.source === right.source;
+}
+
+function sameTrustedFileIdentity(
+  left: TrustedFileIdentity,
+  right: TrustedFileIdentity,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.birthtimeNs === right.birthtimeNs
+  );
+}
+
+function externalEffectConflict(message: string): Error {
+  process.exitCode = 1;
+  console.error(`[lore] ${message}`);
+  return new Error(message);
+}
+
+function restoreOwnedNpmPackageState(
+  npmPackage: string,
+  priorState: KnownNpmPackageSnapshot,
+  ownedState: KnownNpmPackageSnapshot,
+  guard: LifecycleLock,
+): void {
+  const assertStillOwned = (): void => {
+    setupExternalEffectHook?.("before-rollback-mutation");
+    guard.assertOwned();
+    const current = inspectNpmPackage(npmPackage);
+    if (
+      current.state === "unknown" ||
+      !sameNpmPackageSnapshot(current, ownedState)
+    ) {
+      throw externalEffectConflict(
+        `Global package ${npmPackage} no longer matches Lore's installed generation; successor state was preserved.`,
+      );
+    }
+    guard.assertOwned();
+  };
+  let commandSucceeded: boolean;
+  if (priorState.state === "absent") {
+    commandSucceeded = runNpmUninstall(npmPackage, assertStillOwned);
+  } else {
+    const restoreSpec =
+      priorState.source ??
+      (priorState.version ? `${npmPackage}@${priorState.version}` : null);
+    if (!restoreSpec) {
+      throw externalEffectConflict(
+        `The prior ${npmPackage} version/source is unavailable; refusing to guess during rollback.`,
+      );
+    }
+    commandSucceeded = runNpmInstall(
+      restoreSpec,
+      `${npmPackage} at its prior version/source`,
+      assertStillOwned,
+    );
+  }
+
+  const restored = inspectNpmPackage(npmPackage);
+  if (
+    !commandSucceeded ||
+    restored.state === "unknown" ||
+    !sameNpmPackageMetadata(restored, priorState)
+  ) {
+    throw externalEffectConflict(
+      `Could not restore the prior global state of ${npmPackage}.`,
+    );
+  }
+}
+
+function preserveNpmExternalEffectJournal(
+  guard: LifecycleLock,
+  journal: NpmExternalEffectJournal,
+): Error | null {
+  try {
+    const existing = readNpmExternalEffectJournal(guard);
+    if (!existing) writeNpmExternalEffectJournal(guard, journal, null);
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+function cleanupCommittedNpmExternalEffectJournal(
+  guard: LifecycleLock,
+  journal: NpmExternalEffectJournal,
+  identity: TrustedFileIdentity,
+  invokeTestHook: boolean,
+): void {
+  const installedState = journal.installedState;
+  if (!installedState || journal.phase !== "committed") {
+    throw new Error("Setup external-effect journal is not committed.");
+  }
+  if (invokeTestHook) setupExternalEffectHook?.("before-journal-cleanup");
+  guard.assertOwned();
+  const before = inspectNpmPackage(journal.npmPackage);
+  if (
+    before.state === "unknown" ||
+    !sameNpmPackageSnapshot(before, installedState)
+  ) {
+    throw externalEffectConflict(
+      `Global package ${journal.npmPackage} changed before setup journal cleanup; successor state and ${setupExternalEffectJournalPath(guard.path)} were preserved.`,
+    );
+  }
+  guard.assertOwned();
+  try {
+    removeNpmExternalEffectJournal(guard, identity);
+  } catch (error) {
+    const evidenceError = preserveNpmExternalEffectJournal(guard, journal);
+    if (evidenceError) {
+      throw new AggregateError(
+        [error, evidenceError],
+        "Committed setup journal cleanup failed and its recovery evidence could not be restored.",
+      );
+    }
+    throw error;
+  }
+
+  const after = inspectNpmPackage(journal.npmPackage);
+  if (
+    after.state !== "unknown" &&
+    sameNpmPackageSnapshot(after, installedState)
+  ) {
+    return;
+  }
+
+  const evidenceError = preserveNpmExternalEffectJournal(guard, journal);
+  const conflict = externalEffectConflict(
+    `Global package ${journal.npmPackage} changed during setup journal cleanup; successor state was preserved and recovery evidence was restored.`,
+  );
+  if (evidenceError) {
+    throw new AggregateError(
+      [conflict, evidenceError],
+      "The package changed during committed setup journal cleanup and recovery evidence could not be restored.",
+    );
+  }
+  throw conflict;
+}
+
+class NpmPluginInstallEffect implements SetupExternalEffect {
+  private installAttempted = false;
+  private changed = false;
+  private installedState: KnownNpmPackageSnapshot | null = null;
+  private journal: NpmExternalEffectJournal | null = null;
+  private journalIdentity: TrustedFileIdentity | null = null;
+
+  constructor(
+    private readonly npmPackage: string,
+    private readonly priorState: KnownNpmPackageSnapshot,
+  ) {}
+
+  apply(guard: LifecycleLock): boolean {
+    guard.assertOwned();
+    if (this.priorState.state === "installed") {
+      const current = inspectNpmPackage(this.npmPackage);
+      if (
+        current.state === "unknown" ||
+        !sameNpmPackageSnapshot(current, this.priorState)
+      ) {
+        console.error(
+          `[lore] Global package state for ${this.npmPackage} changed during setup; refusing to overwrite it.`,
+        );
+        process.exitCode = 1;
+        return false;
+      }
+      this.installedState = this.priorState;
+      console.log(`[lore]   already installed globally.`);
+      return true;
+    }
+
+    guard.assertOwned();
+    const beforeInstall = inspectNpmPackage(this.npmPackage);
+    if (
+      beforeInstall.state === "unknown" ||
+      !sameNpmPackageSnapshot(beforeInstall, this.priorState)
+    ) {
+      console.error(
+        `[lore] Global package state for ${this.npmPackage} changed during setup; refusing to overwrite it.`,
+      );
+      process.exitCode = 1;
+      return false;
+    }
+
+    this.journal = {
+      version: 1,
+      ownerToken: guard.owner.token,
+      npmPackage: this.npmPackage,
+      phase: "prepared",
+      priorState: this.priorState,
+    };
+    this.journalIdentity = writeNpmExternalEffectJournal(
+      guard,
+      this.journal,
+      null,
+    );
+    this.installAttempted = true;
+    console.log(`[lore]   not installed globally — installing…`);
+    const installed = runNpmInstall(this.npmPackage, this.npmPackage, () => {
+      setupExternalEffectHook?.("before-install-mutation");
+      guard.assertOwned();
+      const current = inspectNpmPackage(this.npmPackage);
+      if (
+        current.state === "unknown" ||
+        !sameNpmPackageSnapshot(current, this.priorState)
+      ) {
+        throw externalEffectConflict(
+          `Global package state for ${this.npmPackage} changed immediately before installation; successor state was preserved.`,
+        );
+      }
+      guard.assertOwned();
+    });
+    const after = inspectNpmPackage(this.npmPackage);
+    if (after.state === "unknown") {
+      console.error(
+        `[lore] Could not verify ${this.npmPackage} after npm install.`,
+      );
+      process.exitCode = 1;
+      return false;
+    }
+    this.installedState = after;
+    this.changed = !sameNpmPackageSnapshot(this.priorState, after);
+    this.journal = {
+      ...this.journal,
+      phase: "installed",
+      installedState: after,
+    };
+    this.journalIdentity = writeNpmExternalEffectJournal(
+      guard,
+      this.journal,
+      this.journalIdentity,
+    );
+    setupExternalEffectHook?.("after-installed-journal");
+    if (!installed || after.state !== "installed") {
+      if (installed) {
+        console.error(
+          `[lore] npm install completed but ${this.npmPackage} is not installed globally.`,
+        );
+      }
+      process.exitCode = 1;
+      return false;
+    }
+    return true;
+  }
+
+  prepareCommit(guard: LifecycleLock): void {
+    guard.assertOwned();
+    if (!this.installedState) return;
+    const current = inspectNpmPackage(this.npmPackage);
+    if (
+      current.state === "unknown" ||
+      !sameNpmPackageSnapshot(current, this.installedState)
+    ) {
+      throw externalEffectConflict(
+        `Global package ${this.npmPackage} changed before setup commit; file commit was refused and successor state was preserved.`,
+      );
+    }
+    if (this.journal && this.journalIdentity) {
+      this.journal = { ...this.journal, phase: "commit-prepared" };
+      this.journalIdentity = writeNpmExternalEffectJournal(
+        guard,
+        this.journal,
+        this.journalIdentity,
+      );
+    }
+  }
+
+  establishCommitPoint(guard: LifecycleLock): boolean {
+    if (!this.journal || !this.journalIdentity || !this.installedState) {
+      return false;
+    }
+    guard.assertOwned();
+    const current = inspectNpmPackage(this.npmPackage);
+    if (
+      current.state === "unknown" ||
+      !sameNpmPackageSnapshot(current, this.installedState)
+    ) {
+      throw externalEffectConflict(
+        `Global package ${this.npmPackage} changed before setup's logical commit; successor state was preserved.`,
+      );
+    }
+    const committedJournal: NpmExternalEffectJournal = {
+      ...this.journal,
+      phase: "committed",
+    };
+    try {
+      this.journalIdentity = writeNpmExternalEffectJournal(
+        guard,
+        committedJournal,
+        this.journalIdentity,
+      );
+      this.journal = committedJournal;
+    } catch (error) {
+      if (error instanceof CommittedAtomicWriteError) {
+        const published = readNpmExternalEffectJournal(guard);
+        if (
+          published?.journal.phase === "committed" &&
+          sameTrustedFileIdentity(published.identity, error.identity)
+        ) {
+          this.journal = committedJournal;
+          this.journalIdentity = published.identity;
+          throw new PublishedSetupCommitError(error);
+        }
+        if (!published) this.journalIdentity = null;
+      }
+      throw error;
+    }
+    return true;
+  }
+
+  commit(guard: LifecycleLock): void {
+    if (!this.journal || !this.journalIdentity) return;
+    cleanupCommittedNpmExternalEffectJournal(
+      guard,
+      this.journal,
+      this.journalIdentity,
+      true,
+    );
+    this.journal = null;
+    this.journalIdentity = null;
+  }
+
+  rollback(guard: LifecycleLock): void {
+    if (!this.installAttempted) return;
+    if (this.journal?.phase === "committed") {
+      throw new Error("A logically committed npm setup cannot be rolled back.");
+    }
+    guard.assertOwned();
+
+    if (!this.installedState) {
+      const current = inspectNpmPackage(this.npmPackage);
+      if (
+        current.state !== "unknown" &&
+        sameNpmPackageSnapshot(current, this.priorState)
+      ) {
+        if (this.journalIdentity) {
+          removeNpmExternalEffectJournal(guard, this.journalIdentity);
+        }
+        this.journalIdentity = null;
+        return;
+      }
+      throw externalEffectConflict(
+        `Could not prove ownership of ${this.npmPackage} after an unverifiable npm install; it was left untouched.`,
+      );
+    }
+    if (this.changed) {
+      restoreOwnedNpmPackageState(
+        this.npmPackage,
+        this.priorState,
+        this.installedState,
+        guard,
+      );
+    } else {
+      const current = inspectNpmPackage(this.npmPackage);
+      if (
+        current.state === "unknown" ||
+        !sameNpmPackageSnapshot(current, this.priorState)
+      ) {
+        throw externalEffectConflict(
+          `Global package ${this.npmPackage} changed during rollback; successor state was preserved.`,
+        );
+      }
+    }
+    if (this.journalIdentity) {
+      removeNpmExternalEffectJournal(guard, this.journalIdentity);
+    }
+    this.journal = null;
+    this.journalIdentity = null;
+  }
+}
+
+/** Recover an interrupted npm setup effect while holding the lifecycle lock. */
+export function reconcileSetupExternalEffects(guard: LifecycleLock): void {
+  guard.assertOwned();
+  const file = readNpmExternalEffectJournal(guard);
+  if (!file) return;
+  const { journal } = file;
+  const current = inspectNpmPackage(journal.npmPackage);
+  if (current.state === "unknown") {
+    throw externalEffectConflict(
+      `Could not inspect ${journal.npmPackage} while recovering ${setupExternalEffectJournalPath(guard.path)}; the journal was preserved.`,
+    );
+  }
+
+  if (
+    journal.phase !== "committed" &&
+    sameNpmPackageSnapshot(current, journal.priorState)
+  ) {
+    removeNpmExternalEffectJournal(guard, file.identity);
+    return;
+  }
+
+  if (journal.phase === "committed") {
+    if (
+      journal.installedState &&
+      sameNpmPackageSnapshot(current, journal.installedState)
+    ) {
+      cleanupCommittedNpmExternalEffectJournal(
+        guard,
+        journal,
+        file.identity,
+        false,
+      );
+      return;
+    }
+    throw externalEffectConflict(
+      `Global package ${journal.npmPackage} no longer matches the committed setup generation; successor state and ${setupExternalEffectJournalPath(guard.path)} were preserved.`,
+    );
+  }
+
+  if (
+    journal.installedState &&
+    sameNpmPackageSnapshot(current, journal.installedState)
+  ) {
+    console.error(
+      `[lore] Recovering interrupted global installation of ${journal.npmPackage}.`,
+    );
+    restoreOwnedNpmPackageState(
+      journal.npmPackage,
+      journal.priorState,
+      journal.installedState,
+      guard,
+    );
+    removeNpmExternalEffectJournal(guard, file.identity);
+    return;
+  }
+
+  throw externalEffectConflict(
+    `Global package ${journal.npmPackage} no longer matches the interrupted setup generation; successor state and ${setupExternalEffectJournalPath(guard.path)} were preserved.`,
+  );
+}
+
 /**
  * Apply the plugin's config registration and write the result back to disk.
  * `configPath` is the path the user-facing handler writes to (so the
  * plugin registration is in the same file the user just inspected).
  */
-function applyPluginRegistration(
-  spec: PluginSpec,
-  configPath: string,
-  config: Record<string, unknown>,
-): boolean {
-  const modified = spec.apply(config);
-  if (!modified) {
-    console.log(`[lore] Plugin "${spec.npmPackage}" already registered.`);
-    return false;
-  }
-  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
-  return true;
-}
+// Plugin registration is committed with the config transaction below.
 
 /**
  * Install a plugin (if not already installed) and register it in the
@@ -253,28 +1194,7 @@ function applyPluginRegistration(
  * The config file the user-facing handler just wrote is the one we
  * re-read, register the plugin into, and write back.
  */
-function installPlugin(spec: PluginSpec, configPath: string): boolean {
-  console.log(`[lore] Plugin: ${spec.npmPackage}`);
-
-  if (!isNpmPackageInstalled(spec.npmPackage)) {
-    console.log(`[lore]   not installed globally — installing…`);
-    if (!runNpmInstall(spec.npmPackage)) {
-      return false;
-    }
-  } else {
-    console.log(`[lore]   already installed globally.`);
-  }
-
-  // Re-read the config the user-facing handler just wrote, register the
-  // plugin, and write it back. We do this AFTER the install so a failed
-  // install doesn't leave the user with a half-configured setup.
-  const config = readJsonConfig(configPath);
-  const registered = applyPluginRegistration(spec, configPath, config);
-  if (registered) {
-    console.log(`[lore]   registered in: ${configPath}`);
-  }
-  return true;
-}
+// npm installation is deliberately the final transaction callback.
 
 // ---------------------------------------------------------------------------
 // Gateway URL normalization
@@ -297,11 +1217,11 @@ const DEFAULT_PORT = 3207;
 export function chooseSetupPort(input: {
   explicitPort?: number;
   remoteUrl?: string;
-  livePort?: number | null;
+  authenticatedPort?: number | null;
 }): number | undefined {
   if (input.remoteUrl) return undefined;
   if (input.explicitPort !== undefined) return input.explicitPort;
-  if (input.livePort != null) return input.livePort;
+  if (input.authenticatedPort != null) return input.authenticatedPort;
   return undefined;
 }
 
@@ -354,29 +1274,31 @@ export function formatSetupGuidance(): string[] {
 }
 
 /**
- * Detect a running local gateway and return its port, or null. Reads the port
- * file written by a running gateway, then verifies it actually answers.
+ * Detect an owner-authenticated local gateway and return its recorded port.
  */
-async function detectLiveGatewayPort(): Promise<number | null> {
-  const port = readPortFile();
-  if (!port) return null;
-  return (await probeGateway(`http://127.0.0.1:${port}`)) ? port : null;
+async function detectAuthenticatedGatewayPort(): Promise<number | null> {
+  const record = readGatewayProcessFile();
+  if (!record) return null;
+  const { probeGatewayProcess } = await import("./start");
+  return (await probeGatewayProcess(record)) ? record.port : null;
 }
 
 /**
  * Normalize a gateway URL for use as a provider base URL.
- * Ensures the URL ends with `/v1` (required by Codex).
- * Rejects URLs with characters that would break TOML string embedding.
+ * Ensures the URL ends with `/v1` (required by Codex). Remote values must be
+ * absolute HTTP(S) URLs without credentials, a query, or a fragment.
  */
 export function normalizeBaseUrl(
   remoteUrl: string | undefined,
   port: number | undefined,
 ): string {
-  if (remoteUrl) {
-    const stripped = remoteUrl.trim().replace(/\/+$/, "");
-    if (!stripped) throw new Error("Remote URL cannot be empty.");
-    validateUrl(stripped);
-    return stripped.endsWith("/v1") ? stripped : `${stripped}/v1`;
+  if (remoteUrl !== undefined) {
+    const value = remoteUrl.trim();
+    if (!value) throw new Error("Remote URL cannot be empty.");
+    const parsed = parseRemoteUrl(value);
+    const path = parsed.pathname.replace(/\/+$/, "");
+    parsed.pathname = path.endsWith("/v1") ? path : `${path}/v1`;
+    return parsed.toString();
   }
   if (port !== undefined) {
     if (!Number.isInteger(port) || port < 0 || port > 65535) {
@@ -387,14 +1309,41 @@ export function normalizeBaseUrl(
 }
 
 /**
- * Reject URLs containing characters that would produce malformed TOML
- * or could be used for injection (double-quotes, backslashes, control chars).
+ * Parse an untrusted remote URL without including its potentially sensitive
+ * value in any error. Raw delimiters are checked so empty userinfo/query/hash
+ * components cannot disappear during WHATWG URL normalization.
  */
-function validateUrl(url: string): void {
+function parseRemoteUrl(value: string): URL {
+  const invalid = (): never => {
+    throw new Error(
+      "Invalid remote URL. Only HTTP and HTTPS URLs without credentials, query parameters, or fragments are allowed.",
+    );
+  };
   // oxlint-disable-next-line no-control-regex -- intentional control-character sanitization
-  if (/[\x00-\x1f"\\]/.test(url)) {
-    throw new Error(`Invalid characters in URL: ${url}`);
-  }
+  if (/[\x00-\x1f\x7f"\\]/.test(value)) invalid();
+  if (!/^[a-z][a-z\d+.-]*:\/\//i.test(value)) invalid();
+
+  const parsed = (() => {
+    try {
+      return new URL(value);
+    } catch {
+      return invalid();
+    }
+  })();
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") invalid();
+
+  const authorityStart = value.indexOf("://") + 3;
+  const authorityEndOffset = value.slice(authorityStart).search(/[/?#]/);
+  const authorityEnd =
+    authorityEndOffset === -1
+      ? value.length
+      : authorityStart + authorityEndOffset;
+  const authority = value.slice(authorityStart, authorityEnd);
+  if (!authority || authority.includes("@") || !parsed.hostname) invalid();
+  if (value.includes("?") || value.includes("#")) invalid();
+  if (parsed.username || parsed.password) invalid();
+
+  return parsed;
 }
 
 // ---------------------------------------------------------------------------
@@ -514,33 +1463,30 @@ function isTopLevel(lines: string[], index: number): boolean {
 // Codex setup
 // ---------------------------------------------------------------------------
 
-function setupCodex(baseUrl: string): void {
+function setupCodex(baseUrl: string, guard: SetupGuard): void {
+  guard.assertOwned();
   const configPath = codexConfigPath();
   const configDir = join(homedir(), ".codex");
 
-  // Ensure ~/.codex/ exists (recursive: true is a no-op when it already exists)
-  mkdirSync(configDir, { recursive: true });
+  guard.assertOwned();
+  ensureTrustedDirectory(configDir);
 
-  // Read existing config or start fresh
-  let content = "";
-  try {
-    content = readFileSync(configPath, "utf8");
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
-  }
+  const existingFile = readTrustedTextFile(configPath, { allowMissing: true });
+  const content = existingFile?.text ?? "";
 
   // Capture a commented backup block from the ORIGINAL content (before lore's
   // writes), recording the values lore is about to set so undo can revert only
   // if the file still holds them. Then apply lore's changes and prepend it.
-  const backupBlock = buildTomlBackupBlock(content, {
+  const prepared = refreshTomlBackupBlock(content, {
     openai_base_url: `"${baseUrl}"`,
     model_auto_compact_token_limit: String(CODEX_COMPACT_DISABLE_LIMIT),
   });
-  const updated = updateCodexConfig(content, baseUrl);
-  const final = backupBlock
-    ? prependTomlBackupBlock(updated, backupBlock)
-    : updated;
-  writeFileSync(configPath, final, "utf8");
+  const updated = updateCodexConfig(prepared.content, baseUrl);
+  const final = prependTomlBackupBlock(updated, prepared.block);
+  guard.assertOwned();
+  atomicWriteTrustedFile(configPath, final, {
+    expectedIdentity: existingFile?.identity ?? null,
+  });
 
   console.log(`[lore] Codex configured to use Lore gateway.`);
   console.log(`[lore]   openai_base_url = "${baseUrl}"`);
@@ -560,17 +1506,8 @@ function setupCodex(baseUrl: string): void {
  * validate the resulting object structure before use.
  */
 export function readJsonConfig(path: string): Record<string, unknown> {
-  try {
-    const raw = readFileSync(path, "utf8");
-    return JSON.parse(raw) as Record<string, unknown>;
-  } catch (e: unknown) {
-    const err = e as NodeJS.ErrnoException;
-    if (err.code === "ENOENT") return {};
-    console.warn(
-      `[lore] Warning: could not parse ${path} as JSON (${err.message}). Starting with empty config.`,
-    );
-    return {};
-  }
+  const file = readJsonConfigFileIfExists(path);
+  return file?.config ?? {};
 }
 
 /**
@@ -587,9 +1524,11 @@ export function updateJsonConfig(
   path: string,
   updates: Record<string, unknown>,
 ): void {
-  const existing = readJsonConfig(path);
-  const merged = deepMerge(existing, updates);
-  writeFileSync(path, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+  const file = readJsonConfigFileIfExists(path);
+  const merged = deepMerge(file?.config ?? {}, updates);
+  atomicWriteTrustedFile(path, `${JSON.stringify(merged, null, 2)}\n`, {
+    expectedIdentity: file?.identity ?? null,
+  });
 }
 
 /**
@@ -647,56 +1586,349 @@ export function jsonBackupPath(configPath: string): string {
  * status`) and `undo` degrade gracefully instead of crashing on a bad file.
  */
 export function loadJsonSetupBackup(configPath: string): JsonBackup | null {
-  let raw: string;
   try {
-    raw = readFileSync(jsonBackupPath(configPath), "utf8");
+    const sidecar = requireJsonSetupSidecar(configPath);
+    if (!sidecar) return null;
+    return isJsonSetupJournal(sidecar.value)
+      ? selectPendingJsonSetupBackup(configPath, sidecar.value)
+      : sidecar.value;
   } catch {
-    // Absent (ENOENT) or unreadable (EACCES, EISDIR, ...) — report no backup
-    // rather than propagating an exception into a read-only command.
     return null;
   }
+}
+
+interface JsonSetupSidecarFile {
+  value: JsonBackup | JsonSetupJournal;
+  identity: TrustedFileIdentity;
+}
+
+function backupGeneration(identity: TrustedFileIdentity): {
+  device: string;
+  inode: string;
+  birthtimeNs: string;
+  size: string;
+  mtimeNs: string;
+} {
+  return {
+    device: identity.dev.toString(),
+    inode: identity.ino.toString(),
+    birthtimeNs: identity.birthtimeNs.toString(),
+    size: identity.size.toString(),
+    mtimeNs: identity.mtimeNs.toString(),
+  };
+}
+
+function requireJsonSetupSidecar(
+  configPath: string,
+): JsonSetupSidecarFile | null {
+  const backupPath = jsonBackupPath(configPath);
+  let file: ReturnType<typeof readTrustedTextFile>;
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      Array.isArray((parsed as { entries?: unknown }).entries)
-    ) {
-      return parsed as JsonBackup;
-    }
-  } catch {
-    // Corrupt sidecar — fall through and report "no backup".
+    file = readTrustedTextFile(backupPath, { allowMissing: true });
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? ` ${error.message}` : "";
+    throw new Error(
+      `Could not read Lore setup backup ${backupPath}.${detail}`,
+      {
+        cause: error,
+      },
+    );
   }
-  return null;
+  if (!file) return null;
+  try {
+    const value = JSON.parse(file.text) as unknown;
+    return {
+      value:
+        typeof value === "object" &&
+        value !== null &&
+        "version" in value &&
+        value.version === 2
+          ? parseJsonSetupJournal(value)
+          : parseStableJsonBackup(value),
+      identity: file.identity,
+    };
+  } catch (error) {
+    throw new Error(`Invalid Lore setup backup ${backupPath}.`, {
+      cause: error,
+    });
+  }
+}
+
+function isJsonSetupJournal(
+  value: JsonBackup | JsonSetupJournal,
+): value is JsonSetupJournal {
+  return value.version === 2;
+}
+
+function selectPendingJsonSetupBackup(
+  configPath: string,
+  journal: JsonSetupJournal,
+): JsonBackup | null {
+  const configFile = readJsonConfigFileIfExists(configPath);
+  const state = selectJsonSetupJournalState(
+    journal,
+    configFile?.text ?? null,
+    configFile?.config ?? {},
+  );
+  return state === "old" ? journal.oldBackup : journal.newBackup;
+}
+
+interface JsonSetupBackupFile {
+  backup: JsonBackup | null;
+  identity: TrustedFileIdentity;
+}
+
+function requireJsonSetupBackup(
+  configPath: string,
+): JsonSetupBackupFile | null {
+  const sidecar = requireJsonSetupSidecar(configPath);
+  if (!sidecar) return null;
+  if (!isJsonSetupJournal(sidecar.value) && sidecar.value.version === 1) {
+    const configFile = readJsonConfigFileIfExists(configPath);
+    if (!configFile) {
+      throw new Error(
+        `Legacy Lore setup backup cannot prove whether missing config ${configPath} should be restored; provenance was preserved.`,
+      );
+    }
+  }
+  if (!isJsonSetupJournal(sidecar.value) && sidecar.value.version === 3) {
+    const configFile = readJsonConfigFileIfExists(configPath);
+    if (!configFile) {
+      if (sidecar.value.originalExists) {
+        throw new Error(
+          `Current config generation is missing for Lore setup backup ${jsonBackupPath(configPath)}.`,
+        );
+      }
+    } else {
+      assertJsonBackupConfigState(
+        sidecar.value,
+        configFile.config,
+        backupGeneration(configFile.identity),
+      );
+    }
+  }
+  return {
+    backup: isJsonSetupJournal(sidecar.value)
+      ? selectPendingJsonSetupBackup(configPath, sidecar.value)
+      : sidecar.value,
+    identity: sidecar.identity,
+  };
+}
+
+/** Resolve a prepared journal to a stable, generation-bound sidecar. */
+function recoverJsonSetupJournal(
+  configPath: string,
+  guard: SetupGuard,
+): JsonSetupBackupFile | null {
+  const sidecar = requireJsonSetupSidecar(configPath);
+  if (!sidecar) return null;
+  if (!isJsonSetupJournal(sidecar.value)) {
+    const configFile = readJsonConfigFileIfExists(configPath);
+    if (!configFile && sidecar.value.version === 1) {
+      throw new Error(
+        `Legacy Lore setup backup cannot prove whether missing config ${configPath} should be restored; provenance was preserved.`,
+      );
+    }
+    if (
+      !configFile &&
+      sidecar.value.version === 3 &&
+      sidecar.value.originalExists
+    ) {
+      throw new Error(
+        `Current config generation is missing for Lore setup backup ${jsonBackupPath(configPath)}.`,
+      );
+    }
+    if (configFile) {
+      assertJsonBackupConfigState(
+        sidecar.value,
+        configFile.config,
+        backupGeneration(configFile.identity),
+      );
+    }
+    return { backup: sidecar.value, identity: sidecar.identity };
+  }
+
+  const configFile = readJsonConfigFileIfExists(configPath);
+  const state = selectJsonSetupJournalState(
+    sidecar.value,
+    configFile?.text ?? null,
+    configFile?.config ?? {},
+  );
+  const backup =
+    state === "old" ? sidecar.value.oldBackup : sidecar.value.newBackup;
+  let identity: TrustedFileIdentity | null = null;
+  guard.assertOwned();
+  withTrustedFileTransaction(
+    [configPath, jsonBackupPath(configPath)],
+    (transaction) => {
+      transaction.assertSnapshotIdentity(
+        configPath,
+        configFile?.identity ?? null,
+      );
+      transaction.assertSnapshotIdentity(
+        jsonBackupPath(configPath),
+        sidecar.identity,
+      );
+      guard.assertOwned();
+      if (backup) {
+        identity = commitJsonSetupBackup(
+          transaction,
+          configPath,
+          backup,
+          configFile?.identity ?? null,
+        );
+      } else {
+        transaction.remove(jsonBackupPath(configPath));
+      }
+      transaction.assertCurrentIdentity(configPath);
+      transaction.assertCurrentIdentity(jsonBackupPath(configPath));
+      guard.assertOwned();
+    },
+  );
+  return backup && identity ? { backup, identity } : null;
 }
 
 /** Remove the sidecar backup file (no-op if it doesn't exist). */
-function removeJsonSetupBackup(configPath: string): void {
-  try {
-    rmSync(jsonBackupPath(configPath));
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
-  }
+function removeJsonSetupBackup(
+  configPath: string,
+  guard: SetupGuard,
+  expectedIdentity?: TrustedFileIdentity,
+): void {
+  const backupPath = jsonBackupPath(configPath);
+  guard.assertOwned();
+  withTrustedFileTransaction([configPath, backupPath], (transaction) => {
+    transaction.assertSnapshotIdentity(configPath, null);
+    transaction.assertSnapshotIdentity(
+      backupPath,
+      expectedIdentity ?? transaction.snapshot(backupPath).identity,
+    );
+    guard.assertOwned();
+    transaction.remove(backupPath);
+    transaction.assertCurrentIdentity(configPath);
+    transaction.assertCurrentIdentity(backupPath);
+    guard.assertOwned();
+  });
 }
 
-/**
- * Persist the backup for a JSON config to its sidecar file. Preserves the TRUE
- * original: if a sidecar already exists it is kept (re-running setup never
- * overwrites the original with lore's own values); otherwise a migrated
- * `legacyBackup` (from an old in-config `_loreBackup` key) is written, else the
- * freshly-captured `freshBackup`.
- */
-function persistJsonSetupBackup(
+function commitJsonSetupBackup(
+  transaction: TrustedFileTransaction,
   configPath: string,
-  legacyBackup: JsonBackup | null,
-  freshBackup: JsonBackup,
-): void {
-  if (existsSync(jsonBackupPath(configPath))) return;
-  writeFileSync(
+  backup: JsonBackup,
+  configIdentity: TrustedFileIdentity | null,
+): TrustedFileIdentity {
+  const bound =
+    backup.version === 3 && configIdentity
+      ? bindJsonBackupGeneration(backup, backupGeneration(configIdentity))
+      : backup;
+  parseStableJsonBackup(bound);
+  return transaction.write(
     jsonBackupPath(configPath),
-    `${JSON.stringify(legacyBackup ?? freshBackup, null, 2)}\n`,
-    "utf8",
+    `${JSON.stringify(bound, null, 2)}\n`,
+    { mode: 0o600 },
   );
+}
+
+function commitJsonSetupJournal(
+  transaction: TrustedFileTransaction,
+  configPath: string,
+  journal: JsonSetupJournal,
+): TrustedFileIdentity {
+  parseJsonSetupJournal(journal);
+  return transaction.write(
+    jsonBackupPath(configPath),
+    `${JSON.stringify(journal, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+}
+
+function replaceJsonConfigWithJournal(
+  input: {
+    configPath: string;
+    configIdentity: TrustedFileIdentity | null;
+    sidecarIdentity: TrustedFileIdentity | null;
+    beforeText: string | null;
+    beforeConfig: Record<string, unknown>;
+    afterText: string | null;
+    afterConfig: Record<string, unknown>;
+    oldBackup: JsonBackup | null;
+    newBackup: JsonBackup | null;
+    projectionPaths?: readonly string[];
+    afterFinalize?: () => void;
+  },
+  guard: SetupGuard,
+): void {
+  const backupPath = jsonBackupPath(input.configPath);
+  if (input.beforeText === input.afterText) {
+    guard.assertOwned();
+    withTrustedFileTransaction(
+      [input.configPath, backupPath],
+      (transaction) => {
+        transaction.assertSnapshotIdentity(
+          input.configPath,
+          input.configIdentity,
+        );
+        transaction.assertSnapshotIdentity(backupPath, input.sidecarIdentity);
+        guard.assertOwned();
+        if (input.newBackup) {
+          commitJsonSetupBackup(
+            transaction,
+            input.configPath,
+            input.newBackup,
+            input.configIdentity,
+          );
+        } else {
+          transaction.remove(backupPath);
+        }
+        transaction.assertCurrentIdentity(input.configPath);
+        transaction.assertCurrentIdentity(backupPath);
+        guard.assertOwned();
+        input.afterFinalize?.();
+      },
+    );
+    return;
+  }
+  const journal = prepareJsonSetupJournal({
+    oldBackup: input.oldBackup,
+    newBackup: input.newBackup,
+    beforeText: input.beforeText,
+    beforeConfig: input.beforeConfig,
+    afterText: input.afterText,
+    afterConfig: input.afterConfig,
+    projectionPaths: input.projectionPaths,
+  });
+  guard.assertOwned();
+  withTrustedFileTransaction([input.configPath, backupPath], (transaction) => {
+    transaction.assertSnapshotIdentity(input.configPath, input.configIdentity);
+    transaction.assertSnapshotIdentity(backupPath, input.sidecarIdentity);
+    guard.assertOwned();
+    commitJsonSetupJournal(transaction, input.configPath, journal);
+    guard.assertOwned();
+    const configIdentity =
+      input.afterText === null
+        ? (transaction.remove(input.configPath), null)
+        : transaction.write(input.configPath, input.afterText);
+    guard.assertOwned();
+    if (input.newBackup) {
+      commitJsonSetupBackup(
+        transaction,
+        input.configPath,
+        input.newBackup,
+        configIdentity,
+      );
+    } else {
+      transaction.remove(backupPath);
+    }
+    try {
+      transaction.assertCurrentIdentity(input.configPath);
+    } catch (error) {
+      transaction.assertCurrentIdentity(backupPath);
+      commitJsonSetupJournal(transaction, input.configPath, journal);
+      throw error;
+    }
+    transaction.assertCurrentIdentity(backupPath);
+    guard.assertOwned();
+    input.afterFinalize?.();
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -706,6 +1938,10 @@ function persistJsonSetupBackup(
 /** Path to the OpenCode user-level config file. */
 export function opencodeConfigPath(): string {
   return join(homedir(), ".config", "opencode", "opencode.json");
+}
+
+export function activeOpencodeConfigPath(): string {
+  return resolveOpencodeConfigPath(opencodeConfigPath());
 }
 
 /**
@@ -723,7 +1959,7 @@ export function opencodeConfigPath(): string {
  * `resolveSDK()` always passes `options.baseURL` to the @ai-sdk factory,
  * so setting it here routes every chat call through the gateway.
  */
-const OPENCODE_SETUP_PROVIDER_IDS = [
+export const OPENCODE_SETUP_PROVIDER_IDS = [
   "amazon-bedrock",
   "anthropic",
   "azure",
@@ -798,18 +2034,53 @@ export function updateOpencodeConfig(
   });
 }
 
-function setupOpencode(baseUrl: string, noPlugin: boolean): void {
-  const configPath = opencodeConfigPath();
+function setupOpencode(
+  baseUrl: string,
+  noPlugin: boolean,
+  guard: SetupGuard,
+  external: SetupExternalTransaction,
+): boolean | void {
+  guard.assertOwned();
+  let packageState: KnownNpmPackageSnapshot | null = null;
+  if (!noPlugin) {
+    console.log(`[lore] Plugin: ${opencodePluginSpec.npmPackage}`);
+    const state = inspectNpmPackage(opencodePluginSpec.npmPackage);
+    if (state.state === "unknown") {
+      console.error(
+        `[lore] Could not determine whether ${opencodePluginSpec.npmPackage} is installed globally.`,
+      );
+      console.error(`[lore] No package or config changes were kept.`);
+      process.exitCode = 1;
+      return false;
+    }
+    packageState = state;
+  }
+
+  const configPath = activeOpencodeConfigPath();
   const configDir = join(homedir(), ".config", "opencode");
 
-  mkdirSync(configDir, { recursive: true });
+  guard.assertOwned();
+  ensureTrustedDirectory(configDir);
 
-  const existing = readJsonConfig(configPath);
+  guard.assertOwned();
+  const sidecarFile = recoverJsonSetupJournal(configPath, guard);
+  const existingFile: {
+    text: string;
+    config: Record<string, unknown>;
+    identity: TrustedFileIdentity | null;
+  } = readJsonConfigFileIfExists(configPath) ?? {
+    text: "{}\n",
+    config: {},
+    identity: null,
+  };
+  const beforeConfig = existingFile.config;
   // Migrate away from any legacy in-config `_loreBackup` key: capture it for the
   // sidecar, then strip it so every config we write is schema-valid for
   // OpenCode (its schema is `additionalProperties: false` and rejects unknown
   // keys — the illegal key made OpenCode refuse to start).
-  const legacyBackup = readLegacyJsonBackup(existing);
+  const legacyBackup = requireLegacyJsonBackup(beforeConfig);
+  const previousBackup = sidecarFile?.backup ?? legacyBackup;
+  const existing = structuredClone(beforeConfig);
   delete existing[LORE_BACKUP_KEY];
 
   // Values lore is about to set (provider baseURLs + compaction), captured from
@@ -823,22 +2094,64 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
     Array.isArray(existingPlugins) &&
     existingPlugins.includes("@loreai/opencode");
 
-  // Write the provider/compaction config first WITHOUT a backup. The backup is
-  // finalized at the end, after the plugin install, so `pluginAdded` reflects
-  // what actually happened (a failed install must NOT later cause undo to
-  // remove a plugin the user added themselves).
-  const updated = updateOpencodeConfig(existing, baseUrl);
-  writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
-
-  console.log(`[lore] OpenCode configured to use Lore gateway.`);
-  console.log(
-    `[lore]   provider.<id>.options.baseURL = "${baseUrl}" (all ${OPENCODE_SETUP_PROVIDER_IDS.length} providers, --no-plugin fallback)`,
-  );
-  console.log(`[lore]   compaction.auto = false (auto-compaction disabled)`);
-  console.log(`[lore]   Config: ${configPath}`);
-  console.log(`[lore]`);
-
-  let pluginInstalled = false;
+  let updatedText = existingFile.text;
+  if (
+    existing.provider !== undefined &&
+    (typeof existing.provider !== "object" ||
+      existing.provider === null ||
+      Array.isArray(existing.provider))
+  ) {
+    updatedText = setJsonConfigValue(updatedText, ["provider"], {});
+  }
+  if (
+    existing.compaction !== undefined &&
+    (typeof existing.compaction !== "object" ||
+      existing.compaction === null ||
+      Array.isArray(existing.compaction))
+  ) {
+    updatedText = setJsonConfigValue(updatedText, ["compaction"], {});
+  }
+  for (const id of OPENCODE_SETUP_PROVIDER_IDS) {
+    const provider =
+      typeof existing.provider === "object" &&
+      existing.provider !== null &&
+      !Array.isArray(existing.provider)
+        ? (existing.provider as Record<string, unknown>)[id]
+        : undefined;
+    if (
+      provider !== undefined &&
+      (typeof provider !== "object" ||
+        provider === null ||
+        Array.isArray(provider))
+    ) {
+      updatedText = setJsonConfigValue(updatedText, ["provider", id], {});
+    }
+    const options =
+      typeof provider === "object" &&
+      provider !== null &&
+      !Array.isArray(provider)
+        ? (provider as Record<string, unknown>).options
+        : undefined;
+    if (
+      options !== undefined &&
+      (typeof options !== "object" ||
+        options === null ||
+        Array.isArray(options))
+    ) {
+      updatedText = setJsonConfigValue(
+        updatedText,
+        ["provider", id, "options"],
+        {},
+      );
+    }
+    updatedText = setJsonConfigValue(
+      updatedText,
+      ["provider", id, "options", "baseURL"],
+      baseUrl,
+    );
+  }
+  updatedText = setJsonConfigValue(updatedText, ["compaction", "auto"], false);
+  let pluginRegistered = false;
   if (noPlugin) {
     console.log(
       `[lore] Skipped @loreai/opencode plugin install (--no-plugin).`,
@@ -850,27 +2163,79 @@ function setupOpencode(baseUrl: string, noPlugin: boolean): void {
       `[lore] "@loreai/opencode" to the "plugin" array in ${configPath}.`,
     );
   } else {
-    pluginInstalled = installPlugin(opencodePluginSpec, configPath);
-    if (!pluginInstalled) process.exitCode = 1;
+    pluginRegistered = opencodePluginSpec.apply(existing);
+    if (pluginRegistered) {
+      loreValues.plugin = existing.plugin;
+      updatedText = setJsonConfigValue(
+        updatedText,
+        ["plugin"],
+        existing.plugin,
+      );
+      console.log(`[lore]   registered in: ${configPath}`);
+    } else {
+      console.log(
+        `[lore] Plugin "${opencodePluginSpec.npmPackage}" already registered.`,
+      );
+    }
+  }
+  updatedText = deleteJsonConfigValue(updatedText, [LORE_BACKUP_KEY]);
+  const finalConfig = parseJsonConfigText(updatedText, configPath);
+  const backup = refreshJsonBackup(
+    structuredClone(beforeConfig),
+    loreValues,
+    previousBackup,
+    {
+      pluginAdded: pluginRegistered && !pluginAlreadyPresent,
+      originalExists: existingFile.identity !== null,
+      afterConfig: finalConfig,
+    },
+  );
+  try {
+    replaceJsonConfigWithJournal(
+      {
+        configPath,
+        configIdentity: existingFile.identity,
+        sidecarIdentity: sidecarFile?.identity ?? null,
+        beforeText: existingFile.identity ? existingFile.text : null,
+        beforeConfig,
+        afterText: updatedText,
+        afterConfig: finalConfig,
+        oldBackup: sidecarFile?.backup ?? null,
+        newBackup: backup,
+        projectionPaths: ["plugin", LORE_BACKUP_KEY],
+        afterFinalize: () => {
+          if (packageState) {
+            guard.assertOwned();
+            const installed = external.apply(
+              new NpmPluginInstallEffect(
+                opencodePluginSpec.npmPackage,
+                packageState,
+              ),
+            );
+            guard.assertOwned();
+            if (!installed) {
+              process.exitCode = 1;
+              throw new PluginInstallFailure();
+            }
+          }
+        },
+      },
+      guard,
+    );
+  } catch (error) {
+    if (error instanceof PluginInstallFailure) return false;
+    throw error;
   }
 
-  // Finalize the backup now that the (possibly config-rewriting) plugin install
-  // has run. `installPlugin` returns true on full success (both npm install and
-  // registration of the plugin in the config), so `pluginInstalled && !pluginAlreadyPresent`
-  // accurately reflects whether lore actually added the plugin.
-  const finalConfig = readJsonConfig(configPath);
-  // Defensive: never let the schema-invalid key reach OpenCode's config, even
-  // if some earlier write reintroduced it.
-  delete finalConfig[LORE_BACKUP_KEY];
-  const backup = captureJsonBackup(existing, loreValues, {
-    pluginAdded: pluginInstalled && !pluginAlreadyPresent,
+  external.onCommit(() => {
+    console.log(`[lore] OpenCode configured to use Lore gateway.`);
+    console.log(
+      `[lore]   provider.<id>.options.baseURL = "${baseUrl}" (all ${OPENCODE_SETUP_PROVIDER_IDS.length} providers, --no-plugin fallback)`,
+    );
+    console.log(`[lore]   compaction.auto = false (auto-compaction disabled)`);
+    console.log(`[lore]   Config: ${configPath}`);
+    console.log(`[lore]`);
   });
-  persistJsonSetupBackup(configPath, legacyBackup, backup);
-  writeFileSync(
-    configPath,
-    `${JSON.stringify(finalConfig, null, 2)}\n`,
-    "utf8",
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -916,28 +2281,57 @@ export function updateClaudeCodeSettings(
   });
 }
 
-function setupClaudeCode(baseUrl: string): void {
+function setupClaudeCode(baseUrl: string, guard: SetupGuard): void {
+  guard.assertOwned();
   const configPath = claudeCodeSettingsPath();
   const configDir = join(homedir(), ".claude");
 
-  mkdirSync(configDir, { recursive: true });
+  guard.assertOwned();
+  ensureTrustedDirectory(configDir);
 
   // Strip the /v1 suffix — Claude Code appends /v1/messages itself.
   const anthropicBaseUrl = baseUrl.endsWith("/v1")
     ? baseUrl.slice(0, -3)
     : baseUrl;
 
-  const existing = readJsonConfig(configPath);
-  const legacyBackup = readLegacyJsonBackup(existing);
+  guard.assertOwned();
+  const sidecarFile = recoverJsonSetupJournal(configPath, guard);
+  const existingFile = readJsonConfigFileIfExists(configPath);
+  const beforeConfig = existingFile?.config ?? {};
+  const legacyBackup = requireLegacyJsonBackup(beforeConfig);
+  const previousBackup = sidecarFile?.backup ?? legacyBackup;
+  const existing = structuredClone(beforeConfig);
   delete existing[LORE_BACKUP_KEY];
-  const backup = captureJsonBackup(existing, {
-    "env.ANTHROPIC_BASE_URL": anthropicBaseUrl,
-    "env.DISABLE_AUTO_COMPACT": "1",
-    [`env.${CLAUDE_CODE_FIRST_PARTY_ENV}`]: "1",
-  });
   const updated = updateClaudeCodeSettings(existing, anthropicBaseUrl);
-  persistJsonSetupBackup(configPath, legacyBackup, backup);
-  writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
+  const backup = refreshJsonBackup(
+    existing,
+    {
+      "env.ANTHROPIC_BASE_URL": anthropicBaseUrl,
+      "env.DISABLE_AUTO_COMPACT": "1",
+      [`env.${CLAUDE_CODE_FIRST_PARTY_ENV}`]: "1",
+    },
+    previousBackup,
+    {
+      originalExists: existingFile !== null,
+      afterConfig: updated,
+    },
+  );
+  const updatedText = `${JSON.stringify(updated, null, 2)}\n`;
+  replaceJsonConfigWithJournal(
+    {
+      configPath,
+      configIdentity: existingFile?.identity ?? null,
+      sidecarIdentity: sidecarFile?.identity ?? null,
+      beforeText: existingFile?.text ?? null,
+      beforeConfig,
+      afterText: updatedText,
+      afterConfig: updated,
+      oldBackup: sidecarFile?.backup ?? null,
+      newBackup: backup,
+      projectionPaths: [LORE_BACKUP_KEY],
+    },
+    guard,
+  );
 
   console.log(`[lore] Claude Code configured to use Lore gateway.`);
   console.log(`[lore]   env.ANTHROPIC_BASE_URL = "${anthropicBaseUrl}"`);
@@ -963,8 +2357,11 @@ function setupClaudeCode(baseUrl: string): void {
  * agent dir gets the file Pi actually reads.
  */
 export function piModelsConfigPath(): string {
-  const agentDir =
-    process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+  const customDir = process.env.PI_CODING_AGENT_DIR;
+  const agentDir = customDir || join(homedir(), ".pi", "agent");
+  if (customDir) {
+    assertNoSymlinkPathComponents(agentDir, "PI_CODING_AGENT_DIR");
+  }
   return join(agentDir, "models.json");
 }
 
@@ -982,7 +2379,7 @@ export function piModelsConfigPath(): string {
  * until the user defines models for them — same trade-off as opencode's
  * write-all fallback list.
  */
-const PI_ANTHROPIC_PROVIDERS = [
+export const PI_ANTHROPIC_PROVIDERS = [
   "anthropic",
   "fireworks",
   "minimax",
@@ -990,7 +2387,7 @@ const PI_ANTHROPIC_PROVIDERS = [
   "kimi-coding",
 ] as const;
 
-const PI_OPENAI_PROVIDERS = [
+export const PI_OPENAI_PROVIDERS = [
   "github-copilot",
   "deepseek",
   "xai",
@@ -1038,17 +2435,27 @@ export function updatePiModelsConfig(
   return deepMerge(config, { providers });
 }
 
-function setupPi(baseUrl: string): void {
+function setupPi(baseUrl: string, guard: SetupGuard): void {
+  guard.assertOwned();
   const configPath = piModelsConfigPath();
-  mkdirSync(dirname(configPath), { recursive: true });
+  guard.assertOwned();
+  ensureTrustedDirectory(dirname(configPath));
+  if (process.env.PI_CODING_AGENT_DIR) {
+    assertNoSymlinkPathComponents(dirname(configPath), "PI_CODING_AGENT_DIR");
+  }
 
   // Anthropic-family Pi providers hit the gateway root; OpenAI-family get
   // `/v1`. `baseUrl` arrives with `/v1` (setup writer contract) so strip it
   // back to the origin first.
   const root = baseUrl.replace(/\/v1$/, "");
 
-  const existing = readJsonConfig(configPath);
-  const legacyBackup = readLegacyJsonBackup(existing);
+  guard.assertOwned();
+  const sidecarFile = recoverJsonSetupJournal(configPath, guard);
+  const existingFile = readJsonConfigFileIfExists(configPath);
+  const beforeConfig = existingFile?.config ?? {};
+  const legacyBackup = requireLegacyJsonBackup(beforeConfig);
+  const previousBackup = sidecarFile?.backup ?? legacyBackup;
+  const existing = structuredClone(beforeConfig);
   delete existing[LORE_BACKUP_KEY];
 
   // Record the exact values lore is about to set so undo reverts only if the
@@ -1061,10 +2468,27 @@ function setupPi(baseUrl: string): void {
     loreValues[`providers.${id}.baseUrl`] = `${root}/v1`;
   }
 
-  const backup = captureJsonBackup(existing, loreValues);
   const updated = updatePiModelsConfig(existing, root);
-  persistJsonSetupBackup(configPath, legacyBackup, backup);
-  writeFileSync(configPath, `${JSON.stringify(updated, null, 2)}\n`, "utf8");
+  const updatedText = `${JSON.stringify(updated, null, 2)}\n`;
+  const backup = refreshJsonBackup(existing, loreValues, previousBackup, {
+    originalExists: existingFile !== null,
+    afterConfig: updated,
+  });
+  replaceJsonConfigWithJournal(
+    {
+      configPath,
+      configIdentity: existingFile?.identity ?? null,
+      sidecarIdentity: sidecarFile?.identity ?? null,
+      beforeText: existingFile?.text ?? null,
+      beforeConfig,
+      afterText: updatedText,
+      afterConfig: updated,
+      oldBackup: sidecarFile?.backup ?? null,
+      newBackup: backup,
+      projectionPaths: [LORE_BACKUP_KEY],
+    },
+    guard,
+  );
 
   const total = PI_ANTHROPIC_PROVIDERS.length + PI_OPENAI_PROVIDERS.length;
   console.log(`[lore] Pi configured to use Lore gateway.`);
@@ -1097,7 +2521,11 @@ function setupPi(baseUrl: string): void {
  * redirect belongs. We honor `HERMES_HOME` for relocated installs.
  */
 export function hermesEnvPath(): string {
-  const home = process.env.HERMES_HOME || join(homedir(), ".hermes");
+  const customHome = process.env.HERMES_HOME;
+  const home = customHome || join(homedir(), ".hermes");
+  if (customHome) {
+    assertNoSymlinkPathComponents(home, "HERMES_HOME");
+  }
   return join(home, ".env");
 }
 
@@ -1119,28 +2547,31 @@ export function updateHermesEnv(content: string, baseUrl: string): string {
     OPENAI_BASE_URL: baseUrl,
     HERMES_INFERENCE_PROVIDER: "custom",
   };
-  // Build the backup from the ORIGINAL content (prior values) before we edit.
-  const block = buildEnvBackupBlock(content, loreValues);
-  let result = content;
+  const prepared = refreshEnvBackupBlock(content, loreValues);
+  let result = prepared.content;
   for (const [key, value] of Object.entries(loreValues)) {
     result = setEnvValueRaw(result, key, value);
   }
-  return block ? prependEnvBackupBlock(result, block) : result;
+  return prependEnvBackupBlock(result, prepared.block);
 }
 
-function setupHermes(baseUrl: string): void {
+function setupHermes(baseUrl: string, guard: SetupGuard): void {
+  guard.assertOwned();
   const configPath = hermesEnvPath();
-  mkdirSync(dirname(configPath), { recursive: true });
-
-  let content = "";
-  try {
-    content = readFileSync(configPath, "utf8");
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  guard.assertOwned();
+  ensureTrustedDirectory(dirname(configPath));
+  if (process.env.HERMES_HOME) {
+    assertNoSymlinkPathComponents(dirname(configPath), "HERMES_HOME");
   }
 
+  const existingFile = readTrustedTextFile(configPath, { allowMissing: true });
+  const content = existingFile?.text ?? "";
+
   const updated = updateHermesEnv(content, baseUrl);
-  writeFileSync(configPath, updated, "utf8");
+  guard.assertOwned();
+  atomicWriteTrustedFile(configPath, updated, {
+    expectedIdentity: existingFile?.identity ?? null,
+  });
 
   console.log(`[lore] Hermes Agent configured to use Lore gateway.`);
   console.log(`[lore]   OPENAI_BASE_URL=${baseUrl}`);
@@ -1181,7 +2612,8 @@ export function copilotApiUrlFromBaseUrl(baseUrl: string): string {
  * and recommend `lore run copilot` for the zero-config path. `lore setup status`
  * / `doctor` read COPILOT_API_URL to show the current routing.
  */
-function setupCopilot(baseUrl: string): void {
+function setupCopilot(baseUrl: string, guard: SetupGuard): void {
+  guard.assertOwned();
   const apiUrl = copilotApiUrlFromBaseUrl(baseUrl);
   console.log(`[lore] GitHub Copilot CLI routes through Lore via an env var.`);
   console.log(
@@ -1229,27 +2661,28 @@ export function updateGeminiEnv(content: string, baseUrl: string): string {
   const loreValues: Record<string, string> = {
     GOOGLE_GEMINI_BASE_URL: root,
   };
-  const block = buildEnvBackupBlock(content, loreValues);
-  let result = content;
+  const prepared = refreshEnvBackupBlock(content, loreValues);
+  let result = prepared.content;
   for (const [key, value] of Object.entries(loreValues)) {
     result = setEnvValueRaw(result, key, value);
   }
-  return block ? prependEnvBackupBlock(result, block) : result;
+  return prependEnvBackupBlock(result, prepared.block);
 }
 
-function setupGemini(baseUrl: string): void {
+function setupGemini(baseUrl: string, guard: SetupGuard): void {
+  guard.assertOwned();
   const configPath = geminiEnvPath();
-  mkdirSync(dirname(configPath), { recursive: true });
+  guard.assertOwned();
+  ensureTrustedDirectory(dirname(configPath));
 
-  let content = "";
-  try {
-    content = readFileSync(configPath, "utf8");
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
-  }
+  const existingFile = readTrustedTextFile(configPath, { allowMissing: true });
+  const content = existingFile?.text ?? "";
 
   const updated = updateGeminiEnv(content, baseUrl);
-  writeFileSync(configPath, updated, "utf8");
+  guard.assertOwned();
+  atomicWriteTrustedFile(configPath, updated, {
+    expectedIdentity: existingFile?.identity ?? null,
+  });
 
   const root = copilotApiUrlFromBaseUrl(baseUrl);
   console.log(`[lore] Gemini CLI configured to use Lore gateway.`);
@@ -1275,9 +2708,23 @@ function setupGemini(baseUrl: string): void {
  * consumed only when everything was reverted; if the user changed a value
  * after setup it is kept so their prior value stays recoverable.
  */
-function undoJsonApp(configPath: string): RestoreSummary {
-  const cfg = readJsonConfig(configPath);
-  const backup = loadJsonSetupBackup(configPath) ?? readLegacyJsonBackup(cfg);
+function undoJsonApp(configPath: string, guard: SetupGuard): RestoreSummary {
+  const sidecarFile = recoverJsonSetupJournal(configPath, guard);
+  const configFile = readJsonConfigFileIfExists(configPath);
+  if (!configFile && !sidecarFile) {
+    return { hadBackup: false, restored: [], skipped: [] };
+  }
+  if (!configFile && sidecarFile) {
+    removeJsonSetupBackup(configPath, guard, sidecarFile.identity);
+    return {
+      hadBackup: true,
+      restored: ["orphaned setup backup"],
+      skipped: [],
+    };
+  }
+  const beforeConfig = configFile?.config ?? {};
+  const cfg = structuredClone(beforeConfig);
+  const backup = sidecarFile?.backup ?? requireLegacyJsonBackup(cfg);
   const hadLegacyKey = LORE_BACKUP_KEY in cfg;
 
   if (!backup) {
@@ -1285,7 +2732,21 @@ function undoJsonApp(configPath: string): RestoreSummary {
     // config can't linger (e.g. a corrupt sidecar with an in-config key).
     if (hadLegacyKey) {
       delete cfg[LORE_BACKUP_KEY];
-      writeFileSync(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+      replaceJsonConfigWithJournal(
+        {
+          configPath,
+          configIdentity: configFile?.identity ?? null,
+          sidecarIdentity: sidecarFile?.identity ?? null,
+          beforeText: configFile?.text ?? null,
+          beforeConfig,
+          afterText: `${JSON.stringify(cfg, null, 2)}\n`,
+          afterConfig: cfg,
+          oldBackup: sidecarFile?.backup ?? null,
+          newBackup: sidecarFile?.backup ?? null,
+          projectionPaths: [LORE_BACKUP_KEY],
+        },
+        guard,
+      );
     }
     return { hadBackup: false, restored: [], skipped: [] };
   }
@@ -1293,83 +2754,249 @@ function undoJsonApp(configPath: string): RestoreSummary {
   const summary = applyJsonBackup(cfg, backup);
   // Always drop any legacy in-config backup key (migration cleanup).
   delete cfg[LORE_BACKUP_KEY];
-  writeFileSync(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
-  if (summary.skipped.length === 0) removeJsonSetupBackup(configPath);
+  const restoredText = `${JSON.stringify(cfg, null, 2)}\n`;
+  const remaining = retainSkippedJsonBackup(backup, summary.skipped, cfg);
+  const restoreAbsence =
+    backup.version === 3 &&
+    !backup.originalExists &&
+    summary.skipped.length === 0 &&
+    Object.keys(cfg).length === 0;
+  replaceJsonConfigWithJournal(
+    {
+      configPath,
+      configIdentity: configFile?.identity ?? null,
+      sidecarIdentity: sidecarFile?.identity ?? null,
+      beforeText: configFile?.text ?? null,
+      beforeConfig,
+      afterText: restoreAbsence ? null : restoredText,
+      afterConfig: cfg,
+      oldBackup: sidecarFile?.backup ?? null,
+      newBackup: remaining,
+      projectionPaths: [
+        ...backup.entries.map((entry) => entry.path),
+        "plugin",
+        LORE_BACKUP_KEY,
+      ],
+    },
+    guard,
+  );
   return summary;
 }
 
-function undoClaudeCode(): RestoreSummary {
-  return undoJsonApp(claudeCodeSettingsPath());
+/** Strictly read every JSON undo input without writing it. */
+function prevalidateJsonUndo(configPath: string): void {
+  const configFile = readJsonConfigFileIfExists(configPath);
+  const sidecarFile = requireJsonSetupBackup(configPath);
+  if (!sidecarFile?.backup && configFile) {
+    requireLegacyJsonBackup(configFile.config);
+  }
 }
 
-function undoOpencode(): RestoreSummary {
-  return undoJsonApp(opencodeConfigPath());
+function undoClaudeCode(guard: SetupGuard): RestoreSummary {
+  return undoJsonApp(claudeCodeSettingsPath(), guard);
 }
 
-function undoPi(): RestoreSummary {
-  return undoJsonApp(piModelsConfigPath());
+function undoOpencode(
+  guard: SetupGuard,
+  candidates: readonly string[] = opencodeUndoCandidates(),
+): RestoreSummary {
+  let combined: RestoreSummary = {
+    hadBackup: false,
+    restored: [],
+    skipped: [],
+  };
+  for (const configPath of candidates) {
+    const summary = undoOpencodeConfig(configPath, guard);
+    combined = {
+      hadBackup: combined.hadBackup || summary.hadBackup,
+      restored: [...combined.restored, ...summary.restored],
+      skipped: [...combined.skipped, ...summary.skipped],
+    };
+  }
+  return combined;
 }
 
-function undoHermes(): RestoreSummary {
-  const configPath = hermesEnvPath();
-  let content: string;
-  try {
-    content = readFileSync(configPath, "utf8");
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+function opencodeUndoCandidates(): string[] {
+  return opencodeConfigPaths(opencodeConfigPath()).filter(
+    (path) =>
+      trustedFileExists(path) || trustedFileExists(jsonBackupPath(path)),
+  );
+}
+
+function prevalidateOpencodeUndo(
+  candidates: readonly string[] = opencodeUndoCandidates(),
+): void {
+  for (const configPath of candidates) {
+    prevalidateJsonUndo(configPath);
+  }
+}
+
+function undoOpencodeConfig(
+  configPath: string,
+  guard: SetupGuard,
+): RestoreSummary {
+  if (!trustedFileExists(configPath)) {
+    const sidecarFile = recoverJsonSetupJournal(configPath, guard);
+    if (!sidecarFile) {
       return { hadBackup: false, restored: [], skipped: [] };
     }
-    throw e;
+    removeJsonSetupBackup(configPath, guard, sidecarFile.identity);
+    return {
+      hadBackup: true,
+      restored: ["orphaned setup backup"],
+      skipped: [],
+    };
   }
-  const { content: restored, summary } = restoreEnvBackup(content);
-  if (summary.hadBackup) writeFileSync(configPath, restored, "utf8");
+  if (!configPath.endsWith(".jsonc")) {
+    return undoJsonApp(configPath, guard);
+  }
+
+  const sidecarFile = recoverJsonSetupJournal(configPath, guard);
+  const {
+    text,
+    config: beforeConfig,
+    identity,
+  } = readJsonConfigFile(configPath);
+  const config = structuredClone(beforeConfig);
+  const backup = sidecarFile?.backup ?? requireLegacyJsonBackup(config);
+  if (!backup) return { hadBackup: false, restored: [], skipped: [] };
+  const summary = applyJsonBackup(config, backup);
+  let restoredText = text;
+  for (const entry of backup.entries) {
+    if (!summary.restored.includes(entry.path)) continue;
+    const path = entry.path.split(".");
+    restoredText = entry.hadPrior
+      ? setJsonConfigValue(restoredText, path, entry.priorValue)
+      : deleteJsonConfigValue(restoredText, path);
+  }
+  if (backup.version === 3) {
+    for (const ancestor of [...backup.createdAncestors].sort(
+      (left, right) => right.split(".").length - left.split(".").length,
+    )) {
+      if (getPath(config, ancestor) === undefined) {
+        restoredText = deleteJsonConfigValue(restoredText, ancestor.split("."));
+      }
+    }
+  }
+  if (summary.restored.includes("plugin[@loreai/opencode]")) {
+    restoredText = config.plugin
+      ? setJsonConfigValue(restoredText, ["plugin"], config.plugin)
+      : deleteJsonConfigValue(restoredText, ["plugin"]);
+  }
+  restoredText = deleteJsonConfigValue(restoredText, [LORE_BACKUP_KEY]);
+  delete config[LORE_BACKUP_KEY];
+  const remaining = retainSkippedJsonBackup(backup, summary.skipped, config);
+  const restoreAbsence =
+    backup.version === 3 &&
+    !backup.originalExists &&
+    summary.skipped.length === 0 &&
+    Object.keys(config).length === 0;
+  replaceJsonConfigWithJournal(
+    {
+      configPath,
+      configIdentity: identity,
+      sidecarIdentity: sidecarFile?.identity ?? null,
+      beforeText: text,
+      beforeConfig,
+      afterText: restoreAbsence ? null : restoredText,
+      afterConfig: config,
+      oldBackup: sidecarFile?.backup ?? null,
+      newBackup: remaining,
+      projectionPaths: [
+        ...backup.entries.map((entry) => entry.path),
+        "plugin",
+        LORE_BACKUP_KEY,
+      ],
+    },
+    guard,
+  );
   return summary;
 }
 
-function undoCopilot(): RestoreSummary {
+function undoPi(guard: SetupGuard): RestoreSummary {
+  return undoJsonApp(piModelsConfigPath(), guard);
+}
+
+function undoHermes(guard: SetupGuard): RestoreSummary {
+  const configPath = hermesEnvPath();
+  const file = readTrustedTextFile(configPath, { allowMissing: true });
+  if (!file) return { hadBackup: false, restored: [], skipped: [] };
+  const { content: restored, summary } = restoreEnvBackup(file.text);
+  if (summary.hadBackup) {
+    guard.assertOwned();
+    atomicWriteTrustedFile(configPath, restored, {
+      expectedIdentity: file.identity,
+    });
+  }
+  return summary;
+}
+
+function prevalidateHermesUndo(): void {
+  const file = readTrustedTextFile(hermesEnvPath(), { allowMissing: true });
+  if (file) restoreEnvBackup(file.text);
+}
+
+function undoCopilot(guard: SetupGuard): RestoreSummary {
+  guard.assertOwned();
   // `lore setup copilot` never persists anything (Copilot CLI has no config-file
   // endpoint field), so there is nothing to restore. Tell the user how to stop
   // routing and return an empty summary.
-  console.log(
-    `[lore] GitHub Copilot CLI setup is env-var based (COPILOT_API_URL); lore`,
-  );
-  console.log(
-    `[lore] wrote no config. Remove the COPILOT_API_URL export from your shell`,
-  );
-  console.log(`[lore] profile to stop routing through the gateway.`);
+  const variables = [
+    process.env.COPILOT_API_URL ? "COPILOT_API_URL" : null,
+    process.env.COPILOT_PROVIDER_BASE_URL ? "COPILOT_PROVIDER_BASE_URL" : null,
+  ].filter((name): name is string => name !== null);
+  if (variables.length > 0) {
+    console.log(`[lore] GitHub Copilot CLI setup is env-var based; lore`);
+    console.log(
+      `[lore] wrote no config. Unset ${variables.join(" and ")} where`,
+    );
+    console.log(
+      `[lore] your shell or service defines it to stop Lore routing.`,
+    );
+  } else {
+    console.log(
+      `[lore] GitHub Copilot CLI: no Lore routing environment variable is set.`,
+    );
+  }
   return { hadBackup: false, restored: [], skipped: [] };
 }
 
-function undoGemini(): RestoreSummary {
+function undoGemini(guard: SetupGuard): RestoreSummary {
   const configPath = geminiEnvPath();
-  let content: string;
-  try {
-    content = readFileSync(configPath, "utf8");
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
-      return { hadBackup: false, restored: [], skipped: [] };
-    }
-    throw e;
+  const file = readTrustedTextFile(configPath, { allowMissing: true });
+  if (!file) return { hadBackup: false, restored: [], skipped: [] };
+  const { content: restored, summary } = restoreEnvBackup(file.text);
+  if (summary.hadBackup) {
+    guard.assertOwned();
+    atomicWriteTrustedFile(configPath, restored, {
+      expectedIdentity: file.identity,
+    });
   }
-  const { content: restored, summary } = restoreEnvBackup(content);
-  if (summary.hadBackup) writeFileSync(configPath, restored, "utf8");
   return summary;
 }
 
-function undoCodex(): RestoreSummary {
+function prevalidateGeminiUndo(): void {
+  const file = readTrustedTextFile(geminiEnvPath(), { allowMissing: true });
+  if (file) restoreEnvBackup(file.text);
+}
+
+function undoCodex(guard: SetupGuard): RestoreSummary {
   const configPath = codexConfigPath();
-  let content: string;
-  try {
-    content = readFileSync(configPath, "utf8");
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
-      return { hadBackup: false, restored: [], skipped: [] };
-    }
-    throw e;
+  const file = readTrustedTextFile(configPath, { allowMissing: true });
+  if (!file) return { hadBackup: false, restored: [], skipped: [] };
+  const { content: restored, summary } = restoreTomlBackup(file.text);
+  if (summary.hadBackup) {
+    guard.assertOwned();
+    atomicWriteTrustedFile(configPath, restored, {
+      expectedIdentity: file.identity,
+    });
   }
-  const { content: restored, summary } = restoreTomlBackup(content);
-  if (summary.hadBackup) writeFileSync(configPath, restored, "utf8");
   return summary;
+}
+
+function prevalidateCodexUndo(): void {
+  const file = readTrustedTextFile(codexConfigPath(), { allowMissing: true });
+  if (file) restoreTomlBackup(file.text);
 }
 
 /** Print the result of one app's undo. */
@@ -1392,7 +3019,7 @@ function reportUndo(app: AppSetup, summary: RestoreSummary, explicit: boolean) {
   }
 }
 
-async function commandUndo(args: string[]): Promise<void> {
+async function commandUndo(args: string[], guard: SetupGuard): Promise<void> {
   const appName = args[0]?.toLowerCase();
   let targets: AppSetup[];
   if (appName) {
@@ -1409,12 +3036,25 @@ async function commandUndo(args: string[]): Promise<void> {
     }
     targets = [app];
   } else {
-    targets = SUPPORTED_APPS;
+    targets = SUPPORTED_APPS.filter(
+      (app) =>
+        app.agentName !== "copilot" ||
+        Boolean(
+          process.env.COPILOT_API_URL || process.env.COPILOT_PROVIDER_BASE_URL,
+        ),
+    );
+  }
+
+  // Validate the complete undo set before changing the first file.
+  for (const app of targets) {
+    guard.assertOwned();
+    app.prevalidateUndo();
   }
 
   let restoredAny = false;
   for (const app of targets) {
-    const summary = app.undo();
+    guard.assertOwned();
+    const summary = app.undo(guard);
     if (summary.hadBackup) restoredAny = true;
     reportUndo(app, summary, Boolean(appName));
   }
@@ -1424,14 +3064,253 @@ async function commandUndo(args: string[]): Promise<void> {
   }
 }
 
+/** Validate every setup backup an integration may consume without mutation. */
+export function prevalidateSetupUndo(): void {
+  for (const app of SUPPORTED_APPS) app.prevalidateUndo();
+}
+
+export interface SetupUndoTransaction {
+  prepareCommit: () => void;
+  commit: () => void;
+  rollback: () => void;
+}
+
+/**
+ * Undo every persistent setup integration while retaining the exact original
+ * file generations until the caller crosses its irreversible commit boundary.
+ */
+export function stageSetupUndo(guard: LifecycleLock): SetupUndoTransaction {
+  const targets = SUPPORTED_APPS.filter(
+    (app) =>
+      app.agentName !== "copilot" ||
+      Boolean(
+        process.env.COPILOT_API_URL || process.env.COPILOT_PROVIDER_BASE_URL,
+      ),
+  ).map((app) => ({ app, paths: app.undoPaths() }));
+
+  for (const { app, paths } of targets) {
+    guard.assertOwned();
+    app.prevalidateUndo(paths);
+  }
+
+  const transactions: Array<StagedTrustedFileMutation<RestoreSummary>> = [];
+  let restoredAny = false;
+  try {
+    for (const { app, paths } of targets) {
+      guard.assertOwned();
+      const transaction =
+        paths.length > 0
+          ? stageTrustedFileMutation(paths, () => app.undo(guard, paths))
+          : null;
+      const summary = transaction?.result ?? app.undo(guard);
+      if (transaction) transactions.push(transaction);
+      if (summary.hadBackup) restoredAny = true;
+      reportUndo(app, summary, false);
+    }
+  } catch (error) {
+    const rollbackErrors: unknown[] = [];
+    for (const transaction of transactions.reverse()) {
+      try {
+        transaction.rollback();
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        "Setup undo staging failed and could not be fully rolled back.",
+      );
+    }
+    throw error;
+  }
+
+  if (!restoredAny) {
+    console.log(`[lore] No lore setup backups found — nothing to undo.`);
+  }
+
+  return {
+    prepareCommit: () => {
+      guard.assertOwned();
+      for (const transaction of transactions) transaction.prepareCommit();
+      guard.assertOwned();
+    },
+    commit: () => {
+      for (const transaction of transactions) transaction.commit();
+    },
+    rollback: () => {
+      const rollbackErrors: unknown[] = [];
+      for (const transaction of [...transactions].reverse()) {
+        try {
+          transaction.rollback();
+        } catch (rollbackError) {
+          rollbackErrors.push(rollbackError);
+        }
+      }
+      if (rollbackErrors.length > 0) {
+        throw new AggregateError(
+          rollbackErrors,
+          "Setup undo could not be fully rolled back.",
+        );
+      }
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Command entry point
 // ---------------------------------------------------------------------------
 
-export async function commandSetup(
+function rollbackSetupTransaction(
+  transaction: StagedTrustedFileMutation<boolean> | null,
+  external: SetupExternalTransaction,
+  cause?: unknown,
+): void {
+  const rollbackErrors: unknown[] = [];
+  if (cause !== undefined && containsLifecycleLockLoss(cause)) {
+    external.abandon();
+    process.exitCode = 1;
+    console.error(
+      `[lore] Lifecycle-lock ownership was lost; external package state was not rolled back and recovery evidence was preserved.`,
+    );
+  } else {
+    try {
+      external.rollback();
+    } catch (error) {
+      rollbackErrors.push(error);
+    }
+  }
+  try {
+    transaction?.rollback();
+  } catch (error) {
+    rollbackErrors.push(error);
+  }
+  if (rollbackErrors.length > 0) {
+    throw new AggregateError(
+      cause === undefined ? rollbackErrors : [cause, ...rollbackErrors],
+      "Setup failed and could not be fully rolled back.",
+    );
+  }
+}
+
+function containsLifecycleLockLoss(error: unknown): boolean {
+  if (error instanceof LifecycleLockLostError) return true;
+  if (error instanceof AggregateError) {
+    return error.errors.some(containsLifecycleLockLoss);
+  }
+  return (
+    error instanceof Error &&
+    error.cause !== undefined &&
+    containsLifecycleLockLoss(error.cause)
+  );
+}
+
+function runSetupTargetsTransactionally(
+  targets: readonly AppSetup[],
+  baseUrl: string,
+  noPlugin: boolean,
+  lifecycleLock: LifecycleLock,
+): boolean {
+  const external = new SetupExternalTransaction(lifecycleLock);
+  const runTargets = (): boolean => {
+    for (const app of targets) {
+      lifecycleLock.assertOwned();
+      if (app.run(baseUrl, noPlugin, lifecycleLock, external) === false) {
+        return false;
+      }
+    }
+    return true;
+  };
+  const setupPaths = targets.flatMap((app) => app.undoPaths());
+  let transaction: StagedTrustedFileMutation<boolean> | null = null;
+  let succeeded: boolean;
+  try {
+    if (setupPaths.length === 0) {
+      succeeded = runTargets();
+    } else {
+      transaction = stageTrustedFileMutation(setupPaths, runTargets);
+      succeeded = transaction.result;
+    }
+  } catch (error) {
+    // stageTrustedFileMutation already restores files when its action throws.
+    rollbackSetupTransaction(null, external, error);
+    throw error;
+  }
+
+  if (!succeeded) {
+    rollbackSetupTransaction(transaction, external);
+    return false;
+  }
+
+  try {
+    lifecycleLock.assertOwned();
+    transaction?.prepareCommit();
+    setupExternalEffectHook?.("before-prepare");
+    lifecycleLock.assertOwned();
+    external.prepareCommit();
+    lifecycleLock.assertOwned();
+    external.establishCommitPoint();
+  } catch (error) {
+    if (!external.hasDurableCommitPoint()) {
+      rollbackSetupTransaction(transaction, external, error);
+    } else {
+      external.abandon();
+      process.exitCode = 1;
+      console.error(
+        `[lore] Setup crossed its durable commit point; committed package and config state were preserved with recovery evidence.`,
+      );
+    }
+    throw error;
+  }
+
+  try {
+    lifecycleLock.assertOwned();
+    transaction?.commit();
+  } catch (error) {
+    if (!external.hasDurableCommitPoint()) {
+      rollbackSetupTransaction(transaction, external, error);
+    } else {
+      external.abandon();
+      process.exitCode = 1;
+      console.error(
+        `[lore] Setup crossed its durable commit point; committed package and config state were preserved with recovery evidence.`,
+      );
+    }
+    throw error;
+  }
+  // Visible files and the package crossed one durable logical commit point
+  // before rollback artifacts were released. Journal cleanup is validation and
+  // evidence cleanup only; failures after this point must never compensate npm.
+  external.commit();
+  return true;
+}
+
+async function commandSetupLocked(
   args: string[],
   values: Record<string, unknown>,
-): Promise<void> {
+  lifecycleLock: LifecycleLock,
+): Promise<{
+  baseUrl: string;
+  remoteUrl: string | undefined;
+  authenticatedPort: number | null;
+} | null> {
+  lifecycleLock.assertOwned();
+  reconcileSetupExternalEffects(lifecycleLock);
+
+  // Read-only/restore operations do not write a new gateway route and must work
+  // even when the current shell has a Claude cloud-routing conflict.
+  if (args[0]?.toLowerCase() === "status") {
+    lifecycleLock.assertOwned();
+    const { printInventoryStatus } = await import("./inventory");
+    printInventoryStatus();
+    return null;
+  }
+  if (args[0]?.toLowerCase() === "undo") {
+    lifecycleLock.assertOwned();
+    await commandUndo(args.slice(1), lifecycleLock);
+    return null;
+  }
+
   // Detect conflicting Claude Code native cloud flags — these break the
   // plain-Anthropic-to-lore path. The client must NOT use CLAUDE_CODE_USE_BEDROCK
   // or CLAUDE_CODE_USE_VERTEX; the gateway handles cloud translation instead.
@@ -1451,43 +3330,30 @@ export async function commandSetup(
       `[lore] Unset ${flag} and let Lore handle the cloud provider routing.`,
     );
     process.exitCode = 1;
-    return;
-  }
-
-  // `lore setup undo [app]` — restore the backup written by a prior setup.
-  if (args[0]?.toLowerCase() === "undo") {
-    await commandUndo(args.slice(1));
-    return;
-  }
-
-  // `lore setup status` — read-only inventory of what setup has touched.
-  if (args[0]?.toLowerCase() === "status") {
-    const { printInventoryStatus } = await import("./inventory");
-    printInventoryStatus();
-    return;
+    return null;
   }
 
   const remoteUrl = values.remote as string | undefined;
   const explicitPort = values.port ? Number(values.port) : undefined;
-  const noPlugin = values.noPlugin === true;
+  const noPlugin = values["no-plugin"] === true || values.noPlugin === true;
 
-  // Detect a running local gateway so we write its actual port (handles the
-  // 3207 → 5673 → random fallback chain) rather than blindly assuming 3207.
-  const livePort =
-    remoteUrl || explicitPort !== undefined
-      ? null
-      : await detectLiveGatewayPort();
+  // Authenticate local process state even when --port is explicit: explicit
+  // selection still wins, but only a matching owner-authenticated record can
+  // produce a successful local liveness notice.
+  const authenticatedPort = remoteUrl
+    ? null
+    : await detectAuthenticatedGatewayPort();
 
   let baseUrl: string;
   try {
     baseUrl = normalizeBaseUrl(
       remoteUrl,
-      chooseSetupPort({ explicitPort, remoteUrl, livePort }),
+      chooseSetupPort({ explicitPort, remoteUrl, authenticatedPort }),
     );
   } catch (e) {
     console.error(`[lore] ${e instanceof Error ? e.message : String(e)}`);
     process.exitCode = 1;
-    return;
+    return null;
   }
 
   const appName = args[0]?.toLowerCase();
@@ -1504,7 +3370,7 @@ export async function commandSetup(
         `[lore] Unknown app "${args[0]}". Supported apps: ${supported}`,
       );
       process.exitCode = 1;
-      return;
+      return null;
     }
 
     // Warn if the binary isn't detected, but proceed anyway
@@ -1515,9 +3381,13 @@ export async function commandSetup(
       );
     }
 
-    app.run(baseUrl, noPlugin);
-    await reportLiveness(baseUrl, remoteUrl, livePort);
-    return;
+    lifecycleLock.assertOwned();
+    if (
+      !runSetupTargetsTransactionally([app], baseUrl, noPlugin, lifecycleLock)
+    ) {
+      return null;
+    }
+    return { baseUrl, remoteUrl, authenticatedPort };
   }
 
   // No app name — auto-detect
@@ -1536,28 +3406,60 @@ export async function commandSetup(
       `[lore] You can also specify an app explicitly: lore setup <app>`,
     );
     process.exitCode = 1;
-    return;
+    return null;
   }
 
-  for (const app of setupTargets) {
-    app.run(baseUrl, noPlugin);
+  // Auto-detected setup is one operation: retain every target's pre-run file
+  // generation and any owned external changes until all handlers succeed.
+  if (
+    !runSetupTargetsTransactionally(
+      setupTargets,
+      baseUrl,
+      noPlugin,
+      lifecycleLock,
+    )
+  ) {
+    return null;
   }
-  await reportLiveness(baseUrl, remoteUrl, livePort);
+  return { baseUrl, remoteUrl, authenticatedPort };
+}
+
+export async function commandSetup(
+  args: string[],
+  values: Record<string, unknown>,
+): Promise<void> {
+  const liveness = await withLifecycleLock("setup", (lifecycleLock) =>
+    commandSetupLocked(args, values, lifecycleLock),
+  );
+  if (liveness) {
+    await reportLiveness(
+      liveness.baseUrl,
+      liveness.remoteUrl,
+      liveness.authenticatedPort,
+    );
+  }
 }
 
 /**
- * Probe the configured gateway and print a PASS/WARN notice. Reuses the
- * already-probed `livePort` result for the default-local case to avoid a
- * second network round-trip.
+ * Probe remote health, or compare local configuration to the already
+ * authenticated owner process record. Public local health is not identity.
  */
 async function reportLiveness(
   baseUrl: string,
   remoteUrl: string | undefined,
-  livePort: number | null,
+  authenticatedPort: number | null,
 ): Promise<void> {
   const origin = baseUrl.replace(/\/v1$/, "");
-  // If we already confirmed a live local port, we know it's reachable.
-  const alive = livePort != null ? true : await probeGateway(origin);
+  const expectedLocalOrigin =
+    authenticatedPort === null
+      ? null
+      : normalizeBaseUrl(undefined, authenticatedPort).replace(/\/v1$/, "");
+  const alive = remoteUrl
+    ? await (async () => {
+        const { probeGateway } = await import("./start");
+        return probeGateway(origin);
+      })()
+    : origin === expectedLocalOrigin;
   const notice = formatLivenessNotice({
     alive,
     origin,

--- a/packages/gateway/src/cli/shutdown.ts
+++ b/packages/gateway/src/cli/shutdown.ts
@@ -1,48 +1,29 @@
 /**
  * Graceful-but-bounded process shutdown helpers.
  *
- * The gateway only exits via `safeExit()`, which is reached *after* the
- * `shutdown()` closure resolves. Several shutdown steps (batch-queue drain,
+ * The gateway exits normally only after the `shutdown()` closure resolves.
+ * Several shutdown steps (batch-queue drain,
  * embedding-worker exit) can, in pathological cases, take a long time — which
  * is why Ctrl+C used to appear to "hang for minutes" with no way to break out.
  *
  * These helpers guarantee that:
  *   1. shutdown can never block the process longer than a hard deadline, and
- *   2. a *second* SIGINT/SIGTERM forces an immediate exit.
+ *   2. a *second* child-owning SIGINT/SIGTERM immediately escalates the child
+ *      while retaining the hard wrapper deadline.
  */
-import { forcedExit } from "./exit";
+import { forcedExit, safeExit } from "./exit";
+import { SHUTDOWN_DEADLINE_MS } from "../shutdown-deadline";
 
-const DEFAULT_SHUTDOWN_DEADLINE_MS = 4000;
-
-/**
- * Parse a shutdown-deadline value (ms). Invalid / non-positive / non-finite
- * values fall back to `fallback` — mirrors the `LORE_MAX_RETRIES` parsing
- * convention so a typo can never *disable* the safety net. Exported for tests.
- */
-export function parseShutdownDeadline(
-  raw: string | undefined,
-  fallback: number = DEFAULT_SHUTDOWN_DEADLINE_MS,
-): number {
-  if (!raw) return fallback;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return fallback;
-  return n;
-}
-
-/**
- * Hard cap (ms) on how long graceful shutdown may run before the gateway
- * force-exits, so Ctrl+C can never hang. Env: `LORE_SHUTDOWN_TIMEOUT_MS`
- * (default 4000). Invalid / non-positive / non-finite values fall back to the
- * default — the timeout can never be disabled.
- */
-export const SHUTDOWN_DEADLINE_MS: number = parseShutdownDeadline(
-  process.env.LORE_SHUTDOWN_TIMEOUT_MS,
-);
+export {
+  parseShutdownDeadline,
+  SHUTDOWN_DEADLINE_MS,
+} from "../shutdown-deadline";
 
 const SIGNAL_NUMBERS: Record<string, number> = {
   SIGHUP: 1,
   SIGINT: 2,
   SIGQUIT: 3,
+  SIGKILL: 9,
   SIGTERM: 15,
 };
 
@@ -61,6 +42,8 @@ export function signalExitCode(signal: NodeJS.Signals): number {
 export interface ShutdownResult {
   /** True if the deadline fired before shutdown() resolved. */
   timedOut: boolean;
+  /** True if shutdown rejected before the deadline. */
+  failed: boolean;
 }
 
 /**
@@ -75,6 +58,7 @@ export async function runShutdownWithDeadline(
 ): Promise<ShutdownResult> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
+  let failed = false;
   const deadline = new Promise<void>((resolve) => {
     timer = setTimeout(() => {
       timedOut = true;
@@ -85,21 +69,211 @@ export async function runShutdownWithDeadline(
     }, deadlineMs);
     // Intentionally NOT unref'd: keep the event loop alive for the duration of
     // the (bounded) shutdown so the caller deterministically reaches
-    // `safeExit()` with the right code. The timer is cleared the instant
+    // the process exit decision with the right code. The timer is cleared the instant
     // shutdown resolves (see finally), so a fast shutdown still exits
     // immediately.
   });
   try {
     await Promise.race([
-      shutdown().catch((e) => {
-        console.error("[lore] Error during shutdown:", e);
-      }),
+      Promise.resolve()
+        .then(shutdown)
+        .catch((e) => {
+          failed = true;
+          console.error("[lore] Error during shutdown:", e);
+        }),
       deadline,
     ]);
   } finally {
     if (timer) clearTimeout(timer);
   }
-  return { timedOut };
+  return { timedOut, failed };
+}
+
+export interface ProcessShutdownOptions {
+  deadlineMs?: number;
+  safeExit?: (code: number) => never;
+  forcedExit?: (code: number) => never;
+}
+
+export interface OwnedChildProcess {
+  kill: (signal: NodeJS.Signals) => boolean;
+  exitCode?: number | null;
+  signalCode?: NodeJS.Signals | null;
+}
+
+export interface ProcessShutdownController {
+  (exitCode: number, childSignal?: NodeJS.Signals): Promise<never>;
+  /** Attach the child owned by `lore run` before any shutdown trigger can fire. */
+  attachChild: (child: OwnedChildProcess) => void;
+  /** Whether any signal or authenticated request has started shutdown. */
+  isShutdownStarted: () => boolean;
+  /** Immediately SIGKILL a live child, then retain the shared reap deadline. */
+  killChildAndWait: (exitCode: number) => Promise<never>;
+  /** Record and reap a child outcome, upgrading a pending successful exit. */
+  childExited: (exitCode: number) => Promise<never>;
+}
+
+/**
+ * Create the one-shot shutdown controller used at process command/control
+ * boundaries. The whole teardown gets one deadline; a timeout or rejection
+ * force-exits nonzero, while a completed teardown exits normally. Repeated
+ * signal/control requests share the same in-flight teardown.
+ *
+ * Do not apply this to ordinary library handles: exiting belongs to the CLI
+ * process boundary, not to in-process plugin callers.
+ */
+export function makeProcessShutdownController(
+  shutdown: () => Promise<void>,
+  options: ProcessShutdownOptions = {},
+): ProcessShutdownController {
+  const exitNormally = options.safeExit ?? safeExit;
+  const exitForcibly = options.forcedExit ?? forcedExit;
+  const deadlineMs = options.deadlineMs ?? SHUTDOWN_DEADLINE_MS;
+  // Leave half of the one shared deadline for the escalated child to exit and
+  // for gateway teardown to finish. This is derived from (and strictly inside)
+  // the outer bound rather than introducing a second independently-sized wait.
+  const childGraceMs = Math.floor(deadlineMs / 2);
+  let shutdownPromise: Promise<never> | undefined;
+  let shutdownStartedAt: number | undefined;
+  let requestedExitCode = 0;
+  let requestedChildSignal: NodeJS.Signals = "SIGTERM";
+  let child: OwnedChildProcess | undefined;
+  let childSignalSent = false;
+  let childKillSent = false;
+  let childEscalationFailed = false;
+  let childEscalationTimer: ReturnType<typeof setTimeout> | undefined;
+  let childSettled = true;
+  let resolveChildExit: (() => void) | undefined;
+  let childExit = Promise.resolve();
+
+  const preserveOutcome = (exitCode: number): void => {
+    if (requestedExitCode === 0 && exitCode !== 0) requestedExitCode = exitCode;
+  };
+
+  const clearChildEscalation = (): void => {
+    if (childEscalationTimer) clearTimeout(childEscalationTimer);
+    childEscalationTimer = undefined;
+  };
+
+  const escalateChild = (): void => {
+    if (!child || childSettled || childKillSent) return;
+    childKillSent = true;
+    try {
+      if (!child.kill("SIGKILL")) {
+        childEscalationFailed = true;
+        console.error("[lore] Failed to force-stop child process.");
+      }
+    } catch (error) {
+      childEscalationFailed = true;
+      console.error("[lore] Failed to force-stop child process:", error);
+    }
+  };
+
+  const scheduleChildEscalation = (): void => {
+    if (
+      !child ||
+      childSettled ||
+      childKillSent ||
+      childEscalationTimer ||
+      shutdownStartedAt === undefined
+    ) {
+      return;
+    }
+    const elapsed = Date.now() - shutdownStartedAt;
+    childEscalationTimer = setTimeout(
+      escalateChild,
+      Math.max(0, childGraceMs - elapsed),
+    );
+    // Intentionally ref'ed: even if a ChildProcess implementation does not
+    // hold the event loop open, the wrapper must reach escalation/reaping or
+    // the outer forced-exit decision rather than silently orphaning the child.
+  };
+
+  const signalChild = (): void => {
+    if (!child || childSettled || childSignalSent) return;
+    childSignalSent = true;
+    try {
+      child.kill(requestedChildSignal);
+    } catch {
+      // A concurrent exit/error listener will reap the child. If it does not,
+      // the shared process deadline still bounds the wait.
+    }
+    scheduleChildEscalation();
+  };
+
+  const controller = ((
+    exitCode: number,
+    childSignal?: NodeJS.Signals,
+  ): Promise<never> => {
+    preserveOutcome(exitCode);
+    if (childSignal && !childSignalSent) requestedChildSignal = childSignal;
+    shutdownPromise ??= (async (): Promise<never> => {
+      shutdownStartedAt = Date.now();
+      // Register escalation before the outer deadline. Even if both timers are
+      // observed in one delayed timers turn, SIGKILL is therefore dispatched
+      // first; the parsed deadline also keeps this timer strictly earlier.
+      signalChild();
+      const result = await runShutdownWithDeadline(async () => {
+        const outcomes = await Promise.allSettled([
+          Promise.resolve().then(shutdown),
+          childExit,
+        ]);
+        const failure = outcomes.find(
+          (outcome): outcome is PromiseRejectedResult =>
+            outcome.status === "rejected",
+        );
+        if (failure) throw failure.reason;
+      }, deadlineMs);
+      clearChildEscalation();
+      if (result.timedOut || result.failed || childEscalationFailed) {
+        return exitForcibly(requestedExitCode === 0 ? 1 : requestedExitCode);
+      }
+      return exitNormally(requestedExitCode);
+    })();
+    return shutdownPromise;
+  }) as ProcessShutdownController;
+
+  controller.attachChild = (ownedChild): void => {
+    if (shutdownPromise) {
+      throw new Error("Cannot attach a child after shutdown has started");
+    }
+    if (child) throw new Error("A shutdown controller may own only one child");
+    child = ownedChild;
+    childSettled =
+      ownedChild.exitCode !== undefined && ownedChild.exitCode !== null;
+    if (childSettled) preserveOutcome(ownedChild.exitCode ?? 0);
+    if (!childSettled && ownedChild.signalCode) {
+      childSettled = true;
+      preserveOutcome(signalExitCode(ownedChild.signalCode));
+    }
+    if (!childSettled) {
+      childExit = new Promise<void>((resolve) => {
+        resolveChildExit = resolve;
+      });
+    }
+  };
+
+  controller.isShutdownStarted = (): boolean => shutdownPromise !== undefined;
+
+  controller.killChildAndWait = (exitCode): Promise<never> => {
+    preserveOutcome(exitCode);
+    const pending = controller(exitCode);
+    escalateChild();
+    return pending;
+  };
+
+  controller.childExited = (exitCode): Promise<never> => {
+    preserveOutcome(exitCode);
+    if (!childSettled) {
+      childSettled = true;
+      clearChildEscalation();
+      resolveChildExit?.();
+      resolveChildExit = undefined;
+    }
+    return controller(exitCode);
+  };
+
+  return controller;
 }
 
 /**
@@ -110,15 +284,14 @@ export async function runShutdownWithDeadline(
  *   - Second signal: force an immediate exit (don't wait for the in-flight
  *     graceful shutdown). This is what makes repeated Ctrl+C responsive.
  *
- * On every exit path we use `forcedExit` (not `safeExit`) because the deadline
- * or the second-interrupt shortcut means the embedding worker may still be
- * mid-inference in a native call — `safeExit` would walk NAPI destructors
- * under it and SIGABRT (the "💣 Program crashed" report).
+ * A completed teardown uses `safeExit`; a deadline/error or second interrupt
+ * uses `forcedExit` because native worker teardown may still be in flight.
  *
  * Exported for testing; prefer `installSignalShutdown` at call sites.
  */
 export function makeSignalShutdownHandler(
   shutdown: () => Promise<void>,
+  processShutdown = makeProcessShutdownController(shutdown),
 ): (signal: NodeJS.Signals) => Promise<void> {
   let count = 0;
   return async (signal: NodeJS.Signals): Promise<void> => {
@@ -128,55 +301,55 @@ export function makeSignalShutdownHandler(
       console.error("[lore] Received second interrupt — forcing exit.");
       forcedExit(code);
     }
-    await runShutdownWithDeadline(shutdown);
-    // Bounded shutdown could have timed out → worker may still be alive.
-    // Use forcedExit unconditionally on this path for the same reason
-    // second-signal does — the 4000ms cap is the only timing guarantee we have.
-    forcedExit(code);
+    await processShutdown(code);
   };
 }
 
 /** Install the direct-owns-teardown signal handler (see makeSignalShutdownHandler). */
-export function installSignalShutdown(shutdown: () => Promise<void>): void {
-  const handle = makeSignalShutdownHandler(shutdown);
+export function installSignalShutdown(
+  shutdown: () => Promise<void>,
+  processShutdown?: ProcessShutdownController,
+): void {
+  const handle = makeSignalShutdownHandler(shutdown, processShutdown);
   process.on("SIGINT", () => void handle("SIGINT"));
   process.on("SIGTERM", () => void handle("SIGTERM"));
 }
 
 /**
- * Build the SIGINT/SIGTERM handler for `lore run <agent>`: forward the first
- * signal to the child (whose exit then drives gateway teardown) and force-exit
- * on a second interrupt so the user is never stuck on a hung child/shutdown.
- *
- * Uses `forcedExit` on the second interrupt because the first one may already
- * have triggered a deadline-bounded shutdown that left the embedding worker
- * mid-inference. See `makeSignalShutdownHandler` for the full rationale.
+ * Build the SIGINT/SIGTERM handler for `lore run <agent>`: the first signal
+ * starts the shared child + gateway teardown deadline and forwards that signal
+ * to the child. A second interrupt immediately escalates the child to SIGKILL
+ * but keeps the wrapper alive until the child is reaped or the deadline fires.
  *
  * Exported for testing; prefer `installChildSignalForwarding` at call sites.
  */
-export function makeChildForwardHandler(child: {
-  kill: (signal: NodeJS.Signals) => void;
-}): (signal: NodeJS.Signals) => void {
+export function makeChildForwardHandler(
+  child: {
+    kill: (signal: NodeJS.Signals) => boolean;
+  },
+  processShutdown: ProcessShutdownController,
+): (signal: NodeJS.Signals) => void {
+  processShutdown.attachChild(child);
   let count = 0;
   return (signal: NodeJS.Signals): void => {
     count++;
     if (count >= 2) {
-      console.error("[lore] Received second interrupt — forcing exit.");
-      forcedExit(signalExitCode(signal));
+      console.error("[lore] Received second interrupt — force-stopping child.");
+      void processShutdown.killChildAndWait(signalExitCode(signal));
+      return;
     }
-    try {
-      child.kill(signal);
-    } catch {
-      // Child already gone — the exit handler will clean up.
-    }
+    void processShutdown(signalExitCode(signal), signal);
   };
 }
 
 /** Install the forward-to-child signal handler (see makeChildForwardHandler). */
-export function installChildSignalForwarding(child: {
-  kill: (signal: NodeJS.Signals) => void;
-}): void {
-  const handle = makeChildForwardHandler(child);
+export function installChildSignalForwarding(
+  child: {
+    kill: (signal: NodeJS.Signals) => boolean;
+  },
+  processShutdown: ProcessShutdownController,
+): void {
+  const handle = makeChildForwardHandler(child, processShutdown);
   process.on("SIGINT", () => handle("SIGINT"));
   process.on("SIGTERM", () => handle("SIGTERM"));
 }

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -4,13 +4,24 @@
  * Extracted from the old top-level index.ts boot logic.
  */
 import { spawn } from "node:child_process";
-import { openSync, mkdirSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { closeSync } from "node:fs";
 import { join } from "node:path";
-import { loadConfig, DEFAULT_PORTS, type GatewayConfig } from "../config";
+import {
+  assertGatewayAccessConfigured,
+  loadConfig,
+  DEFAULT_PORTS,
+  type GatewayConfig,
+} from "../config";
 import { startServer, bracketHost } from "../server";
 import { resetPipelineState } from "../pipeline";
-import { writePortFile, removePortFile, readPortFile } from "../portfile";
-import { writePidFile, removePidFile } from "../pidfile";
+import { writePortFile, removePortFile } from "../portfile";
+import {
+  writeGatewayProcessFile,
+  readGatewayProcessFile,
+  removeGatewayProcessFile,
+  type GatewayProcessRecord,
+} from "../pidfile";
 import {
   dataDir,
   embedding,
@@ -20,7 +31,22 @@ import {
   DEFAULT_VECTOR_POOL_SHUTDOWN_DEADLINE_MS,
 } from "@loreai/core";
 import { safeExit } from "./exit";
-import { installSignalShutdown, SHUTDOWN_DEADLINE_MS } from "./shutdown";
+import {
+  installSignalShutdown,
+  makeProcessShutdownController,
+  SHUTDOWN_DEADLINE_MS,
+  type ProcessShutdownController,
+} from "./shutdown";
+import { openRuntimeFileForAppend } from "../runtime-files";
+import { nodeHttpFetch } from "../fetch";
+import {
+  currentProcessIdentity,
+  inspectProcessGeneration,
+  withoutLifecycleLock,
+  withLifecycleLock,
+  type LifecycleLock,
+  type ProcessInspection,
+} from "../lifecycle-lock";
 
 /**
  * Bound for the in-flight document-embed drain on graceful shutdown (#1331).
@@ -72,6 +98,8 @@ export interface StartOptions {
    * CLI: `--bg` / `--daemon`.
    */
   bg?: boolean;
+  /** @internal CLI-owned process boundary; never set by in-process plugins. */
+  processBoundary?: boolean;
 }
 
 export interface GatewayHandle {
@@ -79,29 +107,212 @@ export interface GatewayHandle {
   port: number;
   /** Whether this process owns the server (started it). False when reusing an existing instance. */
   owned: boolean;
+  /** Owner-only token used to authenticate the gateway control endpoint. */
+  managementToken: string;
   /** Shut down the gateway. No-op when `owned` is false. */
   shutdown: () => Promise<void>;
+  /** @internal One-shot CLI process shutdown shared by signals and control. */
+  processShutdown?: ProcessShutdownController;
+}
+
+export interface GatewayHealthIdentity {
+  pid: number;
+}
+
+export type GatewayIdentityProbe =
+  | { kind: "authenticated"; identity: GatewayHealthIdentity }
+  | { kind: "rejected" }
+  | { kind: "unavailable" }
+  | { kind: "timeout" };
+
+export type GatewayShutdownRequestResult =
+  | "accepted"
+  | "unsupported"
+  | "failed";
+
+export interface StartGatewayIO {
+  readProcess: () => GatewayProcessRecord | null;
+  authenticate: (record: GatewayProcessRecord) => Promise<string | null>;
+  writePort: (port: number, token: string) => void;
+  removePort: (port: number, token: string) => void;
+  writeProcess: (record: GatewayProcessRecord) => void;
+  removeProcess: (pid: number, record?: GatewayProcessRecord) => void;
+  startServer: typeof startServer;
+  resetPipelineState: typeof resetPipelineState;
+  createProcessShutdownController: typeof makeProcessShutdownController;
+}
+
+const realStartGatewayIO: StartGatewayIO = {
+  readProcess: readGatewayProcessFile,
+  authenticate: probeGatewayProcessHost,
+  writePort: writePortFile,
+  removePort: removePortFile,
+  writeProcess: writeGatewayProcessFile,
+  removeProcess: (pid, record) => {
+    if (record) removeGatewayProcessFile(record);
+    else {
+      const current = readGatewayProcessFile();
+      if (current?.pid === pid) removeGatewayProcessFile(current);
+    }
+  },
+  startServer,
+  resetPipelineState,
+  createProcessShutdownController: makeProcessShutdownController,
+};
+
+function isLoopbackProbeUrl(value: string): boolean {
+  try {
+    const hostname = new URL(value).hostname
+      .replace(/^\[/, "")
+      .replace(/\]$/, "")
+      .toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "localhost." ||
+      hostname === "::1" ||
+      /^127(?:\.\d{1,3}){3}$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
- * Probe a running gateway at the given URL via its `/health` endpoint.
- * Returns `true` if the response is 2xx, `false` on any error or timeout.
+ * Fetch an internal gateway endpoint without WHATWG's browser forbidden-port
+ * list breaking valid loopback listeners. Non-loopback URLs retain the normal
+ * Fetch transport and semantics used for remote/LAN gateways.
  */
+export function internalProbeFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  return isLoopbackProbeUrl(url)
+    ? nodeHttpFetch(url, init)
+    : Promise.resolve(fetch(url, init));
+}
+
+/** Probe the owner-only control endpoint and return its process identity. */
+export async function probeGatewayIdentity(
+  baseURL: string,
+  token: string,
+  timeoutMs = 1500,
+): Promise<GatewayHealthIdentity | null> {
+  const result = await probeGatewayIdentityDetailed(baseURL, token, timeoutMs);
+  return result.kind === "authenticated" ? result.identity : null;
+}
+
+export async function probeGatewayIdentityDetailed(
+  baseURL: string,
+  token: string,
+  timeoutMs = 1500,
+): Promise<GatewayIdentityProbe> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await internalProbeFetch(`${baseURL}/_lore/control`, {
+      signal: controller.signal,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return { kind: "rejected" };
+    const body = (await res.json()) as {
+      status?: unknown;
+      service?: unknown;
+      pid?: unknown;
+    };
+    return body.status === "ok" &&
+      body.service === "lore" &&
+      typeof body.pid === "number" &&
+      Number.isSafeInteger(body.pid) &&
+      body.pid > 0
+      ? { kind: "authenticated", identity: { pid: body.pid } }
+      : { kind: "rejected" };
+  } catch (error) {
+    return controller.signal.aborted || (error as Error).name === "AbortError"
+      ? { kind: "timeout" }
+      : { kind: "unavailable" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function probeGatewayProcessStatus(
+  record: GatewayProcessRecord,
+  timeoutMs = 1500,
+): Promise<"authenticated" | "rejected" | "unavailable" | "timeout"> {
+  const results = await Promise.all(
+    record.hosts.map((host) =>
+      probeGatewayIdentityDetailed(
+        probeUrlFor(host, record.port),
+        record.token,
+        timeoutMs,
+      ),
+    ),
+  );
+  if (
+    results.some(
+      (result) =>
+        result.kind === "authenticated" && result.identity.pid === record.pid,
+    )
+  ) {
+    return "authenticated";
+  }
+  if (results.some((result) => result.kind === "timeout")) return "timeout";
+  if (results.some((result) => result.kind === "rejected")) return "rejected";
+  return "unavailable";
+}
+
+export type GatewayHealthStatus =
+  | "healthy"
+  | "not-running"
+  | "error"
+  | "timeout";
+
+function errorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) return null;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : null;
+}
+
+function isConnectionRefused(error: unknown): boolean {
+  if (error instanceof AggregateError) {
+    return (
+      error.errors.length > 0 &&
+      error.errors.every((candidate) => isConnectionRefused(candidate))
+    );
+  }
+  if (errorCode(error) === "ECONNREFUSED") return true;
+  if (typeof error !== "object" || error === null) return false;
+  return isConnectionRefused((error as { cause?: unknown }).cause);
+}
+
+/** Probe public health while preserving ambiguous failure states. */
+export async function probeGatewayStatus(
+  baseURL: string,
+  timeoutMs = 1500,
+): Promise<GatewayHealthStatus> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await internalProbeFetch(`${baseURL}/health`, {
+      signal: controller.signal,
+    });
+    return res.ok ? "healthy" : "error";
+  } catch (error) {
+    if (controller.signal.aborted || (error as Error).name === "AbortError") {
+      return "timeout";
+    }
+    return isConnectionRefused(error) ? "not-running" : "error";
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Boolean compatibility wrapper for non-destructive health checks. */
 export async function probeGateway(
   baseURL: string,
   timeoutMs = 1500,
 ): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(`${baseURL}/health`, {
-      signal: controller.signal,
-    });
-    clearTimeout(timer);
-    return res.ok;
-  } catch {
-    return false;
-  }
+  return (await probeGatewayStatus(baseURL, timeoutMs)) === "healthy";
 }
 
 /**
@@ -110,8 +321,82 @@ export async function probeGateway(
  * A bare `:` in the host marks it as an IPv6 address (hostnames/IPv4 never
  * contain one); an already-bracketed value is left untouched.
  */
-function probeUrlFor(host: string, port: number): string {
-  return `http://${bracketHost(host)}:${port}`;
+export function probeUrlFor(host: string, port: number): string {
+  const connectHost =
+    host === "0.0.0.0" ? "127.0.0.1" : host === "::" ? "::1" : host;
+  return `http://${bracketHost(connectHost)}:${port}`;
+}
+
+/** Authenticate a persisted process record against every host it bound. */
+export async function probeGatewayProcessHost(
+  record: GatewayProcessRecord,
+  timeoutMs = 1500,
+): Promise<string | null> {
+  const identities = await Promise.all(
+    record.hosts.map((host) =>
+      probeGatewayIdentity(
+        probeUrlFor(host, record.port),
+        record.token,
+        timeoutMs,
+      ),
+    ),
+  );
+  const index = identities.findIndex(
+    (identity) => identity?.pid === record.pid,
+  );
+  return index === -1 ? null : record.hosts[index];
+}
+
+/** Authenticate a persisted process record against every host it bound. */
+export async function probeGatewayProcess(
+  record: GatewayProcessRecord,
+  timeoutMs = 1500,
+): Promise<boolean> {
+  return (await probeGatewayProcessHost(record, timeoutMs)) !== null;
+}
+
+/** Request graceful shutdown from the exact token-authenticated gateway. */
+export async function requestGatewayShutdown(
+  record: GatewayProcessRecord,
+  timeoutMs = 1500,
+): Promise<GatewayShutdownRequestResult> {
+  const results = await Promise.all(
+    record.hosts.map(async (host): Promise<GatewayShutdownRequestResult> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await internalProbeFetch(
+          `${probeUrlFor(host, record.port)}/_lore/control`,
+          {
+            method: "POST",
+            signal: controller.signal,
+            headers: { authorization: `Bearer ${record.token}` },
+          },
+        );
+        if (response.status === 404) return "unsupported";
+        if (!response.ok) return "failed";
+        const body = (await response.json()) as {
+          status?: unknown;
+          service?: unknown;
+          pid?: unknown;
+          shutdown?: unknown;
+        };
+        return body.status === "ok" &&
+          body.service === "lore" &&
+          body.pid === record.pid &&
+          body.shutdown === "requested"
+          ? "accepted"
+          : "failed";
+      } catch {
+        return "failed";
+      } finally {
+        clearTimeout(timer);
+      }
+    }),
+  );
+  if (results.some((result) => result === "accepted")) return "accepted";
+  if (results.some((result) => result === "failed")) return "failed";
+  return "unsupported";
 }
 
 /**
@@ -136,6 +421,11 @@ async function firstReachableHost(
 /** Path to the daemon's combined stdout/stderr log. */
 export function daemonLogPath(): string {
   return join(dataDir(), "gateway.log");
+}
+
+/** Open the daemon log for safe owner-only append. Caller must close it. */
+export function openDaemonLogFile(): number {
+  return openRuntimeFileForAppend("gateway.log");
 }
 
 /**
@@ -199,10 +489,15 @@ export function daemonProbeHost(opts: StartOptions): string {
 
 /** Injectable IO for the daemon orchestration, so `runDaemon` is testable. */
 export interface DaemonIO {
-  readPort: () => number | null;
-  probe: (url: string) => Promise<boolean>;
+  readProcess: () => GatewayProcessRecord | null;
+  authenticate: (record: GatewayProcessRecord) => Promise<string | null>;
+  probeHealth: (url: string) => Promise<boolean>;
   /** Spawn the detached child gateway; returns its pid (or undefined). */
   spawnDaemon: () => number | undefined;
+  inspectProcess: (pid: number) => ProcessInspection;
+  terminate: (pid: number, signal: "SIGTERM" | "SIGKILL") => void;
+  removeProcess: (record: GatewayProcessRecord) => void;
+  removePort: (port: number, token: string) => void;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
   logInfo: (msg: string) => void;
@@ -211,45 +506,202 @@ export interface DaemonIO {
   timeoutMs?: number;
   /** Poll interval in ms (default 250). */
   intervalMs?: number;
+  /** Per-signal child-exit wait budget in ms. */
+  cleanupTimeoutMs?: number;
+}
+
+async function waitForDaemonExit(
+  pid: number,
+  expectedProcessIdentity: string,
+  io: DaemonIO,
+  intervalMs: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = io.now() + timeoutMs;
+  while (
+    !daemonGenerationExited(pid, expectedProcessIdentity, io) &&
+    io.now() < deadline
+  ) {
+    await io.sleep(intervalMs);
+  }
+  return daemonGenerationExited(pid, expectedProcessIdentity, io);
+}
+
+function inspectDaemonProcess(pid: number, io: DaemonIO): ProcessInspection {
+  try {
+    return io.inspectProcess(pid);
+  } catch {
+    return { state: "unknown" };
+  }
+}
+
+function verifiedProcessIdentity(inspection: ProcessInspection): string | null {
+  return inspection.state === "alive" &&
+    inspection.identity !== null &&
+    !inspection.identity.startsWith("unverified:")
+    ? inspection.identity
+    : null;
+}
+
+function daemonGenerationExited(
+  pid: number,
+  expectedProcessIdentity: string,
+  io: DaemonIO,
+): boolean {
+  const inspection = inspectDaemonProcess(pid, io);
+  return (
+    inspection.state === "dead" ||
+    (inspection.state === "alive" &&
+      inspection.identity !== null &&
+      inspection.identity !== expectedProcessIdentity)
+  );
+}
+
+async function signalDaemonGeneration(
+  pid: number,
+  expectedProcessIdentity: string,
+  signal: "SIGTERM" | "SIGKILL",
+  io: DaemonIO,
+): Promise<"signalled" | "exited" | "uncertain"> {
+  try {
+    return await withLifecycleLock("gateway-shutdown", (lock) => {
+      lock.assertOwned();
+      const inspection = inspectDaemonProcess(pid, io);
+      if (
+        inspection.state === "dead" ||
+        (inspection.state === "alive" &&
+          inspection.identity !== null &&
+          inspection.identity !== expectedProcessIdentity)
+      ) {
+        return "exited";
+      }
+      if (
+        inspection.state !== "alive" ||
+        inspection.identity === null ||
+        inspection.identity !== expectedProcessIdentity
+      ) {
+        return "uncertain";
+      }
+      lock.assertOwned();
+      try {
+        io.terminate(pid, signal);
+      } catch (error) {
+        const afterSignalFailure = inspectDaemonProcess(pid, io);
+        if (
+          afterSignalFailure.state === "dead" ||
+          (afterSignalFailure.state === "alive" &&
+            afterSignalFailure.identity !== null &&
+            afterSignalFailure.identity !== expectedProcessIdentity)
+        ) {
+          return "exited";
+        }
+        throw error;
+      }
+      return "signalled";
+    });
+  } catch {
+    // Lock loss, failed inspection, and signal errors are all ambiguous. Never
+    // guess that the numeric PID still names the detached child.
+    return "uncertain";
+  }
+}
+
+async function terminateTimedOutDaemon(
+  pid: number,
+  expectedProcessIdentity: string | null,
+  io: DaemonIO,
+  intervalMs: number,
+  expectedRecord: GatewayProcessRecord | null,
+): Promise<{ stopped: boolean; signalled: boolean }> {
+  if (expectedProcessIdentity === null) {
+    // A live child without a verifiable start identity cannot be signalled.
+    // A definitively dead PID is safe to classify as stopped, but a live or
+    // unknown PID remains ambiguous even if its number matches the spawn result.
+    return {
+      stopped: inspectDaemonProcess(pid, io).state === "dead",
+      signalled: false,
+    };
+  }
+
+  const cleanupTimeout = io.cleanupTimeoutMs ?? SHUTDOWN_DEADLINE_MS;
+  let signalled = false;
+  const termResult = await signalDaemonGeneration(
+    pid,
+    expectedProcessIdentity,
+    "SIGTERM",
+    io,
+  );
+  if (termResult === "uncertain") {
+    return { stopped: false, signalled };
+  }
+  signalled = termResult === "signalled";
+
+  let exited =
+    termResult === "exited" ||
+    (await waitForDaemonExit(
+      pid,
+      expectedProcessIdentity,
+      io,
+      intervalMs,
+      cleanupTimeout,
+    ));
+  if (!exited) {
+    const killResult = await signalDaemonGeneration(
+      pid,
+      expectedProcessIdentity,
+      "SIGKILL",
+      io,
+    );
+    if (killResult === "uncertain") {
+      return { stopped: false, signalled };
+    }
+    signalled ||= killResult === "signalled";
+    exited =
+      killResult === "exited" ||
+      (await waitForDaemonExit(
+        pid,
+        expectedProcessIdentity,
+        io,
+        intervalMs,
+        cleanupTimeout,
+      ));
+  }
+
+  if (exited) {
+    await withLifecycleLock("gateway-start", async (lifecycleLock) => {
+      lifecycleLock.assertOwned();
+      const record = io.readProcess();
+      lifecycleLock.assertOwned();
+      if (
+        expectedRecord &&
+        record?.pid === expectedRecord.pid &&
+        record.token === expectedRecord.token &&
+        record.processIdentity === expectedRecord.processIdentity
+      ) {
+        io.removeProcess(expectedRecord);
+        lifecycleLock.assertOwned();
+        io.removePort(expectedRecord.port, expectedRecord.token);
+      }
+    });
+  }
+  return { stopped: exited, signalled };
 }
 
 /**
- * Daemon orchestration: reuse an already-running gateway, else spawn the
- * detached child and poll until it's serving. Returns the process exit code
- * (0 = healthy/reused, 1 = timed out). Pure of `process.exit` so it is
- * unit-testable; `startDaemon` is the thin shell that wires real IO + exit.
+ * Daemon orchestration: reuse an authenticated gateway, else spawn a detached
+ * child and poll until its process record authenticates.
  */
 export async function runDaemon(
   opts: StartOptions,
   io: DaemonIO,
 ): Promise<number> {
-  const host = daemonProbeHost(opts);
-
-  // If a gateway is already up on the recorded port, don't start a second one.
-  //
-  // The running gateway may be bound to an interface that does NOT overlap with
-  // ours (issue #908) — e.g. it's on 127.0.0.1 while we asked for a LAN/Tailscale
-  // IP only. Probe every configured host plus 127.0.0.1 and adopt the first that
-  // answers; otherwise we'd spawn a child that itself reuses-and-exits (its own
-  // pre-bind probe finds the loopback gateway), leaving us polling an interface
-  // nothing ever bound until the health-poll deadline. Configured hosts are
-  // probed first so the reported address is the one the user asked for (#875),
-  // falling back to loopback.
-  const existingPort = io.readPort();
-  if (existingPort) {
-    const probeHosts = [
-      ...new Set([
-        ...(opts.hosts ?? []).filter((h) => h && h.length > 0),
-        "127.0.0.1",
-      ]),
-    ];
-    const reusedHost = await firstReachableHost(
-      probeHosts,
-      existingPort,
-      io.probe,
-    );
+  // Public health proves availability, not ownership. Reuse only a process
+  // record whose owner-only challenge authenticates against the recorded PID.
+  const existingRecord = io.readProcess();
+  if (existingRecord) {
+    const reusedHost = await io.authenticate(existingRecord);
     if (reusedHost) {
-      const url = probeUrlFor(reusedHost, existingPort);
+      const url = probeUrlFor(reusedHost, existingRecord.port);
       io.logInfo(`Gateway already running on ${url}`);
       io.logInfo(`Dashboard: ${url}/ui`);
       io.logInfo(`Stop it with: lore stop`);
@@ -257,18 +709,69 @@ export async function runDaemon(
     }
   }
 
-  const pid = io.spawnDaemon();
+  // Generic health classifies a preferred-port occupant, but never authorizes
+  // reuse. An explicit occupied port is an error; default ports may fall back.
+  const configuredHosts = (
+    opts.hosts?.length ? opts.hosts : ["127.0.0.1"]
+  ).filter((host) => host.length > 0);
+  const preferredPorts = opts.port === undefined ? DEFAULT_PORTS : [opts.port];
+  for (const preferredPort of preferredPorts) {
+    const foreignHost = await firstReachableHost(
+      configuredHosts,
+      preferredPort,
+      io.probeHealth,
+    );
+    if (!foreignHost) continue;
+    if (opts.port !== undefined) {
+      io.logError(
+        `Port ${opts.port} is already in use by another process (not an authenticated lore gateway).`,
+      );
+      return 1;
+    }
+    io.logInfo(
+      `Preferred port ${preferredPort} is occupied by a foreign service; the background gateway will use its fallback chain.`,
+    );
+    break;
+  }
+
+  const spawned = await withLifecycleLock("gateway-start", (lifecycleLock) => {
+    lifecycleLock.assertOwned();
+    const pid = io.spawnDaemon();
+    if (pid === undefined) return undefined;
+    // Capture the process-start identity immediately while spawn ownership is
+    // serialized. The numeric PID alone is never sufficient for later cleanup.
+    const inspection = inspectDaemonProcess(pid, io);
+    return {
+      pid,
+      processIdentity: verifiedProcessIdentity(inspection),
+    };
+  });
+  if (spawned === undefined) {
+    io.logError("Failed to spawn the background gateway.");
+    return 1;
+  }
+  const { pid, processIdentity: spawnedProcessIdentity } = spawned;
   const timeout = io.timeoutMs ?? 10_000;
   const interval = io.intervalMs ?? 250;
   const deadline = io.now() + timeout;
+  let spawnedRecord: GatewayProcessRecord | null = null;
   while (io.now() < deadline) {
     await io.sleep(interval);
-    const port = io.readPort();
-    // probeUrlFor brackets IPv6 literals (e.g. http://[::1]:3207); a raw
-    // template would yield the malformed http://::1:3207 and never connect.
-    const url = port ? probeUrlFor(host, port) : "";
-    if (port && (await io.probe(url))) {
-      io.logInfo(`Gateway started in the background (pid ${pid})`);
+    const record = io.readProcess();
+    const isSpawnedGeneration =
+      spawnedProcessIdentity !== null &&
+      record?.version === 2 &&
+      record.pid === pid &&
+      record.processIdentity === spawnedProcessIdentity;
+    if (isSpawnedGeneration) spawnedRecord = record;
+    const authenticatedHost = record ? await io.authenticate(record) : null;
+    if (record && authenticatedHost) {
+      const url = probeUrlFor(authenticatedHost, record.port);
+      io.logInfo(
+        isSpawnedGeneration
+          ? `Gateway started in the background (pid ${pid})`
+          : `Gateway already running in the background (pid ${record.pid})`,
+      );
       io.logInfo(`Listening on ${url}`);
       io.logInfo(`Dashboard: ${url}/ui`);
       io.logInfo(`Logs: ${daemonLogPath()}`);
@@ -277,23 +780,43 @@ export async function runDaemon(
     }
   }
 
-  io.logError(
-    `Gateway did not become healthy within ${timeout}ms. Check the log: ${daemonLogPath()}`,
+  const cleanup = await terminateTimedOutDaemon(
+    pid,
+    spawnedProcessIdentity,
+    io,
+    interval,
+    spawnedRecord,
   );
+  if (cleanup.stopped && cleanup.signalled) {
+    io.logError(
+      `Gateway did not establish authenticated ownership within ${timeout}ms; terminated background pid ${pid}. Check the log: ${daemonLogPath()}`,
+    );
+  } else if (cleanup.stopped) {
+    io.logError(
+      `Gateway did not establish authenticated ownership within ${timeout}ms; background pid ${pid}'s spawned process generation is no longer running. Check the log: ${daemonLogPath()}`,
+    );
+  } else {
+    io.logError(
+      `Gateway startup failed with unknown child state: background pid ${pid} did not establish authenticated ownership and could not be confirmed stopped. Check the log and process before retrying: ${daemonLogPath()}`,
+    );
+  }
   return 1;
 }
 
 /** Spawn the detached child gateway with stdio redirected to the log file. */
 function spawnDetachedGateway(opts: StartOptions): number | undefined {
-  const logPath = daemonLogPath();
-  mkdirSync(dataDir(), { recursive: true });
-  const logFd = openSync(logPath, "a");
+  const logFd = openDaemonLogFile();
   const { command, args } = daemonSpawnSpec(opts);
-  const child = spawn(command, args, {
-    detached: true,
-    stdio: ["ignore", logFd, logFd],
-    env: process.env,
-  });
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(command, args, {
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+      env: process.env,
+    });
+  } finally {
+    closeSync(logFd);
+  }
   child.unref();
   return child.pid;
 }
@@ -301,9 +824,14 @@ function spawnDetachedGateway(opts: StartOptions): number | undefined {
 /** Build the real (production) IO for {@link runDaemon}. */
 export function realDaemonIO(opts: StartOptions): DaemonIO {
   return {
-    readPort: readPortFile,
-    probe: probeGateway,
+    readProcess: readGatewayProcessFile,
+    authenticate: probeGatewayProcessHost,
+    probeHealth: probeGateway,
     spawnDaemon: () => spawnDetachedGateway(opts),
+    inspectProcess: inspectProcessGeneration,
+    terminate: (pid, signal) => process.kill(pid, signal),
+    removeProcess: removeGatewayProcessFile,
+    removePort: removePortFile,
     sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
     now: Date.now,
     logInfo: (msg) => console.log(`[lore] ${msg}`),
@@ -329,12 +857,25 @@ async function startDaemon(opts: StartOptions): Promise<never> {
  * When the port is not explicitly set (no `--port` / `LORE_LISTEN_PORT`),
  * the server tries a fallback chain: 3207 → 5673 → OS-assigned random port.
  * At each step, if the port is occupied by an existing lore gateway
- * (verified via `/health` probe), returns a handle with `owned: false`
+ * (verified via its process record and owner-only control token), returns a
+ * handle with `owned: false`
  * so the caller can reuse the existing instance.
  */
 export async function startGateway(
   opts: StartOptions = {},
+  ioOverrides: Partial<StartGatewayIO> = {},
 ): Promise<GatewayHandle> {
+  return withLifecycleLock("gateway-start", (lifecycleLock) =>
+    startGatewayLocked(opts, ioOverrides, lifecycleLock),
+  );
+}
+
+async function startGatewayLocked(
+  opts: StartOptions,
+  ioOverrides: Partial<StartGatewayIO>,
+  lifecycleLock: LifecycleLock,
+): Promise<GatewayHandle> {
+  const io: StartGatewayIO = { ...realStartGatewayIO, ...ioOverrides };
   const config = loadConfig();
 
   // In-process callers (OpenCode plugin, Pi extension) pass `quiet: true`.
@@ -402,55 +943,117 @@ export async function startGateway(
     }
   }
 
+  // Validate after CLI/env/default mode precedence is fully applied. In
+  // particular, `--local` must be able to opt out before this invariant runs.
+  assertGatewayAccessConfigured(config);
+
   // Build the list of ports to try.
   // Explicit port: single attempt, fail hard on conflict.
   // Default: 3207 → 5673 → 0 (OS-assigned random).
   const portsToTry: number[] = config.portExplicit
     ? [config.port]
     : [...DEFAULT_PORTS, 0];
+  const controlToken = randomBytes(32).toString("base64url");
+  // Windows has no race-free creation-time query in Node. Publish an explicit
+  // unverified identity so discovery works, while destructive stop fails closed.
+  const processIdentity =
+    currentProcessIdentity() ?? `unverified:${controlToken}`;
+
+  // With no explicit port, reuse an authenticated gateway wherever it actually
+  // bound (including a fallback/random port). The process record is the source
+  // of identity; public health and the port file are not.
+  if (!config.portExplicit) {
+    const record = io.readProcess();
+    if (record) {
+      const authenticatedHost = await io.authenticate(record);
+      if (authenticatedHost) {
+        config.port = record.port;
+        config.hosts = [authenticatedHost];
+        return {
+          config,
+          port: record.port,
+          owned: false,
+          managementToken: record.token,
+          shutdown: async () => {},
+        };
+      }
+    }
+  }
 
   for (const candidatePort of portsToTry) {
     config.port = candidatePort;
 
-    // Pre-bind reuse probe (issue #908): an existing gateway may be bound to an
-    // interface that does NOT overlap with ours (e.g. it's on 127.0.0.1 while
-    // we're configured for a LAN/Tailscale IP only). Binding our interface would
-    // then SUCCEED — no EADDRINUSE — and we'd silently start a SECOND redundant
-    // gateway sharing this port's port file, pid file, and SQLite DB. Probe
-    // first; if a live lore gateway answers on 127.0.0.1 or any configured host,
-    // reuse it instead of binding. The post-bind catch below stays as a backstop
-    // for the race where a gateway binds between this probe and our bind.
+    // Pre-bind identity/occupancy probe (issue #908). Only an authenticated
+    // owner record establishes Lore identity; public /health merely classifies
+    // an unauthenticated occupant as foreign.
     //
     // Skip port 0 (OS-assigned random): nothing can already be listening there,
     // and port 0 is not a probeable address. Default config.hosts is
     // ["127.0.0.1"], so the common cold-start cost here is a single fast,
     // connection-refused loopback probe.
     if (candidatePort !== 0) {
-      const probeHosts = [...new Set(["127.0.0.1", ...config.hosts])];
-      const reachableHost = await firstReachableHost(probeHosts, candidatePort);
-      if (reachableHost) {
-        // Report the interface the existing gateway actually answered on — not
-        // the (possibly non-overlapping) hosts we were configured to bind.
-        // Callers derive the agent's gateway URL from config.hosts[0]
-        // (run.ts), so this MUST be a reachable address or the agent would be
-        // pointed at a dead interface.
-        config.hosts = [reachableHost];
+      const record = io.readProcess();
+      const authenticatedHost =
+        record?.port === candidatePort ? await io.authenticate(record) : null;
+      if (record && authenticatedHost) {
+        config.hosts = [authenticatedHost];
         return {
           config,
           port: candidatePort,
           owned: false,
+          managementToken: record.token,
           shutdown: async () => {},
         };
+      }
+
+      const probeHosts = [
+        ...new Set([
+          "127.0.0.1",
+          ...config.hosts,
+          ...(record?.port === candidatePort ? record.hosts : []),
+        ]),
+      ];
+      const foreignHost = await firstReachableHost(probeHosts, candidatePort);
+      if (foreignHost) {
+        if (config.portExplicit) {
+          throw new Error(
+            `Port ${candidatePort} is already in use by another process (not an authenticated lore gateway). ` +
+              `Use --port / LORE_LISTEN_PORT to pick a different port.`,
+          );
+        }
+        const nextIdx = portsToTry.indexOf(candidatePort) + 1;
+        const nextPort = portsToTry[nextIdx];
+        const nextLabel = nextPort === 0 ? "random port" : String(nextPort);
+        notify(
+          `Port ${candidatePort} in use (not an authenticated lore gateway), trying ${nextLabel}…`,
+        );
+        continue;
       }
     }
 
     let server: Awaited<ReturnType<typeof startServer>> | undefined;
+    let remoteShutdown: (() => void) | undefined;
     try {
       // startServer() binds each host and awaits the OS bind internally, so an
       // EADDRINUSE rejection surfaces from THIS await (not from `server.ready`).
       // It MUST be inside the try so the catch below can probe for and reuse an
       // existing lore gateway instead of crashing.
-      server = await startServer(config);
+      lifecycleLock.assertOwned();
+      server = await withoutLifecycleLock(() =>
+        io.startServer(config, {
+          controlToken,
+          onShutdown: () => {
+            if (!remoteShutdown) {
+              notify(
+                "Remote shutdown was requested before gateway publication; refusing.",
+              );
+              process.exitCode = 1;
+              return;
+            }
+            remoteShutdown();
+          },
+        }),
+      );
       await server.ready; // already resolved by startServer; kept for clarity
       const actualPort = server.port;
       // startServer() may drop hosts that aren't currently bindable (e.g. a
@@ -459,70 +1062,153 @@ export async function startGateway(
       // an interface that's down.
       if (server.hosts.length) config.hosts = server.hosts;
 
-      // Write port file so plugins can discover us (even on random port).
-      writePortFile(actualPort);
-      // Write pid file so `lore stop` can find and signal this process.
-      writePidFile();
-
-      const boundServer = server;
-      let shutdownStarted = false;
-      const shutdown = async () => {
-        if (shutdownStarted) return;
-        shutdownStarted = true;
-        notify("Shutting down…");
-        boundServer.stop();
-        removePortFile(actualPort);
-        removePidFile();
-        // `fast`: skip the synchronous batch-queue LLM drain on process exit —
-        // replaying queued background prompts through retries is what made
-        // Ctrl+C hang for minutes. They resume next session.
-        await resetPipelineState({ fast: true });
-        // Drain any document embed ALREADY in flight (esp. a distillation
-        // embed created this session that would otherwise never write its
-        // `distillation_vec` row before the worker is torn down — #1331).
-        // BOUNDED so a slow/stuck embed can't reintroduce the Ctrl+C hang
-        // `fast: true` exists to avoid; must run while the worker is still alive
-        // (resetProvider below kills it) and after resetPipelineState so no new
-        // background work is scheduled mid-drain. NOTE: this covers embeds that
-        // have already been dispatched — it does NOT wait on a distillation
-        // whose LLM call is still in flight (fast-path shutdown deliberately
-        // skips that background drain), so that embed is never enqueued here.
-        // Both the mid-distillation case and anything still pending at the
-        // deadline are re-indexed by runStartupBackfill on the next boot.
-        await embedding.settleDocumentEmbeds(EMBED_DRAIN_DEADLINE_MS);
-        // Shut down the embedding worker thread gracefully. Done after
-        // resetPipelineState (which clears sessions/timers) but before
-        // safeExit — gives the worker time to exit cleanly via its
-        // "shutdown" message handler rather than being killed by _exit().
-        await embedding.resetProvider();
-        // Tear down the vector/read worker pool and WAIT for every worker to
-        // close its own SQLite reader (#1599). Done after the embedding worker
-        // is gone (it had its own short-lived budget) and before the writer
-        // close below: SQLite WAL TRUNCATE requires ZERO concurrent
-        // readers on the connection — each worker's `reader.db` holds a WAL
-        // read-mark, so leaving readers alive means the writer's checkpoint
-        // either busy-returns or hangs on `busy_timeout`, both of which leak
-        // the `-wal` to next-boot recovery. The bounded helper force-terminates
-        // any worker that hasn't exited by its deadline, so a stuck reader
-        // can't reintroduce the Ctrl+C hang the embedding budget above
-        // prevents.
-        await shutdownVectorPoolAsync(VECTOR_POOL_SHUTDOWN_DEADLINE_MS);
-        // Close the main SQLite writer. The core `close()` is itself best-
-        // effort (busy_timeout=0 around TRUNCATE so a slow reader can't hang
-        // it; the `-wal` is just recovered on next open) and idempotent (no-op
-        // if the DB was never opened), so calling it unconditionally on the
-        // graceful path is safe. Done AFTER vector-pool shutdown so the writer
-        // can finally grab an exclusive checkpoint lock. Done BEFORE safeExit so
-        // the lazy singleton's atexit isn't the only thing closing it.
+      try {
+        // Publish a shared generation token in both discovery records. The PID
+        // record additionally binds the token to this process-start identity.
+        lifecycleLock.assertOwned();
+        io.writePort(actualPort, controlToken);
+        lifecycleLock.assertOwned();
+        const processRecord: GatewayProcessRecord = {
+          version: 2,
+          pid: process.pid,
+          port: actualPort,
+          hosts: server.hosts,
+          token: controlToken,
+          processIdentity,
+        };
+        io.writeProcess(processRecord);
+      } catch (publicationError) {
+        let closeError: unknown;
         try {
-          closeDb();
-        } catch (e) {
-          // A checkpoint or close failure must NEVER block process exit —
-          // SQLite WAL recovery handles an unclean shutdown on next boot.
-          notify(
-            `Database close warning: ${e instanceof Error ? e.message : String(e)}`,
+          await server.stop();
+        } catch (error) {
+          closeError = error;
+        }
+        if (closeError === undefined) {
+          // Remove discovery only after listener closure is confirmed. If close
+          // fails, retain evidence for the possibly-live listener.
+          const published = io.readProcess();
+          try {
+            lifecycleLock.assertOwned();
+            io.removePort(actualPort, controlToken);
+          } finally {
+            if (
+              published?.pid === process.pid &&
+              published.token === controlToken &&
+              published.processIdentity === processIdentity
+            ) {
+              lifecycleLock.assertOwned();
+              io.removeProcess(process.pid, published);
+            }
+          }
+        } else {
+          server = undefined;
+          throw new AggregateError(
+            [publicationError, closeError],
+            "Gateway publication failed and the live listener could not be closed; discovery evidence was retained.",
           );
         }
+        throw publicationError;
+      }
+
+      const boundServer = server;
+      let shutdownPromise: Promise<void> | undefined;
+      const shutdown = (): Promise<void> => {
+        shutdownPromise ??= withLifecycleLock(
+          "gateway-shutdown",
+          async (shutdownLock) => {
+            notify("Shutting down…");
+            let shutdownError: unknown;
+            let listenerClose: Promise<void> | undefined;
+            let listenerCloseError: unknown;
+            try {
+              shutdownLock.assertOwned();
+              // server.close() synchronously stops accepting new work, but its
+              // promise waits for active streams. Start closure first, then
+              // cancel/reset pipeline work so those streams can settle.
+              listenerClose = boundServer.stop().catch((error: unknown) => {
+                listenerCloseError = error;
+              });
+            } catch (error) {
+              listenerCloseError = error;
+            }
+            try {
+              shutdownLock.assertOwned();
+              await io.resetPipelineState({ fast: true });
+            } catch (error) {
+              shutdownError ??= error;
+            }
+            if (listenerClose) {
+              await listenerClose;
+            }
+            shutdownError ??= listenerCloseError;
+            // Preserve current-main embed/vector/DB ordering while the
+            // lifecycle lock excludes a successor start.
+            try {
+              shutdownLock.assertOwned();
+              await embedding.settleDocumentEmbeds(EMBED_DRAIN_DEADLINE_MS);
+            } catch (error) {
+              shutdownError ??= error;
+            }
+            try {
+              shutdownLock.assertOwned();
+              await embedding.resetProvider();
+            } catch (error) {
+              shutdownError ??= error;
+            }
+            try {
+              shutdownLock.assertOwned();
+              await shutdownVectorPoolAsync(VECTOR_POOL_SHUTDOWN_DEADLINE_MS);
+            } catch (error) {
+              shutdownError ??= error;
+            }
+            try {
+              shutdownLock.assertOwned();
+              closeDb();
+            } catch (error) {
+              // SQLite recovery handles a failed best-effort checkpoint. Keep
+              // the established current-main behavior: warn but do not wedge
+              // shutdown or retain an otherwise-stale process record for it.
+              notify(
+                `Database close warning: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+
+            if (shutdownError) throw shutdownError;
+
+            // Discovery is removed only after listener and worker teardown.
+            shutdownLock.assertOwned();
+            io.removePort(actualPort, controlToken);
+            const current = io.readProcess();
+            if (
+              current?.pid === process.pid &&
+              current.token === controlToken &&
+              current.processIdentity === processIdentity
+            ) {
+              shutdownLock.assertOwned();
+              io.removeProcess(current.pid, current);
+            }
+          },
+          {
+            timeoutMs: Math.max(1, Math.floor(SHUTDOWN_DEADLINE_MS / 2)),
+          },
+        );
+        return shutdownPromise;
+      };
+      const processShutdown = opts.processBoundary
+        ? io.createProcessShutdownController(shutdown)
+        : undefined;
+      remoteShutdown = () => {
+        if (processShutdown) {
+          void processShutdown(0);
+          return;
+        }
+        void shutdown().catch((error: unknown) => {
+          notify(
+            `Remote shutdown failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          process.exitCode = 1;
+        });
       };
 
       if (candidatePort === 0) {
@@ -531,46 +1217,40 @@ export async function startGateway(
         );
       }
 
-      return { config, port: actualPort, owned: true, shutdown };
+      return {
+        config,
+        port: actualPort,
+        owned: true,
+        managementToken: controlToken,
+        shutdown,
+        processShutdown,
+      };
     } catch (e) {
       // Clean up any successfully-bound servers before retrying.
       // In multi-host configs, some hosts may have bound before another
       // failed with EADDRINUSE — stop them to avoid leaking FDs.
       // `server` is undefined when startServer() itself rejected (the common
       // EADDRINUSE case), in which case there is nothing to stop here.
-      server?.stop();
+      if (server) await server.stop();
 
       const msg = e instanceof Error ? e.message : String(e);
       if (!(/port\b.*\bin use/i.test(msg) || /EADDRINUSE/i.test(msg))) {
         throw e; // Not a port conflict — don't retry
       }
 
-      // Port is occupied — check if it's a lore gateway we can reuse.
-      // (Skip probe for port 0 — it can't EADDRINUSE.)
-      //
-      // The running gateway may be bound to an interface other than
-      // config.hosts[0] (e.g. it's on 127.0.0.1 while we're configured for a
-      // LAN/Tailscale IP, or vice versa). Probe 127.0.0.1 (always reachable for
-      // a local gateway) plus every configured host before declaring the port
-      // foreign-owned — otherwise a healthy lore gateway gets misreported as
-      // "port in use".
-      //
-      // Probe in parallel and adopt the first interface that answers: probes
-      // are independent, and a hanging/unreachable host (e.g. a stale Tailscale
-      // address) must not serialize 1.5s timeouts onto the others.
+      // Port is occupied — re-read and authenticate the exact persisted owner.
+      // Public health never establishes identity.
       if (candidatePort !== 0) {
-        const probeHosts = [...new Set(["127.0.0.1", ...config.hosts])];
-        const reachableHost = await firstReachableHost(
-          probeHosts,
-          candidatePort,
-        );
-        if (reachableHost) {
-          // Pin to the interface that actually answered (see pre-bind probe).
-          config.hosts = [reachableHost];
+        const record = io.readProcess();
+        const authenticatedHost =
+          record?.port === candidatePort ? await io.authenticate(record) : null;
+        if (record && authenticatedHost) {
+          config.hosts = [authenticatedHost];
           return {
             config,
             port: candidatePort,
             owned: false,
+            managementToken: record.token,
             shutdown: async () => {},
           };
         }
@@ -579,7 +1259,7 @@ export async function startGateway(
       // Port is taken by something else — try next candidate if available.
       if (config.portExplicit) {
         throw new Error(
-          `Port ${candidatePort} is already in use by another process (not a lore gateway). ` +
+          `Port ${candidatePort} is already in use by another process (not an authenticated lore gateway). ` +
             `Use --port / LORE_LISTEN_PORT to pick a different port.`,
         );
       }
@@ -590,7 +1270,7 @@ export async function startGateway(
         const nextPort = portsToTry[nextIdx];
         const nextLabel = nextPort === 0 ? "random port" : String(nextPort);
         notify(
-          `Port ${candidatePort} in use (not a lore gateway), trying ${nextLabel}…`,
+          `Port ${candidatePort} in use (not an authenticated lore gateway), trying ${nextLabel}…`,
         );
       }
     }
@@ -610,9 +1290,14 @@ export async function commandStart(opts: StartOptions): Promise<never> {
     return startDaemon(opts);
   }
 
-  const { config, port, owned, shutdown } = await startGateway(opts);
+  const { config, port, owned, shutdown, processShutdown } = await startGateway(
+    {
+      ...opts,
+      processBoundary: true,
+    },
+  );
 
-  const addrs = config.hosts.map((h) => `http://${bracketHost(h)}:${port}`);
+  const addrs = config.hosts.map((host) => probeUrlFor(host, port));
 
   if (!owned) {
     // Another lore gateway is already running — nothing to do.
@@ -698,6 +1383,9 @@ export async function commandStart(opts: StartOptions): Promise<never> {
       `  LORE_REMOTE_URL         Remote gateway URL for \`lore run\` (delegates instead of starting local)`,
     );
     console.log(
+      `  LORE_GATEWAY_AUTH_TOKEN Access token required by remote/hosted data-plane routes (value is never printed)`,
+    );
+    console.log(
       `  LORE_HOSTED_MODE        Hosted mode — disable FS ops on client-controlled paths (current: ${config.hostedMode}, default for \`lore start\`: true)`,
     );
     console.log(
@@ -705,7 +1393,7 @@ export async function commandStart(opts: StartOptions): Promise<never> {
     );
   }
   // Block until signal — bounded shutdown + force-exit on a second interrupt.
-  installSignalShutdown(shutdown);
+  installSignalShutdown(shutdown, processShutdown);
 
   // Keep the process alive (the HTTP server already does this, but be explicit)
   return new Promise(() => {});

--- a/packages/gateway/src/cli/stop.ts
+++ b/packages/gateway/src/cli/stop.ts
@@ -9,51 +9,80 @@
  *   3. Stale PID file (process already gone) → clean it up, report nothing.
  *   4. Nothing running     → no-op message.
  */
-import { readPidFile, removePidFile, isProcessAlive } from "../pidfile";
+import {
+  readGatewayProcessFile,
+  inspectPidFile,
+  removeGatewayProcessFile,
+  removeLegacyPidFile,
+  type GatewayProcessRecord,
+  type LegacyPidFileRecord,
+  type LegacyPidRemovalResult,
+  type PidFileInspection,
+} from "../pidfile";
 import { readPortFile } from "../portfile";
-import { probeGateway } from "./start";
+import {
+  probeGateway,
+  probeGatewayProcess,
+  probeUrlFor,
+  requestGatewayShutdown,
+  type GatewayShutdownRequestResult,
+} from "./start";
 import { SHUTDOWN_DEADLINE_MS } from "./shutdown";
+import {
+  inspectProcessGeneration,
+  withLifecycleLock,
+  type ProcessInspection,
+} from "../lifecycle-lock";
 
 export type StopPlan =
   | { action: "signal"; pid: number }
   | { action: "foreground"; port: number }
   | { action: "stale"; pid: number }
+  | { action: "uncertain"; pid: number }
   | { action: "none" };
 
-/**
- * Decide what `lore stop` should do given the observed pid/port state.
- * Pure and unit-testable — no process signalling or IO here.
- */
+/** Decide what `lore stop` should do from the observed process/port state. */
 export function planStop(input: {
   pid: number | null;
-  pidAlive: boolean;
+  pidState: ProcessInspection["state"];
   port: number | null;
   portAlive: boolean;
+  pidMatchesGateway: boolean;
 }): StopPlan {
-  // A live PID always wins — we can signal it directly.
-  if (input.pid !== null && input.pidAlive) {
+  // Signal only when the live PID is confirmed by the gateway control response.
+  // PID numbers are reused, so liveness alone cannot establish ownership.
+  if (
+    input.pid !== null &&
+    input.pidState === "alive" &&
+    input.pidMatchesGateway
+  ) {
     return { action: "signal", pid: input.pid };
   }
-  // No signallable PID, but a gateway is still answering — it's a foreground
-  // process (or one started without a PID file) we can't kill by PID.
   if (input.port !== null && input.portAlive) {
     return { action: "foreground", port: input.port };
   }
-  // A PID file is present but the process is gone and nothing is serving.
-  if (input.pid !== null) {
+  if (input.pid !== null && input.pidState === "dead") {
     return { action: "stale", pid: input.pid };
   }
+  if (input.pid !== null) return { action: "uncertain", pid: input.pid };
   return { action: "none" };
 }
 
 /** Injectable IO for the stop orchestration, so `runStop` is testable. */
 export interface StopIO {
-  readPid: () => number | null;
+  inspectPidFile: () => PidFileInspection;
+  readRecord: () => GatewayProcessRecord | null;
   readPort: () => number | null;
-  probe: (url: string) => Promise<boolean>;
+  authenticate: (record: GatewayProcessRecord) => Promise<boolean>;
+  requestShutdown: (
+    record: GatewayProcessRecord,
+  ) => Promise<GatewayShutdownRequestResult>;
+  probeHealth: (url: string) => Promise<boolean>;
+  inspectProcess?: (pid: number) => ProcessInspection;
   isAlive: (pid: number) => boolean;
   kill: (pid: number) => void;
-  removePid: (pid: number) => void;
+  removeRecord: (record: GatewayProcessRecord) => void;
+  removeLegacyPid: (record: LegacyPidFileRecord) => LegacyPidRemovalResult;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
   logInfo: (msg: string) => void;
@@ -62,61 +91,307 @@ export interface StopIO {
   timeoutMs?: number;
 }
 
+function sameProcessRecord(
+  current: GatewayProcessRecord | null,
+  expected: GatewayProcessRecord,
+): current is GatewayProcessRecord {
+  return (
+    current?.version === expected.version &&
+    current.pid === expected.pid &&
+    current.port === expected.port &&
+    current.token === expected.token &&
+    current.processIdentity === expected.processIdentity &&
+    current.hosts.length === expected.hosts.length &&
+    current.hosts.every((host, index) => host === expected.hosts[index])
+  );
+}
+
 /**
  * Stop orchestration: resolve the running gateway, signal it, and wait for it
- * to exit. Returns the process exit code (0 = stopped/nothing-running,
- * 1 = foreground or stuck). Pure of `process.exit`/real IO so it is
- * unit-testable; `commandStop` is the thin shell that wires real IO.
+ * to exit. Returns the process exit code. Pure of process.exit/real IO.
  */
 export async function runStop(io: StopIO): Promise<number> {
-  const pid = io.readPid();
-  const port = io.readPort();
-  const portAlive = port ? await io.probe(`http://127.0.0.1:${port}`) : false;
+  const pidFile = io.inspectPidFile();
+  if (pidFile.state === "invalid") {
+    io.logError(
+      `Gateway PID record is invalid (${pidFile.reason}); preserving it without signalling any process.`,
+    );
+    return 1;
+  }
+  const record = pidFile.state === "process" ? pidFile.record : null;
+  const legacyPid = pidFile.state === "legacy" ? pidFile.record : null;
+  const inspect = (candidatePid: number): ProcessInspection =>
+    io.inspectProcess?.(candidatePid) ??
+    (io.isAlive(candidatePid)
+      ? { state: "alive", identity: null }
+      : { state: "dead" });
+  const pid = record?.pid ?? legacyPid?.pid ?? null;
+  const port = record?.port ?? io.readPort();
+  if (pidFile.state === "absent") {
+    const healthUrls = port ? [probeUrlFor("127.0.0.1", port)] : [];
+    const healthResults = await Promise.all(
+      healthUrls.map((url) => io.probeHealth(url)),
+    );
+    const plan = planStop({
+      pid: null,
+      pidState: "dead",
+      port,
+      portAlive: healthResults.some(Boolean),
+      pidMatchesGateway: false,
+    });
+    if (plan.action === "foreground") {
+      io.logError(
+        `A gateway is running on port ${plan.port} but no matching PID was found.`,
+      );
+      io.logError(
+        `It's likely a foreground \`lore start\` — stop it with Ctrl+C in its terminal.`,
+      );
+      return 1;
+    }
+    io.logInfo("No running gateway found.");
+    return 0;
+  }
+  const pidMatchesGateway = record ? await io.authenticate(record) : false;
+  const healthUrls = record
+    ? record.hosts.map((host) => probeUrlFor(host, record.port))
+    : port
+      ? [probeUrlFor("127.0.0.1", port)]
+      : [];
+  const healthResults = pidMatchesGateway
+    ? [true]
+    : await Promise.all(healthUrls.map((url) => io.probeHealth(url)));
+  const initialInspection =
+    pid === null ? { state: "dead" as const } : inspect(pid);
+  if (
+    record?.version === 2 &&
+    !pidMatchesGateway &&
+    (initialInspection.state === "unknown" ||
+      (initialInspection.state === "alive" &&
+        (initialInspection.identity === null ||
+          initialInspection.identity === record.processIdentity)))
+  ) {
+    io.logError(
+      `Gateway process generation ${record.pid} is still live but control authentication is unavailable; preserving its process record.`,
+    );
+    return 1;
+  }
   const plan = planStop({
     pid,
-    pidAlive: pid !== null && io.isAlive(pid),
+    pidState: initialInspection.state,
     port,
-    portAlive,
+    portAlive: healthResults.some(Boolean),
+    pidMatchesGateway,
   });
 
   switch (plan.action) {
     case "signal": {
-      try {
-        io.kill(plan.pid);
-      } catch {
-        // Raced with exit — fall through to cleanup.
+      if (!record) {
+        io.logError(
+          `Refusing to signal pid ${plan.pid} without an authenticated process-generation record.`,
+        );
+        return 1;
       }
-      // Wait for the process to exit (bounded a bit beyond its own shutdown
-      // deadline so a clean graceful shutdown has time to finish).
+      // Revalidate the exact persisted generation and make the authenticated
+      // request while serialized. The target schedules shutdown after flushing
+      // the response, so this lock is released before it needs to acquire it.
+      const graceful = await withLifecycleLock(
+        "gateway-shutdown",
+        async (lock) => {
+          lock.assertOwned();
+          const current = io.readRecord();
+          if (!sameProcessRecord(current, record)) return "changed" as const;
+          if (!(await io.authenticate(current))) return "changed" as const;
+          lock.assertOwned();
+          let request: GatewayShutdownRequestResult;
+          try {
+            request = await io.requestShutdown(current);
+          } catch {
+            request = "failed";
+          }
+          lock.assertOwned();
+          return sameProcessRecord(io.readRecord(), record)
+            ? request
+            : ("changed" as const);
+        },
+      );
+
+      if (graceful === "changed") {
+        io.logError(
+          `Gateway process record changed during the shutdown request for pid ${plan.pid}; nothing was removed or signalled.`,
+        );
+        return 1;
+      }
+      if (graceful === "failed") {
+        io.logError(
+          `Authenticated graceful shutdown request failed for pid ${plan.pid}; preserving the process record without signalling it.`,
+        );
+        return 1;
+      }
+
+      const expectedProcessIdentity = record.processIdentity;
+      const hasStrongIdentity =
+        record.version === 2 &&
+        expectedProcessIdentity !== undefined &&
+        !expectedProcessIdentity.startsWith("unverified:");
+
+      if (graceful === "unsupported") {
+        // Version-transition fallback only: an authenticated GET from an older
+        // gateway may not implement POST. Never signal without a matching strong
+        // process generation.
+        if (!hasStrongIdentity) {
+          io.logError(
+            `Gateway does not support authenticated graceful shutdown and pid ${plan.pid} lacks a verified start identity; nothing was signalled.`,
+          );
+          return 1;
+        }
+        const signalled = await withLifecycleLock(
+          "gateway-shutdown",
+          async (lock) => {
+            lock.assertOwned();
+            const current = io.readRecord();
+            if (
+              !sameProcessRecord(current, record) ||
+              !(await io.authenticate(current))
+            ) {
+              return false;
+            }
+            const inspection = inspect(current.pid);
+            if (
+              inspection.state !== "alive" ||
+              inspection.identity !== expectedProcessIdentity
+            ) {
+              return false;
+            }
+            lock.assertOwned();
+            try {
+              io.kill(current.pid);
+            } catch (error) {
+              const afterSignalFailure = inspect(current.pid);
+              if (
+                afterSignalFailure.state === "dead" ||
+                (afterSignalFailure.state === "alive" &&
+                  afterSignalFailure.identity !== null &&
+                  afterSignalFailure.identity !== expectedProcessIdentity)
+              ) {
+                return true;
+              }
+              throw error;
+            }
+            return true;
+          },
+        );
+        if (!signalled) {
+          io.logError(
+            `Gateway process generation changed before signalling pid ${plan.pid}; nothing was signalled.`,
+          );
+          return 1;
+        }
+      }
+
       const deadline = io.now() + (io.timeoutMs ?? SHUTDOWN_DEADLINE_MS + 3000);
+      let stopped = false;
+      let recordChanged = false;
       while (io.now() < deadline) {
-        if (!io.isAlive(plan.pid)) break;
+        const currentRecord = io.readRecord();
+        if (currentRecord === null) {
+          stopped = true;
+          break;
+        }
+        if (!sameProcessRecord(currentRecord, record)) {
+          recordChanged = true;
+          break;
+        }
+        const current = inspect(plan.pid);
+        if (
+          current.state === "dead" ||
+          (hasStrongIdentity &&
+            current.state === "alive" &&
+            current.identity !== null &&
+            current.identity !== expectedProcessIdentity)
+        ) {
+          stopped = true;
+          break;
+        }
         await io.sleep(200);
       }
-      if (io.isAlive(plan.pid)) {
+      if (recordChanged) {
+        io.logError(
+          `Gateway process record was replaced while waiting for pid ${plan.pid}; preserving the replacement.`,
+        );
+        return 1;
+      }
+      if (!stopped) {
         io.logError(
           `Gateway (pid ${plan.pid}) did not stop within the deadline.`,
         );
         return 1;
       }
-      io.removePid(plan.pid);
+      await withLifecycleLock("gateway-shutdown", (lock) => {
+        lock.assertOwned();
+        const current = io.readRecord();
+        if (sameProcessRecord(current, record)) {
+          io.removeRecord(record);
+        }
+      });
       io.logInfo(`Gateway stopped (pid ${plan.pid}).`);
       return 0;
     }
     case "foreground":
       io.logError(
-        `A gateway is running on port ${plan.port} but no PID file was found.`,
+        `A gateway is running on port ${plan.port} but no matching PID was found.`,
       );
       io.logError(
         `It's likely a foreground \`lore start\` — stop it with Ctrl+C in its terminal.`,
       );
       return 1;
     case "stale":
-      io.removePid(plan.pid);
-      io.logInfo(`No running gateway found (cleaned up stale PID file).`);
+      if (record) {
+        const currentInspection = inspect(record.pid);
+        if (currentInspection.state !== "dead") {
+          io.logError(
+            `Gateway process generation ${record.pid} is live or could not be inspected; preserving its process record.`,
+          );
+          return 1;
+        }
+        io.removeRecord(record);
+      } else if (legacyPid) {
+        const result = await withLifecycleLock(
+          "gateway-shutdown",
+          (lock): LegacyPidRemovalResult | "process-changed" => {
+            lock.assertOwned();
+            if (inspect(legacyPid.pid).state !== "dead") {
+              return "process-changed";
+            }
+            lock.assertOwned();
+            return io.removeLegacyPid(legacyPid);
+          },
+        );
+        if (result === "process-changed") {
+          io.logError(
+            `PID ${legacyPid.pid} is live or could not be inspected; preserving its process record without signalling it.`,
+          );
+          return 1;
+        }
+        if (result === "changed") {
+          io.logError(
+            "Gateway PID record changed before stale cleanup; preserving the replacement record.",
+          );
+          return 1;
+        }
+        if (result === "absent") {
+          io.logInfo("No running gateway found.");
+          return 0;
+        }
+      }
+      io.logInfo("No running gateway found (cleaned up stale PID file).");
       return 0;
+    case "uncertain":
+      io.logError(
+        `PID ${plan.pid} is live or could not be inspected; preserving its process record without signalling it.`,
+      );
+      return 1;
     case "none":
-      io.logInfo(`No running gateway found.`);
+      io.logInfo("No running gateway found.");
       return 0;
   }
 }
@@ -124,13 +399,18 @@ export async function runStop(io: StopIO): Promise<number> {
 /** Build the real (production) IO for {@link runStop}. */
 export function realStopIO(): StopIO {
   return {
-    readPid: readPidFile,
+    inspectPidFile,
+    readRecord: readGatewayProcessFile,
     readPort: readPortFile,
-    probe: probeGateway,
-    isAlive: isProcessAlive,
+    authenticate: probeGatewayProcess,
+    requestShutdown: requestGatewayShutdown,
+    probeHealth: probeGateway,
+    inspectProcess: inspectProcessGeneration,
+    isAlive: (pid) => inspectProcessGeneration(pid).state === "alive",
     kill: (pid) => process.kill(pid, "SIGTERM"),
-    removePid: removePidFile,
-    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    removeRecord: removeGatewayProcessFile,
+    removeLegacyPid: removeLegacyPidFile,
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     now: Date.now,
     logInfo: (msg) => console.log(`[lore] ${msg}`),
     logError: (msg) => console.error(`[lore] ${msg}`),

--- a/packages/gateway/src/cli/uninstall.ts
+++ b/packages/gateway/src/cli/uninstall.ts
@@ -1,0 +1,2801 @@
+/**
+ * `lore uninstall` — reverse persistent setup and remove the standalone CLI.
+ *
+ * The default preserves the Lore data directory. `--purge` additionally
+ * removes the database, logs, and runtime state. Project-owned `.lore.md`,
+ * `.lore.json`, and agent instruction files are never searched for or removed.
+ */
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import { homedir } from "node:os";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  parse,
+  posix,
+  relative,
+  resolve,
+  sep,
+  win32,
+} from "node:path";
+import { createInterface } from "node:readline/promises";
+import type { GatewayProcessRecord, ProcessFileInspection } from "../pidfile";
+import type { PortFileInspection } from "../portfile";
+import type { GatewayHealthStatus } from "./start";
+import { getConfigDir } from "./lib/binary";
+import { createUninstallTombstone, withLifecycleLock } from "../lifecycle-lock";
+
+const INSTALLER_PATH_MARKER = "# Added by lore installer";
+const UNINSTALL_USAGE = `Usage: lore uninstall [--purge] [--yes] [--dry-run]
+
+Undo persistent agent setup and remove the standalone Lore CLI.
+By default, the database and project files are preserved.
+
+  --purge  Also delete local Lore data, logs, credentials, and runtime state
+  --yes    Skip the --purge confirmation prompt
+  --dry-run  Show the cleanup plan without changing anything`;
+
+export interface UninstallPlan {
+  binaryPath: string | null;
+  binaryIdentity: ExecutableIdentity | null;
+  manualBinaryPath: string | null;
+  manualReceiptPath: string | null;
+  receiptPath: string | null;
+  receiptIdentity?: InstallReceiptIdentity | null;
+  installDir: string | null;
+  removals: Array<{ path: string; recursive: boolean }>;
+  preservedDataPaths: string[];
+  packageManaged: boolean;
+}
+
+export interface ExecutableIdentity {
+  device: bigint;
+  inode: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  sha256: string;
+}
+
+export type InstallReceiptIdentity = ExecutableIdentity;
+
+export interface StandaloneInstallProvenance {
+  hostedInstall: boolean;
+  receiptPath?: string;
+  pathInstallDir?: string;
+  executableIdentity?: ExecutableIdentity;
+  receiptIdentity?: InstallReceiptIdentity;
+}
+
+export interface ParsedInstallReceipt {
+  version: "legacy" | 1 | 2 | 3;
+  executable: string;
+  pathInstallDir?: string;
+  executableIdentity?: ExecutableIdentity;
+  executableSha256?: string;
+}
+
+export interface StagedFileRemoval {
+  stageDeletion: () => void;
+  assertDeleted: () => void;
+  state: () => "expected" | "missing" | "replaced" | "unknown";
+  prepareCommit: () => void;
+  commit: () => void;
+  finalize: () => void;
+  rollback: (restore?: boolean) => "restored" | "preserved";
+}
+
+export interface StandaloneUpgradeReceiptTransaction {
+  refresh: (replacementSha256: string) => void;
+  rollback: () => "restored" | "preserved";
+  commit: () => void;
+}
+
+export interface UpgradePublicationHooks {
+  beforeReceiptPublish?: () => void;
+  afterReceiptPublish?: () => void;
+}
+
+export interface PathBlockRemoval {
+  prepareCommit: () => void;
+  commit: () => void;
+  rollback: (restore?: boolean) => void;
+}
+
+export class IrreversibleUninstallError extends AggregateError {
+  constructor(errors: Iterable<unknown>) {
+    super(
+      errors,
+      "Uninstall failed after irreversible cleanup began; automatic rollback was not attempted.",
+    );
+    this.name = "IrreversibleUninstallError";
+  }
+}
+
+export interface RemovalPathIdentity {
+  device: bigint;
+  inode: bigint;
+  directory: boolean;
+}
+
+export interface RemovalPathHooks {
+  beforeQuarantine?: () => void;
+  afterQuarantine?: () => void;
+}
+
+export interface PathBlockRemovalHooks {
+  beforeProfileQuarantine?: (path: string) => void;
+  beforeProfilePublish?: (path: string) => void;
+}
+
+export interface UninstallIO {
+  gatewayRunning: () => Promise<boolean>;
+  prevalidateSetupUndo: () => void;
+  stageSetupUndo: () => PathBlockRemoval | Promise<PathBlockRemoval>;
+  removePathBlocks: (
+    installDir: string,
+    assertInstallRemoved: () => void,
+  ) => PathBlockRemoval;
+  removePath: (path: string, recursive: boolean) => PathBlockRemoval;
+  removeBinary: (
+    path: string,
+    identity: ExecutableIdentity,
+  ) => StagedFileRemoval;
+  removeReceipt?: (
+    path: string,
+    identity: InstallReceiptIdentity,
+  ) => StagedFileRemoval;
+  recoverReplacementReceipt?: (
+    executable: string,
+    receiptPath: string,
+    pathInstallDir: string,
+  ) => void;
+  log: (message: string) => void;
+  beginUninstall?: () => { rollback: () => void };
+}
+
+export interface GatewayRunningIO {
+  inspectProcessRecord?: () => ProcessFileInspection;
+  readProcessRecord: () => GatewayProcessRecord | null;
+  authenticateProcess: (
+    record: GatewayProcessRecord,
+  ) => Promise<"authenticated" | "rejected" | "unavailable" | "timeout">;
+  inspectPort?: () => PortFileInspection;
+  readPort: () => number | null;
+  probePort: (baseURL: string) => Promise<GatewayHealthStatus>;
+}
+
+/** Build a deterministic cleanup plan without touching the filesystem. */
+export function planUninstall(input: {
+  currentExecutable: string;
+  hostedInstall: boolean;
+  receiptPath?: string;
+  pathInstallDir?: string;
+  packageManaged: boolean;
+  platform: NodeJS.Platform;
+  purge: boolean;
+  home: string;
+  cwd?: string;
+  dataDir: string;
+  configDir: string;
+  dbPath?: string;
+  executableIdentity?: ExecutableIdentity;
+  receiptIdentity?: InstallReceiptIdentity;
+  packageEntryPath?: string;
+  canonicalProtectedPaths?: string[];
+}): UninstallPlan {
+  const defaultConfigDir = join(input.home, ".lore");
+  const defaultDataDir = join(input.home, ".local", "share", "lore");
+  const removals: Array<{ path: string; recursive: boolean }> = [
+    { path: join(defaultConfigDir, "channel"), recursive: false },
+    { path: join(defaultConfigDir, "latest-version"), recursive: false },
+    { path: join(defaultConfigDir, "version-check.json"), recursive: false },
+    { path: join(defaultConfigDir, "patch-cache"), recursive: true },
+    { path: join(defaultConfigDir, "embeddings-vendored"), recursive: true },
+    { path: join(input.home, ".cache", "lore"), recursive: true },
+  ];
+  const dataDirIsDefault = resolve(input.dataDir) === resolve(defaultDataDir);
+  const configDirIsDefault =
+    resolve(input.configDir) === resolve(defaultConfigDir);
+  const verifiedInstall =
+    !input.packageManaged &&
+    input.hostedInstall &&
+    input.receiptPath &&
+    input.executableIdentity !== undefined &&
+    input.receiptIdentity !== undefined;
+  const installReceiptPresent =
+    !input.packageManaged && input.hostedInstall && input.receiptPath;
+  const binaryPath =
+    verifiedInstall &&
+    input.platform !== "win32" &&
+    input.executableIdentity !== undefined &&
+    pathIsInside(input.currentExecutable, input.home)
+      ? resolve(input.currentExecutable)
+      : null;
+  const manualBinaryPath =
+    !input.packageManaged && binaryPath === null
+      ? resolve(input.currentExecutable)
+      : null;
+  const externalDbPath =
+    input.dbPath &&
+    (!isAbsolute(input.dbPath) || !pathIsInside(input.dbPath, defaultDataDir))
+      ? input.dbPath
+      : null;
+  const protectedPaths = [
+    ...(!dataDirIsDefault ? [input.dataDir] : []),
+    ...(!configDirIsDefault ? [input.configDir] : []),
+    ...(externalDbPath
+      ? [
+          isAbsolute(externalDbPath)
+            ? externalDbPath
+            : resolve(input.cwd ?? process.cwd(), externalDbPath),
+        ]
+      : []),
+    ...(binaryPath === null ? [input.currentExecutable] : []),
+    ...(input.packageManaged && input.packageEntryPath
+      ? [input.packageEntryPath]
+      : []),
+    ...(input.canonicalProtectedPaths ?? []),
+  ].map((path) => resolve(path));
+
+  if (input.purge && dataDirIsDefault) {
+    removals.push({ path: defaultDataDir, recursive: true });
+  }
+
+  const uniqueRemovals = new Map<string, boolean>();
+  for (const removal of removals) {
+    const path = resolve(removal.path);
+    const overlapsProtectedPath = protectedPaths.some(
+      (protectedPath) =>
+        pathIsInside(path, protectedPath) ||
+        (removal.recursive && pathIsInside(protectedPath, path)),
+    );
+    if (overlapsProtectedPath) continue;
+    uniqueRemovals.set(
+      path,
+      removal.recursive || (uniqueRemovals.get(path) ?? false),
+    );
+  }
+
+  return {
+    binaryPath,
+    binaryIdentity:
+      binaryPath === null || input.executableIdentity === undefined
+        ? null
+        : { ...input.executableIdentity },
+    manualBinaryPath,
+    manualReceiptPath:
+      installReceiptPresent && binaryPath === null && input.receiptPath
+        ? resolve(input.receiptPath)
+        : null,
+    receiptPath:
+      binaryPath !== null && input.receiptPath
+        ? resolve(input.receiptPath)
+        : null,
+    receiptIdentity:
+      binaryPath !== null && input.receiptIdentity !== undefined
+        ? { ...input.receiptIdentity }
+        : null,
+    installDir:
+      verifiedInstall && input.pathInstallDir !== undefined
+        ? input.pathInstallDir
+        : null,
+    removals: [...uniqueRemovals].map(([path, recursive]) => ({
+      path,
+      recursive,
+    })),
+    preservedDataPaths: [
+      ...(!input.purge || !dataDirIsDefault ? [input.dataDir] : []),
+      ...(!configDirIsDefault ? [input.configDir] : []),
+      ...(externalDbPath ? [externalDbPath] : []),
+    ],
+    packageManaged: input.packageManaged,
+  };
+}
+
+function pathIsInside(path: string, parent: string): boolean {
+  const rel = relative(resolve(parent), resolve(path));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function syncUninstallDirectory(directory: string): void {
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(
+      directory,
+      constants.O_RDONLY |
+        (constants.O_DIRECTORY ?? 0) |
+        (constants.O_NOFOLLOW ?? 0),
+    );
+    fsyncSync(descriptor);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (
+      code !== "EINVAL" &&
+      code !== "ENOTSUP" &&
+      code !== "ENOSYS" &&
+      !(
+        process.platform === "win32" &&
+        (code === "EACCES" || code === "EISDIR" || code === "EPERM")
+      )
+    ) {
+      throw error;
+    }
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+  }
+}
+
+function syncUninstallFile(path: string, expected: ExecutableIdentity): void {
+  let descriptor: number | null = null;
+  try {
+    const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+    descriptor = openSync(path, constants.O_RDONLY | noFollow);
+    const info = fstatSync(descriptor, { bigint: true });
+    if (
+      !info.isFile() ||
+      info.dev !== expected.device ||
+      info.ino !== expected.inode ||
+      info.size !== expected.size ||
+      info.mtimeNs !== expected.mtimeNs
+    ) {
+      throw new Error(`Uninstall recovery file changed before sync: ${path}`);
+    }
+    fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+  }
+}
+
+/** Remove the exact two-line PATH stanza emitted by the hosted installer. */
+export function removeInstallerPathBlock(
+  content: string,
+  installDir: string,
+  shell: "posix" | "fish" = "posix",
+): string {
+  const expected =
+    shell === "fish"
+      ? [
+          `set -gx PATH '${installDir.replaceAll("\\", "\\\\").replaceAll("'", "\\'")}' $PATH`,
+          `set -gx PATH "${installDir}" $PATH`,
+        ]
+      : [
+          `export PATH='${installDir.replaceAll("'", `'"'"'`)}':"$PATH"`,
+          `export PATH="${installDir}:$PATH"`,
+        ];
+  const lines = content.split("\n");
+  const output: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (
+      lines[i] === INSTALLER_PATH_MARKER &&
+      expected.includes(lines[i + 1] ?? "")
+    ) {
+      if (output.at(-1) === "") output.pop();
+      i++;
+      continue;
+    }
+    output.push(lines[i]);
+  }
+
+  return output.join("\n");
+}
+
+/** Execute cleanup in an order that never strands a running gateway. */
+export async function runUninstall(
+  plan: UninstallPlan,
+  io: UninstallIO,
+): Promise<number> {
+  if (await io.gatewayRunning()) {
+    io.log(
+      "A gateway may still be running. Run `lore stop`, verify it stopped, then run uninstall again.",
+    );
+    return 1;
+  }
+
+  io.prevalidateSetupUndo();
+
+  let binaryRemoval: StagedFileRemoval | null = null;
+  let receiptRemoval: StagedFileRemoval | null = null;
+  let pathRemoval: PathBlockRemoval | null = null;
+  let setupRemoval: PathBlockRemoval | null = null;
+  const stagedPathRemovals: PathBlockRemoval[] = [];
+  if (plan.binaryPath) {
+    if (!plan.binaryIdentity) {
+      throw new Error("Refusing to remove an executable without file identity");
+    }
+    binaryRemoval = io.removeBinary(plan.binaryPath, plan.binaryIdentity);
+  }
+  if (plan.receiptPath) {
+    if (!plan.receiptIdentity) {
+      binaryRemoval?.rollback();
+      throw new Error("Refusing to remove an install receipt without identity");
+    }
+    if (!io.removeReceipt) {
+      binaryRemoval?.rollback();
+      throw new Error("Install receipt removal is unavailable");
+    }
+    try {
+      receiptRemoval = io.removeReceipt(plan.receiptPath, plan.receiptIdentity);
+    } catch (error) {
+      binaryRemoval?.rollback();
+      throw error;
+    }
+  }
+
+  const assertInstallRemoved = (): void => {
+    binaryRemoval?.assertDeleted();
+    receiptRemoval?.assertDeleted();
+  };
+
+  let uninstallMarker: { rollback: () => void } | null = null;
+  let irreversibleCommitStarted = false;
+  try {
+    uninstallMarker = plan.binaryPath ? (io.beginUninstall?.() ?? null) : null;
+    setupRemoval = await io.stageSetupUndo();
+    if (
+      binaryRemoval?.state() === "replaced" ||
+      receiptRemoval?.state() === "replaced"
+    ) {
+      throw new Error(
+        "Executable or install receipt replaced during uninstall",
+      );
+    }
+    binaryRemoval?.stageDeletion();
+    receiptRemoval?.stageDeletion();
+    assertInstallRemoved();
+    for (const removal of plan.removals) {
+      stagedPathRemovals.push(io.removePath(removal.path, removal.recursive));
+    }
+    if (plan.installDir) {
+      pathRemoval = io.removePathBlocks(plan.installDir, assertInstallRemoved);
+    }
+    assertInstallRemoved();
+    setupRemoval.prepareCommit();
+    for (const stagedRemoval of stagedPathRemovals) {
+      stagedRemoval.prepareCommit();
+    }
+    pathRemoval?.prepareCommit();
+    receiptRemoval?.prepareCommit();
+    binaryRemoval?.prepareCommit();
+    receiptRemoval?.finalize();
+    binaryRemoval?.finalize();
+
+    // No canonical state may be rolled back after this point: recursive
+    // deletion can partially succeed before reporting an IO error. Every
+    // remaining operation has already validated its exact staged generation.
+    irreversibleCommitStarted = true;
+    const commitErrors: unknown[] = [];
+    const commit = (action: () => void): void => {
+      try {
+        action();
+      } catch (error) {
+        commitErrors.push(error);
+      }
+    };
+    for (const stagedRemoval of stagedPathRemovals) {
+      commit(() => stagedRemoval.commit());
+    }
+    commit(() => setupRemoval?.commit());
+    commit(() => receiptRemoval?.commit());
+    commit(() => binaryRemoval?.commit());
+    commit(() => pathRemoval?.commit());
+    if (commitErrors.length > 0) {
+      throw new IrreversibleUninstallError(commitErrors);
+    }
+  } catch (error) {
+    if (irreversibleCommitStarted) {
+      if (error instanceof IrreversibleUninstallError) throw error;
+      throw new IrreversibleUninstallError([error]);
+    }
+    const rollbacks: unknown[] = [];
+    const binaryState = binaryRemoval?.state();
+    let receiptState = receiptRemoval?.state();
+    if (binaryState === "replaced" && receiptState === "expected") {
+      try {
+        receiptRemoval?.stageDeletion();
+        receiptState = receiptRemoval?.state();
+      } catch (receiptError) {
+        receiptState = receiptRemoval?.state();
+        if (receiptState !== "replaced") rollbacks.push(receiptError);
+      }
+    }
+    const states = [binaryState, receiptState].filter(
+      (state): state is ReturnType<StagedFileRemoval["state"]> =>
+        state !== undefined,
+    );
+    const identityUnknown = states.includes("unknown");
+    const replacementPresent = states.includes("replaced");
+    let recoveredReplacementReceipt = false;
+    if (
+      !identityUnknown &&
+      binaryState === "replaced" &&
+      receiptState === "missing" &&
+      plan.binaryPath &&
+      plan.receiptPath &&
+      plan.installDir &&
+      io.recoverReplacementReceipt
+    ) {
+      try {
+        io.recoverReplacementReceipt(
+          plan.binaryPath,
+          plan.receiptPath,
+          plan.installDir,
+        );
+        receiptState = receiptRemoval?.state();
+        recoveredReplacementReceipt = receiptState === "replaced";
+      } catch (recoveryError) {
+        rollbacks.push(recoveryError);
+      }
+    }
+    try {
+      pathRemoval?.rollback();
+    } catch (rollbackError) {
+      rollbacks.push(rollbackError);
+    }
+    for (const stagedRemoval of [...stagedPathRemovals].reverse()) {
+      try {
+        stagedRemoval.rollback();
+      } catch (rollbackError) {
+        rollbacks.push(rollbackError);
+      }
+    }
+    if (!identityUnknown) {
+      try {
+        binaryRemoval?.rollback(!replacementPresent);
+      } catch (rollbackError) {
+        rollbacks.push(rollbackError);
+      }
+      try {
+        receiptRemoval?.rollback(
+          recoveredReplacementReceipt || receiptState === "replaced"
+            ? false
+            : true,
+        );
+      } catch (rollbackError) {
+        rollbacks.push(rollbackError);
+      }
+    }
+    if (identityUnknown) {
+      rollbacks.push(
+        new Error(
+          "Could not establish the current executable and receipt identity; recovery data was preserved.",
+        ),
+      );
+    }
+    try {
+      setupRemoval?.rollback();
+    } catch (rollbackError) {
+      rollbacks.push(rollbackError);
+    }
+    try {
+      uninstallMarker?.rollback();
+    } catch (rollbackError) {
+      rollbacks.push(rollbackError);
+    }
+    if (rollbacks.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbacks],
+        "Uninstall failed and the standalone installation could not be restored deterministically.",
+      );
+    }
+    throw error;
+  }
+  return 0;
+}
+
+export async function gatewayRunning(io: GatewayRunningIO): Promise<boolean> {
+  const processInspection = io.inspectProcessRecord?.();
+  if (processInspection?.state === "invalid") {
+    throw new Error(
+      `Gateway process discovery evidence is invalid: ${processInspection.reason}. Run \`lore stop\`, inspect runtime records, then retry uninstall.`,
+    );
+  }
+  const record =
+    processInspection?.state === "valid"
+      ? processInspection.record
+      : io.readProcessRecord();
+  if (record !== null) {
+    const status = await io.authenticateProcess(record);
+    if (status === "timeout") {
+      throw new Error(
+        "Gateway identity check timed out; run `lore stop` and retry uninstall.",
+      );
+    }
+    if (status === "unavailable") {
+      throw new Error(
+        "Gateway identity check was unavailable; a gateway may still be running. Run `lore stop` and retry uninstall.",
+      );
+    }
+    if (status === "rejected") {
+      throw new Error(
+        "Gateway identity check was rejected; the recorded gateway identity may have changed or another listener may be running. Run `lore stop`, verify it stopped, then retry uninstall.",
+      );
+    }
+    return true;
+  }
+
+  const portInspection = io.inspectPort?.();
+  if (portInspection?.state === "invalid") {
+    throw new Error(
+      `Gateway port discovery evidence is invalid: ${portInspection.reason}. Run \`lore stop\`, inspect runtime records, then retry uninstall.`,
+    );
+  }
+  const port =
+    portInspection?.state === "valid"
+      ? portInspection.record.port
+      : io.readPort();
+  if (port === null) return false;
+  switch (await io.probePort(`http://127.0.0.1:${port}`)) {
+    case "healthy":
+      return true;
+    case "not-running":
+      return false;
+    case "timeout":
+      throw new Error(
+        "Gateway health check timed out; a gateway may still be running. Run `lore stop` and retry uninstall.",
+      );
+    case "error":
+      throw new Error(
+        "Gateway health check failed; could not safely determine whether a gateway is running. Run `lore stop` and retry uninstall.",
+      );
+  }
+}
+
+function isSeaBinary(): boolean {
+  try {
+    const sea = require("node:sea") as { isSea?: () => boolean };
+    return typeof sea.isSea === "function" ? sea.isSea() : false;
+  } catch {
+    return false;
+  }
+}
+
+function resolvedDataDir(): string {
+  const base = process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+  return join(base, "lore");
+}
+
+function canonicalPath(path: string): string | null {
+  try {
+    return realpathSync.native(path);
+  } catch {
+    return null;
+  }
+}
+
+export function standaloneInstallProvenance(
+  executable: string,
+  options: {
+    seaBinary?: boolean;
+    home?: string;
+    uid?: number;
+    platform?: NodeJS.Platform;
+  } = {},
+): StandaloneInstallProvenance {
+  if (!(options.seaBinary ?? isSeaBinary())) return { hostedInstall: false };
+  const home = options.home ?? homedir();
+  const uid = options.uid ?? process.getuid?.();
+  const platform = options.platform ?? process.platform;
+  const statePath = join(home, ".lore", "install-path");
+
+  try {
+    const state = lstatSync(statePath);
+    if (!state.isFile() || state.isSymbolicLink()) {
+      return { hostedInstall: false };
+    }
+    if (uid !== undefined && state.uid !== uid) return { hostedInstall: false };
+    const canonicalHome = realpathSync.native(home);
+    const canonicalParent = realpathSync.native(dirname(statePath));
+    const expectedCanonicalParent = join(canonicalHome, ".lore");
+    if (canonicalParent !== expectedCanonicalParent) {
+      return { hostedInstall: false };
+    }
+    const parent = lstatSync(canonicalParent);
+    if (
+      !parent.isDirectory() ||
+      parent.isSymbolicLink() ||
+      (uid !== undefined && parent.uid !== uid) ||
+      (platform !== "win32" && (parent.mode & 0o022) !== 0)
+    ) {
+      return { hostedInstall: false };
+    }
+
+    const capturedReceipt = captureFile(statePath, uid);
+    if (capturedReceipt === null) return { hostedInstall: false };
+    const receipt = parseInstallReceipt(
+      capturedReceipt.content.toString("utf8"),
+    );
+    if (
+      receipt === null ||
+      !executablePathsMatch(receipt.executable, executable, platform)
+    ) {
+      return { hostedInstall: false };
+    }
+    const capturedExecutable = captureFile(executable, uid);
+    if (
+      capturedExecutable === null ||
+      !receiptMatchesExecutable(
+        receipt,
+        capturedExecutable,
+        executable,
+        platform,
+      ) ||
+      !fileStillMatches(statePath, capturedReceipt) ||
+      !fileStillMatches(executable, capturedExecutable)
+    ) {
+      return { hostedInstall: false };
+    }
+    return {
+      hostedInstall: true,
+      receiptPath: statePath,
+      receiptIdentity: fileIdentity(capturedReceipt),
+      pathInstallDir: receipt.pathInstallDir,
+      executableIdentity: fileIdentity(capturedExecutable),
+    };
+  } catch {
+    return { hostedInstall: false };
+  }
+}
+
+function receiptMatchesExecutable(
+  receipt: ParsedInstallReceipt,
+  executable: CapturedFile,
+  executablePath: string,
+  platform: NodeJS.Platform,
+): receipt is ParsedInstallReceipt & { pathInstallDir: string } {
+  if (
+    receipt.pathInstallDir === undefined ||
+    !executablePathsMatch(receipt.executable, executablePath, platform)
+  ) {
+    return false;
+  }
+  if (
+    platform !== "win32" &&
+    resolve(receipt.pathInstallDir) !== dirname(resolve(executablePath))
+  ) {
+    return false;
+  }
+  if (receipt.version === 2) {
+    return receipt.executableSha256 === executable.sha256;
+  }
+  if (receipt.version !== 3 || receipt.executableIdentity === undefined) {
+    return false;
+  }
+  return identitiesEqual(receipt.executableIdentity, executable);
+}
+
+function identitiesEqual(
+  expected: ExecutableIdentity,
+  actual: ExecutableIdentity,
+): boolean {
+  return (
+    expected.device === actual.device &&
+    expected.inode === actual.inode &&
+    expected.size === actual.size &&
+    expected.mtimeNs === actual.mtimeNs &&
+    expected.sha256 === actual.sha256
+  );
+}
+
+export function formatStandaloneInstallReceipt(input: {
+  executable: string;
+  pathInstallDir: string;
+  executableIdentity: ExecutableIdentity;
+  platform?: NodeJS.Platform;
+}): string {
+  const platform = input.platform ?? process.platform;
+  const pathApi = platform === "win32" ? win32 : posix;
+  if (
+    !pathApi.isAbsolute(input.executable) ||
+    !posix.isAbsolute(input.pathInstallDir) ||
+    input.executable.includes("\n") ||
+    input.executable.includes("\r") ||
+    input.pathInstallDir.includes("\n") ||
+    input.pathInstallDir.includes("\r") ||
+    !/^[a-f0-9]{64}$/.test(input.executableIdentity.sha256) ||
+    input.executableIdentity.device < 0n ||
+    input.executableIdentity.inode < 0n ||
+    input.executableIdentity.size < 0n ||
+    input.executableIdentity.mtimeNs < 0n ||
+    input.executableIdentity.device === 0n ||
+    input.executableIdentity.inode === 0n ||
+    (platform !== "win32" &&
+      resolve(input.pathInstallDir) !== dirname(resolve(input.executable)))
+  ) {
+    throw new Error("Refusing invalid standalone install receipt fields");
+  }
+  return [
+    "lore-install-receipt-v3",
+    `executable=${input.executable}`,
+    `path-install-dir=${input.pathInstallDir}`,
+    `sha256=${input.executableIdentity.sha256}`,
+    `device=${input.executableIdentity.device}`,
+    `inode=${input.executableIdentity.inode}`,
+    `size=${input.executableIdentity.size}`,
+    `mtime-ns=${input.executableIdentity.mtimeNs}`,
+    "",
+  ].join("\n");
+}
+
+export function refreshStandaloneInstallReceipt(input: {
+  executable: string;
+  executableSha256: string;
+  receiptPath: string;
+  receiptIdentity: InstallReceiptIdentity;
+  pathInstallDir: string;
+  home?: string;
+  uid?: number;
+  hooks?: UpgradePublicationHooks;
+}): void {
+  const home = input.home ?? homedir();
+  const uid = input.uid ?? process.getuid?.();
+  const canonicalHome = realpathSync.native(home);
+  const canonicalParent = realpathSync.native(dirname(input.receiptPath));
+  if (canonicalParent !== join(canonicalHome, ".lore")) {
+    throw new Error(
+      `Refusing installer receipt outside the trusted state directory: ${input.receiptPath}`,
+    );
+  }
+  assertFileIdentity(
+    input.receiptPath,
+    input.receiptIdentity,
+    home,
+    "Install receipt",
+  );
+  const executable = captureFile(input.executable, uid);
+  if (executable === null || executable.sha256 !== input.executableSha256) {
+    throw new Error(
+      `Upgraded executable changed before receipt commit: ${input.executable}`,
+    );
+  }
+  const content = formatStandaloneInstallReceipt({
+    executable: input.executable,
+    pathInstallDir: input.pathInstallDir,
+    executableIdentity: executable,
+  });
+  const temp = join(
+    dirname(input.receiptPath),
+    `.${basename(input.receiptPath)}.upgrade-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+  try {
+    writeFileSync(temp, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    assertFileIdentity(
+      input.receiptPath,
+      input.receiptIdentity,
+      home,
+      "Install receipt",
+    );
+    assertFileIdentity(input.executable, executable, home);
+    const claim = `${input.receiptPath}.upgrade-displaced-${process.pid}-${randomBytes(8).toString("hex")}`;
+    renameSync(input.receiptPath, claim);
+    try {
+      assertFileIdentity(claim, input.receiptIdentity, home, "Install receipt");
+      input.hooks?.beforeReceiptPublish?.();
+      linkSync(temp, input.receiptPath);
+    } catch (error) {
+      try {
+        if (!existsSync(input.receiptPath)) linkSync(claim, input.receiptPath);
+      } catch {
+        // Preserve the displaced receipt for recovery.
+      }
+      throw error;
+    }
+    input.hooks?.afterReceiptPublish?.();
+    const refreshed = captureFile(input.receiptPath, uid);
+    if (
+      refreshed === null ||
+      parseInstallReceipt(refreshed.content.toString("utf8"))?.version !== 3 ||
+      !fileStillMatches(input.executable, executable)
+    ) {
+      throw new Error(
+        `Install receipt or executable changed during receipt commit: ${input.receiptPath}`,
+      );
+    }
+    rmSync(claim, { force: true });
+  } finally {
+    rmSync(temp, { force: true });
+  }
+}
+
+export function stageStandaloneUpgradeReceipt(input: {
+  executable: string;
+  receiptPath: string;
+  receiptIdentity: InstallReceiptIdentity;
+  executableIdentity: ExecutableIdentity;
+  pathInstallDir: string;
+  home?: string;
+  uid?: number;
+  hooks?: UpgradePublicationHooks;
+}): StandaloneUpgradeReceiptTransaction {
+  const home = input.home ?? homedir();
+  const uid = input.uid ?? process.getuid?.();
+  assertFileIdentity(input.executable, input.executableIdentity, home);
+  assertFileIdentity(
+    input.receiptPath,
+    input.receiptIdentity,
+    home,
+    "Install receipt",
+  );
+
+  const token = `${process.pid}-${randomBytes(8).toString("hex")}`;
+  const executableBackup = join(
+    dirname(input.executable),
+    `.${basename(input.executable)}.upgrade-backup-${token}`,
+  );
+  const receiptBackup = join(
+    dirname(input.receiptPath),
+    `.${basename(input.receiptPath)}.upgrade-backup-${token}`,
+  );
+  try {
+    linkSync(input.executable, executableBackup);
+    linkSync(input.receiptPath, receiptBackup);
+    assertFileIdentity(executableBackup, input.executableIdentity, home);
+    assertFileIdentity(
+      receiptBackup,
+      input.receiptIdentity,
+      home,
+      "Install receipt",
+    );
+  } catch (error) {
+    rmSync(executableBackup, { force: true });
+    rmSync(receiptBackup, { force: true });
+    throw error;
+  }
+
+  let active = true;
+  let replacement: CapturedFile | null = null;
+  let replacementReceipt: CapturedFile | null = null;
+  const cleanup = (): void => {
+    rmSync(executableBackup, { force: true });
+    rmSync(receiptBackup, { force: true });
+    active = false;
+  };
+  const preserveCoherentGeneration = (): boolean => {
+    const currentExecutable = captureFile(input.executable, uid);
+    const currentReceipt = captureFile(input.receiptPath, uid);
+    if (currentExecutable === null || currentReceipt === null) return false;
+    const parsed = parseInstallReceipt(currentReceipt.content.toString("utf8"));
+    return (
+      parsed !== null &&
+      receiptMatchesExecutable(
+        parsed,
+        currentExecutable,
+        input.executable,
+        process.platform,
+      )
+    );
+  };
+  const captureReplacement = (sha256: string): CapturedFile => {
+    const captured = captureFile(input.executable, uid);
+    if (
+      captured === null ||
+      captured.sha256 !== sha256 ||
+      (captured.device === input.executableIdentity.device &&
+        captured.inode === input.executableIdentity.inode)
+    ) {
+      throw new Error(
+        `Upgraded executable identity is invalid: ${input.executable}`,
+      );
+    }
+    replacement = captured;
+    return captured;
+  };
+
+  return {
+    refresh: (replacementSha256) => {
+      if (!active) throw new Error("Standalone upgrade transaction is closed");
+      captureReplacement(replacementSha256);
+      refreshStandaloneInstallReceipt({
+        executable: input.executable,
+        executableSha256: replacementSha256,
+        receiptPath: input.receiptPath,
+        receiptIdentity: input.receiptIdentity,
+        pathInstallDir: input.pathInstallDir,
+        home,
+        uid,
+        hooks: input.hooks,
+      });
+      const refreshed = captureFile(input.receiptPath, uid);
+      if (refreshed === null) {
+        throw new Error(
+          `Could not capture refreshed install receipt: ${input.receiptPath}`,
+        );
+      }
+      replacementReceipt = refreshed;
+    },
+    rollback: () => {
+      if (!active) return "preserved";
+      const currentExecutable = captureFile(input.executable, uid);
+      const currentReceipt = captureFile(input.receiptPath, uid);
+      if (currentExecutable === null || currentReceipt === null) {
+        if (preserveCoherentGeneration()) {
+          cleanup();
+          return "preserved";
+        }
+        throw new Error(
+          "Could not establish executable and receipt identity during upgrade rollback; recovery links were preserved.",
+        );
+      }
+      const oldExecutable = identitiesEqual(
+        currentExecutable,
+        input.executableIdentity,
+      );
+      const oldReceipt = identitiesEqual(currentReceipt, input.receiptIdentity);
+      const replacementExecutable =
+        replacement !== null && identitiesEqual(currentExecutable, replacement);
+      const parsedReceipt = parseInstallReceipt(
+        currentReceipt.content.toString("utf8"),
+      );
+      const coherentCurrentReceipt =
+        parsedReceipt !== null &&
+        receiptMatchesExecutable(
+          parsedReceipt,
+          currentExecutable,
+          input.executable,
+          process.platform,
+        );
+      const coherentReplacementReceipt =
+        replacement !== null &&
+        parsedReceipt !== null &&
+        replacementReceipt !== null &&
+        identitiesEqual(currentReceipt, replacementReceipt) &&
+        receiptMatchesExecutable(
+          parsedReceipt,
+          replacement,
+          input.executable,
+          process.platform,
+        );
+      if (oldExecutable && oldReceipt) {
+        cleanup();
+        return "restored";
+      }
+      if (!replacementExecutable) {
+        if (coherentCurrentReceipt) {
+          cleanup();
+          return "preserved";
+        }
+        if (
+          replacementReceipt !== null &&
+          identitiesEqual(currentReceipt, replacementReceipt)
+        ) {
+          refreshStandaloneInstallReceipt({
+            executable: input.executable,
+            executableSha256: currentExecutable.sha256,
+            receiptPath: input.receiptPath,
+            receiptIdentity: currentReceipt,
+            pathInstallDir: input.pathInstallDir,
+            home,
+            uid,
+          });
+          cleanup();
+          return "preserved";
+        }
+        throw new Error(
+          "Executable changed during upgrade rollback; recovery links were preserved.",
+        );
+      }
+      if (!oldReceipt && !coherentReplacementReceipt) {
+        throw new Error(
+          "Install receipt changed during upgrade rollback; recovery links were preserved.",
+        );
+      }
+      if (replacement === null) {
+        throw new Error(
+          "Replacement executable identity was lost during upgrade rollback.",
+        );
+      }
+      assertFileIdentity(input.executable, replacement, home);
+      assertFileIdentity(
+        input.receiptPath,
+        oldReceipt ? input.receiptIdentity : currentReceipt,
+        home,
+        "Install receipt",
+      );
+      renameSync(executableBackup, input.executable);
+      try {
+        if (coherentReplacementReceipt) {
+          assertFileIdentity(
+            input.receiptPath,
+            currentReceipt,
+            home,
+            "Install receipt",
+          );
+          renameSync(receiptBackup, input.receiptPath);
+        }
+        assertFileIdentity(input.executable, input.executableIdentity, home);
+        assertFileIdentity(
+          input.receiptPath,
+          input.receiptIdentity,
+          home,
+          "Install receipt",
+        );
+      } catch (error) {
+        throw new Error(
+          `Standalone upgrade rollback did not restore a coherent generation: ${String(error)}`,
+          { cause: error },
+        );
+      }
+      cleanup();
+      return "restored";
+    },
+    commit: () => {
+      if (!active) return;
+      if (replacement === null) {
+        throw new Error("Standalone receipt was not refreshed");
+      }
+      const currentExecutable = captureFile(input.executable, uid);
+      const currentReceipt = captureFile(input.receiptPath, uid);
+      const parsedReceipt =
+        currentReceipt === null
+          ? null
+          : parseInstallReceipt(currentReceipt.content.toString("utf8"));
+      if (
+        currentExecutable === null ||
+        currentReceipt === null ||
+        !identitiesEqual(currentExecutable, replacement) ||
+        parsedReceipt === null ||
+        !receiptMatchesExecutable(
+          parsedReceipt,
+          currentExecutable,
+          input.executable,
+          process.platform,
+        )
+      ) {
+        throw new Error(
+          "Standalone executable or receipt changed before upgrade commit",
+        );
+      }
+      cleanup();
+    },
+  };
+}
+
+export function recoverReplacementInstallReceipt(
+  executablePath: string,
+  receiptPath: string,
+  pathInstallDir: string,
+  home: string = homedir(),
+  uid: number | undefined = process.getuid?.(),
+): void {
+  const canonicalHome = realpathSync.native(home);
+  if (
+    realpathSync.native(dirname(receiptPath)) !== join(canonicalHome, ".lore")
+  ) {
+    throw new Error(
+      `Refusing installer receipt outside the trusted state directory: ${receiptPath}`,
+    );
+  }
+  const executable = captureFile(executablePath, uid);
+  if (executable === null) {
+    throw new Error(
+      `Could not establish replacement executable identity: ${executablePath}`,
+    );
+  }
+  if (!fileStillMatches(executablePath, executable)) {
+    throw new Error(
+      `Replacement executable changed before receipt recovery: ${executablePath}`,
+    );
+  }
+  const content = formatStandaloneInstallReceipt({
+    executable: executablePath,
+    pathInstallDir,
+    executableIdentity: executable,
+  });
+  const temp = join(
+    dirname(receiptPath),
+    `.${basename(receiptPath)}.recovery-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+  let linked = false;
+  try {
+    writeFileSync(temp, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    try {
+      linkSync(temp, receiptPath);
+      linked = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+    if (linked) {
+      const linkedReceipt = captureFile(receiptPath, uid);
+      if (
+        linkedReceipt === null ||
+        linkedReceipt.sha256 !==
+          createHash("sha256").update(content).digest("hex")
+      ) {
+        throw new Error(
+          `Install receipt changed during replacement recovery: ${receiptPath}`,
+        );
+      }
+    }
+    if (!fileStillMatches(executablePath, executable)) {
+      if (linked) {
+        const generatedReceipt = captureFile(receiptPath, uid);
+        if (generatedReceipt !== null) {
+          assertFileIdentity(
+            receiptPath,
+            generatedReceipt,
+            home,
+            "Install receipt",
+          );
+          unlinkSync(receiptPath);
+        }
+      }
+      throw new Error(
+        `Replacement executable changed during receipt recovery: ${executablePath}`,
+      );
+    }
+    const receipt = captureFile(receiptPath, uid);
+    const parsed =
+      receipt === null
+        ? null
+        : parseInstallReceipt(receipt.content.toString("utf8"));
+    if (
+      parsed === null ||
+      !receiptMatchesExecutable(
+        parsed,
+        executable,
+        executablePath,
+        process.platform,
+      )
+    ) {
+      throw new Error(
+        `A concurrent install receipt does not match the live executable: ${receiptPath}`,
+      );
+    }
+  } finally {
+    rmSync(temp, { force: true });
+  }
+}
+
+interface CapturedFile extends InstallReceiptIdentity {
+  content: Buffer;
+}
+
+function captureFile(
+  path: string,
+  uid: number | undefined,
+): CapturedFile | null {
+  let fd: number | null = null;
+  try {
+    const initial = lstatSync(path, { bigint: true });
+    if (!initial.isFile() || initial.isSymbolicLink()) return null;
+    const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+    fd = openSync(path, constants.O_RDONLY | noFollow);
+    const info = fstatSync(fd, { bigint: true });
+    if (!info.isFile() || info.isSymbolicLink()) return null;
+    if (uid !== undefined && info.uid !== BigInt(uid)) return null;
+    if (initial.dev !== info.dev || initial.ino !== info.ino) return null;
+    const content = readFileSync(fd);
+    const final = fstatSync(fd, { bigint: true });
+    if (
+      info.dev !== final.dev ||
+      info.ino !== final.ino ||
+      info.size !== final.size ||
+      info.mtimeNs !== final.mtimeNs
+    ) {
+      return null;
+    }
+    return {
+      device: info.dev,
+      inode: info.ino,
+      size: info.size,
+      mtimeNs: info.mtimeNs,
+      sha256: createHash("sha256").update(content).digest("hex"),
+      content,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+function fileIdentity(file: CapturedFile): InstallReceiptIdentity {
+  return {
+    device: file.device,
+    inode: file.inode,
+    size: file.size,
+    mtimeNs: file.mtimeNs,
+    sha256: file.sha256,
+  };
+}
+
+function fileStillMatches(
+  path: string,
+  expected: InstallReceiptIdentity,
+): boolean {
+  try {
+    const info = lstatSync(path, { bigint: true });
+    return (
+      info.isFile() &&
+      !info.isSymbolicLink() &&
+      info.dev === expected.device &&
+      info.ino === expected.inode &&
+      info.size === expected.size &&
+      info.mtimeNs === expected.mtimeNs
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function parseInstallReceipt(
+  content: string,
+): ParsedInstallReceipt | null {
+  if (!content.includes("\n") && !content.includes("\r")) {
+    return content.length > 0
+      ? { version: "legacy", executable: content }
+      : null;
+  }
+
+  const lines = content.split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  const version = lines[0];
+  if (
+    version !== "lore-install-receipt-v1" &&
+    version !== "lore-install-receipt-v2" &&
+    version !== "lore-install-receipt-v3"
+  ) {
+    return null;
+  }
+  const expectedLines =
+    version === "lore-install-receipt-v3"
+      ? 8
+      : version === "lore-install-receipt-v2"
+        ? 4
+        : 3;
+  if (
+    lines.length !== expectedLines ||
+    !lines[1]?.startsWith("executable=") ||
+    !lines[2]?.startsWith("path-install-dir=") ||
+    (version !== "lore-install-receipt-v1" &&
+      !lines[3]?.startsWith("sha256=")) ||
+    (version === "lore-install-receipt-v3" &&
+      (!lines[4]?.startsWith("device=") ||
+        !lines[5]?.startsWith("inode=") ||
+        !lines[6]?.startsWith("size=") ||
+        !lines[7]?.startsWith("mtime-ns=")))
+  ) {
+    return null;
+  }
+  const executable = lines[1].slice("executable=".length);
+  const pathInstallDir = lines[2].slice("path-install-dir=".length);
+  const executableSha256 =
+    version !== "lore-install-receipt-v1"
+      ? lines[3].slice("sha256=".length)
+      : undefined;
+  if (
+    executable.length === 0 ||
+    !posix.isAbsolute(pathInstallDir) ||
+    executable.includes("\r") ||
+    pathInstallDir.includes("\r") ||
+    (executableSha256 !== undefined && !/^[a-f0-9]{64}$/.test(executableSha256))
+  ) {
+    return null;
+  }
+  if (version === "lore-install-receipt-v1") {
+    return { version: 1, executable, pathInstallDir };
+  }
+  if (version === "lore-install-receipt-v2") {
+    return { version: 2, executable, pathInstallDir, executableSha256 };
+  }
+  if (executableSha256 === undefined) return null;
+  const identityValues = [
+    lines[4].slice("device=".length),
+    lines[5].slice("inode=".length),
+    lines[6].slice("size=".length),
+    lines[7].slice("mtime-ns=".length),
+  ];
+  if (identityValues.some((value) => !/^\d+$/.test(value))) return null;
+  const [device, inode, size, mtimeNs] = identityValues.map(BigInt) as [
+    bigint,
+    bigint,
+    bigint,
+    bigint,
+  ];
+  return {
+    version: 3,
+    executable,
+    pathInstallDir,
+    executableSha256,
+    executableIdentity: {
+      device,
+      inode,
+      size,
+      mtimeNs,
+      sha256: executableSha256,
+    },
+  };
+}
+
+function executablePathsMatch(
+  recorded: string,
+  current: string,
+  platform: NodeJS.Platform,
+): boolean {
+  const pathApi = platform === "win32" ? win32 : posix;
+  if (!pathApi.isAbsolute(recorded) || !pathApi.isAbsolute(current))
+    return false;
+  const recordedPath = pathApi.resolve(recorded);
+  const currentPath = pathApi.resolve(current);
+  return platform === "win32"
+    ? recordedPath.toLowerCase() === currentPath.toLowerCase()
+    : recordedPath === currentPath;
+}
+
+function shellConfigPaths(home: string): Array<{
+  path: string;
+  shell: "posix" | "fish";
+}> {
+  return [
+    { path: join(home, ".zshrc"), shell: "posix" },
+    { path: join(home, ".bash_profile"), shell: "posix" },
+    { path: join(home, ".bashrc"), shell: "posix" },
+    { path: join(home, ".profile"), shell: "posix" },
+    { path: join(home, ".config", "fish", "config.fish"), shell: "fish" },
+  ];
+}
+
+export function removePathBlocks(
+  installDir: string,
+  assertInstallRemoved: () => void,
+  homeDirectory: string = homedir(),
+  hooks: PathBlockRemovalHooks = {},
+): PathBlockRemoval {
+  const canonicalHome = realpathSync.native(homeDirectory);
+  interface ProfileBackup {
+    path: string;
+    originalClaim: string;
+    afterClaim: string;
+    journalPath: string;
+    journal: CapturedFile;
+    before: ExecutableIdentity;
+    after: ExecutableIdentity;
+  }
+  interface ProfileJournal {
+    version: 1;
+    token: string;
+    profile: string;
+    before: {
+      device: string;
+      inode: string;
+      size: string;
+      mtimeNs: string;
+      sha256: string;
+    };
+    after: {
+      device: string;
+      inode: string;
+      size: string;
+      mtimeNs: string;
+      sha256: string;
+    };
+  }
+  const backups: ProfileBackup[] = [];
+  const successorRecoveries: Array<{
+    backup: ProfileBackup;
+    successor: CapturedFile;
+  }> = [];
+  const recoveredSuccessorPaths = new Set<string>();
+  const uid = process.getuid?.();
+  const encodeIdentity = (identity: ExecutableIdentity) => ({
+    device: identity.device.toString(),
+    inode: identity.inode.toString(),
+    size: identity.size.toString(),
+    mtimeNs: identity.mtimeNs.toString(),
+    sha256: identity.sha256,
+  });
+  const parseIdentity = (value: unknown): ExecutableIdentity | null => {
+    if (typeof value !== "object" || value === null) return null;
+    const record = value as Record<string, unknown>;
+    if (
+      typeof record.device !== "string" ||
+      typeof record.inode !== "string" ||
+      typeof record.size !== "string" ||
+      typeof record.mtimeNs !== "string" ||
+      typeof record.sha256 !== "string" ||
+      !/^\d+$/.test(record.device) ||
+      !/^\d+$/.test(record.inode) ||
+      !/^\d+$/.test(record.size) ||
+      !/^\d+$/.test(record.mtimeNs) ||
+      !/^[a-f0-9]{64}$/.test(record.sha256)
+    ) {
+      return null;
+    }
+    return {
+      device: BigInt(record.device),
+      inode: BigInt(record.inode),
+      size: BigInt(record.size),
+      mtimeNs: BigInt(record.mtimeNs),
+      sha256: record.sha256,
+    };
+  };
+  const captureProfile = (path: string): CapturedFile | null => {
+    assertSafeRemovalPath(path, homeDirectory);
+    try {
+      const info = lstatSync(path);
+      if (!info.isFile() || info.isSymbolicLink()) {
+        throw new Error(`Refusing unsafe shell profile recovery path: ${path}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    }
+    const captured = captureFile(path, uid);
+    if (captured === null) {
+      throw new Error(`Shell profile changed during uninstall: ${path}`);
+    }
+    return captured;
+  };
+  const assertProfileIdentity = (
+    path: string,
+    expected: ExecutableIdentity,
+    phase: "uninstall" | "uninstall rollback",
+  ): void => {
+    assertSafeRemovalPath(path, homeDirectory);
+    const current = captureFile(path, uid);
+    if (current === null || !identitiesEqual(current, expected)) {
+      throw new Error(`Shell profile changed during ${phase}: ${path}`);
+    }
+  };
+  const removeProfileRecoveryFile = (
+    path: string,
+    expected: ExecutableIdentity,
+  ): void => {
+    assertProfileIdentity(path, expected, "uninstall");
+    const deleting = `${path}.deleting-${process.pid}-${randomBytes(8).toString("hex")}`;
+    renameSync(path, deleting);
+    assertProfileIdentity(deleting, expected, "uninstall");
+    syncUninstallDirectory(dirname(path));
+    unlinkSync(deleting);
+    syncUninstallDirectory(dirname(path));
+  };
+  const cleanupProfileRecovery = (
+    backup: ProfileBackup,
+    options: { original?: boolean; after?: boolean } = {},
+  ): void => {
+    if (options.after !== false && existsSync(backup.afterClaim)) {
+      removeProfileRecoveryFile(backup.afterClaim, backup.after);
+    }
+    if (options.original !== false && existsSync(backup.originalClaim)) {
+      removeProfileRecoveryFile(backup.originalClaim, backup.before);
+    }
+    removeProfileRecoveryFile(backup.journalPath, backup.journal);
+  };
+  const assertProfileRecovery = (backup: ProfileBackup): void => {
+    if (existsSync(backup.afterClaim)) {
+      assertProfileIdentity(backup.afterClaim, backup.after, "uninstall");
+    }
+    if (existsSync(backup.originalClaim)) {
+      assertProfileIdentity(backup.originalClaim, backup.before, "uninstall");
+    }
+    assertProfileIdentity(backup.journalPath, backup.journal, "uninstall");
+  };
+  const recoverProfile = (config: {
+    path: string;
+    shell: "posix" | "fish";
+  }): void => {
+    const parent = dirname(config.path);
+    if (!existsSync(parent)) return;
+    const profileName = basename(config.path);
+    const journalPrefix = `${profileName}.lore-uninstall-profile-`;
+    const originalPrefix = `${profileName}.lore-uninstall-original-`;
+    const afterPrefix = `${profileName}.lore-uninstall-`;
+    const entries = readdirSync(parent);
+    const journals = entries.filter((name) => name.startsWith(journalPrefix));
+    const rawClaims = entries.filter(
+      (name) =>
+        name.startsWith(originalPrefix) ||
+        (name.startsWith(afterPrefix) &&
+          !name.startsWith(journalPrefix) &&
+          !name.startsWith(`${profileName}.lore-uninstall-rollback-`)),
+    );
+    if (journals.length === 0) {
+      if (rawClaims.length > 0) {
+        throw new Error(
+          `Shell profile recovery metadata is missing for: ${config.path}`,
+        );
+      }
+      return;
+    }
+    if (journals.length !== 1) {
+      throw new Error(
+        `Multiple shell profile recovery generations exist for: ${config.path}`,
+      );
+    }
+
+    const journalPath = join(parent, journals[0]);
+    const journalFile = captureProfile(journalPath);
+    if (journalFile === null) {
+      throw new Error(
+        `Shell profile recovery journal vanished: ${journalPath}`,
+      );
+    }
+    let value: unknown;
+    try {
+      value = JSON.parse(journalFile.content.toString("utf8"));
+    } catch (error) {
+      throw new Error(
+        `Invalid shell profile recovery journal: ${journalPath}`,
+        {
+          cause: error,
+        },
+      );
+    }
+    if (typeof value !== "object" || value === null) {
+      throw new Error(`Invalid shell profile recovery journal: ${journalPath}`);
+    }
+    const record = value as Record<string, unknown>;
+    const token = record.token;
+    const beforeIdentity = parseIdentity(record.before);
+    const afterIdentity = parseIdentity(record.after);
+    if (
+      record.version !== 1 ||
+      typeof token !== "string" ||
+      !/^\d+-[a-f0-9]{16}$/.test(token) ||
+      record.profile !== config.path ||
+      (journals[0] !== `${journalPrefix}${token}.json` &&
+        !(
+          journals[0].startsWith(`${journalPrefix}${token}.json.deleting-`) &&
+          /^\d+-[a-f0-9]{16}$/.test(
+            journals[0].slice(`${journalPrefix}${token}.json.deleting-`.length),
+          )
+        )) ||
+      beforeIdentity === null ||
+      afterIdentity === null
+    ) {
+      throw new Error(`Invalid shell profile recovery journal: ${journalPath}`);
+    }
+    const originalBase = `${profileName}.lore-uninstall-original-${token}`;
+    const afterBase = `${profileName}.lore-uninstall-${token}`;
+    const matchesClaim = (name: string, base: string): boolean =>
+      name === base ||
+      (name.startsWith(`${base}.deleting-`) &&
+        /^\d+-[a-f0-9]{16}$/.test(name.slice(`${base}.deleting-`.length)));
+    const originalClaims = rawClaims.filter((name) =>
+      matchesClaim(name, originalBase),
+    );
+    const afterClaims = rawClaims.filter((name) =>
+      matchesClaim(name, afterBase),
+    );
+    if (
+      originalClaims.length > 1 ||
+      afterClaims.length > 1 ||
+      rawClaims.some(
+        (name) =>
+          !matchesClaim(name, originalBase) && !matchesClaim(name, afterBase),
+      )
+    ) {
+      throw new Error(
+        `Multiple shell profile recovery generations exist for: ${config.path}`,
+      );
+    }
+    const originalClaim = join(parent, originalClaims[0] ?? originalBase);
+    const afterClaim = join(parent, afterClaims[0] ?? afterBase);
+    const original = captureProfile(originalClaim);
+    const stagedAfter = captureProfile(afterClaim);
+    const current = captureProfile(config.path);
+    if (original && !identitiesEqual(original, beforeIdentity)) {
+      throw new Error(
+        `Shell profile recovery generation changed: ${originalClaim}`,
+      );
+    }
+    if (stagedAfter && !identitiesEqual(stagedAfter, afterIdentity)) {
+      throw new Error(
+        `Shell profile recovery generation changed: ${afterClaim}`,
+      );
+    }
+    if (original) {
+      const expectedAfter = removeInstallerPathBlock(
+        original.content.toString("utf8"),
+        installDir,
+        config.shell,
+      );
+      if (
+        (stagedAfter &&
+          stagedAfter.content.toString("utf8") !== expectedAfter) ||
+        (current &&
+          identitiesEqual(current, afterIdentity) &&
+          current.content.toString("utf8") !== expectedAfter)
+      ) {
+        throw new Error(
+          `Shell profile recovery content is inconsistent: ${config.path}`,
+        );
+      }
+    }
+    const recovery: ProfileBackup = {
+      path: config.path,
+      originalClaim,
+      afterClaim,
+      journalPath,
+      journal: journalFile,
+      before: beforeIdentity,
+      after: afterIdentity,
+    };
+
+    assertInstallRemoved();
+    if (current && identitiesEqual(current, beforeIdentity)) {
+      cleanupProfileRecovery(recovery);
+      return;
+    }
+    if (current && identitiesEqual(current, afterIdentity)) {
+      if (original) {
+        recovery.before = original;
+        recovery.after = current;
+        backups.push(recovery);
+      } else {
+        cleanupProfileRecovery(recovery, { original: false });
+      }
+      return;
+    }
+    if (current) {
+      successorRecoveries.push({ backup: recovery, successor: current });
+      recoveredSuccessorPaths.add(config.path);
+      return;
+    }
+    if (!original) {
+      throw new Error(
+        `Shell profile recovery generation is missing: ${originalClaim}`,
+      );
+    }
+    linkSync(originalClaim, config.path);
+    assertProfileIdentity(config.path, beforeIdentity, "uninstall rollback");
+    syncUninstallDirectory(parent);
+    recovery.before = original;
+    cleanupProfileRecovery(recovery);
+  };
+  const restoreBackups = (): void => {
+    while (backups.length > 0) {
+      const backup = backups.at(-1);
+      if (!backup) break;
+      assertProfileIdentity(backup.path, backup.after, "uninstall rollback");
+      const displaced = `${backup.path}.lore-uninstall-rollback-${process.pid}-${randomBytes(8).toString("hex")}`;
+      try {
+        renameSync(backup.path, displaced);
+        assertProfileIdentity(displaced, backup.after, "uninstall rollback");
+        syncUninstallDirectory(dirname(backup.path));
+        linkSync(backup.originalClaim, backup.path);
+        assertProfileIdentity(backup.path, backup.before, "uninstall rollback");
+        syncUninstallDirectory(dirname(backup.path));
+        unlinkSync(displaced);
+        syncUninstallDirectory(dirname(backup.path));
+        cleanupProfileRecovery(backup);
+        backups.pop();
+      } catch (error) {
+        try {
+          if (!existsSync(backup.path)) linkSync(displaced, backup.path);
+        } catch {
+          // Preserve both claims instead of clobbering a successor.
+        }
+        throw error;
+      }
+    }
+  };
+  const discardBackups = (): void => {
+    for (const backup of backups) {
+      try {
+        cleanupProfileRecovery(backup);
+      } catch {
+        // Preserve unidentified recovery claims.
+      }
+    }
+    backups.length = 0;
+  };
+
+  try {
+    for (const config of shellConfigPaths(homeDirectory)) {
+      recoverProfile(config);
+      if (recoveredSuccessorPaths.has(config.path)) continue;
+      if (!existsSync(config.path)) continue;
+      const initial = lstatSync(config.path);
+      if (!initial.isFile() || initial.isSymbolicLink()) continue;
+      if (
+        typeof process.getuid === "function" &&
+        initial.uid !== process.getuid()
+      ) {
+        continue;
+      }
+      const canonicalParent = realpathSync.native(dirname(config.path));
+      if (!pathIsInside(canonicalParent, canonicalHome)) continue;
+      const beforeFile = captureFile(config.path, uid);
+      if (beforeFile === null) {
+        throw new Error(
+          `Shell profile changed during uninstall: ${config.path}`,
+        );
+      }
+      const before = beforeFile.content.toString("utf8");
+      const after = removeInstallerPathBlock(before, installDir, config.shell);
+      if (after === before) continue;
+
+      const token = `${process.pid}-${randomBytes(8).toString("hex")}`;
+      const temp = `${config.path}.lore-uninstall-${token}`;
+      const originalClaim = `${config.path}.lore-uninstall-original-${token}`;
+      const journalPath = `${config.path}.lore-uninstall-profile-${token}.json`;
+      let quarantined = false;
+      let journalFile: CapturedFile | null = null;
+      let afterFile: CapturedFile | null = null;
+      try {
+        assertInstallRemoved();
+        writeFileSync(temp, after, {
+          encoding: "utf8",
+          flag: "wx",
+          mode: initial.mode,
+        });
+        afterFile = captureFile(temp, uid);
+        if (afterFile === null) {
+          throw new Error(
+            `Shell profile changed during uninstall: ${config.path}`,
+          );
+        }
+        syncUninstallFile(temp, afterFile);
+        writeFileSync(
+          journalPath,
+          `${JSON.stringify({
+            version: 1,
+            token,
+            profile: config.path,
+            before: encodeIdentity(beforeFile),
+            after: encodeIdentity(afterFile),
+          } satisfies ProfileJournal)}\n`,
+          { encoding: "utf8", flag: "wx", mode: 0o600 },
+        );
+        journalFile = captureFile(journalPath, uid);
+        if (journalFile === null) {
+          throw new Error(
+            `Could not verify shell profile recovery journal: ${journalPath}`,
+          );
+        }
+        syncUninstallFile(journalPath, journalFile);
+        syncUninstallDirectory(dirname(config.path));
+        hooks.beforeProfileQuarantine?.(config.path);
+        assertProfileIdentity(config.path, beforeFile, "uninstall");
+        renameSync(config.path, originalClaim);
+        quarantined = true;
+        assertProfileIdentity(originalClaim, beforeFile, "uninstall");
+        syncUninstallDirectory(dirname(config.path));
+        assertInstallRemoved();
+        hooks.beforeProfilePublish?.(config.path);
+        linkSync(temp, config.path);
+        assertProfileIdentity(config.path, afterFile, "uninstall");
+        syncUninstallDirectory(dirname(config.path));
+        backups.push({
+          path: config.path,
+          originalClaim,
+          afterClaim: temp,
+          journalPath,
+          journal: journalFile,
+          before: beforeFile,
+          after: afterFile,
+        });
+        quarantined = false;
+      } catch (error) {
+        if (quarantined) {
+          try {
+            if (!existsSync(config.path)) {
+              linkSync(originalClaim, config.path);
+              assertProfileIdentity(config.path, beforeFile, "uninstall");
+              if (afterFile && journalFile) {
+                cleanupProfileRecovery({
+                  path: config.path,
+                  originalClaim,
+                  afterClaim: temp,
+                  journalPath,
+                  journal: journalFile,
+                  before: beforeFile,
+                  after: afterFile,
+                });
+              }
+            }
+          } catch {
+            // Preserve original claim when no-clobber restoration is impossible.
+          }
+        } else {
+          if (afterFile && existsSync(temp)) {
+            removeProfileRecoveryFile(temp, afterFile);
+          }
+          if (journalFile && existsSync(journalPath)) {
+            removeProfileRecoveryFile(journalPath, journalFile);
+          }
+        }
+        throw error;
+      }
+    }
+  } catch (error) {
+    try {
+      restoreBackups();
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "PATH cleanup failed and shell profiles could not be restored.",
+      );
+    }
+    throw error;
+  }
+  return {
+    prepareCommit: () => {
+      assertInstallRemoved();
+      for (const backup of backups) {
+        assertProfileIdentity(backup.path, backup.after, "uninstall");
+      }
+      for (const recovery of successorRecoveries) {
+        assertProfileIdentity(
+          recovery.backup.path,
+          recovery.successor,
+          "uninstall",
+        );
+        assertProfileRecovery(recovery.backup);
+      }
+    },
+    commit: () => {
+      discardBackups();
+      for (const recovery of successorRecoveries) {
+        try {
+          cleanupProfileRecovery(recovery.backup);
+        } catch {
+          // Preserve unidentified recovery claims and the canonical successor.
+        }
+      }
+      successorRecoveries.length = 0;
+    },
+    rollback: (restore = true) => {
+      if (restore) restoreBackups();
+      else discardBackups();
+    },
+  };
+}
+
+export function assertSafeRemovalPath(
+  path: string,
+  homeDirectory: string = homedir(),
+): void {
+  const target = resolve(path);
+  const home = resolve(homeDirectory);
+  if (
+    target === parse(target).root ||
+    target === home ||
+    !pathIsInside(target, home)
+  ) {
+    throw new Error(`Refusing to remove unsafe path: ${target}`);
+  }
+  const canonicalHome = realpathSync.native(homeDirectory);
+  if (canonicalHome === parse(canonicalHome).root) {
+    throw new Error(`Refusing unsafe home directory: ${home}`);
+  }
+  const canonicalTarget = resolve(canonicalHome, relative(home, target));
+  const parts = relative(canonicalHome, canonicalTarget).split(sep);
+  let ancestor = canonicalHome;
+  for (const part of parts.slice(0, -1)) {
+    ancestor = join(ancestor, part);
+    try {
+      if (lstatSync(ancestor).isSymbolicLink()) {
+        throw new Error(
+          `Refusing to follow an intermediate symbolic link: ${target}`,
+        );
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  let existingAncestor = dirname(canonicalTarget);
+  while (!existsSync(existingAncestor)) {
+    const parent = dirname(existingAncestor);
+    if (parent === existingAncestor) break;
+    existingAncestor = parent;
+  }
+  const canonicalAncestor = realpathSync.native(existingAncestor);
+  if (!pathIsInside(canonicalAncestor, canonicalHome)) {
+    throw new Error(
+      `Refusing to follow a path outside the home directory: ${target}`,
+    );
+  }
+}
+
+function assertRemovalIdentity(
+  path: string,
+  expected: RemovalPathIdentity,
+  homeDirectory: string,
+): void {
+  assertSafeRemovalPath(path, homeDirectory);
+  const info = lstatSync(path, { bigint: true });
+  if (
+    info.isSymbolicLink() ||
+    info.isDirectory() !== expected.directory ||
+    info.dev !== expected.device ||
+    info.ino !== expected.inode
+  ) {
+    throw new Error(
+      `Removal path changed during uninstall quarantine: ${path}`,
+    );
+  }
+  if (
+    typeof process.getuid === "function" &&
+    info.uid !== BigInt(process.getuid())
+  ) {
+    throw new Error(`Refusing to remove a path owned by another user: ${path}`);
+  }
+}
+
+function discoverRemovalClaim(
+  path: string,
+  recursive: boolean,
+  homeDirectory: string,
+): { path: string; identity: RemovalPathIdentity } | null {
+  const parent = dirname(path);
+  if (!existsSync(parent)) return null;
+  const prefix = `.${basename(path)}.lore-uninstall-claim-v1-`;
+  const names = readdirSync(parent).filter((name) => name.startsWith(prefix));
+  if (names.length === 0) return null;
+  if (names.length !== 1) {
+    throw new Error(`Multiple removal recovery claims exist for: ${path}`);
+  }
+  const claimPath = join(parent, names[0]);
+  const fields = names[0].slice(prefix.length).split("-");
+  if (
+    fields.length !== 5 ||
+    !/^\d+$/.test(fields[0]) ||
+    !/^\d+$/.test(fields[1]) ||
+    (fields[2] !== "d" && fields[2] !== "f") ||
+    !/^\d+$/.test(fields[3]) ||
+    !/^[a-f0-9]{16}$/.test(fields[4])
+  ) {
+    throw new Error(`Invalid removal recovery claim: ${claimPath}`);
+  }
+  const identity: RemovalPathIdentity = {
+    device: BigInt(fields[0]),
+    inode: BigInt(fields[1]),
+    directory: fields[2] === "d",
+  };
+  if (identity.directory !== recursive) {
+    throw new Error(`Removal recovery claim type changed: ${claimPath}`);
+  }
+  assertRemovalIdentity(claimPath, identity, homeDirectory);
+  return { path: claimPath, identity };
+}
+
+function removalClaimPath(path: string, identity: RemovalPathIdentity): string {
+  return join(
+    dirname(path),
+    `.${basename(path)}.lore-uninstall-claim-v1-${identity.device}-${identity.inode}-${identity.directory ? "d" : "f"}-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+}
+
+function stagedRemovalClaim(
+  path: string,
+  claim: string,
+  expected: RemovalPathIdentity,
+  recursive: boolean,
+  homeDirectory: string,
+  successorIdentity: RemovalPathIdentity | null,
+): PathBlockRemoval {
+  let currentClaim = claim;
+  let active = true;
+  let prepared = false;
+  return {
+    prepareCommit: () => {
+      if (!active) return;
+      assertRemovalIdentity(currentClaim, expected, homeDirectory);
+      if (successorIdentity) {
+        assertRemovalIdentity(path, successorIdentity, homeDirectory);
+      }
+      prepared = true;
+    },
+    commit: () => {
+      if (!active) return;
+      if (!prepared) {
+        throw new Error(`Removal path was not prepared for commit: ${path}`);
+      }
+      assertRemovalIdentity(currentClaim, expected, homeDirectory);
+      const deletingClaim = removalClaimPath(path, expected);
+      renameSync(currentClaim, deletingClaim);
+      currentClaim = deletingClaim;
+      assertRemovalIdentity(currentClaim, expected, homeDirectory);
+      syncUninstallDirectory(dirname(currentClaim));
+      rmSync(currentClaim, { recursive, force: false });
+      syncUninstallDirectory(dirname(currentClaim));
+      active = false;
+    },
+    rollback: () => {
+      if (!active) return;
+      assertRemovalIdentity(currentClaim, expected, homeDirectory);
+      if (existsSync(path)) {
+        // A successor owns the canonical name. Preserve both generations and
+        // let a later uninstall safely continue the durable claim.
+        return;
+      }
+      renameSync(currentClaim, path);
+      assertRemovalIdentity(path, expected, homeDirectory);
+      syncUninstallDirectory(dirname(path));
+      active = false;
+    },
+  };
+}
+
+export function removePath(
+  path: string,
+  recursive: boolean,
+  preflight?: RemovalPathIdentity | null,
+  homeDirectory: string = homedir(),
+  hooks: RemovalPathHooks = {},
+): PathBlockRemoval {
+  const expected =
+    preflight === undefined
+      ? preflightRemoval(path, recursive, homeDirectory)
+      : preflight;
+  assertSafeRemovalPath(path, homeDirectory);
+  const recoveredClaim = discoverRemovalClaim(path, recursive, homeDirectory);
+  if (recoveredClaim) {
+    return stagedRemovalClaim(
+      path,
+      recoveredClaim.path,
+      recoveredClaim.identity,
+      recursive,
+      homeDirectory,
+      expected,
+    );
+  }
+  if (expected === null) {
+    try {
+      lstatSync(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return {
+          prepareCommit: () => {
+            try {
+              lstatSync(path);
+            } catch (prepareError) {
+              if ((prepareError as NodeJS.ErrnoException).code === "ENOENT") {
+                return;
+              }
+              throw prepareError;
+            }
+            throw new Error(
+              `Removal path appeared after uninstall preflight: ${path}`,
+            );
+          },
+          commit: () => {},
+          rollback: () => {},
+        };
+      }
+      throw error;
+    }
+    throw new Error(`Removal path appeared after uninstall preflight: ${path}`);
+  }
+  assertRemovalIdentity(path, expected, homeDirectory);
+  hooks.beforeQuarantine?.();
+  const claim = removalClaimPath(path, expected);
+  try {
+    renameSync(path, claim);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        `Removal path changed during uninstall quarantine: ${path}`,
+      );
+    }
+    throw error;
+  }
+  // Never republish a claim whose exact staged generation is unknown.
+  assertRemovalIdentity(claim, expected, homeDirectory);
+  try {
+    syncUninstallDirectory(dirname(claim));
+  } catch (error) {
+    try {
+      assertRemovalIdentity(claim, expected, homeDirectory);
+      if (!existsSync(path)) {
+        renameSync(claim, path);
+        assertRemovalIdentity(path, expected, homeDirectory);
+        syncUninstallDirectory(dirname(path));
+      }
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        `Removal path quarantine was not durable and could not be restored: ${path}`,
+      );
+    }
+    throw error;
+  }
+  try {
+    hooks.afterQuarantine?.();
+  } catch (error) {
+    try {
+      assertRemovalIdentity(claim, expected, homeDirectory);
+      if (!existsSync(path)) {
+        renameSync(claim, path);
+        assertRemovalIdentity(path, expected, homeDirectory);
+        syncUninstallDirectory(dirname(path));
+      }
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        `Removal path quarantine failed and could not be restored: ${path}`,
+      );
+    }
+    throw error;
+  }
+  assertRemovalIdentity(claim, expected, homeDirectory);
+
+  return stagedRemovalClaim(
+    path,
+    claim,
+    expected,
+    recursive,
+    homeDirectory,
+    null,
+  );
+}
+
+export function preflightRemoval(
+  path: string,
+  recursive: boolean,
+  homeDirectory: string = homedir(),
+): RemovalPathIdentity | null {
+  assertSafeRemovalPath(path, homeDirectory);
+  let info: ReturnType<typeof lstatSync>;
+  try {
+    info = lstatSync(path, { bigint: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  if (info.isSymbolicLink())
+    throw new Error(`Refusing symbolic link removal: ${path}`);
+  if (
+    typeof process.getuid === "function" &&
+    info.uid !== BigInt(process.getuid())
+  ) {
+    throw new Error(`Refusing to remove a path owned by another user: ${path}`);
+  }
+  if (info.isDirectory() && !recursive) {
+    throw new Error(`Refusing recursive removal for: ${path}`);
+  }
+  if (recursive && !info.isDirectory()) {
+    throw new Error(`Refusing recursive removal for non-directory: ${path}`);
+  }
+  return {
+    device: info.dev,
+    inode: info.ino,
+    directory: info.isDirectory(),
+  };
+}
+
+function assertFileIdentity(
+  path: string,
+  expected: ExecutableIdentity,
+  homeDirectory: string = homedir(),
+  description: "Executable" | "Install receipt" = "Executable",
+): void {
+  assertSafeRemovalPath(path, homeDirectory);
+  const info = lstatSync(path, { bigint: true });
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error(
+      `Refusing to remove a replaced ${description.toLowerCase()}: ${path}`,
+    );
+  }
+  if (
+    typeof process.getuid === "function" &&
+    info.uid !== BigInt(process.getuid())
+  ) {
+    throw new Error(`Refusing to remove a path owned by another user: ${path}`);
+  }
+  if (
+    info.dev !== expected.device ||
+    info.ino !== expected.inode ||
+    info.size !== expected.size ||
+    info.mtimeNs !== expected.mtimeNs
+  ) {
+    throw new Error(`${description} changed during uninstall: ${path}`);
+  }
+  const content = readFileSync(path);
+  const final = lstatSync(path, { bigint: true });
+  if (
+    final.dev !== expected.device ||
+    final.ino !== expected.inode ||
+    final.size !== expected.size ||
+    final.mtimeNs !== expected.mtimeNs ||
+    createHash("sha256").update(content).digest("hex") !== expected.sha256
+  ) {
+    throw new Error(`${description} changed during uninstall: ${path}`);
+  }
+}
+
+function pathIdentityState(
+  path: string,
+  expected: ExecutableIdentity,
+  homeDirectory: string,
+): ReturnType<StagedFileRemoval["state"]> {
+  try {
+    assertSafeRemovalPath(path, homeDirectory);
+    const info = lstatSync(path, { bigint: true });
+    if (!info.isFile() || info.isSymbolicLink()) return "replaced";
+    if (info.dev !== expected.device || info.ino !== expected.inode) {
+      return "replaced";
+    }
+    assertFileIdentity(path, expected, homeDirectory);
+    return "expected";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+    return "unknown";
+  }
+}
+
+function removeIdentifiedFile(
+  path: string,
+  expected: ExecutableIdentity,
+  homeDirectory: string,
+  description: "Executable" | "Install receipt",
+): StagedFileRemoval {
+  const stageDir = `${path}.lore-uninstall`;
+  const stagedPath = join(stageDir, basename(path));
+  const assertExpected = (target: string): void =>
+    assertFileIdentity(target, expected, homeDirectory, description);
+  const state = (): ReturnType<StagedFileRemoval["state"]> =>
+    pathIdentityState(path, expected, homeDirectory);
+
+  if (existsSync(stageDir)) {
+    assertSafeRemovalPath(stageDir, homeDirectory);
+    const stageInfo = lstatSync(stageDir);
+    if (!stageInfo.isDirectory() || stageInfo.isSymbolicLink()) {
+      throw new Error(
+        `Refusing unsafe ${description.toLowerCase()} recovery path: ${stageDir}`,
+      );
+    }
+    const stagedFiles = readdirSync(stageDir).map((name) =>
+      join(stageDir, name),
+    );
+    const recoverySource = stagedFiles.find((file) => {
+      try {
+        assertExpected(file);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    const currentState = state();
+    if (currentState === "missing" && recoverySource) {
+      linkSync(recoverySource, path);
+      assertExpected(path);
+    } else if (currentState !== "expected") {
+      throw new Error(`${description} changed during uninstall: ${path}`);
+    }
+    for (const file of stagedFiles) {
+      assertExpected(file);
+      unlinkSync(file);
+    }
+    rmdirSync(stageDir);
+  }
+  mkdirSync(stageDir, { mode: 0o700 });
+  try {
+    assertExpected(path);
+    linkSync(path, stagedPath);
+    assertExpected(stagedPath);
+  } catch (error) {
+    if (existsSync(stagedPath)) unlinkSync(stagedPath);
+    rmdirSync(stageDir);
+    throw error;
+  }
+
+  let active = true;
+  let committed = false;
+  let finalized = false;
+  let stagedDeleted = false;
+  const recoverySource = (): string | null => {
+    if (!existsSync(stageDir)) return null;
+    for (const name of readdirSync(stageDir)) {
+      const candidate = join(stageDir, name);
+      try {
+        assertExpected(candidate);
+        return candidate;
+      } catch {
+        // A mismatched file is not a recovery source.
+      }
+    }
+    return null;
+  };
+  const cleanupStage = (): void => {
+    if (!existsSync(stageDir)) return;
+    for (const name of readdirSync(stageDir)) {
+      const candidate = join(stageDir, name);
+      assertExpected(candidate);
+      unlinkSync(candidate);
+    }
+    rmdirSync(stageDir);
+  };
+  const discardRecovery = (): void => {
+    try {
+      cleanupStage();
+    } catch {
+      // Never remove an unidentified recovery artifact.
+    }
+    active = false;
+  };
+  return {
+    stageDeletion: () => {
+      if (!active || stagedDeleted) return;
+      assertExpected(path);
+      assertExpected(stagedPath);
+      const removingPath = join(
+        stageDir,
+        `removing-${randomBytes(8).toString("hex")}`,
+      );
+      renameSync(path, removingPath);
+      try {
+        assertExpected(removingPath);
+        if (existsSync(path)) {
+          throw new Error(`${description} replaced during uninstall: ${path}`);
+        }
+        unlinkSync(removingPath);
+        stagedDeleted = true;
+      } catch (error) {
+        try {
+          if (!existsSync(path)) linkSync(removingPath, path);
+        } catch (rollbackError) {
+          throw new AggregateError(
+            [error, rollbackError],
+            `A ${description.toLowerCase()} was moved during cleanup and could not be restored.`,
+          );
+        }
+        throw error;
+      }
+    },
+    assertDeleted: () => {
+      if (!stagedDeleted || state() !== "missing") {
+        throw new Error(`${description} replaced during uninstall: ${path}`);
+      }
+      if (active && !recoverySource()) {
+        throw new Error(
+          `${description} recovery data is missing from: ${stageDir}`,
+        );
+      }
+    },
+    state,
+    prepareCommit: () => {
+      if (!active) return;
+      if (!stagedDeleted)
+        throw new Error(`${description} deletion was not staged`);
+      if (state() !== "missing") {
+        throw new Error(`${description} replaced during uninstall: ${path}`);
+      }
+      committed = true;
+    },
+    commit: () => {
+      if (!active) return;
+      if (!committed) {
+        if (!stagedDeleted)
+          throw new Error(`${description} deletion was not staged`);
+        committed = true;
+      }
+      if (!finalized && state() !== "missing") {
+        throw new Error(`${description} replaced during uninstall: ${path}`);
+      }
+      try {
+        cleanupStage();
+      } catch {
+        // Preserve unidentified recovery artifacts.
+      }
+      active = false;
+    },
+    finalize: () => {
+      if (!active) return;
+      if (!committed || state() !== "missing") {
+        throw new Error(`${description} replaced during uninstall: ${path}`);
+      }
+      finalized = true;
+    },
+    rollback: (restore = true) => {
+      if (!active) return restore ? "restored" : "preserved";
+      const currentState = state();
+      if (currentState === "unknown") {
+        throw new Error(
+          `Could not establish ${description.toLowerCase()} identity: ${path}`,
+        );
+      }
+      if (!restore && currentState !== "expected") {
+        if (currentState === "replaced") discardRecovery();
+        return "preserved";
+      }
+      let result: "restored" | "preserved";
+      if (currentState === "missing" && restore) {
+        const source = recoverySource();
+        if (!source) {
+          throw new Error(
+            `${description} recovery data is missing from: ${stageDir}`,
+          );
+        }
+        linkSync(source, path);
+        assertExpected(path);
+        result = "restored";
+      } else if (currentState === "expected") {
+        result = "restored";
+      } else {
+        result = "preserved";
+      }
+      cleanupStage();
+      active = false;
+      return result;
+    },
+  };
+}
+
+export function removeBinary(
+  path: string,
+  expected: ExecutableIdentity,
+  homeDirectory: string = homedir(),
+): StagedFileRemoval {
+  return removeIdentifiedFile(path, expected, homeDirectory, "Executable");
+}
+
+export function removeReceipt(
+  path: string,
+  expected: InstallReceiptIdentity,
+  homeDirectory: string = homedir(),
+): StagedFileRemoval {
+  return removeIdentifiedFile(path, expected, homeDirectory, "Install receipt");
+}
+
+function printPlan(plan: UninstallPlan): void {
+  console.log("[lore] Planned cleanup:");
+  console.log("[lore]   restore configs changed by `lore setup`");
+  for (const removal of plan.removals) {
+    console.log(`[lore]   remove ${removal.path}`);
+  }
+  if (plan.binaryPath) console.log(`[lore]   remove ${plan.binaryPath}`);
+  if (plan.receiptPath) console.log(`[lore]   remove ${plan.receiptPath}`);
+  if (plan.manualBinaryPath) {
+    console.log(
+      `[lore]   preserve executable for manual deletion ${plan.manualBinaryPath}`,
+    );
+  }
+  if (plan.manualReceiptPath) {
+    console.log(`[lore]   preserve install receipt ${plan.manualReceiptPath}`);
+  }
+  for (const path of plan.preservedDataPaths) {
+    console.log(`[lore]   preserve ${path}`);
+  }
+}
+
+async function confirmPurge(): Promise<boolean> {
+  if (!process.stdin.isTTY) {
+    console.error(
+      "[lore] --purge requires confirmation in non-interactive mode. Re-run with --yes.",
+    );
+    return false;
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question(
+      'Delete Lore\'s database, logs, credentials, and runtime data? Type "yes" to confirm: ',
+    );
+    return answer.trim().toLowerCase() === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+export async function commandUninstall(
+  args: string[],
+  values: Record<string, unknown>,
+): Promise<void> {
+  if (values.help === true) {
+    console.log(UNINSTALL_USAGE);
+    return;
+  }
+  if (args.length > 0) {
+    console.error(`[lore] Unknown uninstall argument: ${args[0]}`);
+    console.error(UNINSTALL_USAGE);
+    process.exitCode = 1;
+    return;
+  }
+  const allowedOptions = new Set(["purge", "yes", "help", "dry-run"]);
+  const unsupportedOption = Object.keys(values).find(
+    (name) => !allowedOptions.has(name),
+  );
+  if (unsupportedOption) {
+    console.error(`[lore] Unknown uninstall option: --${unsupportedOption}`);
+    console.error(UNINSTALL_USAGE);
+    process.exitCode = 1;
+    return;
+  }
+
+  const purge = values.purge === true;
+  const standalone = isSeaBinary();
+  const packageManaged = !standalone;
+  const executable = process.execPath;
+  const home = homedir();
+  const dataDir = resolvedDataDir();
+  const configDir = getConfigDir();
+  const dbPath = process.env.LORE_DB_PATH;
+  const provenance = standaloneInstallProvenance(executable);
+  const defaultDataDir = join(home, ".local", "share", "lore");
+  const defaultConfigDir = join(home, ".lore");
+  const externalDbPath =
+    dbPath && (!isAbsolute(dbPath) || !pathIsInside(dbPath, defaultDataDir))
+      ? isAbsolute(dbPath)
+        ? dbPath
+        : resolve(process.cwd(), dbPath)
+      : null;
+  const canonicalProtectedPaths = [
+    ...(resolve(dataDir) !== resolve(defaultDataDir) ? [dataDir] : []),
+    ...(resolve(configDir) !== resolve(defaultConfigDir) ? [configDir] : []),
+    ...(externalDbPath ? [externalDbPath] : []),
+    ...(!provenance.hostedInstall || process.platform === "win32"
+      ? [executable]
+      : []),
+    ...(packageManaged && process.argv[1] ? [resolve(process.argv[1])] : []),
+  ]
+    .map(canonicalPath)
+    .filter((path): path is string => path !== null);
+  const plan = planUninstall({
+    currentExecutable: executable,
+    hostedInstall: provenance.hostedInstall,
+    receiptPath: provenance.receiptPath,
+    pathInstallDir: provenance.pathInstallDir,
+    packageManaged,
+    platform: process.platform,
+    purge,
+    home,
+    cwd: process.cwd(),
+    dataDir,
+    configDir,
+    dbPath,
+    executableIdentity: provenance.executableIdentity,
+    receiptIdentity: provenance.receiptIdentity,
+    packageEntryPath:
+      packageManaged && process.argv[1] ? resolve(process.argv[1]) : undefined,
+    canonicalProtectedPaths,
+  });
+  printPlan(plan);
+
+  if (values["dry-run"] === true || values.dryRun === true) return;
+  if (purge && values.yes !== true && !(await confirmPurge())) {
+    console.log("[lore] Uninstall cancelled; no files were changed.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const {
+    prevalidateSetupUndo,
+    reconcileSetupExternalEffects,
+    stageSetupUndo,
+  } = await import("./setup");
+  const { inspectGatewayProcessFile, readGatewayProcessFile } =
+    await import("../pidfile");
+  const { inspectPortFile, readPortFile } = await import("../portfile");
+  const { probeGatewayStatus, probeGatewayProcessStatus } =
+    await import("./start");
+  let code: number;
+  let executionStarted = false;
+  try {
+    const removalPreflights = new Map<string, RemovalPathIdentity | null>();
+    for (const removal of plan.removals) {
+      removalPreflights.set(
+        removal.path,
+        preflightRemoval(removal.path, removal.recursive, home),
+      );
+    }
+    if (plan.binaryPath && plan.binaryIdentity) {
+      assertFileIdentity(plan.binaryPath, plan.binaryIdentity);
+    }
+    if (plan.receiptPath && plan.receiptIdentity) {
+      assertFileIdentity(
+        plan.receiptPath,
+        plan.receiptIdentity,
+        home,
+        "Install receipt",
+      );
+    }
+    executionStarted = true;
+    code = await withLifecycleLock("uninstall", (lifecycleLock) => {
+      lifecycleLock.assertOwned();
+      reconcileSetupExternalEffects(lifecycleLock);
+      lifecycleLock.assertOwned();
+      return runUninstall(plan, {
+        gatewayRunning: () =>
+          gatewayRunning({
+            inspectProcessRecord: () =>
+              inspectGatewayProcessFile({ requireLoopbackHosts: true }),
+            readProcessRecord: readGatewayProcessFile,
+            authenticateProcess: probeGatewayProcessStatus,
+            inspectPort: inspectPortFile,
+            readPort: readPortFile,
+            probePort: probeGatewayStatus,
+          }),
+        prevalidateSetupUndo,
+        stageSetupUndo: () => stageSetupUndo(lifecycleLock),
+        removePathBlocks,
+        removePath: (path, recursive) => {
+          if (!removalPreflights.has(path)) {
+            throw new Error(`Removal path was not preflighted: ${path}`);
+          }
+          return removePath(
+            path,
+            recursive,
+            removalPreflights.get(path) ?? null,
+            home,
+          );
+        },
+        removeBinary,
+        removeReceipt,
+        recoverReplacementReceipt: recoverReplacementInstallReceipt,
+        beginUninstall: plan.binaryPath
+          ? () => createUninstallTombstone(lifecycleLock)
+          : undefined,
+        log: (message) => console.error(`[lore] ${message}`),
+      });
+    });
+  } catch (error) {
+    console.error(
+      `[lore] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.error(
+      error instanceof IrreversibleUninstallError
+        ? "[lore] Irreversible cleanup began; no unsafe rollback was attempted and recovery artifacts may remain."
+        : executionStarted
+          ? "[lore] Uninstall did not complete; rollback was attempted and recovery artifacts may remain."
+          : "[lore] No files were changed.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (code !== 0) {
+    process.exitCode = code;
+    return;
+  }
+
+  for (const path of plan.preservedDataPaths) {
+    console.log(`[lore] Preserved data: ${path}`);
+  }
+  if (plan.preservedDataPaths.length > 0) {
+    console.log(
+      purge
+        ? "[lore] Custom data paths are never deleted automatically; review them manually."
+        : "[lore] Use `lore uninstall --purge` to delete the default data directory too.",
+    );
+  }
+  console.log(
+    "[lore] Project .lore.md, .lore.json, AGENTS.md, and CLAUDE.md files were not removed.",
+  );
+
+  if (packageManaged) {
+    const script = process.argv[1]
+      ? basename(process.argv[1])
+      : "package entry";
+    console.log(`[lore] Package-managed CLI detected (${script}).`);
+    console.log(
+      "[lore] Remove it with your package manager (global npm: npm uninstall -g @loreai/gateway).",
+    );
+  } else if (plan.binaryPath) {
+    console.log("[lore] Lore uninstalled. Restart your shell to refresh PATH.");
+  } else if (plan.manualBinaryPath) {
+    const reason =
+      process.platform === "win32" && provenance.hostedInstall
+        ? "Windows cannot remove its running executable; delete it after this command exits"
+        : "Executable provenance could not be verified; remove it with its installer or package manager";
+    console.log(`[lore] ${reason}: ${plan.manualBinaryPath}`);
+    if (plan.manualReceiptPath) {
+      console.log(
+        `[lore] After deleting the executable, also delete: ${plan.manualReceiptPath}`,
+      );
+    }
+  }
+  console.log(
+    "[lore] If setup installed the OpenCode plugin globally, remove it with: npm uninstall -g @loreai/opencode",
+  );
+}

--- a/packages/gateway/src/cli/upgrade-recovery.ts
+++ b/packages/gateway/src/cli/upgrade-recovery.ts
@@ -1,0 +1,1270 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  parseInstallReceipt,
+  recoverReplacementInstallReceipt,
+  refreshStandaloneInstallReceipt,
+  type ExecutableIdentity,
+} from "./uninstall";
+
+const BACKUP_TOKEN = /^\d+-[a-f0-9]{16}$/;
+const JOURNAL_VERSION = 1;
+
+interface CapturedFile extends ExecutableIdentity {
+  content: Buffer;
+}
+
+interface BackupPair {
+  token: string;
+  executable: string;
+  receiptPath: string;
+  pathInstallDir: string;
+  executableBackup: string;
+  receiptBackup: string;
+  oldExecutable: ExecutableIdentity;
+  oldReceipt: ExecutableIdentity;
+}
+
+type RecoveryMode = "complete" | "rollback";
+
+interface RecoveryJournalData {
+  version: 1;
+  mode: RecoveryMode;
+  token: string;
+  executable: string;
+  receiptPath: string;
+  pathInstallDir: string;
+  executableBackup: string;
+  receiptBackup: string;
+  oldExecutable: SerializedIdentity;
+  oldReceipt: SerializedIdentity;
+  replacement: SerializedIdentity;
+}
+
+interface RecoveryJournal extends BackupPair {
+  mode: RecoveryMode;
+  replacement: ExecutableIdentity;
+  journalPath: string;
+  journalIdentity: ExecutableIdentity;
+}
+
+interface SerializedIdentity {
+  device: string;
+  inode: string;
+  size: string;
+  mtimeNs: string;
+  sha256: string;
+}
+
+export interface StandaloneUpgradeRecoveryOptions {
+  executable: string;
+  receiptPath?: string;
+  home?: string;
+  uid?: number;
+}
+
+export interface StandaloneUpgradeRecoveryResult {
+  executable: string;
+  action: "none" | "completed" | "restored" | "cleaned";
+}
+
+export interface PersistStandaloneUpgradeRecoveryInput {
+  executable: string;
+  receiptPath: string;
+  pathInstallDir: string;
+  oldExecutable: ExecutableIdentity;
+  oldReceipt: ExecutableIdentity;
+  replacementPath: string;
+  expectedReplacementSha256: string;
+  previousBackupTokens?: ReadonlySet<string>;
+  home?: string;
+  uid?: number;
+}
+
+function identityEqual(
+  left: ExecutableIdentity,
+  right: ExecutableIdentity,
+): boolean {
+  return (
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.sha256 === right.sha256
+  );
+}
+
+function serializeIdentity(identity: ExecutableIdentity): SerializedIdentity {
+  return {
+    device: identity.device.toString(),
+    inode: identity.inode.toString(),
+    size: identity.size.toString(),
+    mtimeNs: identity.mtimeNs.toString(),
+    sha256: identity.sha256,
+  };
+}
+
+function deserializeIdentity(value: unknown): ExecutableIdentity | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<SerializedIdentity>;
+  if (
+    typeof candidate.device !== "string" ||
+    typeof candidate.inode !== "string" ||
+    typeof candidate.size !== "string" ||
+    typeof candidate.mtimeNs !== "string" ||
+    typeof candidate.sha256 !== "string" ||
+    !/^\d+$/.test(candidate.device) ||
+    !/^\d+$/.test(candidate.inode) ||
+    !/^\d+$/.test(candidate.size) ||
+    !/^\d+$/.test(candidate.mtimeNs) ||
+    !/^[a-f0-9]{64}$/.test(candidate.sha256)
+  ) {
+    return null;
+  }
+  return {
+    device: BigInt(candidate.device),
+    inode: BigInt(candidate.inode),
+    size: BigInt(candidate.size),
+    mtimeNs: BigInt(candidate.mtimeNs),
+    sha256: candidate.sha256,
+  };
+}
+
+function captureFile(
+  path: string,
+  uid: number | undefined,
+  ownerOnly: boolean,
+): CapturedFile | null {
+  let descriptor: number | null = null;
+  try {
+    const initial = lstatSync(path, { bigint: true });
+    if (
+      !initial.isFile() ||
+      initial.isSymbolicLink() ||
+      (uid !== undefined && initial.uid !== BigInt(uid)) ||
+      (process.platform !== "win32" && (initial.mode & 0o022n) !== 0n) ||
+      (process.platform !== "win32" &&
+        ownerOnly &&
+        (initial.mode & 0o077n) !== 0n)
+    ) {
+      return null;
+    }
+    const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+    descriptor = openSync(path, constants.O_RDONLY | noFollow);
+    const opened = fstatSync(descriptor, { bigint: true });
+    if (
+      !opened.isFile() ||
+      opened.isSymbolicLink() ||
+      opened.dev !== initial.dev ||
+      opened.ino !== initial.ino ||
+      (uid !== undefined && opened.uid !== BigInt(uid))
+    ) {
+      return null;
+    }
+    const content = readFileSync(descriptor);
+    const final = fstatSync(descriptor, { bigint: true });
+    if (
+      opened.dev !== final.dev ||
+      opened.ino !== final.ino ||
+      opened.size !== final.size ||
+      opened.mtimeNs !== final.mtimeNs ||
+      (uid !== undefined && final.uid !== BigInt(uid)) ||
+      (process.platform !== "win32" && (final.mode & 0o022n) !== 0n) ||
+      (process.platform !== "win32" &&
+        ownerOnly &&
+        (final.mode & 0o077n) !== 0n)
+    ) {
+      return null;
+    }
+    return {
+      device: final.dev,
+      inode: final.ino,
+      size: final.size,
+      mtimeNs: final.mtimeNs,
+      sha256: createHash("sha256").update(content).digest("hex"),
+      content,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+  }
+}
+
+function assertTrustedDirectory(
+  path: string,
+  uid: number | undefined,
+  requireOwner: boolean,
+): void {
+  const info = lstatSync(path);
+  if (
+    !info.isDirectory() ||
+    info.isSymbolicLink() ||
+    (requireOwner && uid !== undefined && info.uid !== uid) ||
+    (process.platform !== "win32" && (info.mode & 0o022) !== 0) ||
+    realpathSync.native(path) !== resolve(path)
+  ) {
+    throw new Error(
+      `Refusing unsafe standalone upgrade recovery directory: ${path}`,
+    );
+  }
+}
+
+function assertTrustedPaths(
+  executable: string,
+  receiptPath: string,
+  home: string,
+  uid: number | undefined,
+): void {
+  const executableDirectory = dirname(executable);
+  const receiptDirectory = dirname(receiptPath);
+  assertTrustedDirectory(executableDirectory, uid, true);
+  assertTrustedDirectory(receiptDirectory, uid, true);
+  if (
+    realpathSync.native(receiptDirectory) !==
+    join(realpathSync.native(home), ".lore")
+  ) {
+    throw new Error(
+      `Refusing standalone upgrade recovery outside the trusted state directory: ${receiptPath}`,
+    );
+  }
+}
+
+function receiptBindsExecutable(
+  receipt: CapturedFile,
+  executable: CapturedFile,
+  executablePath: string,
+  pathInstallDir: string,
+): boolean {
+  const parsed = parseInstallReceipt(receipt.content.toString("utf8"));
+  return (
+    parsed?.version === 3 &&
+    parsed.executableIdentity !== undefined &&
+    resolve(parsed.executable) === resolve(executablePath) &&
+    parsed.pathInstallDir !== undefined &&
+    resolve(parsed.pathInstallDir) === resolve(pathInstallDir) &&
+    resolve(pathInstallDir) === resolve(dirname(executablePath)) &&
+    identityEqual(parsed.executableIdentity, executable)
+  );
+}
+
+function backupName(path: string, token: string): string {
+  return `.${basename(path)}.upgrade-backup-${token}`;
+}
+
+function journalName(receiptPath: string, token: string): string {
+  return `.${basename(receiptPath)}.upgrade-recovery-${token}.json`;
+}
+
+function tokenFromBackupName(path: string, name: string): string | null {
+  const prefix = `.${basename(path)}.upgrade-backup-`;
+  if (!name.startsWith(prefix)) return null;
+  const token = name.slice(prefix.length);
+  return BACKUP_TOKEN.test(token) ? token : null;
+}
+
+function tokenFromJournalName(
+  receiptPath: string,
+  name: string,
+): string | null {
+  const prefix = `.${basename(receiptPath)}.upgrade-recovery-`;
+  if (!name.startsWith(prefix) || !name.endsWith(".json")) return null;
+  const token = name.slice(prefix.length, -".json".length);
+  return BACKUP_TOKEN.test(token) ? token : null;
+}
+
+function tokenFromTemporaryJournalName(
+  receiptPath: string,
+  name: string,
+): string | null {
+  const prefix = `.${basename(receiptPath)}.upgrade-recovery-`;
+  if (!name.startsWith(prefix)) return null;
+  const match = /^(\d+-[a-f0-9]{16})\.json\.temporary-\d+-[a-f0-9]{16}$/.exec(
+    name.slice(prefix.length),
+  );
+  return match?.[1] ?? null;
+}
+
+function directoryEntries(path: string): string[] {
+  try {
+    return readdirSync(path);
+  } catch {
+    return [];
+  }
+}
+
+export function standaloneUpgradeBackupTokens(
+  executable: string,
+): ReadonlySet<string> {
+  const tokens = directoryEntries(dirname(executable))
+    .map((name) => tokenFromBackupName(executable, name))
+    .filter((token): token is string => token !== null);
+  return new Set(tokens);
+}
+
+function inspectBackupPair(
+  executable: string,
+  receiptPath: string,
+  token: string,
+  uid: number | undefined,
+): BackupPair | null {
+  const executableBackup = join(
+    dirname(executable),
+    backupName(executable, token),
+  );
+  const receiptBackup = join(
+    dirname(receiptPath),
+    backupName(receiptPath, token),
+  );
+  const oldExecutable = captureFile(executableBackup, uid, false);
+  const oldReceipt = captureFile(receiptBackup, uid, true);
+  if (
+    oldExecutable === null ||
+    oldReceipt === null ||
+    !receiptBindsExecutable(
+      oldReceipt,
+      oldExecutable,
+      executable,
+      dirname(executable),
+    )
+  ) {
+    return null;
+  }
+  return {
+    token,
+    executable,
+    receiptPath,
+    pathInstallDir: dirname(executable),
+    executableBackup,
+    receiptBackup,
+    oldExecutable,
+    oldReceipt,
+  };
+}
+
+function inspectBackupPairs(
+  executable: string,
+  receiptPath: string,
+  uid: number | undefined,
+): BackupPair[] {
+  return [...standaloneUpgradeBackupTokens(executable)]
+    .map((token) => inspectBackupPair(executable, receiptPath, token, uid))
+    .filter((pair): pair is BackupPair => pair !== null);
+}
+
+function cleanupCoherentSingletonBackups(
+  executable: string,
+  receiptPath: string,
+  executableFile: CapturedFile,
+  receiptFile: CapturedFile,
+  pairedTokens: ReadonlySet<string>,
+  uid: number | undefined,
+): number {
+  let removed = 0;
+  for (const name of directoryEntries(dirname(executable))) {
+    const token = tokenFromBackupName(executable, name);
+    if (token === null || pairedTokens.has(token)) continue;
+    const path = join(dirname(executable), name);
+    const artifact = captureFile(path, uid, false);
+    if (artifact !== null && identityEqual(artifact, executableFile)) {
+      removeIdentifiedFile(path, artifact, uid, false);
+      removed++;
+    }
+  }
+  for (const name of directoryEntries(dirname(receiptPath))) {
+    const token = tokenFromBackupName(receiptPath, name);
+    if (token === null || pairedTokens.has(token)) continue;
+    const path = join(dirname(receiptPath), name);
+    const artifact = captureFile(path, uid, true);
+    if (artifact !== null && identityEqual(artifact, receiptFile)) {
+      removeIdentifiedFile(path, artifact, uid, true);
+      removed++;
+    }
+  }
+  if (removed > 0)
+    fsyncDirectories([dirname(executable), dirname(receiptPath)]);
+  return removed;
+}
+
+function discardMatchingTemporaryJournals(
+  recovery: RecoveryJournal,
+  uid: number | undefined,
+): void {
+  for (const name of directoryEntries(dirname(recovery.receiptPath))) {
+    if (
+      tokenFromTemporaryJournalName(recovery.receiptPath, name) !==
+      recovery.token
+    ) {
+      continue;
+    }
+    const path = join(dirname(recovery.receiptPath), name);
+    const temporary = captureFile(path, uid, true);
+    if (
+      temporary !== null &&
+      identityEqual(temporary, recovery.journalIdentity)
+    ) {
+      removeIdentifiedFile(path, temporary, uid, true);
+    }
+  }
+}
+
+function fsyncFile(path: string): void {
+  let descriptor: number | null = null;
+  try {
+    const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+    descriptor = openSync(path, constants.O_RDONLY | noFollow);
+    fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+  }
+}
+
+function fsyncDirectory(path: string): void {
+  if (process.platform === "win32") return;
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(path, constants.O_RDONLY);
+    fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+  }
+}
+
+function fsyncDirectories(paths: string[]): void {
+  for (const path of new Set(paths)) fsyncDirectory(path);
+}
+
+function writeJournal(
+  pair: BackupPair,
+  mode: RecoveryMode,
+  replacement: ExecutableIdentity,
+  uid: number | undefined,
+): RecoveryJournal {
+  const journalPath = join(
+    dirname(pair.receiptPath),
+    journalName(pair.receiptPath, pair.token),
+  );
+  const data: RecoveryJournalData = {
+    version: JOURNAL_VERSION,
+    mode,
+    token: pair.token,
+    executable: pair.executable,
+    receiptPath: pair.receiptPath,
+    pathInstallDir: pair.pathInstallDir,
+    executableBackup: pair.executableBackup,
+    receiptBackup: pair.receiptBackup,
+    oldExecutable: serializeIdentity(pair.oldExecutable),
+    oldReceipt: serializeIdentity(pair.oldReceipt),
+    replacement: serializeIdentity(replacement),
+  };
+  const content = `${JSON.stringify(data)}\n`;
+  const existing = captureFile(journalPath, uid, true);
+  if (existing !== null) {
+    if (existing.content.toString("utf8") !== content) {
+      throw new Error(
+        `Standalone upgrade recovery journal changed: ${journalPath}`,
+      );
+    }
+    return {
+      ...pair,
+      mode,
+      replacement,
+      journalPath,
+      journalIdentity: existing,
+    };
+  }
+
+  fsyncDirectories([
+    dirname(pair.executableBackup),
+    dirname(pair.receiptBackup),
+  ]);
+  const temporary = join(
+    dirname(journalPath),
+    `.${basename(journalPath)}.temporary-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+  let descriptor: number | null = null;
+  let operationError: unknown;
+  try {
+    descriptor = openSync(
+      temporary,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL,
+      0o600,
+    );
+    writeFileSync(descriptor, content, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = null;
+    linkSync(temporary, journalPath);
+    fsyncDirectory(dirname(journalPath));
+  } catch (error) {
+    operationError = error;
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+    try {
+      unlinkSync(temporary);
+      fsyncDirectory(dirname(temporary));
+    } catch (error) {
+      if (
+        operationError === undefined &&
+        (error as NodeJS.ErrnoException).code !== "ENOENT"
+      ) {
+        operationError = error;
+      }
+    }
+  }
+  if (operationError !== undefined) throw operationError;
+  const journal = captureFile(journalPath, uid, true);
+  if (journal === null || journal.content.toString("utf8") !== content) {
+    throw new Error(
+      `Could not verify standalone upgrade recovery journal: ${journalPath}`,
+    );
+  }
+  return {
+    ...pair,
+    mode,
+    replacement,
+    journalPath,
+    journalIdentity: journal,
+  };
+}
+
+export function persistStandaloneUpgradeRecoveryJournal(
+  input: PersistStandaloneUpgradeRecoveryInput,
+): string {
+  if (!/^[a-f0-9]{64}$/.test(input.expectedReplacementSha256)) {
+    throw new Error("Refusing invalid standalone upgrade replacement hash");
+  }
+  const home = input.home ?? homedir();
+  const uid = input.uid ?? process.getuid?.();
+  assertTrustedPaths(input.executable, input.receiptPath, home, uid);
+  const previous = input.previousBackupTokens ?? new Set<string>();
+  const candidates = inspectBackupPairs(
+    input.executable,
+    input.receiptPath,
+    uid,
+  ).filter(
+    (pair) =>
+      !previous.has(pair.token) &&
+      identityEqual(pair.oldExecutable, input.oldExecutable) &&
+      identityEqual(pair.oldReceipt, input.oldReceipt) &&
+      resolve(pair.pathInstallDir) === resolve(input.pathInstallDir),
+  );
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Could not identify one newly staged standalone upgrade backup pair (found ${candidates.length})`,
+    );
+  }
+  fsyncFile(input.replacementPath);
+  const replacement = captureFile(input.replacementPath, uid, false);
+  if (
+    replacement === null ||
+    replacement.sha256 !== input.expectedReplacementSha256 ||
+    identityEqual(replacement, input.oldExecutable)
+  ) {
+    throw new Error(
+      `Could not authenticate the staged standalone upgrade replacement: ${input.replacementPath}`,
+    );
+  }
+  return writeJournal(candidates[0], "complete", replacement, uid).journalPath;
+}
+
+function parseJournal(
+  journalPath: string,
+  token: string,
+  executable: string,
+  receiptPath: string,
+  uid: number | undefined,
+): RecoveryJournal {
+  const journal = captureFile(journalPath, uid, true);
+  if (journal === null) {
+    throw new Error(
+      `Standalone upgrade recovery journal is not an owner-only regular file: ${journalPath}`,
+    );
+  }
+  let data: Partial<RecoveryJournalData>;
+  try {
+    data = JSON.parse(
+      journal.content.toString("utf8"),
+    ) as Partial<RecoveryJournalData>;
+  } catch (error) {
+    throw new Error(
+      `Standalone upgrade recovery journal is malformed: ${journalPath}`,
+      {
+        cause: error,
+      },
+    );
+  }
+  const oldExecutable = deserializeIdentity(data.oldExecutable);
+  const oldReceipt = deserializeIdentity(data.oldReceipt);
+  const replacement = deserializeIdentity(data.replacement);
+  const expectedExecutableBackup = join(
+    dirname(executable),
+    backupName(executable, token),
+  );
+  const expectedReceiptBackup = join(
+    dirname(receiptPath),
+    backupName(receiptPath, token),
+  );
+  if (
+    data.version !== JOURNAL_VERSION ||
+    (data.mode !== "complete" && data.mode !== "rollback") ||
+    data.token !== token ||
+    typeof data.executable !== "string" ||
+    resolve(data.executable) !== resolve(executable) ||
+    typeof data.receiptPath !== "string" ||
+    resolve(data.receiptPath) !== resolve(receiptPath) ||
+    typeof data.pathInstallDir !== "string" ||
+    resolve(data.pathInstallDir) !== resolve(dirname(executable)) ||
+    data.executableBackup !== expectedExecutableBackup ||
+    data.receiptBackup !== expectedReceiptBackup ||
+    oldExecutable === null ||
+    oldReceipt === null ||
+    replacement === null
+  ) {
+    throw new Error(
+      `Standalone upgrade recovery journal fields are invalid: ${journalPath}`,
+    );
+  }
+
+  const executableBackup = captureFile(expectedExecutableBackup, uid, false);
+  const receiptBackup = captureFile(expectedReceiptBackup, uid, true);
+  if (
+    (executableBackup !== null &&
+      !identityEqual(executableBackup, oldExecutable)) ||
+    (receiptBackup !== null && !identityEqual(receiptBackup, oldReceipt))
+  ) {
+    throw new Error(
+      `Standalone upgrade recovery artifact changed; refusing recovery for ${executable}`,
+    );
+  }
+  if (receiptBackup !== null) {
+    const executableForBinding = executableBackup ?? {
+      ...oldExecutable,
+      content: Buffer.alloc(0),
+    };
+    const parsed = parseInstallReceipt(receiptBackup.content.toString("utf8"));
+    if (
+      parsed?.version !== 3 ||
+      parsed.executableIdentity === undefined ||
+      resolve(parsed.executable) !== resolve(executable) ||
+      resolve(parsed.pathInstallDir ?? "") !== resolve(dirname(executable)) ||
+      !identityEqual(parsed.executableIdentity, executableForBinding)
+    ) {
+      throw new Error(
+        `Standalone upgrade receipt backup is not identity-bound: ${expectedReceiptBackup}`,
+      );
+    }
+  }
+  return {
+    token,
+    executable,
+    receiptPath,
+    pathInstallDir: dirname(executable),
+    executableBackup: expectedExecutableBackup,
+    receiptBackup: expectedReceiptBackup,
+    oldExecutable,
+    oldReceipt,
+    mode: data.mode,
+    replacement,
+    journalPath,
+    journalIdentity: journal,
+  };
+}
+
+function inspectJournals(
+  executable: string,
+  receiptPath: string,
+  uid: number | undefined,
+): RecoveryJournal[] {
+  const journals: RecoveryJournal[] = [];
+  for (const name of directoryEntries(dirname(receiptPath))) {
+    const token = tokenFromJournalName(receiptPath, name);
+    if (token === null) continue;
+    journals.push(
+      parseJournal(
+        join(dirname(receiptPath), name),
+        token,
+        executable,
+        receiptPath,
+        uid,
+      ),
+    );
+  }
+  return journals;
+}
+
+function recoverTemporaryJournals(
+  executable: string,
+  receiptPath: string,
+  uid: number | undefined,
+): void {
+  const temporaryByToken = new Map<string, string[]>();
+  for (const name of directoryEntries(dirname(receiptPath))) {
+    const token = tokenFromTemporaryJournalName(receiptPath, name);
+    if (token === null) continue;
+    const paths = temporaryByToken.get(token) ?? [];
+    paths.push(join(dirname(receiptPath), name));
+    temporaryByToken.set(token, paths);
+  }
+  for (const [token, paths] of temporaryByToken) {
+    if (paths.length !== 1) {
+      throw new Error(
+        `Multiple temporary standalone upgrade journals exist for ${token}; no artifact was consumed`,
+      );
+    }
+    const temporaryPath = paths[0];
+    let temporary: RecoveryJournal;
+    try {
+      temporary = parseJournal(
+        temporaryPath,
+        token,
+        executable,
+        receiptPath,
+        uid,
+      );
+    } catch {
+      continue;
+    }
+    const canonicalPath = join(
+      dirname(receiptPath),
+      journalName(receiptPath, token),
+    );
+    const canonical = captureFile(canonicalPath, uid, true);
+    if (canonical === null) {
+      if (existsSync(canonicalPath)) {
+        throw new Error(
+          `Standalone upgrade recovery journal is not trusted: ${canonicalPath}`,
+        );
+      }
+      linkSync(temporaryPath, canonicalPath);
+      fsyncDirectory(dirname(canonicalPath));
+      assertIdentity(canonicalPath, temporary.journalIdentity, uid, true);
+    } else if (!identityEqual(canonical, temporary.journalIdentity)) {
+      throw new Error(
+        `Temporary standalone upgrade journal conflicts with ${canonicalPath}`,
+      );
+    }
+    removeIdentifiedFile(temporaryPath, temporary.journalIdentity, uid, true);
+    fsyncDirectory(dirname(temporaryPath));
+  }
+}
+
+function assertIdentity(
+  path: string,
+  expected: ExecutableIdentity,
+  uid: number | undefined,
+  ownerOnly: boolean,
+): CapturedFile {
+  const current = captureFile(path, uid, ownerOnly);
+  if (current === null || !identityEqual(current, expected)) {
+    throw new Error(`Standalone upgrade recovery artifact changed: ${path}`);
+  }
+  return current;
+}
+
+function removeIdentifiedFile(
+  path: string,
+  expected: ExecutableIdentity,
+  uid: number | undefined,
+  ownerOnly: boolean,
+): void {
+  if (!existsSync(path)) return;
+  assertIdentity(path, expected, uid, ownerOnly);
+  unlinkSync(path);
+}
+
+function durableCoherentPair(
+  executable: string,
+  receiptPath: string,
+  uid: number | undefined,
+): { executable: CapturedFile; receipt: CapturedFile } {
+  const executableFile = captureFile(executable, uid, false);
+  const receiptFile = captureFile(receiptPath, uid, true);
+  if (
+    executableFile === null ||
+    receiptFile === null ||
+    !receiptBindsExecutable(
+      receiptFile,
+      executableFile,
+      executable,
+      dirname(executable),
+    )
+  ) {
+    throw new Error(
+      "Standalone upgrade recovery did not establish a coherent executable and receipt",
+    );
+  }
+  fsyncFile(executable);
+  fsyncFile(receiptPath);
+  fsyncDirectories([dirname(executable), dirname(receiptPath)]);
+  const verifiedExecutable = captureFile(executable, uid, false);
+  const verifiedReceipt = captureFile(receiptPath, uid, true);
+  if (
+    verifiedExecutable === null ||
+    verifiedReceipt === null ||
+    !identityEqual(verifiedExecutable, executableFile) ||
+    !identityEqual(verifiedReceipt, receiptFile)
+  ) {
+    throw new Error(
+      "Standalone executable or receipt changed during recovery durability verification",
+    );
+  }
+  return { executable: verifiedExecutable, receipt: verifiedReceipt };
+}
+
+function recoveryScratchPath(
+  executable: string,
+  kind: "displaced" | "publish",
+  token: string,
+): string {
+  return join(
+    dirname(executable),
+    `.${basename(executable)}.upgrade-recovery-${kind}-${token}`,
+  );
+}
+
+function ensureHardLink(
+  source: string,
+  destination: string,
+  expected: ExecutableIdentity,
+  uid: number | undefined,
+  ownerOnly: boolean,
+): void {
+  try {
+    linkSync(source, destination);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+  }
+  assertIdentity(destination, expected, uid, ownerOnly);
+}
+
+function restoreOldGeneration(
+  recovery: RecoveryJournal,
+  currentExecutable: CapturedFile | null,
+  currentReceipt: CapturedFile | null,
+  uid: number | undefined,
+): void {
+  if (currentReceipt === null) {
+    assertIdentity(recovery.receiptBackup, recovery.oldReceipt, uid, true);
+    ensureHardLink(
+      recovery.receiptBackup,
+      recovery.receiptPath,
+      recovery.oldReceipt,
+      uid,
+      true,
+    );
+    fsyncDirectory(dirname(recovery.receiptPath));
+  } else if (!identityEqual(currentReceipt, recovery.oldReceipt)) {
+    if (
+      receiptBindsExecutable(
+        currentReceipt,
+        assertIdentity(
+          recovery.executableBackup,
+          recovery.oldExecutable,
+          uid,
+          false,
+        ),
+        recovery.executable,
+        recovery.pathInstallDir,
+      )
+    ) {
+      throw new Error(
+        "Standalone receipt content matches the recovery generation but its inode was replaced; artifacts were preserved",
+      );
+    }
+    assertIdentity(recovery.receiptBackup, recovery.oldReceipt, uid, true);
+    const displacedReceipt = recoveryScratchPath(
+      recovery.receiptPath,
+      "displaced",
+      recovery.token,
+    );
+    ensureHardLink(
+      recovery.receiptPath,
+      displacedReceipt,
+      currentReceipt,
+      uid,
+      true,
+    );
+    const publishReceipt = recoveryScratchPath(
+      recovery.receiptPath,
+      "publish",
+      recovery.token,
+    );
+    ensureHardLink(
+      recovery.receiptBackup,
+      publishReceipt,
+      recovery.oldReceipt,
+      uid,
+      true,
+    );
+    fsyncDirectory(dirname(recovery.receiptPath));
+    assertIdentity(recovery.receiptPath, currentReceipt, uid, true);
+    renameSync(publishReceipt, recovery.receiptPath);
+    assertIdentity(recovery.receiptPath, recovery.oldReceipt, uid, true);
+    fsyncDirectory(dirname(recovery.receiptPath));
+  }
+
+  if (currentExecutable === null) {
+    assertIdentity(
+      recovery.executableBackup,
+      recovery.oldExecutable,
+      uid,
+      false,
+    );
+    ensureHardLink(
+      recovery.executableBackup,
+      recovery.executable,
+      recovery.oldExecutable,
+      uid,
+      false,
+    );
+    fsyncDirectory(dirname(recovery.executable));
+    return;
+  }
+  if (identityEqual(currentExecutable, recovery.oldExecutable)) return;
+
+  assertIdentity(recovery.executableBackup, recovery.oldExecutable, uid, false);
+  const displaced = recoveryScratchPath(
+    recovery.executable,
+    "displaced",
+    recovery.token,
+  );
+  ensureHardLink(recovery.executable, displaced, currentExecutable, uid, false);
+  const publish = recoveryScratchPath(
+    recovery.executable,
+    "publish",
+    recovery.token,
+  );
+  ensureHardLink(
+    recovery.executableBackup,
+    publish,
+    recovery.oldExecutable,
+    uid,
+    false,
+  );
+  fsyncDirectory(dirname(recovery.executable));
+  assertIdentity(recovery.executable, currentExecutable, uid, false);
+  renameSync(publish, recovery.executable);
+  assertIdentity(recovery.executable, recovery.oldExecutable, uid, false);
+  fsyncDirectory(dirname(recovery.executable));
+}
+
+function cleanupRecovery(
+  recovery: RecoveryJournal,
+  coherentExecutable: CapturedFile,
+  coherentReceipt: CapturedFile,
+  uid: number | undefined,
+): void {
+  removeIdentifiedFile(
+    recovery.executableBackup,
+    recovery.oldExecutable,
+    uid,
+    false,
+  );
+  removeIdentifiedFile(recovery.receiptBackup, recovery.oldReceipt, uid, true);
+
+  const publish = recoveryScratchPath(
+    recovery.executable,
+    "publish",
+    recovery.token,
+  );
+  removeIdentifiedFile(publish, recovery.oldExecutable, uid, false);
+  const displaced = recoveryScratchPath(
+    recovery.executable,
+    "displaced",
+    recovery.token,
+  );
+  const displacedFile = captureFile(displaced, uid, false);
+  if (
+    displacedFile !== null &&
+    recovery.mode === "complete" &&
+    identityEqual(displacedFile, recovery.replacement)
+  ) {
+    removeIdentifiedFile(displaced, displacedFile, uid, false);
+  }
+  const receiptPublish = recoveryScratchPath(
+    recovery.receiptPath,
+    "publish",
+    recovery.token,
+  );
+  removeIdentifiedFile(receiptPublish, recovery.oldReceipt, uid, true);
+
+  const downloadPath = `${recovery.executable}.download`;
+  const retainedDownload = captureFile(downloadPath, uid, false);
+  if (
+    retainedDownload !== null &&
+    (identityEqual(retainedDownload, coherentExecutable) ||
+      (recovery.mode === "complete" &&
+        identityEqual(retainedDownload, recovery.replacement)))
+  ) {
+    removeIdentifiedFile(downloadPath, retainedDownload, uid, false);
+  }
+
+  for (const name of directoryEntries(dirname(recovery.executable))) {
+    const path = join(dirname(recovery.executable), name);
+    if (
+      name.startsWith(`${basename(recovery.executable)}.upgrade-displaced-`)
+    ) {
+      const artifact = captureFile(path, uid, false);
+      if (
+        artifact !== null &&
+        identityEqual(artifact, recovery.oldExecutable)
+      ) {
+        removeIdentifiedFile(path, artifact, uid, false);
+      }
+    }
+  }
+  for (const name of directoryEntries(dirname(recovery.receiptPath))) {
+    const path = join(dirname(recovery.receiptPath), name);
+    if (
+      name.startsWith(`${basename(recovery.receiptPath)}.upgrade-displaced-`)
+    ) {
+      const artifact = captureFile(path, uid, true);
+      if (artifact !== null && identityEqual(artifact, recovery.oldReceipt)) {
+        removeIdentifiedFile(path, artifact, uid, true);
+      }
+    }
+    if (
+      name.startsWith(`.${basename(recovery.receiptPath)}.upgrade-`) &&
+      /^\d+-[a-f0-9]{16}$/.test(
+        name.slice(`.${basename(recovery.receiptPath)}.upgrade-`.length),
+      )
+    ) {
+      const artifact = captureFile(path, uid, true);
+      if (artifact !== null && identityEqual(artifact, coherentReceipt)) {
+        removeIdentifiedFile(path, artifact, uid, true);
+      }
+    }
+  }
+
+  fsyncDirectories([
+    dirname(recovery.executable),
+    dirname(recovery.receiptPath),
+  ]);
+  discardMatchingTemporaryJournals(recovery, uid);
+  removeIdentifiedFile(
+    recovery.journalPath,
+    recovery.journalIdentity,
+    uid,
+    true,
+  );
+  fsyncDirectory(dirname(recovery.journalPath));
+}
+
+function journalForLegacyPair(
+  pair: BackupPair,
+  uid: number | undefined,
+): RecoveryJournal {
+  return writeJournal(pair, "rollback", pair.oldExecutable, uid);
+}
+
+function invokedBackupCandidate(
+  invokedExecutable: string,
+  receiptPath: string,
+  uid: number | undefined,
+): { executable: string; token: string } | null {
+  const name = basename(invokedExecutable);
+  const marker = ".upgrade-backup-";
+  const markerIndex = name.lastIndexOf(marker);
+  if (!name.startsWith(".") || markerIndex <= 1) return null;
+  const token = name.slice(markerIndex + marker.length);
+  if (!BACKUP_TOKEN.test(token)) return null;
+  const executable = join(
+    dirname(invokedExecutable),
+    name.slice(1, markerIndex),
+  );
+  const pair = inspectBackupPair(executable, receiptPath, token, uid);
+  if (
+    pair === null ||
+    resolve(pair.executableBackup) !== resolve(invokedExecutable)
+  ) {
+    return null;
+  }
+  return { executable, token };
+}
+
+/** Recover an interrupted standalone publication before provenance is checked. */
+export function recoverStandaloneUpgradePublication(
+  options: StandaloneUpgradeRecoveryOptions,
+): StandaloneUpgradeRecoveryResult {
+  const home = options.home ?? homedir();
+  const uid = options.uid ?? process.getuid?.();
+  const receiptPath =
+    options.receiptPath ?? join(home, ".lore", "install-path");
+  const backupInvocation = invokedBackupCandidate(
+    options.executable,
+    receiptPath,
+    uid,
+  );
+  const executable = backupInvocation?.executable ?? options.executable;
+
+  const hasPossibleArtifacts =
+    standaloneUpgradeBackupTokens(executable).size > 0 ||
+    directoryEntries(dirname(receiptPath)).some(
+      (name) => tokenFromJournalName(receiptPath, name) !== null,
+    );
+  if (!hasPossibleArtifacts) return { executable, action: "none" };
+
+  assertTrustedPaths(executable, receiptPath, home, uid);
+  recoverTemporaryJournals(executable, receiptPath, uid);
+  const journals = inspectJournals(executable, receiptPath, uid);
+  const pairs = inspectBackupPairs(executable, receiptPath, uid);
+  const currentExecutable = captureFile(executable, uid, false);
+  const currentReceipt = captureFile(receiptPath, uid, true);
+  const coherent =
+    currentExecutable !== null &&
+    currentReceipt !== null &&
+    receiptBindsExecutable(
+      currentReceipt,
+      currentExecutable,
+      executable,
+      dirname(executable),
+    );
+
+  if (coherent) {
+    if (journals.length > 1) {
+      throw new Error(
+        "Multiple standalone upgrade recovery journals are present; no artifacts were consumed",
+      );
+    }
+    if (
+      journals.length === 1 &&
+      pairs.some((pair) => pair.token !== journals[0].token)
+    ) {
+      throw new Error(
+        "Standalone upgrade recovery journal is ambiguous with another valid backup generation; no artifacts were consumed",
+      );
+    }
+    const durable = durableCoherentPair(executable, receiptPath, uid);
+    const recoveries = [...journals];
+    for (const pair of pairs) {
+      if (!recoveries.some((journal) => journal.token === pair.token)) {
+        recoveries.push(journalForLegacyPair(pair, uid));
+      }
+    }
+    for (const recovery of recoveries) {
+      cleanupRecovery(recovery, durable.executable, durable.receipt, uid);
+    }
+    const removedSingletons = cleanupCoherentSingletonBackups(
+      executable,
+      receiptPath,
+      durable.executable,
+      durable.receipt,
+      new Set(recoveries.map((recovery) => recovery.token)),
+      uid,
+    );
+    return {
+      executable,
+      action:
+        recoveries.length > 0 || removedSingletons > 0 ? "cleaned" : "none",
+    };
+  }
+
+  let recovery: RecoveryJournal | undefined;
+  if (journals.length > 0) {
+    const matching = journals.filter(
+      (journal) =>
+        (currentReceipt !== null &&
+          identityEqual(currentReceipt, journal.oldReceipt)) ||
+        (currentExecutable !== null &&
+          journal.mode === "complete" &&
+          identityEqual(currentExecutable, journal.replacement)) ||
+        (currentExecutable === null && currentReceipt === null) ||
+        (backupInvocation !== null && journal.token === backupInvocation.token),
+    );
+    if (matching.length === 1) recovery = matching[0];
+    else if (journals.length === 1) recovery = journals[0];
+  }
+  if (recovery === undefined) {
+    const matchingPairs = pairs.filter(
+      (pair) =>
+        (currentReceipt !== null &&
+          identityEqual(currentReceipt, pair.oldReceipt)) ||
+        currentExecutable === null ||
+        (backupInvocation !== null && pair.token === backupInvocation.token),
+    );
+    if (matchingPairs.length === 1) {
+      recovery = journalForLegacyPair(matchingPairs[0], uid);
+    }
+  }
+  if (recovery === undefined) {
+    throw new Error(
+      "Interrupted standalone upgrade artifacts do not authenticate one recovery generation; no files were changed",
+    );
+  }
+
+  if (currentExecutable === null && backupInvocation === null) {
+    throw new Error(
+      "Canonical standalone executable is missing; invoke the authenticated upgrade backup path to recover it",
+    );
+  }
+
+  if (
+    recovery.mode === "complete" &&
+    currentExecutable !== null &&
+    identityEqual(currentExecutable, recovery.replacement)
+  ) {
+    if (currentReceipt === null) {
+      recoverReplacementInstallReceipt(
+        executable,
+        receiptPath,
+        dirname(executable),
+        home,
+        uid,
+      );
+    } else if (identityEqual(currentReceipt, recovery.oldReceipt)) {
+      refreshStandaloneInstallReceipt({
+        executable,
+        executableSha256: recovery.replacement.sha256,
+        receiptPath,
+        receiptIdentity: recovery.oldReceipt,
+        pathInstallDir: dirname(executable),
+        home,
+        uid,
+      });
+    } else {
+      restoreOldGeneration(recovery, currentExecutable, currentReceipt, uid);
+      const durable = durableCoherentPair(executable, receiptPath, uid);
+      cleanupRecovery(recovery, durable.executable, durable.receipt, uid);
+      return { executable, action: "restored" };
+    }
+    const durable = durableCoherentPair(executable, receiptPath, uid);
+    cleanupRecovery(recovery, durable.executable, durable.receipt, uid);
+    return { executable, action: "completed" };
+  }
+
+  restoreOldGeneration(recovery, currentExecutable, currentReceipt, uid);
+  const durable = durableCoherentPair(executable, receiptPath, uid);
+  cleanupRecovery(recovery, durable.executable, durable.receipt, uid);
+  return { executable, action: "restored" };
+}
+
+/** Verify and flush the published pair before any recovery link is removed. */
+export function verifyStandaloneUpgradePublicationDurable(input: {
+  executable: string;
+  receiptPath: string;
+  home?: string;
+  uid?: number;
+}): void {
+  const home = input.home ?? homedir();
+  const uid = input.uid ?? process.getuid?.();
+  assertTrustedPaths(input.executable, input.receiptPath, home, uid);
+  durableCoherentPair(input.executable, input.receiptPath, uid);
+}

--- a/packages/gateway/src/cli/upgrade.ts
+++ b/packages/gateway/src/cli/upgrade.ts
@@ -23,20 +23,27 @@
  * detection, setup spawning, release notes, and Sentry SDK telemetry.
  */
 
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { parseArgs } from "node:util";
-import { dirname } from "node:path";
 import { VERSION } from "./version";
-import {
-  isDowngrade,
-  installBinary,
-  determineInstallDir,
-  releaseLock,
-} from "./lib/binary";
+import { isDowngrade, installBinary } from "./lib/binary";
 import { UpgradeError } from "./lib/errors";
+import {
+  stageStandaloneUpgradeReceipt,
+  standaloneInstallProvenance,
+  type StandaloneInstallProvenance,
+} from "./uninstall";
+import {
+  persistStandaloneUpgradeRecoveryJournal,
+  recoverStandaloneUpgradePublication,
+  standaloneUpgradeBackupTokens,
+  verifyStandaloneUpgradePublicationDurable,
+} from "./upgrade-recovery";
 import {
   executeUpgrade,
   fetchLatestVersion,
-  getCurlInstallPaths,
   getReleaseChannel,
   NIGHTLY_TAG,
   type OfflineMode,
@@ -45,9 +52,23 @@ import {
   versionExists,
   VERSION_PREFIX_REGEX,
 } from "./lib/upgrade";
+import { withLifecycleLock } from "../lifecycle-lock";
 
 /** Special version strings that select a channel */
 const CHANNEL_VERSIONS = new Set(["nightly", "stable"]);
+
+export function standaloneUpgradeTargetDir(
+  executable: string,
+  provenance: StandaloneInstallProvenance,
+): string {
+  if (!provenance.hostedInstall) {
+    throw new UpgradeError(
+      "execution_failed",
+      "This Lore CLI is package-managed or lacks a verified standalone receipt. Upgrade it with its package manager (for global npm: npm install -g @loreai/gateway@latest); no standalone binary was created or overwritten.",
+    );
+  }
+  return resolve(dirname(executable));
+}
 
 // ---------------------------------------------------------------------------
 // Flag parsing
@@ -200,115 +221,209 @@ Examples:
     return;
   }
 
-  const { channel, cleanVersionArg } = resolveChannelAndVersion(
-    rawVersionArg,
-    flags.channel,
-  );
-
-  const currentChannel = getReleaseChannel();
-  const channelChanged = channel !== currentChannel;
-
-  console.error(`[lore] Current version: ${VERSION}`);
-  console.error(`[lore] Channel: ${channel}`);
-
-  // Resolve target version
-  let target: string;
-  let offline: OfflineMode = false;
-
-  if (flags.offline) {
-    // Read cached version BEFORE persisting channel
-    target = resolveOfflineTarget(cleanVersionArg);
-    offline = "explicit";
-    console.error(`[lore] Offline mode: using cached target ${target}`);
-  } else {
-    try {
-      const latest = await fetchLatestVersion(channel);
-      target = cleanVersionArg?.replace(VERSION_PREFIX_REGEX, "") ?? latest;
-
-      // Cache the latest version for future offline use
-      setCachedLatestVersion(latest);
-    } catch (error) {
-      // Try offline fallback
-      if (error instanceof UpgradeError && error.reason === "network_error") {
-        try {
-          target = resolveOfflineTarget(cleanVersionArg);
-          offline = "network-fallback";
-          console.error(
-            "[lore] Network unavailable, falling back to cached upgrade target",
-          );
-        } catch {
-          throw error; // Re-throw original network error
-        }
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  // Persist channel preference
-  if (channelChanged || CHANNEL_VERSIONS.has(rawVersionArg ?? "")) {
-    setReleaseChannel(channel);
-  }
-
-  // --check: just report status
-  if (flags.check) {
-    if (VERSION === target) {
-      console.error(`[lore] Already up to date (${VERSION})`);
-    } else {
-      const direction = isDowngrade(VERSION, target) ? "Downgrade" : "Update";
-      console.error(`[lore] ${direction} available: ${VERSION} -> ${target}`);
-      console.error(`[lore] Run 'lore upgrade' to update.`);
-    }
-    if (offline) {
-      console.error("[lore] (resolved from cache — network unavailable)");
-    }
-    return;
-  }
-
-  // Already on target — unless forced or switching channels
-  if (VERSION === target && !flags.force && !channelChanged) {
-    console.error(`[lore] Already up to date (${VERSION})`);
-    return;
-  }
-
-  // Validate pinned version exists (skip for channel keywords)
-  if (cleanVersionArg && !CHANNEL_VERSIONS.has(cleanVersionArg) && !offline) {
-    const exists = await versionExists(target, channel);
-    if (!exists) {
-      throw new UpgradeError(
-        "version_not_found",
-        `Version ${target} not found`,
+  return withLifecycleLock("upgrade", async (lifecycleLock) => {
+    lifecycleLock.assertOwned();
+    // Recovery must precede channel/network/version early returns and receipt
+    // provenance checks: the crash state we repair is intentionally not yet a
+    // valid standalone installation.
+    const recovery = recoverStandaloneUpgradePublication({
+      executable: process.execPath,
+    });
+    const upgradeExecutable = recovery.executable;
+    if (recovery.action !== "none") {
+      console.error(
+        `[lore] Recovered interrupted standalone upgrade (${recovery.action}).`,
       );
     }
-  }
-
-  const downgrade = isDowngrade(VERSION, target);
-  const verb = downgrade ? "Downgrading" : "Upgrading";
-  console.error(`[lore] ${verb} to ${target}...`);
-
-  // Use the rolling "nightly" tag only when upgrading to latest nightly
-  const downloadTag =
-    channel === "nightly" && !cleanVersionArg ? NIGHTLY_TAG : undefined;
-
-  // Download the new binary
-  const downloadResult = await executeUpgrade(target, downloadTag, offline);
-
-  // Install: replace the current binary atomically
-  try {
-    const currentInstallDir = dirname(getCurlInstallPaths().installPath);
-    const installDir = determineInstallDir(
-      require("node:os").homedir(),
-      process.env,
+    const { channel, cleanVersionArg } = resolveChannelAndVersion(
+      rawVersionArg,
+      flags.channel,
     );
-    // Use current install dir if we're already in a known location
-    const targetDir = process.execPath.startsWith(currentInstallDir)
-      ? currentInstallDir
-      : installDir;
 
-    const installedPath = await installBinary(
-      downloadResult.tempBinaryPath,
-      targetDir,
+    lifecycleLock.assertOwned();
+    const currentChannel = getReleaseChannel();
+    const channelChanged = channel !== currentChannel;
+
+    console.error(`[lore] Current version: ${VERSION}`);
+    console.error(`[lore] Channel: ${channel}`);
+
+    // Resolve target version
+    let target: string;
+    let offline: OfflineMode = false;
+
+    if (flags.offline) {
+      // Read cached version BEFORE persisting channel
+      target = resolveOfflineTarget(cleanVersionArg);
+      offline = "explicit";
+      console.error(`[lore] Offline mode: using cached target ${target}`);
+    } else {
+      try {
+        const latest = await fetchLatestVersion(channel);
+        target = cleanVersionArg?.replace(VERSION_PREFIX_REGEX, "") ?? latest;
+
+        // Cache the latest version for future offline use
+        lifecycleLock.assertOwned();
+        setCachedLatestVersion(latest);
+      } catch (error) {
+        // Try offline fallback
+        if (error instanceof UpgradeError && error.reason === "network_error") {
+          try {
+            target = resolveOfflineTarget(cleanVersionArg);
+            offline = "network-fallback";
+            console.error(
+              "[lore] Network unavailable, falling back to cached upgrade target",
+            );
+          } catch {
+            throw error; // Re-throw original network error
+          }
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    // Persist channel preference
+    if (channelChanged || CHANNEL_VERSIONS.has(rawVersionArg ?? "")) {
+      lifecycleLock.assertOwned();
+      setReleaseChannel(channel);
+    }
+
+    // --check: just report status
+    if (flags.check) {
+      if (VERSION === target) {
+        console.error(`[lore] Already up to date (${VERSION})`);
+      } else {
+        const direction = isDowngrade(VERSION, target) ? "Downgrade" : "Update";
+        console.error(`[lore] ${direction} available: ${VERSION} -> ${target}`);
+        console.error(`[lore] Run 'lore upgrade' to update.`);
+      }
+      if (offline) {
+        console.error("[lore] (resolved from cache — network unavailable)");
+      }
+      return;
+    }
+
+    // Already on target — unless forced or switching channels
+    if (VERSION === target && !flags.force && !channelChanged) {
+      console.error(`[lore] Already up to date (${VERSION})`);
+      return;
+    }
+
+    // Validate pinned version exists (skip for channel keywords)
+    if (cleanVersionArg && !CHANNEL_VERSIONS.has(cleanVersionArg) && !offline) {
+      const exists = await versionExists(target, channel);
+      if (!exists) {
+        throw new UpgradeError(
+          "version_not_found",
+          `Version ${target} not found`,
+        );
+      }
+    }
+
+    const downgrade = isDowngrade(VERSION, target);
+    const verb = downgrade ? "Downgrading" : "Upgrading";
+    console.error(`[lore] ${verb} to ${target}...`);
+
+    // A package invocation must never manufacture or overwrite an unreceipted
+    // standalone binary. Check before download/publication work so guidance is
+    // immediate and a verified custom hosted path remains authoritative.
+    const provenance = standaloneInstallProvenance(upgradeExecutable);
+    const targetDir = standaloneUpgradeTargetDir(upgradeExecutable, provenance);
+
+    // Use the rolling "nightly" tag only when upgrading to latest nightly
+    const downloadTag =
+      channel === "nightly" && !cleanVersionArg ? NIGHTLY_TAG : undefined;
+
+    // Download the new binary
+    const downloadResult = await executeUpgrade(
+      target,
+      lifecycleLock,
+      downloadTag,
+      offline,
+      upgradeExecutable,
     );
+
+    // Install: replace the current binary atomically
+    const downloadedSha256 = createHash("sha256")
+      .update(readFileSync(downloadResult.tempBinaryPath))
+      .digest("hex");
+    const receiptInstallDir =
+      provenance.pathInstallDir ??
+      (process.platform === "win32" ? undefined : dirname(upgradeExecutable));
+    if (
+      resolve(dirname(upgradeExecutable)) !== targetDir ||
+      !provenance.receiptPath ||
+      !provenance.receiptIdentity ||
+      !provenance.executableIdentity ||
+      !receiptInstallDir
+    ) {
+      throw new Error(
+        "Refusing standalone upgrade because the verified executable path/receipt provenance could not be preserved",
+      );
+    }
+    const receiptPath = provenance.receiptPath;
+    const oldReceipt = provenance.receiptIdentity;
+    const oldExecutable = provenance.executableIdentity;
+    const previousBackupTokens =
+      standaloneUpgradeBackupTokens(upgradeExecutable);
+    const receiptTransaction = stageStandaloneUpgradeReceipt({
+      executable: upgradeExecutable,
+      executableIdentity: oldExecutable,
+      receiptPath,
+      receiptIdentity: oldReceipt,
+      pathInstallDir: receiptInstallDir,
+    });
+    let installedPath: string;
+    try {
+      lifecycleLock.assertOwned();
+      installedPath = await installBinary(
+        downloadResult.tempBinaryPath,
+        targetDir,
+        lifecycleLock,
+        {
+          expectedInstallIdentity: oldExecutable,
+          beforeQuarantine: () => {
+            lifecycleLock.assertOwned();
+            persistStandaloneUpgradeRecoveryJournal({
+              executable: upgradeExecutable,
+              receiptPath,
+              pathInstallDir: receiptInstallDir,
+              oldExecutable,
+              oldReceipt,
+              replacementPath: `${upgradeExecutable}.download`,
+              expectedReplacementSha256: downloadedSha256,
+              previousBackupTokens,
+            });
+          },
+        },
+      );
+      lifecycleLock.assertOwned();
+      if (resolve(installedPath) !== resolve(upgradeExecutable)) {
+        throw new Error(
+          "Standalone upgrade changed install path before receipt refresh",
+        );
+      }
+      receiptTransaction.refresh(downloadedSha256);
+      lifecycleLock.assertOwned();
+      verifyStandaloneUpgradePublicationDurable({
+        executable: upgradeExecutable,
+        receiptPath,
+      });
+      receiptTransaction.commit();
+      lifecycleLock.assertOwned();
+      recoverStandaloneUpgradePublication({ executable: upgradeExecutable });
+    } catch (error) {
+      try {
+        lifecycleLock.assertOwned();
+        recoverStandaloneUpgradePublication({ executable: upgradeExecutable });
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          "Upgrade failed and the standalone executable/receipt generation could not be restored deterministically.",
+        );
+      }
+      throw error;
+    }
 
     console.error(
       `[lore] ${downgrade ? "Downgraded" : "Upgraded"} successfully: ${VERSION} -> ${target}`,
@@ -317,7 +432,5 @@ Examples:
     if (offline) {
       console.error("[lore] (upgraded from cached patches)");
     }
-  } finally {
-    releaseLock(downloadResult.lockPath);
-  }
+  });
 }

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -7,10 +7,12 @@
 import {
   normalizeRemoteUrl,
   discoverWorkspaceRoot,
+  GATEWAY_AUTH_HEADER,
   UNATTRIBUTED_PROJECT_PREFIX,
   isUnattributedProjectPath,
   log,
 } from "@loreai/core";
+import { hasConflictingAuthHeaders } from "./auth";
 
 // ---------------------------------------------------------------------------
 // Port defaults
@@ -26,6 +28,10 @@ export const DEFAULT_PORTS = [3207, 5673] as const;
 
 /** The primary default port (first in the fallback chain). */
 export const DEFAULT_PORT = DEFAULT_PORTS[0];
+
+/** Match the existing owner-control token bounds used by gateway pid records. */
+export const GATEWAY_AUTH_TOKEN_MIN_LENGTH = 32;
+export const GATEWAY_AUTH_TOKEN_MAX_LENGTH = 256;
 
 // ---------------------------------------------------------------------------
 // Config shape
@@ -46,6 +52,14 @@ export interface GatewayConfig {
   upstreamAnthropic: string;
   /** Upstream OpenAI API URL. Default: "https://api.openai.com". Env: LORE_UPSTREAM_OPENAI */
   upstreamOpenAI: string;
+  /**
+   * Normalized HTTPS origins that remote/hosted clients may select with
+   * `X-Lore-Upstream-URL`. Empty by default, so caller-selected upstreams are
+   * denied unless the gateway administrator explicitly allows their origins.
+   * Local gateways do not consult this list. Env: LORE_CALLER_UPSTREAM_ALLOWLIST
+   * (comma-separated origins).
+   */
+  callerUpstreamAllowlist: readonly string[];
   /** AWS Bedrock region. Selects both the bedrock-mantle Anthropic endpoint
    * and the bedrock-runtime Converse/InvokeModel endpoint. Resolves from
    * `LORE_BEDROCK_REGION` first, then falls back to `AWS_REGION` /
@@ -68,6 +82,12 @@ export interface GatewayConfig {
   debug: boolean;
   /** Remote gateway URL. When set, `lore run` delegates to this gateway instead of starting a local one. Env: LORE_REMOTE_URL */
   remoteUrl?: string;
+  /**
+   * Gateway access credential required by every remote/hosted data-plane
+   * request. This is separate from provider credentials. Env:
+   * LORE_GATEWAY_AUTH_TOKEN.
+   */
+  gatewayAuthToken?: string;
   /**
    * Hosted/remote mode — disables all filesystem operations that use
    * client-controlled paths (git subprocess, .lore.json/.lore.md read/write,
@@ -124,7 +144,7 @@ export interface GatewayConfig {
    */
   remoteGatewayCommandDefault?: boolean;
   /**
-   * Extra HTTP headers to inject on every upstream call (corporate proxies,
+   * Extra HTTP headers to inject on configured upstream calls (corporate proxies,
    * Cloudflare AI Gateway's `cf-aig-authorization`, LiteLLM team-routing
    * tokens, audit/logging tracing headers, etc.).
    *
@@ -133,13 +153,14 @@ export interface GatewayConfig {
    * for `ANTHROPIC_CUSTOM_HEADERS`. Keys are lowercased; values are
    * whitespace-trimmed. Empty / malformed lines are skipped with a warning.
    *
-   * Precedence (highest wins): gateway-managed headers (`x-api-key`,
-   * `Authorization`, `x-lore-*`) > these user-supplied extras > client
-   * forwarded headers. This means a user-supplied `Authorization: Bearer
-   * svc-token` overrides the session's credential — useful for routing
-   * worker calls or routing sessions to a service account.
+   * These headers are credentials owned by the gateway administrator. They are
+   * base-path-bound to `LORE_UPSTREAM_ANTHROPIC`, `LORE_UPSTREAM_OPENAI`, and
+   * `LORE_WORKER_UPSTREAM` (when configured), and are omitted when a client
+   * selects any other base with `X-Lore-Upstream-URL`.
    */
   upstreamExtraHeaders: Record<string, string>;
+  /** Normalized HTTP(S) base paths authorized to receive upstreamExtraHeaders. */
+  upstreamExtraHeaderBases?: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -150,6 +171,26 @@ export interface GatewayConfig {
 export function loadConfig(): GatewayConfig {
   const env = process.env;
   const hosts = parseHosts(env.LORE_LISTEN_HOST);
+  const upstreamAnthropic = trimTrailingSlash(
+    env.LORE_UPSTREAM_ANTHROPIC || "https://api.anthropic.com",
+  );
+  const upstreamOpenAI = trimTrailingSlash(
+    env.LORE_UPSTREAM_OPENAI || "https://api.openai.com",
+  );
+  const workerUpstream = env.LORE_WORKER_UPSTREAM
+    ? trimTrailingSlash(env.LORE_WORKER_UPSTREAM)
+    : undefined;
+  /**
+   * Comma-separated HTTPS origins that remote/hosted clients may select via
+   * `X-Lore-Upstream-URL`. Entries must be origins only (no credentials, paths,
+   * queries, fragments, or wildcards), and duplicates are rejected after URL
+   * normalization. Unset means deny every caller-selected origin. Configured
+   * provider upstreams are administrator-selected and do not require an entry.
+   * Env: `LORE_CALLER_UPSTREAM_ALLOWLIST`.
+   */
+  const callerUpstreamAllowlist = parseCallerUpstreamAllowlist(
+    env.LORE_CALLER_UPSTREAM_ALLOWLIST,
+  );
   /**
    * Explicitly marks this gateway as a remote / multi-tenant one.
    * When set to `1`, the gateway assumes a per-user bucketing model
@@ -182,16 +223,26 @@ export function loadConfig(): GatewayConfig {
   const hostedModeDefined = "LORE_HOSTED_MODE" in env;
   const autoDetected =
     !remoteGatewayDefined && !hostedModeDefined && hasNonLoopbackHost(hosts);
+  const upstreamExtraHeaders = parseCurlHeaders(
+    env.LORE_UPSTREAM_EXTRA_HEADERS,
+  );
+  if (hasConflictingAuthHeaders(upstreamExtraHeaders)) {
+    throw new Error(
+      "LORE_UPSTREAM_EXTRA_HEADERS must configure at most one provider authentication mechanism",
+    );
+  }
+  if (hasGatewayAccessHeader(upstreamExtraHeaders)) {
+    throw new Error(
+      "LORE_UPSTREAM_EXTRA_HEADERS cannot contain the gateway access header",
+    );
+  }
   return {
     port: parsePort(env.LORE_LISTEN_PORT, DEFAULT_PORT),
     portExplicit: !!env.LORE_LISTEN_PORT,
     hosts,
-    upstreamAnthropic: trimTrailingSlash(
-      env.LORE_UPSTREAM_ANTHROPIC || "https://api.anthropic.com",
-    ),
-    upstreamOpenAI: trimTrailingSlash(
-      env.LORE_UPSTREAM_OPENAI || "https://api.openai.com",
-    ),
+    upstreamAnthropic,
+    upstreamOpenAI,
+    callerUpstreamAllowlist,
     /**
      * Idle timeout in seconds. After this many seconds with no active
      * request, the gateway stops the per-session in-memory cache
@@ -208,12 +259,16 @@ export function loadConfig(): GatewayConfig {
     remoteUrl: env.LORE_REMOTE_URL
       ? trimTrailingSlash(env.LORE_REMOTE_URL)
       : undefined,
+    gatewayAuthToken: parseGatewayAuthToken(env.LORE_GATEWAY_AUTH_TOKEN),
     hostedMode: hostedModeEnv,
     workerApiKey: env.LORE_WORKER_API_KEY || undefined,
-    workerUpstream: env.LORE_WORKER_UPSTREAM
-      ? trimTrailingSlash(env.LORE_WORKER_UPSTREAM)
-      : undefined,
-    upstreamExtraHeaders: parseCurlHeaders(env.LORE_UPSTREAM_EXTRA_HEADERS),
+    workerUpstream,
+    upstreamExtraHeaders,
+    upstreamExtraHeaderBases: configuredUpstreamBases([
+      upstreamAnthropic,
+      upstreamOpenAI,
+      workerUpstream,
+    ]),
     // Bedrock (bedrock-mantle) region — selects the regional mantle endpoint.
     bedrockRegion:
       env.LORE_BEDROCK_REGION ??
@@ -232,6 +287,59 @@ export function loadConfig(): GatewayConfig {
     remoteGateway: remoteGatewayEnv || hostedModeEnv || autoDetected,
     remoteGatewayAutoDetected: autoDetected,
   };
+}
+
+/** Parse a header-safe, brute-force-resistant gateway access token. */
+export function parseGatewayAuthToken(
+  value: string | undefined,
+): string | undefined {
+  if (value === undefined || value === "") return undefined;
+  if (
+    value.length < GATEWAY_AUTH_TOKEN_MIN_LENGTH ||
+    value.length > GATEWAY_AUTH_TOKEN_MAX_LENGTH ||
+    // Visible ASCII excluding comma keeps one configured token distinguishable
+    // from Fetch/Node's comma-joined duplicate-header representation.
+    !/^[\x21-\x2b\x2d-\x7e]+$/.test(value)
+  ) {
+    throw new Error(
+      `LORE_GATEWAY_AUTH_TOKEN must be ${GATEWAY_AUTH_TOKEN_MIN_LENGTH}-${GATEWAY_AUTH_TOKEN_MAX_LENGTH} visible ASCII characters without commas`,
+    );
+  }
+  return value;
+}
+
+/** Apply the fail-closed remote/hosted startup invariant after CLI overrides. */
+export function assertGatewayAccessConfigured(
+  config: Pick<
+    GatewayConfig,
+    "remoteGateway" | "hostedMode" | "gatewayAuthToken"
+  > &
+    Partial<Pick<GatewayConfig, "upstreamExtraHeaders">>,
+): void {
+  const gatewayAuthToken = parseGatewayAuthToken(config.gatewayAuthToken);
+  if ((config.remoteGateway || config.hostedMode) && !gatewayAuthToken) {
+    throw new Error(
+      "Remote/hosted gateway mode requires LORE_GATEWAY_AUTH_TOKEN",
+    );
+  }
+  if (hasConflictingAuthHeaders(config.upstreamExtraHeaders)) {
+    throw new Error(
+      "Configured upstream headers contain conflicting authentication mechanisms",
+    );
+  }
+  if (hasGatewayAccessHeader(config.upstreamExtraHeaders)) {
+    throw new Error(
+      "Configured upstream headers cannot contain the gateway access header",
+    );
+  }
+}
+
+function hasGatewayAccessHeader(
+  headers: Record<string, string> | null | undefined,
+): boolean {
+  return Object.keys(headers ?? {}).some(
+    (name) => name.toLowerCase() === GATEWAY_AUTH_HEADER,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -342,6 +450,99 @@ export function resolveUpstreamRoute(model: string): UpstreamRoute | null {
 const MAX_UPSTREAM_URL_LENGTH = 2048;
 
 /**
+ * Parse the administrator allowlist for caller-selected upstream origins.
+ *
+ * Only comma-separated HTTPS origins are accepted. The whole configuration is
+ * rejected on any invalid or normalization-equivalent duplicate entry so an
+ * administrator never gets a silently weakened or ambiguous policy.
+ */
+export function parseCallerUpstreamAllowlist(
+  input: string | undefined,
+): readonly string[] {
+  if (input === undefined || input.trim() === "") return Object.freeze([]);
+
+  const origins: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, entry] of input.split(",").entries()) {
+    const raw = entry.trim();
+    const invalid = (): never => {
+      throw new Error(
+        `Invalid LORE_CALLER_UPSTREAM_ALLOWLIST entry ${index + 1}: expected a unique HTTPS origin`,
+      );
+    };
+    if (
+      !raw ||
+      raw.length > MAX_UPSTREAM_URL_LENGTH ||
+      !/^https:\/\//i.test(raw) ||
+      raw.includes("*") ||
+      raw.includes("\\") ||
+      raw.includes("?") ||
+      raw.includes("#") ||
+      // oxlint-disable-next-line no-control-regex -- reject URL parser normalization of controls/whitespace
+      /[\x00-\x20\x7f]/.test(raw)
+    ) {
+      invalid();
+    }
+    const authorityStart = raw.indexOf("://") + 3;
+    const pathStart = raw.indexOf("/", authorityStart);
+    if (pathStart !== -1 && raw.slice(pathStart) !== "/") invalid();
+    const authority = raw.slice(
+      authorityStart,
+      pathStart === -1 ? raw.length : pathStart,
+    );
+    if (authority.endsWith(":")) invalid();
+
+    const parsed = (() => {
+      try {
+        return new URL(raw);
+      } catch {
+        return invalid();
+      }
+    })();
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== "/" ||
+      !parsed.hostname
+    ) {
+      invalid();
+    }
+
+    const origin = parsed.origin;
+    if (seen.has(origin)) {
+      throw new Error(
+        `Invalid LORE_CALLER_UPSTREAM_ALLOWLIST entry ${index + 1}: duplicate normalized origin`,
+      );
+    }
+    seen.add(origin);
+    origins.push(origin);
+  }
+  return Object.freeze(origins);
+}
+
+/**
+ * Whether this gateway may honor a caller-selected upstream URL. Local mode
+ * deliberately preserves arbitrary HTTP/private inference endpoints; remote
+ * and hosted modes use only the server-side config and require exact origin
+ * membership in the administrator allowlist.
+ */
+export function isCallerUpstreamAllowed(
+  config: Pick<GatewayConfig, "remoteGateway" | "hostedMode"> &
+    Partial<Pick<GatewayConfig, "callerUpstreamAllowlist">>,
+  upstreamUrl: string,
+): boolean {
+  if (!config.remoteGateway && !config.hostedMode) return true;
+  try {
+    const parsed = new URL(upstreamUrl);
+    if (parsed.protocol !== "https:") return false;
+    return (config.callerUpstreamAllowlist ?? []).includes(parsed.origin);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Extract and validate the `X-Lore-Upstream-URL` header from a request.
  *
  * Used by local/custom providers (vllm, llama.cpp, ollama, etc.) to tell the
@@ -376,6 +577,107 @@ export function extractUpstreamUrlHeader(
   } catch {
     return undefined;
   }
+}
+
+/** Strip credentials and non-routing URL components before diagnostic logging. */
+export function upstreamUrlForLog(value: string | null | undefined): string {
+  if (!value) return "none";
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return "invalid";
+    }
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return "invalid";
+  }
+}
+
+/**
+ * Normalize an HTTP(S) upstream base while preserving its path boundary.
+ * Query/fragment/userinfo are never part of a trusted base. Encoded path
+ * separators and dot bytes are rejected (including double encoding) so an
+ * intermediary cannot decode a value into traversal after this check.
+ */
+export function normalizeUpstreamBase(url: string): string | undefined {
+  try {
+    // Inspect the supplied bytes before WHATWG URL normalization can erase a
+    // literal or encoded dot segment. Repeat decoding to catch `%252e` forms.
+    let raw = url;
+    for (let i = 0; i < 4; i++) {
+      // oxlint-disable-next-line no-control-regex -- intentional URL hardening
+      if (raw.includes("\\") || /[\x00-\x1f\x7f]/.test(raw)) return undefined;
+      if (/%(?:0[0-9a-f]|1[0-9a-f]|2e|2f|5c|7f)/i.test(raw)) {
+        return undefined;
+      }
+      const decoded = decodeURIComponent(raw);
+      if (decoded === raw) break;
+      raw = decoded;
+    }
+    const rawPath = raw
+      .replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]*/i, "")
+      .split(/[?#]/, 1)[0];
+    if (rawPath.split("/").some((part) => part === "." || part === "..")) {
+      return undefined;
+    }
+
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    if (parsed.username || parsed.password) return undefined;
+    if (parsed.search || parsed.hash) return undefined;
+    if (parsed.pathname.includes("\\")) return undefined;
+    const segments = parsed.pathname.split("/");
+    if (segments.some((segment) => segment === "." || segment === "..")) {
+      return undefined;
+    }
+    const pathname = parsed.pathname.replace(/\/+$/, "");
+    return parsed.origin + (pathname === "/" ? "" : pathname);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Segment-safe base containment (`/tenant-a` never matches `/tenant-ab`). */
+export function isUpstreamWithinBase(
+  upstreamUrl: string,
+  configuredBase: string,
+): boolean {
+  const destination = normalizeUpstreamBase(upstreamUrl);
+  const base = normalizeUpstreamBase(configuredBase);
+  if (!destination || !base) return false;
+  if (destination === base) return true;
+  return destination.startsWith(`${base}/`);
+}
+
+/**
+ * Return gateway-admin extra headers only when the destination is one of the
+ * configured upstream base paths. Client URL overrides remain supported, but an
+ * arbitrary override never receives gateway-global credentials.
+ */
+export function extraHeadersForUpstream(
+  config: Pick<
+    GatewayConfig,
+    | "upstreamAnthropic"
+    | "upstreamOpenAI"
+    | "workerUpstream"
+    | "upstreamExtraHeaders"
+  > &
+    Partial<Pick<GatewayConfig, "upstreamExtraHeaderBases">>,
+  upstreamUrl: string,
+): Record<string, string> {
+  if (Object.keys(config.upstreamExtraHeaders).length === 0) return {};
+  const trustedBases =
+    config.upstreamExtraHeaderBases ??
+    configuredUpstreamBases([
+      config.upstreamAnthropic,
+      config.upstreamOpenAI,
+      config.workerUpstream,
+    ]);
+  return trustedBases.some((base) => isUpstreamWithinBase(upstreamUrl, base))
+    ? config.upstreamExtraHeaders
+    : {};
 }
 
 /** Maximum allowed length for an upstream path header value. */
@@ -1101,13 +1403,27 @@ function trimTrailingSlash(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
+function configuredUpstreamBases(
+  upstreams: Array<string | undefined>,
+): readonly string[] {
+  return [
+    ...new Set(
+      upstreams
+        .map((upstream) =>
+          upstream ? normalizeUpstreamBase(upstream) : undefined,
+        )
+        .filter((base): base is string => base !== undefined),
+    ),
+  ];
+}
+
 /**
  * Parse curl-style multi-line header blocks into a `Record<string, string>`.
  *
  * Accepts the same format Anthropic's SDK uses for `ANTHROPIC_CUSTOM_HEADERS`
  * and `OpenAI-Organization`-style env-var header lists: one `Name: Value`
  * per line, separated by `\n`. Keys are lowercased and trimmed; values are
- * trimmed. Empty lines and malformed lines (no colon) are skipped with a
+ * trimmed. Empty lines and malformed lines are skipped with a body-independent
  * warning logged to stderr. Returns `{}` when the input is empty/undefined.
  *
  * Header names are validated to contain only printable ASCII (RFC 7230
@@ -1121,13 +1437,13 @@ export function parseCurlHeaders(
 ): Record<string, string> {
   if (!input) return {};
   const out: Record<string, string> = {};
-  for (const rawLine of input.split(/\r?\n/)) {
+  for (const [index, rawLine] of input.split(/\r?\n/).entries()) {
     const line = rawLine.trim();
     if (!line) continue;
     const colonIdx = line.indexOf(":");
     if (colonIdx <= 0) {
       log.notice(
-        `warning: ignoring malformed LORE_UPSTREAM_EXTRA_HEADERS line: ${JSON.stringify(line)}`,
+        `warning: ignoring malformed LORE_UPSTREAM_EXTRA_HEADERS line ${index + 1}`,
       );
       continue;
     }
@@ -1140,7 +1456,7 @@ export function parseCurlHeaders(
     const value = rawValue.replace(/[\x00-\x1f\x7f]/g, "").trim();
     if (!name || !/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(name)) {
       log.notice(
-        `warning: ignoring invalid header name in LORE_UPSTREAM_EXTRA_HEADERS: ${JSON.stringify(rawName)}`,
+        `warning: ignoring invalid header name in LORE_UPSTREAM_EXTRA_HEADERS line ${index + 1}`,
       );
       continue;
     }

--- a/packages/gateway/src/credential-headers.ts
+++ b/packages/gateway/src/credential-headers.ts
@@ -1,0 +1,6 @@
+export {
+  GATEWAY_AUTH_HEADER,
+  KNOWN_SESSION_HEADERS,
+  isCredentialHeaderName,
+  redactCredentialHeaderAssignments,
+} from "@loreai/core";

--- a/packages/gateway/src/fetch.ts
+++ b/packages/gateway/src/fetch.ts
@@ -59,6 +59,23 @@ let undiciHandles: UndiciHandles | null = null;
  */
 let dispatcherOverride: Dispatcher | null = null;
 
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+async function rejectRedirect(response: Response): Promise<Response> {
+  if (!REDIRECT_STATUSES.has(response.status)) return response;
+
+  let cancellationError: unknown;
+  try {
+    await response.body?.cancel();
+  } catch (error) {
+    cancellationError = error;
+  }
+  throw new Error(
+    `Upstream redirect blocked (status ${response.status})`,
+    cancellationError === undefined ? undefined : { cause: cancellationError },
+  );
+}
+
 /**
  * Byte-based queue for the Bun Node-HTTP bridge. Once this queue is full the
  * IncomingMessage is paused, which in turn bounds Node/socket buffering by its
@@ -204,12 +221,13 @@ export function nodeReadableToWebStream(
  * return a standard Web API `Response` with a streaming `ReadableStream` body.
  *
  * Used under Bun where native `fetch` has a hardcoded ~5-min inactivity timeout
- * (oven-sh/bun#16682) that kills long LLM generations mid-stream. Bun's Node
- * compat layer for `node:https` does NOT have this timeout cap (verified on
- * Bun 1.3.14: survives 310s of total silence; native fetch TimeoutErrors at
- * 300s). Also bypasses the fetch interceptor (no `globalThis.fetch` involved).
+ * and by internal loopback probes, where WHATWG Fetch rejects valid listeners
+ * on its browser-defined forbidden-port list. Bun's Node compat layer for
+ * `node:https` does NOT have this timeout cap (verified on Bun 1.3.14: survives
+ * 310s of total silence; native fetch TimeoutErrors at 300s). Also bypasses the
+ * fetch interceptor (no `globalThis.fetch` involved).
  */
-function nodeHttpFetch(
+export function nodeHttpFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
@@ -306,22 +324,26 @@ export async function upstreamFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
+  const safeInit = { ...init, redirect: "manual" as const };
+
   if (isBun) {
     // Bun: use node:https which has no hardcoded timeout cap under Bun's Node
     // compat layer (verified: survives 310s silence; native fetch dies at 300s).
     // Also bypasses the fetch interceptor (no globalThis.fetch involved).
-    return nodeHttpFetch(input, init);
+    const response = await nodeHttpFetch(input, safeInit);
+    return rejectRedirect(response);
   }
 
   // Node: undici with disabled body/header timeouts. undici's fetch types
   // diverge from the global Web API types but are runtime-compatible — cast
   // through unknown to bridge the compile-time gap.
   const { fetch: undiciFetch, dispatcher } = await getUndici();
-  return undiciFetch(
+  const response = (await undiciFetch(
     input as Parameters<UndiciModule["fetch"]>[0],
     {
-      ...init,
+      ...safeInit,
       dispatcher: dispatcherOverride ?? dispatcher,
     } as Parameters<UndiciModule["fetch"]>[1],
-  ) as unknown as Promise<Response>;
+  )) as unknown as Response;
+  return rejectRedirect(response);
 }

--- a/packages/gateway/src/idle.ts
+++ b/packages/gateway/src/idle.ts
@@ -768,7 +768,7 @@ export function startIdleScheduler(
         continue;
 
       warmupInProgress.add(sessionID);
-      executeWarmup(state, profile, config.upstreamExtraHeaders)
+      executeWarmup(state, profile, config)
         .then((result) => {
           // executeWarmup mutates state.warmup (lastWarmupAt, totalWarmups,
           // lastWarmupRefreshTokens). The periodic flush below skips

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -22,7 +22,14 @@ export type { GatewayConfig } from "./config";
 export { startServer } from "./server";
 export { handleRequest, resetPipelineState } from "./pipeline";
 export { readPortFile } from "./portfile";
-export { startGateway, probeGateway } from "./cli/start";
+export { readGatewayProcessFile } from "./pidfile";
+export {
+  startGateway,
+  probeGateway,
+  probeGatewayProcess,
+  probeGatewayProcessHost,
+  probeUrlFor,
+} from "./cli/start";
 export type { GatewayHandle, StartOptions } from "./cli/start";
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway/src/lifecycle-lock.ts
+++ b/packages/gateway/src/lifecycle-lock.ts
@@ -1,0 +1,1869 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+  type Stats,
+} from "node:fs";
+import { homedir } from "node:os";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
+
+const LOCK_VERSION = 1;
+const DIRECTORY_MODE = 0o700;
+const FILE_MODE = 0o600;
+const OWNER_FILE = "owner.json";
+const UNINSTALL_TOMBSTONE_FILE = "uninstalled.json";
+const INITIALIZATION_CLAIM_MARKER = ".init.";
+const INITIALIZATION_QUARANTINE_MARKER = ".claim.init.";
+const RELEASE_CLAIM_MARKER = ".release.";
+const MAX_OWNER_BYTES = 16 * 1024;
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_RETRY_DELAY_MS = 50;
+const NO_FOLLOW = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
+
+/** Lifecycle transitions serialized by the per-user lock. */
+export type LifecycleOperation =
+  | "gateway-start"
+  | "gateway-shutdown"
+  | "upgrade"
+  | "setup"
+  | "uninstall"
+  | "hosted-install";
+
+export interface LifecycleLockOwner {
+  version: 1;
+  token: string;
+  pid: number;
+  operation: LifecycleOperation;
+  createdAt: string;
+  processStartedAt: string;
+  processIdentity: string;
+}
+
+export type ProcessInspection =
+  | { state: "alive"; identity: string | null }
+  | { state: "dead" }
+  | { state: "unknown" };
+
+export interface LifecycleLockOptions {
+  /** Override used by focused tests and embedders with an isolated home. */
+  lockPath?: string;
+  timeoutMs?: number;
+  retryDelayMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  createToken?: () => string;
+  pid?: number;
+  processIdentity?: string;
+  processStartedAt?: string;
+  inspectProcess?: (pid: number) => ProcessInspection;
+  /** Package CLI entry used to recover a tombstone after a fresh install. */
+  packageEntryPath?: string;
+  /** Explicit SEA state for tests; defaults to node:sea inspection. */
+  seaBinary?: boolean;
+  /** Focused crash-injection seam; called after mkdir and before owner publication. */
+  _afterLockDirectoryCreated?: () => void;
+  /** Focused crash-injection seam; called after owner removal and before rmdir. */
+  _afterLockOwnerRemoved?: () => void;
+  /** Focused crash-injection seam after incomplete-generation validation. */
+  _afterLockRecoveryValidated?: () => void;
+}
+
+interface ResolvedOptions {
+  lockPath: string;
+  timeoutMs: number;
+  retryDelayMs: number;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+  createToken: () => string;
+  pid: number;
+  processIdentity?: string;
+  processStartedAt?: string;
+  inspectProcess: (pid: number) => ProcessInspection;
+  packageEntryPath?: string;
+  seaBinary: boolean;
+  afterLockDirectoryCreated?: () => void;
+  afterLockOwnerRemoved?: () => void;
+  afterLockRecoveryValidated?: () => void;
+}
+
+export interface LifecycleLock {
+  readonly path: string;
+  readonly owner: LifecycleLockOwner;
+  assertOwned(): void;
+  release(): void;
+}
+
+export interface UninstallTombstone {
+  version: 1;
+  token: string;
+  createdAt: string;
+}
+
+export interface UninstallTombstoneTransaction {
+  readonly tombstone: UninstallTombstone;
+  rollback(): void;
+}
+
+export class LifecycleLockBusyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LifecycleLockBusyError";
+  }
+}
+
+export class LifecycleLockLostError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LifecycleLockLostError";
+  }
+}
+
+interface LockSnapshot {
+  owner: LifecycleLockOwner;
+  directory: Stats;
+  ownerFile: Stats;
+  ownerContent: string;
+}
+
+interface OwnerRecordSnapshot {
+  owner: LifecycleLockOwner;
+  file: Stats;
+  content: string;
+}
+
+interface OwnerStage extends OwnerRecordSnapshot {
+  path: string;
+  initializationClaimPath: string;
+}
+
+interface ReleaseClaim {
+  version: 1;
+  token: string;
+  directoryDevice: string;
+  directoryInode: string;
+  directoryBirthtimeMs: string;
+  ownerDevice: string;
+  ownerInode: string;
+  ownerSha256: string;
+}
+
+interface ReleaseClaimSnapshot {
+  claim: ReleaseClaim;
+  file: Stats;
+  content: string;
+  path: string;
+}
+
+interface UninstallTombstoneSnapshot {
+  marker: UninstallTombstone;
+  file: Stats;
+  content: string;
+}
+
+interface PackageInvocationEvidence {
+  entryPath: string;
+  entryIdentity: string;
+  manifestPath: string;
+  manifestIdentity: string;
+}
+
+interface CapturedRegularFile {
+  content: Buffer;
+  identity: string;
+}
+
+const lockContext = new AsyncLocalStorage<LifecycleLock>();
+
+/** Run work without propagating the current lifecycle lock to async resources. */
+export function withoutLifecycleLock<T>(action: () => T): T {
+  return lockContext.exit(action);
+}
+const processEntryPath = (() => {
+  try {
+    return require.main?.filename;
+  } catch {
+    return undefined;
+  }
+})();
+
+function errno(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException | undefined)?.code;
+}
+
+function isMissing(error: unknown): boolean {
+  return errno(error) === "ENOENT";
+}
+
+function assertCurrentOwner(info: Stats, path: string): void {
+  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+    throw new LifecycleLockBusyError(
+      `Refusing lifecycle lock path not owned by the current user: ${path}`,
+    );
+  }
+}
+
+function sameFile(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameGeneration(left: Stats, right: Stats): boolean {
+  return (
+    sameFile(left, right) &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs
+  );
+}
+
+function fsyncDirectory(path: string): void {
+  // Node does not expose a portable Windows directory-flush primitive. The
+  // file itself is still flushed before publication there; on Unix, also
+  // persist every directory-entry transition used by the protocol.
+  if (process.platform === "win32") return;
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function validateDirectory(path: string, tighten: boolean): Stats {
+  const before = lstatSync(path);
+  if (before.isSymbolicLink() || !before.isDirectory()) {
+    throw new LifecycleLockBusyError(
+      `Refusing non-directory lifecycle lock path: ${path}`,
+    );
+  }
+  assertCurrentOwner(before, path);
+
+  if (process.platform === "win32") return before;
+
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isDirectory() || !sameFile(before, opened)) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock directory changed while opening: ${path}`,
+      );
+    }
+    assertCurrentOwner(opened, path);
+    if (tighten && (opened.mode & 0o777) !== DIRECTORY_MODE) {
+      fchmodSync(fd, DIRECTORY_MODE);
+    }
+    const finalInfo = fstatSync(fd);
+    if ((finalInfo.mode & 0o077) !== 0) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock directory is not owner-only: ${path}`,
+      );
+    }
+    if (!sameFile(lstatSync(path), finalInfo)) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock directory changed while validating: ${path}`,
+      );
+    }
+    return finalInfo;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function ensureLockParent(lockPath: string): string {
+  const parent = dirname(lockPath);
+  mkdirSync(parent, { recursive: true, mode: DIRECTORY_MODE });
+  validateDirectory(parent, true);
+  return parent;
+}
+
+function validTimestamp(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 64 &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+const OPERATIONS = new Set<LifecycleOperation>([
+  "gateway-start",
+  "gateway-shutdown",
+  "upgrade",
+  "setup",
+  "uninstall",
+  "hosted-install",
+]);
+
+function validOwner(value: unknown): value is LifecycleLockOwner {
+  if (typeof value !== "object" || value === null) return false;
+  const owner = value as Partial<LifecycleLockOwner>;
+  return (
+    owner.version === LOCK_VERSION &&
+    typeof owner.token === "string" &&
+    /^[A-Za-z0-9_-]{32,256}$/.test(owner.token) &&
+    typeof owner.pid === "number" &&
+    Number.isSafeInteger(owner.pid) &&
+    owner.pid > 0 &&
+    typeof owner.operation === "string" &&
+    OPERATIONS.has(owner.operation) &&
+    validTimestamp(owner.createdAt) &&
+    validTimestamp(owner.processStartedAt) &&
+    typeof owner.processIdentity === "string" &&
+    owner.processIdentity.length > 0 &&
+    owner.processIdentity.length <= 1024
+  );
+}
+
+function readOwnerRecord(ownerPath: string): OwnerRecordSnapshot {
+  const before = lstatSync(ownerPath);
+  if (before.isSymbolicLink() || !before.isFile()) {
+    throw new LifecycleLockBusyError(
+      `Refusing non-regular lifecycle lock owner file: ${ownerPath}`,
+    );
+  }
+  assertCurrentOwner(before, ownerPath);
+  if (before.size > MAX_OWNER_BYTES) {
+    throw new LifecycleLockBusyError(
+      `Lifecycle lock owner record is too large: ${ownerPath}`,
+    );
+  }
+
+  const fd = openSync(
+    ownerPath,
+    constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW,
+  );
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || !sameFile(before, opened)) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock owner file changed while opening: ${ownerPath}`,
+      );
+    }
+    assertCurrentOwner(opened, ownerPath);
+    if (process.platform !== "win32" && (opened.mode & 0o077) !== 0) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock owner file is not owner-only: ${ownerPath}`,
+      );
+    }
+    const content = readFileSync(fd, "utf8");
+    const finalInfo = fstatSync(fd);
+    if (
+      content.length > MAX_OWNER_BYTES ||
+      !sameGeneration(opened, finalInfo) ||
+      !sameFile(lstatSync(ownerPath), finalInfo)
+    ) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock owner record changed while reading: ${ownerPath}`,
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock owner record is malformed: ${ownerPath}`,
+      );
+    }
+    if (!validOwner(parsed)) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle lock owner record is invalid: ${ownerPath}`,
+      );
+    }
+    return { owner: parsed, file: finalInfo, content };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function inspectLockPath(lockPath: string): LockSnapshot {
+  const directory = validateDirectory(lockPath, false);
+  const ownerRecord = readOwnerRecord(join(lockPath, OWNER_FILE));
+  if (!sameFile(lstatSync(lockPath), directory)) {
+    throw new LifecycleLockBusyError(
+      `Lifecycle lock changed while inspecting: ${lockPath}`,
+    );
+  }
+  return {
+    owner: ownerRecord.owner,
+    directory,
+    ownerFile: ownerRecord.file,
+    ownerContent: ownerRecord.content,
+  };
+}
+
+export interface StableUnixProcessMetadata {
+  /** Stable boot generation, such as Linux procfs boot_id. */
+  bootId?: string | null;
+  /** Monotonic process start tick within that boot generation. */
+  startTicks?: string | null;
+  /**
+   * Weak compatibility metadata, intentionally never sufficient for identity.
+   * macOS/BSD `ps -o lstart=` has only one-second resolution, so two process
+   * generations can share it.
+   */
+  secondResolutionStartedAt?: string | null;
+}
+
+/** Build an identity only from stable sub-second process-generation metadata. */
+export function stableUnixProcessIdentity(
+  metadata: StableUnixProcessMetadata,
+  prefix = "unix-procfs",
+): string | null {
+  const bootId = metadata.bootId?.trim();
+  const startTicks = metadata.startTicks?.trim();
+  if (!bootId || !startTicks || !/^\d+$/.test(startTicks)) return null;
+  return `${prefix}:${bootId}:${startTicks}`;
+}
+
+function procfsProcessIdentity(pid: number, prefix: string): string | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const closeParen = stat.lastIndexOf(")");
+    if (closeParen === -1) return null;
+    // The suffix begins at field 3 (state); process start ticks are field 22.
+    const fields = stat
+      .slice(closeParen + 2)
+      .trim()
+      .split(/\s+/);
+    const startTicks = fields[19];
+    if (!startTicks || !/^\d+$/.test(startTicks)) return null;
+    const bootId = readFileSync(
+      "/proc/sys/kernel/random/boot_id",
+      "utf8",
+    ).trim();
+    return stableUnixProcessIdentity({ bootId, startTicks }, prefix);
+  } catch {
+    return null;
+  }
+}
+
+function processIdentity(pid: number): string | null {
+  if (process.platform === "win32") return null;
+  // Linux keeps its established boot-id/start-ticks representation. Other
+  // Unix platforms may use the same strong procfs metadata when available;
+  // otherwise fail closed. Never fall back to one-second `ps lstart` output.
+  if (process.platform === "linux") return procfsProcessIdentity(pid, "linux");
+  return procfsProcessIdentity(pid, "unix-procfs");
+}
+
+/** Stable process-start identity when the current platform exposes one. */
+export function currentProcessIdentity(
+  pid: number = process.pid,
+): string | null {
+  return processIdentity(pid);
+}
+
+/** Inspect liveness and process-start identity as one generation check. */
+export function inspectProcessGeneration(pid: number): ProcessInspection {
+  try {
+    process.kill(pid, 0);
+  } catch (error) {
+    if (errno(error) === "ESRCH") return { state: "dead" };
+    return { state: "unknown" };
+  }
+  return { state: "alive", identity: processIdentity(pid) };
+}
+
+function defaultLifecycleRoot(): string {
+  // The global test harness isolates LORE_DB_PATH but intentionally does not
+  // replace HOME. Derive an equally isolated config root so gateway tests can
+  // never create a lock in the developer's real ~/.lore directory.
+  if (process.env.NODE_ENV === "test" && process.env.LORE_DB_PATH) {
+    return join(dirname(process.env.LORE_DB_PATH), ".lore");
+  }
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+  // Install provenance and lifecycle serialization are fixed per-user state,
+  // not relocatable runtime configuration. The hosted installer uses this
+  // same path even when LORE_CONFIG_DIR points elsewhere.
+  return join(home, ".lore");
+}
+
+/** Path to the per-user lifecycle lock, outside purgeable runtime/data state. */
+export function lifecycleLockPath(): string {
+  return join(defaultLifecycleRoot(), "lifecycle.lock");
+}
+
+function resolveOptions(options: LifecycleLockOptions): ResolvedOptions {
+  return {
+    lockPath: options.lockPath ?? lifecycleLockPath(),
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    retryDelayMs: options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS,
+    now: options.now ?? Date.now,
+    sleep:
+      options.sleep ??
+      ((ms) => new Promise((resolve) => setTimeout(resolve, ms))),
+    createToken:
+      options.createToken ?? (() => randomBytes(32).toString("base64url")),
+    pid: options.pid ?? process.pid,
+    processIdentity: options.processIdentity,
+    processStartedAt: options.processStartedAt,
+    inspectProcess: options.inspectProcess ?? inspectProcessGeneration,
+    packageEntryPath: options.packageEntryPath ?? processEntryPath,
+    seaBinary: options.seaBinary ?? isSeaBinary(),
+    afterLockDirectoryCreated: options._afterLockDirectoryCreated,
+    afterLockOwnerRemoved: options._afterLockOwnerRemoved,
+    afterLockRecoveryValidated: options._afterLockRecoveryValidated,
+  };
+}
+
+function isSeaBinary(): boolean {
+  try {
+    const sea = require("node:sea") as { isSea?: () => boolean };
+    return typeof sea.isSea === "function" ? sea.isSea() : false;
+  } catch {
+    return false;
+  }
+}
+
+function pathIsInside(path: string, parent: string): boolean {
+  const rel = relative(resolve(parent), resolve(path));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function captureRegularFile(path: string): CapturedRegularFile | null {
+  let fd: number | undefined;
+  try {
+    const before = lstatSync(path, { bigint: true });
+    if (!before.isFile() || before.isSymbolicLink()) return null;
+    fd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW);
+    const opened = fstatSync(fd, { bigint: true });
+    if (
+      !opened.isFile() ||
+      opened.dev !== before.dev ||
+      opened.ino !== before.ino
+    ) {
+      return null;
+    }
+    const content = readFileSync(fd);
+    const final = fstatSync(fd, { bigint: true });
+    if (
+      opened.dev !== final.dev ||
+      opened.ino !== final.ino ||
+      opened.size !== final.size ||
+      opened.mtimeNs !== final.mtimeNs ||
+      opened.ctimeNs !== final.ctimeNs
+    ) {
+      return null;
+    }
+    return {
+      content,
+      identity: [
+        final.dev,
+        final.ino,
+        final.size,
+        final.mtimeNs,
+        final.ctimeNs,
+        createHash("sha256").update(content).digest("hex"),
+      ].join(":"),
+    };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function regularFileIdentity(path: string): string | null {
+  return captureRegularFile(path)?.identity ?? null;
+}
+
+function packageInvocationEvidence(input: {
+  entryPath?: string;
+  seaBinary: boolean;
+}): PackageInvocationEvidence | null {
+  if (input.seaBinary || !input.entryPath) return null;
+  try {
+    const entryPath = realpathSync.native(input.entryPath);
+    const packageRoot = dirname(dirname(entryPath));
+    if (
+      basename(entryPath) !== "bin.cjs" ||
+      basename(dirname(entryPath)) !== "dist" ||
+      basename(packageRoot) !== "gateway" ||
+      basename(dirname(packageRoot)) !== "@loreai" ||
+      basename(dirname(dirname(packageRoot))) !== "node_modules" ||
+      !pathIsInside(entryPath, packageRoot)
+    ) {
+      return null;
+    }
+    const manifestPath = join(packageRoot, "package.json");
+    if (realpathSync.native(manifestPath) !== manifestPath) return null;
+    const entry = captureRegularFile(entryPath);
+    const capturedManifest = captureRegularFile(manifestPath);
+    if (entry === null || capturedManifest === null) return null;
+    const manifest = JSON.parse(capturedManifest.content.toString("utf8")) as {
+      name?: unknown;
+      bin?: unknown;
+    };
+    if (
+      manifest.name !== "@loreai/gateway" ||
+      typeof manifest.bin !== "object" ||
+      manifest.bin === null
+    ) {
+      return null;
+    }
+    const bins = manifest.bin as Record<string, unknown>;
+    const declaredEntries = [bins.lore, bins["lore-gateway"]].filter(
+      (value): value is string => typeof value === "string",
+    );
+    if (
+      declaredEntries.length === 0 ||
+      !declaredEntries.some((declared) => {
+        const declaredPath = resolve(packageRoot, declared);
+        return (
+          pathIsInside(declaredPath, packageRoot) &&
+          realpathSync.native(declaredPath) === entryPath
+        );
+      })
+    ) {
+      return null;
+    }
+    return {
+      entryPath,
+      entryIdentity: entry.identity,
+      manifestPath,
+      manifestIdentity: capturedManifest.identity,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** True only for the declared CLI entry of an installed @loreai/gateway package. */
+export function isVerifiedPackageInvocation(input: {
+  entryPath?: string;
+  seaBinary?: boolean;
+}): boolean {
+  return (
+    packageInvocationEvidence({
+      entryPath: input.entryPath,
+      seaBinary: input.seaBinary ?? isSeaBinary(),
+    }) !== null
+  );
+}
+
+function packageEvidenceStillMatches(
+  evidence: PackageInvocationEvidence,
+): boolean {
+  return (
+    regularFileIdentity(evidence.entryPath) === evidence.entryIdentity &&
+    regularFileIdentity(evidence.manifestPath) === evidence.manifestIdentity
+  );
+}
+
+function uninstallTombstonePath(lockPath: string): string {
+  return join(dirname(lockPath), UNINSTALL_TOMBSTONE_FILE);
+}
+
+function validUninstallTombstone(value: unknown): value is UninstallTombstone {
+  if (typeof value !== "object" || value === null) return false;
+  const marker = value as Partial<UninstallTombstone>;
+  return (
+    marker.version === 1 &&
+    typeof marker.token === "string" &&
+    /^[A-Za-z0-9_-]{32,256}$/.test(marker.token) &&
+    validTimestamp(marker.createdAt)
+  );
+}
+
+function readUninstallTombstoneSnapshot(
+  lockPath: string,
+): UninstallTombstoneSnapshot | null {
+  const path = uninstallTombstonePath(lockPath);
+  let before: Stats;
+  try {
+    before = lstatSync(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw new LifecycleLockBusyError(
+      `Uninstall marker could not be inspected: ${path}: ${String(error)}`,
+    );
+  }
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw new LifecycleLockBusyError(
+      `Refusing unsafe uninstall marker: ${path}`,
+    );
+  }
+  assertCurrentOwner(before, path);
+  if (before.size > MAX_OWNER_BYTES) {
+    throw new LifecycleLockBusyError(`Uninstall marker is too large: ${path}`);
+  }
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW,
+  );
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || !sameFile(before, opened)) {
+      throw new LifecycleLockBusyError(
+        `Uninstall marker changed while opening: ${path}`,
+      );
+    }
+    assertCurrentOwner(opened, path);
+    if (process.platform !== "win32" && (opened.mode & 0o077) !== 0) {
+      throw new LifecycleLockBusyError(
+        `Uninstall marker is not owner-only: ${path}`,
+      );
+    }
+    let content: string;
+    let parsed: unknown;
+    try {
+      content = readFileSync(fd, "utf8");
+      parsed = JSON.parse(content);
+    } catch {
+      throw new LifecycleLockBusyError(
+        `Uninstall marker is malformed: ${path}`,
+      );
+    }
+    if (!validUninstallTombstone(parsed)) {
+      throw new LifecycleLockBusyError(`Uninstall marker is invalid: ${path}`);
+    }
+    const final = fstatSync(fd);
+    if (!sameGeneration(opened, final)) {
+      throw new LifecycleLockBusyError(
+        `Uninstall marker changed while reading: ${path}`,
+      );
+    }
+    return { marker: parsed, file: final, content };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function readUninstallTombstone(lockPath: string): UninstallTombstone | null {
+  return readUninstallTombstoneSnapshot(lockPath)?.marker ?? null;
+}
+
+function publishUninstallTombstone(
+  lock: LifecycleLock,
+  marker: UninstallTombstone,
+): void {
+  lock.assertOwned();
+  const parent = ensureLockParent(lock.path);
+  const path = uninstallTombstonePath(lock.path);
+  const temp = join(parent, `.${UNINSTALL_TOMBSTONE_FILE}.${marker.token}.tmp`);
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      temp,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | NO_FOLLOW,
+      FILE_MODE,
+    );
+    if (process.platform !== "win32") fchmodSync(fd, FILE_MODE);
+    writeFileSync(fd, `${JSON.stringify(marker)}\n`, "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    lock.assertOwned();
+    renameSync(temp, path);
+    if (readUninstallTombstone(lock.path)?.token !== marker.token) {
+      throw new LifecycleLockLostError(
+        `Uninstall marker changed during publication: ${path}`,
+      );
+    }
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(temp, { force: true });
+  }
+}
+
+function removeUninstallTombstone(
+  lock: LifecycleLock,
+  expectedToken: string,
+  expected?: UninstallTombstoneSnapshot,
+): void {
+  lock.assertOwned();
+  const current = readUninstallTombstoneSnapshot(lock.path);
+  if (current === null) {
+    if (expected) {
+      throw new LifecycleLockLostError(
+        "Uninstall marker changed during expected-token quarantine",
+      );
+    }
+    return;
+  }
+  if (current.marker.token !== expectedToken) {
+    throw new LifecycleLockLostError(
+      "Refusing to remove a successor uninstall marker",
+    );
+  }
+  if (
+    expected &&
+    (!sameFile(current.file, expected.file) ||
+      current.content !== expected.content)
+  ) {
+    throw new LifecycleLockLostError(
+      "Refusing to remove a successor uninstall marker",
+    );
+  }
+  const path = uninstallTombstonePath(lock.path);
+  const claim = join(
+    dirname(path),
+    `.${UNINSTALL_TOMBSTONE_FILE}.claim.${expectedToken}.${randomBytes(8).toString("hex")}`,
+  );
+  try {
+    renameSync(path, claim);
+  } catch (error) {
+    if (isMissing(error)) {
+      throw new LifecycleLockLostError(
+        "Uninstall marker changed during expected-token quarantine",
+      );
+    }
+    throw error;
+  }
+  try {
+    const claimInfo = lstatSync(claim);
+    if (
+      !claimInfo.isFile() ||
+      claimInfo.isSymbolicLink() ||
+      !sameFile(current.file, claimInfo)
+    ) {
+      throw new LifecycleLockLostError(
+        "Uninstall marker changed during expected-token quarantine",
+      );
+    }
+    assertCurrentOwner(claimInfo, claim);
+    const claimFd = openSync(
+      claim,
+      constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW,
+    );
+    try {
+      const opened = fstatSync(claimFd);
+      const content = readFileSync(claimFd, "utf8");
+      const final = fstatSync(claimFd);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(content);
+      } catch {
+        parsed = null;
+      }
+      if (
+        !sameFile(claimInfo, opened) ||
+        !sameGeneration(opened, final) ||
+        content !== current.content ||
+        !validUninstallTombstone(parsed) ||
+        parsed.token !== expectedToken
+      ) {
+        throw new LifecycleLockLostError(
+          "Uninstall marker changed during expected-token quarantine",
+        );
+      }
+    } finally {
+      closeSync(claimFd);
+    }
+    unlinkSync(claim);
+    if (readUninstallTombstoneSnapshot(lock.path) !== null) {
+      throw new LifecycleLockLostError(
+        "Refusing to remove a successor uninstall marker",
+      );
+    }
+  } catch (error) {
+    try {
+      lstatSync(path);
+    } catch (pathError) {
+      if (isMissing(pathError)) {
+        try {
+          linkSync(claim, path);
+          unlinkSync(claim);
+        } catch {
+          // Preserve the claim if a safe no-clobber restoration is impossible.
+        }
+      }
+    }
+    throw error;
+  }
+}
+
+/** Publish a persistent uninstall generation before destructive mutation. */
+export function createUninstallTombstone(
+  lock: LifecycleLock,
+): UninstallTombstoneTransaction {
+  lock.assertOwned();
+  const previous = readUninstallTombstone(lock.path);
+  const tombstone: UninstallTombstone = {
+    version: 1,
+    token: randomBytes(32).toString("base64url"),
+    createdAt: new Date().toISOString(),
+  };
+  publishUninstallTombstone(lock, tombstone);
+  return {
+    tombstone,
+    rollback: () => {
+      lock.assertOwned();
+      if (readUninstallTombstone(lock.path)?.token !== tombstone.token) {
+        throw new LifecycleLockLostError(
+          "Refusing to roll back a successor uninstall marker",
+        );
+      }
+      if (previous) publishUninstallTombstone(lock, previous);
+      else removeUninstallTombstone(lock, tombstone.token);
+    },
+  };
+}
+
+export function currentUninstallTombstoneToken(
+  lock: LifecycleLock,
+): string | null {
+  lock.assertOwned();
+  return readUninstallTombstone(lock.path)?.token ?? null;
+}
+
+/** Clear a marker only after a fresh installer verifies binary and receipt. */
+export function clearUninstallTombstoneForVerifiedInstall(
+  lock: LifecycleLock,
+  expectedToken: string,
+  verifyInstalledGeneration: () => boolean,
+): void {
+  lock.assertOwned();
+  const expected = readUninstallTombstoneSnapshot(lock.path);
+  if (expected?.marker.token !== expectedToken) {
+    throw new LifecycleLockLostError(
+      "Fresh install no longer matches the current uninstall generation",
+    );
+  }
+  if (!verifyInstalledGeneration()) {
+    throw new Error(
+      "Refusing to clear uninstall marker before binary/receipt verification",
+    );
+  }
+  removeUninstallTombstone(lock, expectedToken, expected);
+}
+
+function sameTombstoneGeneration(
+  left: UninstallTombstone | null,
+  right: UninstallTombstone | null,
+): boolean {
+  return left?.token === right?.token && (left === null) === (right === null);
+}
+
+function observationMayProceed(
+  operation: LifecycleOperation,
+  observed: UninstallTombstone | null,
+  current: UninstallTombstone | null,
+): boolean {
+  if (operation === "uninstall" || operation === "gateway-shutdown")
+    return true;
+  if (operation === "hosted-install") {
+    // A fresh installer loaded after uninstall may recover. An installer that
+    // was already waiting when the marker appeared is stale and must abort.
+    return sameTombstoneGeneration(observed, current);
+  }
+  return current === null && sameTombstoneGeneration(observed, current);
+}
+
+function lockArtifactPrefix(lockPath: string, marker: string): string {
+  return `.${basename(lockPath)}${marker}`;
+}
+
+function sameOwnerRecord(
+  left: OwnerRecordSnapshot,
+  right: OwnerRecordSnapshot,
+): boolean {
+  return sameFile(left.file, right.file) && left.content === right.content;
+}
+
+function createOwnerStage(
+  lockPath: string,
+  owner: LifecycleLockOwner,
+): OwnerStage {
+  const parent = dirname(lockPath);
+  const path = join(
+    parent,
+    `${lockArtifactPrefix(lockPath, ".owner.")}${owner.token}.${randomBytes(8).toString("hex")}.tmp`,
+  );
+  const initializationClaimPath = join(
+    parent,
+    `${lockArtifactPrefix(lockPath, INITIALIZATION_CLAIM_MARKER)}${owner.token}`,
+  );
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | NO_FOLLOW,
+      FILE_MODE,
+    );
+    const info = fstatSync(fd);
+    if (!info.isFile()) {
+      throw new Error(`Failed to stage lifecycle lock owner: ${path}`);
+    }
+    assertCurrentOwner(info, path);
+    if (process.platform !== "win32") fchmodSync(fd, FILE_MODE);
+    writeFileSync(fd, `${JSON.stringify(owner)}\n`, "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    fsyncDirectory(parent);
+    const staged = readOwnerRecord(path);
+    if (
+      staged.owner.token !== owner.token ||
+      staged.owner.pid !== owner.pid ||
+      staged.owner.processIdentity !== owner.processIdentity
+    ) {
+      throw new LifecycleLockLostError(
+        `Lifecycle lock owner changed during staging: ${path}`,
+      );
+    }
+    return { ...staged, path, initializationClaimPath };
+  } catch (error) {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(path, { force: true });
+    throw error;
+  }
+}
+
+function removeExpectedOwnerRecord(
+  path: string,
+  expected: OwnerRecordSnapshot,
+): void {
+  let current: OwnerRecordSnapshot;
+  try {
+    current = readOwnerRecord(path);
+  } catch (error) {
+    if (isMissing(error)) return;
+    throw error;
+  }
+  if (!sameOwnerRecord(current, expected)) {
+    throw new LifecycleLockLostError(
+      `Refusing to remove a changed lifecycle generation artifact: ${path}`,
+    );
+  }
+  unlinkSync(path);
+  fsyncDirectory(dirname(path));
+}
+
+function publishInitializationClaim(stage: OwnerStage): void {
+  const currentStage = readOwnerRecord(stage.path);
+  if (!sameOwnerRecord(currentStage, stage)) {
+    throw new LifecycleLockLostError(
+      `Lifecycle owner stage changed before claim publication: ${stage.path}`,
+    );
+  }
+  try {
+    linkSync(stage.path, stage.initializationClaimPath);
+  } catch (error) {
+    if (errno(error) !== "EEXIST") throw error;
+    const existing = readOwnerRecord(stage.initializationClaimPath);
+    if (!sameOwnerRecord(existing, stage)) {
+      throw new LifecycleLockBusyError(
+        `Refusing occupied lifecycle initialization claim: ${stage.initializationClaimPath}`,
+      );
+    }
+  }
+  const claim = readOwnerRecord(stage.initializationClaimPath);
+  if (!sameOwnerRecord(claim, stage)) {
+    throw new LifecycleLockLostError(
+      `Lifecycle initialization claim changed during publication: ${stage.initializationClaimPath}`,
+    );
+  }
+  fsyncDirectory(dirname(stage.initializationClaimPath));
+}
+
+function emptyLockDirectory(lockPath: string): Stats | null {
+  try {
+    const before = validateDirectory(lockPath, false);
+    if (readdirSync(lockPath).length !== 0) return null;
+    const after = validateDirectory(lockPath, false);
+    return sameGeneration(before, after) ? after : null;
+  } catch (error) {
+    if (isMissing(error) || error instanceof LifecycleLockBusyError)
+      return null;
+    throw error;
+  }
+}
+
+interface InitializationClaimSnapshot extends OwnerRecordSnapshot {
+  path: string;
+}
+
+function initializationClaims(lockPath: string): InitializationClaimSnapshot[] {
+  const parent = dirname(lockPath);
+  const prefix = lockArtifactPrefix(lockPath, INITIALIZATION_CLAIM_MARKER);
+  const before = validateDirectory(parent, false);
+  const claims = readdirSync(parent)
+    .filter((entry) => entry.startsWith(prefix))
+    .map((entry) => {
+      const token = entry.slice(prefix.length);
+      if (!/^[A-Za-z0-9_-]{32,256}$/.test(token)) {
+        throw new LifecycleLockBusyError(
+          `Refusing malformed lifecycle initialization claim: ${join(parent, entry)}`,
+        );
+      }
+      const path = join(parent, entry);
+      const snapshot = readOwnerRecord(path);
+      if (snapshot.owner.token !== token) {
+        throw new LifecycleLockBusyError(
+          `Lifecycle initialization claim token does not match its path: ${path}`,
+        );
+      }
+      return { ...snapshot, path };
+    });
+  const after = validateDirectory(parent, false);
+  if (!sameGeneration(before, after)) {
+    throw new LifecycleLockBusyError(
+      `Lifecycle initialization claims changed while inspecting: ${parent}`,
+    );
+  }
+  return claims;
+}
+
+function statComponent(value: number): string {
+  return String(value);
+}
+
+function releaseClaimFor(snapshot: LockSnapshot): ReleaseClaim {
+  return {
+    version: 1,
+    token: snapshot.owner.token,
+    directoryDevice: statComponent(snapshot.directory.dev),
+    directoryInode: statComponent(snapshot.directory.ino),
+    directoryBirthtimeMs: String(snapshot.directory.birthtimeMs),
+    ownerDevice: statComponent(snapshot.ownerFile.dev),
+    ownerInode: statComponent(snapshot.ownerFile.ino),
+    ownerSha256: createHash("sha256")
+      .update(snapshot.ownerContent)
+      .digest("hex"),
+  };
+}
+
+function validReleaseClaim(value: unknown): value is ReleaseClaim {
+  if (typeof value !== "object" || value === null) return false;
+  const claim = value as Partial<ReleaseClaim>;
+  return (
+    claim.version === 1 &&
+    typeof claim.token === "string" &&
+    /^[A-Za-z0-9_-]{32,256}$/.test(claim.token) &&
+    typeof claim.directoryDevice === "string" &&
+    /^\d+$/.test(claim.directoryDevice) &&
+    typeof claim.directoryInode === "string" &&
+    /^\d+$/.test(claim.directoryInode) &&
+    typeof claim.directoryBirthtimeMs === "string" &&
+    /^\d+(?:\.\d+)?$/.test(claim.directoryBirthtimeMs) &&
+    typeof claim.ownerDevice === "string" &&
+    /^\d+$/.test(claim.ownerDevice) &&
+    typeof claim.ownerInode === "string" &&
+    /^\d+$/.test(claim.ownerInode) &&
+    typeof claim.ownerSha256 === "string" &&
+    /^[a-f0-9]{64}$/.test(claim.ownerSha256)
+  );
+}
+
+function readReleaseClaim(path: string): ReleaseClaimSnapshot {
+  const before = lstatSync(path);
+  if (before.isSymbolicLink() || !before.isFile()) {
+    throw new LifecycleLockBusyError(
+      `Refusing non-regular lifecycle release claim: ${path}`,
+    );
+  }
+  assertCurrentOwner(before, path);
+  if (before.size > MAX_OWNER_BYTES) {
+    throw new LifecycleLockBusyError(
+      `Lifecycle release claim is too large: ${path}`,
+    );
+  }
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_NONBLOCK | NO_FOLLOW,
+  );
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || !sameFile(before, opened)) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle release claim changed while opening: ${path}`,
+      );
+    }
+    assertCurrentOwner(opened, path);
+    if (process.platform !== "win32" && (opened.mode & 0o077) !== 0) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle release claim is not owner-only: ${path}`,
+      );
+    }
+    const content = readFileSync(fd, "utf8");
+    const finalInfo = fstatSync(fd);
+    if (
+      !sameGeneration(opened, finalInfo) ||
+      !sameFile(lstatSync(path), finalInfo)
+    ) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle release claim changed while reading: ${path}`,
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      throw new LifecycleLockBusyError(
+        `Lifecycle release claim is malformed: ${path}`,
+      );
+    }
+    if (!validReleaseClaim(parsed)) {
+      throw new LifecycleLockBusyError(
+        `Lifecycle release claim is invalid: ${path}`,
+      );
+    }
+    return { claim: parsed, file: finalInfo, content, path };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function releaseClaimMatchesDirectory(
+  claim: ReleaseClaim,
+  directory: Stats,
+): boolean {
+  return (
+    claim.directoryDevice === statComponent(directory.dev) &&
+    claim.directoryInode === statComponent(directory.ino) &&
+    claim.directoryBirthtimeMs === String(directory.birthtimeMs)
+  );
+}
+
+function matchingReleaseClaims(
+  lockPath: string,
+  directory: Stats,
+): ReleaseClaimSnapshot[] {
+  const parent = dirname(lockPath);
+  const prefix = lockArtifactPrefix(lockPath, RELEASE_CLAIM_MARKER);
+  const claims = readdirSync(parent)
+    .filter((entry) => entry.startsWith(prefix))
+    .map((entry) => {
+      const token = entry.slice(prefix.length);
+      if (!/^[A-Za-z0-9_-]{32,256}$/.test(token)) {
+        throw new LifecycleLockBusyError(
+          `Refusing malformed lifecycle release claim: ${join(parent, entry)}`,
+        );
+      }
+      const claim = readReleaseClaim(join(parent, entry));
+      if (claim.claim.token !== token) {
+        throw new LifecycleLockBusyError(
+          `Lifecycle release claim token does not match its path: ${claim.path}`,
+        );
+      }
+      return claim;
+    })
+    .filter((claim) => releaseClaimMatchesDirectory(claim.claim, directory));
+  if (claims.length > 1) {
+    throw new LifecycleLockBusyError(
+      `Multiple lifecycle release claims match the same directory: ${lockPath}`,
+    );
+  }
+  return claims;
+}
+
+function publishOwnerLink(
+  lockPath: string,
+  directory: Stats,
+  stage: OwnerStage,
+): boolean {
+  const ownerPath = join(lockPath, OWNER_FILE);
+  try {
+    linkSync(stage.path, ownerPath);
+  } catch (error) {
+    if (errno(error) === "EEXIST" || isMissing(error)) return false;
+    throw error;
+  }
+  const published = readOwnerRecord(ownerPath);
+  const currentDirectory = validateDirectory(lockPath, false);
+  if (
+    !sameOwnerRecord(published, stage) ||
+    !sameFile(directory, currentDirectory)
+  ) {
+    throw new LifecycleLockLostError(
+      `Lifecycle lock changed during atomic owner publication: ${lockPath}`,
+    );
+  }
+  fsyncDirectory(lockPath);
+  return true;
+}
+
+function quarantineInitializationClaim(
+  lockPath: string,
+  claim: InitializationClaimSnapshot,
+): void {
+  const token = claim.owner.token;
+  const target = join(
+    dirname(lockPath),
+    `${lockArtifactPrefix(lockPath, INITIALIZATION_QUARANTINE_MARKER)}${token}`,
+  );
+  try {
+    linkSync(claim.path, target);
+  } catch (error) {
+    if (isMissing(error)) return;
+    if (errno(error) !== "EEXIST") throw error;
+    const existing = readOwnerRecord(target);
+    if (!sameOwnerRecord(existing, claim)) {
+      throw new LifecycleLockBusyError(
+        `Refusing occupied lifecycle initialization quarantine: ${target}`,
+      );
+    }
+  }
+  const quarantined = readOwnerRecord(target);
+  if (!sameOwnerRecord(quarantined, claim)) {
+    throw new LifecycleLockLostError(
+      `Lifecycle initialization claim changed during quarantine: ${claim.path}`,
+    );
+  }
+  const current = readOwnerRecord(claim.path);
+  if (!sameOwnerRecord(current, claim)) {
+    throw new LifecycleLockLostError(
+      `Lifecycle initialization claim changed before quarantine removal: ${claim.path}`,
+    );
+  }
+  unlinkSync(claim.path);
+  fsyncDirectory(dirname(lockPath));
+}
+
+function removeReleaseClaim(claim: ReleaseClaimSnapshot): void {
+  let current: ReleaseClaimSnapshot;
+  try {
+    current = readReleaseClaim(claim.path);
+  } catch (error) {
+    if (isMissing(error)) return;
+    throw error;
+  }
+  if (
+    !sameFile(current.file, claim.file) ||
+    current.content !== claim.content
+  ) {
+    throw new LifecycleLockLostError(
+      `Refusing to remove a changed lifecycle release claim: ${claim.path}`,
+    );
+  }
+  unlinkSync(claim.path);
+  fsyncDirectory(dirname(claim.path));
+}
+
+function createLockDirectory(
+  options: ResolvedOptions,
+  stage: OwnerStage,
+): boolean {
+  const lockPath = options.lockPath;
+  let claimPublished = false;
+  try {
+    publishInitializationClaim(stage);
+    claimPublished = true;
+
+    let directory: Stats;
+    let created = false;
+    try {
+      mkdirSync(lockPath, { mode: DIRECTORY_MODE });
+      created = true;
+      fsyncDirectory(dirname(lockPath));
+      options.afterLockDirectoryCreated?.();
+      directory = validateDirectory(lockPath, false);
+    } catch (error) {
+      if (errno(error) !== "EEXIST") throw error;
+      const empty = emptyLockDirectory(lockPath);
+      if (empty === null) return false;
+      directory = empty;
+    }
+
+    const releaseClaims = created
+      ? []
+      : matchingReleaseClaims(lockPath, directory);
+    const claims = initializationClaims(lockPath);
+    const ownClaim = claims.find(
+      (claim) =>
+        claim.path === stage.initializationClaimPath &&
+        sameOwnerRecord(claim, stage),
+    );
+    if (!ownClaim) {
+      throw new LifecycleLockLostError(
+        `Lifecycle initialization claim disappeared: ${stage.initializationClaimPath}`,
+      );
+    }
+    const deadClaims: InitializationClaimSnapshot[] = [];
+    for (const claim of claims) {
+      if (claim.path === ownClaim.path) continue;
+      if (ownerIsDefinitivelyStale(claim.owner, options)) {
+        deadClaims.push(claim);
+      } else if (!created && releaseClaims.length === 0) {
+        return false;
+      }
+    }
+    if (!created && releaseClaims.length === 0 && deadClaims.length === 0) {
+      // A trusted but otherwise unclaimed empty path is ambiguous. Only a
+      // dead initializer generation proves this shell is recoverable.
+      return false;
+    }
+    for (const claim of deadClaims) {
+      quarantineInitializationClaim(lockPath, claim);
+    }
+    if (!created) {
+      options.afterLockRecoveryValidated?.();
+    }
+
+    if (!publishOwnerLink(lockPath, directory, stage)) return false;
+    for (const claim of releaseClaims) removeReleaseClaim(claim);
+    return true;
+  } catch (error) {
+    if (error instanceof LifecycleLockBusyError) return false;
+    throw error;
+  } finally {
+    if (claimPublished) {
+      removeExpectedOwnerRecord(stage.initializationClaimPath, stage);
+    }
+  }
+}
+
+function ownerIsDefinitivelyStale(
+  owner: LifecycleLockOwner,
+  options: ResolvedOptions,
+): boolean {
+  const processState = options.inspectProcess(owner.pid);
+  if (processState.state === "dead") return true;
+  if (
+    processState.state !== "alive" ||
+    processState.identity === null ||
+    owner.processIdentity.startsWith("unverified:")
+  ) {
+    return false;
+  }
+  return processState.identity !== owner.processIdentity;
+}
+
+function claimPathFor(lockPath: string, token: string): string {
+  return join(dirname(lockPath), `.${basename(lockPath)}.claim.${token}`);
+}
+
+function moveToTokenClaim(
+  snapshot: LockSnapshot,
+  lockPath: string,
+): string | null {
+  const claimPath = claimPathFor(lockPath, snapshot.owner.token);
+  try {
+    // On Unix, rename may replace an attacker-created empty directory or
+    // symlink. Any pre-existing destination is therefore conservatively busy;
+    // legitimate successful claims are deliberately non-empty and persistent.
+    lstatSync(claimPath);
+    return null;
+  } catch (error) {
+    if (!isMissing(error)) throw error;
+  }
+  try {
+    // The claim directory remains non-empty. If another reclaimer moves the old
+    // lock first, any delayed rename of a successor fails because rename cannot
+    // replace this non-empty expected-token directory on Unix or Windows.
+    renameSync(lockPath, claimPath);
+  } catch (error) {
+    if (
+      isMissing(error) ||
+      ["EEXIST", "ENOTEMPTY", "EPERM", "EACCES"].includes(errno(error) ?? "")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+
+  const claimed = inspectLockPath(claimPath);
+  if (
+    claimed.owner.token !== snapshot.owner.token ||
+    !sameFile(claimed.directory, snapshot.directory) ||
+    !sameFile(claimed.ownerFile, snapshot.ownerFile) ||
+    claimed.ownerContent !== snapshot.ownerContent
+  ) {
+    throw new LifecycleLockLostError(
+      `Lifecycle lock changed during expected-token quarantine: ${lockPath}`,
+    );
+  }
+  fsyncDirectory(dirname(lockPath));
+  return claimPath;
+}
+
+function quarantineStaleLock(
+  snapshot: LockSnapshot,
+  options: ResolvedOptions,
+): boolean {
+  const initializationClaimPath = join(
+    dirname(options.lockPath),
+    `${lockArtifactPrefix(options.lockPath, INITIALIZATION_CLAIM_MARKER)}${snapshot.owner.token}`,
+  );
+  try {
+    const initializationClaim = readOwnerRecord(initializationClaimPath);
+    if (
+      !sameOwnerRecord(initializationClaim, {
+        owner: snapshot.owner,
+        file: snapshot.ownerFile,
+        content: snapshot.ownerContent,
+      })
+    ) {
+      return false;
+    }
+    quarantineInitializationClaim(options.lockPath, {
+      ...initializationClaim,
+      path: initializationClaimPath,
+    });
+  } catch (error) {
+    if (!isMissing(error)) throw error;
+  }
+  const claimPath = moveToTokenClaim(snapshot, options.lockPath);
+  if (!claimPath) return false;
+  // Intentionally preserve stale claim directories. They are tiny and make the
+  // expected-token rename safe against arbitrarily delayed reclaimers/releases.
+  return true;
+}
+
+function sameLockSnapshot(left: LockSnapshot, right: LockSnapshot): boolean {
+  return (
+    sameFile(left.directory, right.directory) &&
+    sameFile(left.ownerFile, right.ownerFile) &&
+    left.ownerContent === right.ownerContent &&
+    left.owner.token === right.owner.token &&
+    left.owner.pid === right.owner.pid &&
+    left.owner.processIdentity === right.owner.processIdentity
+  );
+}
+
+function publishReleaseClaim(
+  lockPath: string,
+  snapshot: LockSnapshot,
+): ReleaseClaimSnapshot {
+  const claim = releaseClaimFor(snapshot);
+  const content = `${JSON.stringify(claim)}\n`;
+  const parent = dirname(lockPath);
+  const path = join(
+    parent,
+    `${lockArtifactPrefix(lockPath, RELEASE_CLAIM_MARKER)}${claim.token}`,
+  );
+  try {
+    const existing = readReleaseClaim(path);
+    if (existing.content !== content) {
+      throw new LifecycleLockLostError(
+        `Refusing occupied lifecycle release claim: ${path}`,
+      );
+    }
+    return existing;
+  } catch (error) {
+    if (!isMissing(error)) throw error;
+  }
+
+  const temp = join(
+    parent,
+    `${lockArtifactPrefix(lockPath, ".release-stage.")}${claim.token}.${randomBytes(8).toString("hex")}.tmp`,
+  );
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      temp,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | NO_FOLLOW,
+      FILE_MODE,
+    );
+    const info = fstatSync(fd);
+    if (!info.isFile()) {
+      throw new Error(`Failed to stage lifecycle release claim: ${temp}`);
+    }
+    assertCurrentOwner(info, temp);
+    if (process.platform !== "win32") fchmodSync(fd, FILE_MODE);
+    writeFileSync(fd, content, "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = undefined;
+    linkSync(temp, path);
+    fsyncDirectory(parent);
+    const published = readReleaseClaim(path);
+    const staged = readReleaseClaim(temp);
+    if (
+      published.content !== content ||
+      !sameFile(published.file, staged.file)
+    ) {
+      throw new LifecycleLockLostError(
+        `Lifecycle release claim changed during publication: ${path}`,
+      );
+    }
+    return published;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(temp, { force: true });
+    fsyncDirectory(parent);
+  }
+}
+
+class LifecycleLockHandle implements LifecycleLock {
+  private released = false;
+
+  constructor(
+    readonly path: string,
+    readonly owner: LifecycleLockOwner,
+    private readonly generation: LockSnapshot,
+    private readonly afterOwnerRemoved?: () => void,
+  ) {}
+
+  assertOwned(): void {
+    if (this.released) {
+      throw new LifecycleLockLostError(
+        `Lifecycle lock has already been released: ${this.path}`,
+      );
+    }
+    let snapshot: LockSnapshot;
+    try {
+      snapshot = inspectLockPath(this.path);
+    } catch (error) {
+      throw new LifecycleLockLostError(
+        `Lifecycle lock ownership could not be verified: ${this.path}: ${String(error)}`,
+      );
+    }
+    if (!sameLockSnapshot(snapshot, this.generation)) {
+      throw new LifecycleLockLostError(
+        `Lifecycle lock is now owned by another operation: ${this.path}`,
+      );
+    }
+  }
+
+  release(): void {
+    if (this.released) return;
+    this.assertOwned();
+    const snapshot = inspectLockPath(this.path);
+    if (!sameLockSnapshot(snapshot, this.generation)) {
+      throw new LifecycleLockLostError(
+        `Refusing to release a successor lifecycle lock: ${this.path}`,
+      );
+    }
+
+    // Durably bind the impending empty-directory window to this exact directory
+    // and owner generation. Recovery accepts that window only while this claim
+    // matches the still-empty directory identity.
+    const releaseClaim = publishReleaseClaim(this.path, snapshot);
+    const finalSnapshot = inspectLockPath(this.path);
+    if (!sameLockSnapshot(finalSnapshot, snapshot)) {
+      throw new LifecycleLockLostError(
+        `Lifecycle lock changed before release: ${this.path}`,
+      );
+    }
+    unlinkSync(join(this.path, OWNER_FILE));
+    this.released = true;
+    fsyncDirectory(this.path);
+    this.afterOwnerRemoved?.();
+    let removedDirectory = false;
+    try {
+      rmdirSync(this.path);
+      removedDirectory = true;
+    } catch (error) {
+      if (
+        !isMissing(error) &&
+        !["EEXIST", "ENOTEMPTY"].includes(errno(error) ?? "")
+      ) {
+        throw error;
+      }
+    }
+    if (removedDirectory) fsyncDirectory(dirname(this.path));
+    removeReleaseClaim(releaseClaim);
+  }
+}
+
+/**
+ * Acquire the per-user lifecycle lock with bounded contention.
+ *
+ * Valid live owners are never stolen based on age. Reclamation is limited to
+ * definitively dead owners or a live PID whose process-start identity differs.
+ * Malformed, untrusted, or unverifiable records remain conservatively busy.
+ */
+export async function acquireLifecycleLock(
+  operation: LifecycleOperation,
+  lockOptions: LifecycleLockOptions = {},
+): Promise<LifecycleLock> {
+  const options = resolveOptions(lockOptions);
+  if (
+    !Number.isFinite(options.timeoutMs) ||
+    options.timeoutMs < 0 ||
+    !Number.isFinite(options.retryDelayMs) ||
+    options.retryDelayMs <= 0
+  ) {
+    throw new TypeError(
+      "Lifecycle lock timeout and retry delay must be finite",
+    );
+  }
+
+  ensureLockParent(options.lockPath);
+  const createdAtMs = options.now();
+  const token = options.createToken();
+  const observedIdentity =
+    options.processIdentity ?? processIdentity(options.pid);
+  const owner: LifecycleLockOwner = {
+    version: LOCK_VERSION,
+    token,
+    pid: options.pid,
+    operation,
+    createdAt: new Date(createdAtMs).toISOString(),
+    processStartedAt:
+      options.processStartedAt ??
+      new Date(createdAtMs - process.uptime() * 1000).toISOString(),
+    processIdentity: observedIdentity ?? `unverified:${token}`,
+  };
+  if (!validOwner(owner)) {
+    throw new TypeError("Invalid lifecycle lock owner identity");
+  }
+  const ownerStage = createOwnerStage(options.lockPath, owner);
+  let ownerStageRemoved = false;
+
+  try {
+    const deadline = createdAtMs + options.timeoutMs;
+    const packageEvidence = packageInvocationEvidence({
+      entryPath: options.packageEntryPath,
+      seaBinary: options.seaBinary,
+    });
+    const observedTombstone = readUninstallTombstoneSnapshot(options.lockPath);
+    let lastOwner: LifecycleLockOwner | null = null;
+    while (true) {
+      if (createLockDirectory(options, ownerStage)) {
+        removeExpectedOwnerRecord(ownerStage.path, ownerStage);
+        ownerStageRemoved = true;
+        const generation = inspectLockPath(options.lockPath);
+        const handle = new LifecycleLockHandle(
+          options.lockPath,
+          owner,
+          generation,
+          options.afterLockOwnerRemoved,
+        );
+        try {
+          handle.assertOwned();
+          const currentTombstone = readUninstallTombstoneSnapshot(
+            options.lockPath,
+          );
+          const packageMayRecover =
+            operation !== "uninstall" &&
+            operation !== "gateway-shutdown" &&
+            operation !== "hosted-install" &&
+            packageEvidence !== null &&
+            observedTombstone !== null &&
+            currentTombstone !== null &&
+            observedTombstone.marker.token === currentTombstone.marker.token &&
+            observedTombstone.content === currentTombstone.content &&
+            sameFile(observedTombstone.file, currentTombstone.file);
+          if (packageMayRecover) {
+            if (!packageEvidenceStillMatches(packageEvidence)) {
+              throw new Error(
+                "Package-managed Lore invocation changed before uninstall recovery",
+              );
+            }
+            removeUninstallTombstone(
+              handle,
+              currentTombstone.marker.token,
+              currentTombstone,
+            );
+          } else if (
+            !observationMayProceed(
+              operation,
+              observedTombstone?.marker ?? null,
+              currentTombstone?.marker ?? null,
+            )
+          ) {
+            throw new Error(
+              observedTombstone === null
+                ? `Refusing stale ${operation} invocation because uninstall completed while it was waiting`
+                : `Lore is uninstalled; run a fresh verified install before ${operation}`,
+            );
+          }
+          return handle;
+        } catch (error) {
+          try {
+            handle.release();
+          } catch (releaseError) {
+            throw new AggregateError(
+              [error, releaseError],
+              "Lifecycle acquisition failed and its lock could not be released",
+            );
+          }
+          throw error;
+        }
+      }
+
+      try {
+        const snapshot = inspectLockPath(options.lockPath);
+        lastOwner = snapshot.owner;
+        if (ownerIsDefinitivelyStale(snapshot.owner, options)) {
+          if (quarantineStaleLock(snapshot, options)) continue;
+        }
+      } catch (error) {
+        if (isMissing(error)) {
+          try {
+            // Missing canonical path is an acquisition race: retry immediately.
+            // A present, empty directory is recovered only by createLockDirectory
+            // when a dead init or matching release generation proves its origin.
+            lstatSync(options.lockPath);
+          } catch (pathError) {
+            if (isMissing(pathError)) continue;
+            throw pathError;
+          }
+        } else if (!(error instanceof LifecycleLockBusyError)) {
+          throw error;
+        }
+        // Malformed/untrusted locks are intentionally false-busy until the
+        // bounded contention deadline rather than being guessed stale.
+      }
+
+      if (options.now() >= deadline) {
+        const detail = lastOwner
+          ? ` by pid ${lastOwner.pid} (${lastOwner.operation})`
+          : " by an untrusted or malformed owner";
+        throw new LifecycleLockBusyError(
+          `Lore lifecycle is busy${detail}; retry after the operation completes`,
+        );
+      }
+      await options.sleep(
+        Math.min(options.retryDelayMs, Math.max(0, deadline - options.now())),
+      );
+    }
+  } finally {
+    if (!ownerStageRemoved) {
+      removeExpectedOwnerRecord(ownerStage.initializationClaimPath, ownerStage);
+      removeExpectedOwnerRecord(ownerStage.path, ownerStage);
+    }
+  }
+}
+
+/** Run a lifecycle transition under the lock, with async-context reentrancy. */
+export async function withLifecycleLock<T>(
+  operation: LifecycleOperation,
+  action: (lock: LifecycleLock) => Promise<T> | T,
+  options: LifecycleLockOptions = {},
+): Promise<T> {
+  const inherited = lockContext.getStore();
+  if (inherited) {
+    inherited.assertOwned();
+    return action(inherited);
+  }
+
+  const lock = await acquireLifecycleLock(operation, options);
+  return lockContext.run(lock, async () => {
+    try {
+      const result = await action(lock);
+      if (
+        operation === "hosted-install" &&
+        readUninstallTombstone(lock.path) !== null
+      ) {
+        throw new Error(
+          "Fresh install did not clear the uninstall marker after verifying its binary/receipt generation",
+        );
+      }
+      return result;
+    } finally {
+      lock.release();
+    }
+  });
+}

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -545,14 +545,14 @@ const MAX_WORKER_PROMPT_SOURCE_BYTES = Math.floor(MAX_WORKER_REQUEST_BYTES / 6);
 const WORKER_RESPONSE_INACTIVITY_MS = 120_000;
 const WORKER_REQUEST_TIMEOUT_MS = 300_000;
 
-/** Return only URL origin metadata; userinfo, path, query, and fragment vanish. */
+/** Retain endpoint routing while stripping userinfo, query, and fragment. */
 function sanitizedWorkerOrigin(rawUrl: string): string {
   try {
     const url = new URL(rawUrl);
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       return "invalid-origin";
     }
-    return url.origin;
+    return `${url.origin}${url.pathname}`;
   } catch {
     return "invalid-origin";
   }
@@ -3338,6 +3338,17 @@ export function _clearLastWorkerError(): void {
   lastWorkerError = undefined;
 }
 
+/** Details about a worker upstream auth rejection (HTTP 401/403). */
+export type AuthRejectionInfo = {
+  status: number;
+  providerID: string;
+  modelID: string;
+  url: string;
+  scheme: "api-key" | "bearer";
+  workerID: string | undefined;
+  sessionID: string | undefined;
+};
+
 /**
  * Create an LLMClient that sends single-turn prompts to the appropriate provider.
  *
@@ -3355,13 +3366,19 @@ export function createGatewayLLMClient(
   upstreams: { anthropic: string; openai: string },
   getAuth: (sessionID?: string, providerID?: string) => AuthCredential | null,
   defaultModel: { providerID: string; modelID: string },
-  opts?: { dedicatedWorkerKey?: boolean; vertexProject?: string },
+  opts?: {
+    dedicatedWorkerKey?: boolean;
+    vertexProject?: string;
+    /** Called with body-independent, URL-sanitized auth rejection details. */
+    onAuthRejected?: (info: AuthRejectionInfo) => void;
+  },
 ): GatewayLLMClient {
   const hasDedicatedKey = opts?.dedicatedWorkerKey === true;
   // Configured GCP project for Vertex workers (else derived from ADC at call
   // time). Threaded so an explicit LORE_VERTEX_PROJECT (without GOOGLE_CLOUD_*)
   // is honored — the session base URL carries the region but never the project.
   const factoryVertexProject = opts?.vertexProject;
+  const onAuthRejected = opts?.onAuthRejected;
   const client: GatewayLLMClient = {
     async prompt(system, user, opts) {
       // Reset at the START of every call so callers see only the last
@@ -4357,6 +4374,21 @@ export function createGatewayLLMClient(
               // --- Auth error: 401/403 — mark stale, re-resolve, retry once ---
               if (AUTH_ERROR_CODES.has(response.status)) {
                 await readWorkerResponseText(response, requestSignal);
+                if (onAuthRejected) {
+                  try {
+                    onAuthRejected({
+                      status: response.status,
+                      providerID: model.providerID,
+                      modelID: model.modelID,
+                      url: sanitizedWorkerOrigin(target.url).replace(/\/$/, ""),
+                      scheme: cred.scheme,
+                      workerID: opts?.workerID,
+                      sessionID: opts?.sessionID,
+                    });
+                  } catch {
+                    // Diagnostics must never break the adapter's null contract.
+                  }
+                }
                 // Mark this provider's credential stale so resolveAuth()
                 // falls through to global — but only for THIS provider,
                 // not other providers on the same session. Requires a real

--- a/packages/gateway/src/pidfile.ts
+++ b/packages/gateway/src/pidfile.ts
@@ -2,29 +2,121 @@
  * PID file management — lets `lore stop` find a gateway started in the
  * background (`lore start --bg`) or foreground.
  *
- * When the gateway starts and owns the server, it writes its own PID to
- * `~/.local/share/lore/gateway.pid`. `lore stop` reads this file to send the
- * process a SIGTERM. The file is removed on clean shutdown; a stale file (from
- * a crash) is harmless — `lore stop` verifies the process is actually alive
- * before signalling, and treats a dead PID as "nothing running."
+ * New gateways write an owner-only control record containing the PID, bound
+ * address, and a random challenge token. `lore stop` must authenticate that
+ * token against the gateway before signalling the PID, preventing PID reuse or
+ * a spoofed public health response from causing an unrelated process to die.
  *
  * Mirrors `portfile.ts` semantics (write/read/remove-if-matches).
  */
-import { join } from "node:path";
-import { writeFileSync, unlinkSync, readFileSync, mkdirSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { basename, join } from "node:path";
+import { linkSync, lstatSync, renameSync, rmSync } from "node:fs";
 import { dataDir } from "@loreai/core";
+import { atomicWriteRuntimeFile, readRuntimeFile } from "./runtime-files";
 
 const PIDFILE_NAME = "gateway.pid";
+
+export interface GatewayProcessRecord {
+  version: 1 | 2;
+  pid: number;
+  port: number;
+  hosts: string[];
+  token: string;
+  processIdentity?: string;
+}
+
+export type ProcessFileInspection =
+  | { state: "absent" }
+  | { state: "valid"; record: GatewayProcessRecord }
+  | { state: "invalid"; reason: string };
+
+export interface LegacyPidFileIdentity {
+  device: bigint;
+  inode: bigint;
+  size: bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+  birthtimeNs: bigint;
+}
+
+export interface LegacyPidFileRecord {
+  pid: number;
+  identity: LegacyPidFileIdentity;
+}
+
+export type LegacyPidRemovalResult = "removed" | "absent" | "changed";
+
+export type PidFileInspection =
+  | { state: "absent" }
+  | { state: "process"; record: GatewayProcessRecord }
+  | { state: "legacy"; record: LegacyPidFileRecord }
+  | { state: "invalid"; reason: string };
 
 function pidfilePath(): string {
   return join(dataDir(), PIDFILE_NAME);
 }
 
-/** Write the current process PID to disk so `lore stop` can find us. */
+function isPid(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function validProcessRecord(value: unknown): value is GatewayProcessRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Partial<GatewayProcessRecord>;
+  return (
+    (record.version === 1 || record.version === 2) &&
+    isPid(record.pid) &&
+    typeof record.port === "number" &&
+    Number.isSafeInteger(record.port) &&
+    record.port > 0 &&
+    record.port <= 65535 &&
+    Array.isArray(record.hosts) &&
+    record.hosts.length > 0 &&
+    record.hosts.every(
+      (host) =>
+        typeof host === "string" && host.length > 0 && host.length <= 255,
+    ) &&
+    typeof record.token === "string" &&
+    record.token.length >= 32 &&
+    record.token.length <= 256 &&
+    (record.version === 1 ||
+      (typeof record.processIdentity === "string" &&
+        record.processIdentity.length > 0 &&
+        record.processIdentity.length <= 1024))
+  );
+}
+
+function generationBoundProcessRecord(
+  record: GatewayProcessRecord,
+): record is GatewayProcessRecord & { version: 2; processIdentity: string } {
+  return record.version === 2 && typeof record.processIdentity === "string";
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.toLowerCase().replace(/^\[|\]$/g, "");
+  return (
+    normalized === "127.0.0.1" ||
+    normalized === "localhost" ||
+    normalized === "::1"
+  );
+}
+
+function writeOwnerOnly(content: string): void {
+  atomicWriteRuntimeFile(PIDFILE_NAME, content);
+}
+
+/** Write a legacy PID-only file. Kept for compatibility and focused tests. */
 export function writePidFile(pid: number = process.pid): void {
-  const dir = dataDir();
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(pidfilePath(), String(pid), "utf8");
+  writeOwnerOnly(String(pid));
+}
+
+/** Write the authenticated process record used by new gateways. */
+export function writeGatewayProcessFile(record: GatewayProcessRecord): void {
+  if (!validProcessRecord(record)) {
+    throw new Error("Invalid gateway process record");
+  }
+  writeOwnerOnly(`${JSON.stringify(record)}\n`);
 }
 
 /**
@@ -34,24 +126,288 @@ export function writePidFile(pid: number = process.pid): void {
  */
 export function removePidFile(expectedPid: number = process.pid): void {
   try {
-    const current = readPidFile();
-    if (current === expectedPid) {
-      unlinkSync(pidfilePath());
+    const inspection = inspectGatewayProcessFile();
+    if (inspection.state === "valid" && inspection.record.pid === expectedPid) {
+      removeGatewayProcessFile(inspection.record);
+      return;
     }
+    const legacy = readLegacyPidFile();
+    if (legacy?.pid === expectedPid) removeLegacyPidFile(legacy);
   } catch {
     /* already gone or unreadable */
   }
 }
 
+function pidFileIdentity(path: string): LegacyPidFileIdentity {
+  const info = lstatSync(path, { bigint: true });
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error(`Refusing non-regular PID file: ${path}`);
+  }
+  if (
+    typeof process.getuid === "function" &&
+    info.uid !== BigInt(process.getuid())
+  ) {
+    throw new Error(`Refusing PID file not owned by the current user: ${path}`);
+  }
+  if (process.platform !== "win32" && (info.mode & 0o077n) !== 0n) {
+    throw new Error(`PID file is not owner-only: ${path}`);
+  }
+  return {
+    device: info.dev,
+    inode: info.ino,
+    size: info.size,
+    mtimeNs: info.mtimeNs,
+    ctimeNs: info.ctimeNs,
+    birthtimeNs: info.birthtimeNs,
+  };
+}
+
+function sameLegacyPidIdentity(
+  left: LegacyPidFileIdentity,
+  right: LegacyPidFileIdentity,
+): boolean {
+  return (
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.birthtimeNs === right.birthtimeNs
+  );
+}
+
+function sameQuarantinedLegacyPidIdentity(
+  left: LegacyPidFileIdentity,
+  right: LegacyPidFileIdentity,
+): boolean {
+  // Renaming changes ctime on Unix. The inode binds the quarantined file to
+  // the observed generation; size and mtime additionally reject in-place
+  // content changes made before the rename.
+  return (
+    left.device === right.device &&
+    left.inode === right.inode &&
+    left.size === right.size &&
+    left.mtimeNs === right.mtimeNs &&
+    left.birthtimeNs === right.birthtimeNs
+  );
+}
+
+function inspectPidFileAt(
+  path: string,
+  runtimeName: string,
+): PidFileInspection {
+  try {
+    const before = pidFileIdentity(path);
+    const content = readRuntimeFile(runtimeName, { ownerOnly: true }).trim();
+    const after = pidFileIdentity(path);
+    if (!sameLegacyPidIdentity(before, after)) {
+      return { state: "invalid", reason: "PID file changed while reading" };
+    }
+    if (/^[1-9]\d*$/.test(content)) {
+      const pid = Number(content);
+      return isPid(pid)
+        ? { state: "legacy", record: { pid, identity: after } }
+        : { state: "invalid", reason: "legacy PID is invalid" };
+    }
+    let value: unknown;
+    try {
+      value = JSON.parse(content);
+    } catch {
+      return { state: "invalid", reason: "PID file is malformed" };
+    }
+    return validProcessRecord(value)
+      ? { state: "process", record: value }
+      : { state: "invalid", reason: "process record has invalid fields" };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { state: "absent" };
+    }
+    return {
+      state: "invalid",
+      reason: `PID file is unreadable or unsafe: ${String(error)}`,
+    };
+  }
+}
+
+/** Inspect one stable PID-file generation without conflating invalid evidence. */
+export function inspectPidFile(): PidFileInspection {
+  return inspectPidFileAt(pidfilePath(), PIDFILE_NAME);
+}
+
+/**
+ * Read a legacy numeric PID together with the exact filesystem generation that
+ * supplied it. Authenticated JSON records and raced/unsafe files return null.
+ */
+export function readLegacyPidFile(): LegacyPidFileRecord | null {
+  const inspection = inspectPidFile();
+  return inspection.state === "legacy" ? inspection.record : null;
+}
+
+/**
+ * Quarantine and remove only the exact legacy PID-file generation observed by
+ * the caller. A replacement is restored without clobbering a newer record, or
+ * retained as a recovery artifact if another successor already occupies the
+ * canonical path.
+ */
+export function removeLegacyPidFile(
+  expected: LegacyPidFileRecord,
+): LegacyPidRemovalResult {
+  const path = pidfilePath();
+  const claimName = `.gateway.pid.legacy-cleanup-${process.pid}-${randomBytes(8).toString("hex")}`;
+  const claimPath = join(dataDir(), claimName);
+  try {
+    renameSync(path, claimPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "absent";
+    throw error;
+  }
+
+  const inspection = inspectPidFileAt(claimPath, claimName);
+  const claimed = inspection.state === "legacy" ? inspection.record : null;
+  if (
+    claimed?.pid === expected.pid &&
+    sameQuarantinedLegacyPidIdentity(claimed.identity, expected.identity)
+  ) {
+    rmSync(claimPath, { force: true });
+    try {
+      lstatSync(path);
+      return "changed";
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return "removed";
+      throw error;
+    }
+  }
+  preserveQuarantinedSuccessor(claimPath, path);
+  return "changed";
+}
+
+function preserveQuarantinedSuccessor(claimPath: string, path: string): void {
+  try {
+    linkSync(claimPath, path);
+    rmSync(claimPath, { force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    // A newer record already occupies the canonical path. Keep this displaced
+    // generation quarantined rather than deleting an unrecognized successor.
+  }
+}
+
+/**
+ * Remove only the exact authenticated process generation. A raced-in successor
+ * is restored with no-clobber semantics or retained as a recovery artifact.
+ */
+export function removeGatewayProcessFile(
+  expected: Pick<GatewayProcessRecord, "pid" | "token" | "processIdentity">,
+): void {
+  const path = pidfilePath();
+  const claimPath = join(
+    dataDir(),
+    `.gateway.pid.cleanup-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+  try {
+    renameSync(path, claimPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+
+  const claimed = inspectGatewayProcessFileAt(claimPath);
+  if (
+    claimed.state === "valid" &&
+    claimed.record.pid === expected.pid &&
+    claimed.record.token === expected.token &&
+    claimed.record.processIdentity === expected.processIdentity
+  ) {
+    rmSync(claimPath, { force: true });
+    return;
+  }
+  preserveQuarantinedSuccessor(claimPath, path);
+}
+
 /** Read the PID file. Returns the PID or null if not found/invalid. */
 export function readPidFile(): number | null {
   try {
-    const content = readFileSync(pidfilePath(), "utf8").trim();
+    const content = readRuntimeFile(PIDFILE_NAME).trim();
+    if (content.startsWith("{")) {
+      const record = JSON.parse(content) as unknown;
+      return validProcessRecord(record) ? record.pid : null;
+    }
     const pid = Number.parseInt(content, 10);
     return pid > 0 ? pid : null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Read a new authenticated process record. Legacy numeric PID files return
+ * null: they cannot establish process ownership and must never be signalled.
+ */
+export function readGatewayProcessFile(): GatewayProcessRecord | null {
+  try {
+    const value = JSON.parse(
+      readRuntimeFile(PIDFILE_NAME, { ownerOnly: true }),
+    ) as unknown;
+    return validProcessRecord(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function inspectGatewayProcessFileAt(path?: string): ProcessFileInspection {
+  try {
+    const content = path
+      ? readFileAtClaim(path)
+      : readRuntimeFile(PIDFILE_NAME, { ownerOnly: true });
+    let value: unknown;
+    try {
+      value = JSON.parse(content);
+    } catch {
+      return { state: "invalid", reason: "process record is malformed" };
+    }
+    if (!validProcessRecord(value)) {
+      return { state: "invalid", reason: "process record has invalid fields" };
+    }
+    if (!generationBoundProcessRecord(value)) {
+      return {
+        state: "invalid",
+        reason: "legacy process record lacks process-start identity",
+      };
+    }
+    return { state: "valid", record: value };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { state: "absent" };
+    }
+    return {
+      state: "invalid",
+      reason: `process record is unreadable or unsafe: ${String(error)}`,
+    };
+  }
+}
+
+function readFileAtClaim(path: string): string {
+  // The claim was produced by renaming a file already validated through the
+  // runtime-file reader. Reuse that validation by addressing its basename.
+  return readRuntimeFile(basename(path), { ownerOnly: true });
+}
+
+/** Strict discovery API for destructive lifecycle operations. */
+export function inspectGatewayProcessFile(
+  options: { requireLoopbackHosts?: boolean } = {},
+): ProcessFileInspection {
+  const inspection = inspectGatewayProcessFileAt();
+  if (
+    inspection.state === "valid" &&
+    options.requireLoopbackHosts &&
+    inspection.record.hosts.some((host) => !isLoopbackHost(host))
+  ) {
+    return {
+      state: "invalid",
+      reason: "process record contains a non-loopback listener",
+    };
+  }
+  return inspection;
 }
 
 /**

--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -87,6 +87,8 @@ import {
   enableHostedMode,
   importLoreFileAs,
   resolveWorkspaces,
+  currentTenantId,
+  withTenant,
 } from "@loreai/core";
 
 import type {
@@ -104,10 +106,10 @@ import type {
 } from "./translate/types";
 import {
   applyUpstreamExtraHeaders,
+  buildUpstreamSnapshotHeaders,
   blocksToText,
   isEmptyCompletion,
   looksLikeSSE,
-  forwardClientHeaders,
   providerRoutingValue,
   requestTargetsOpenRouter,
   ZERO_USAGE,
@@ -123,8 +125,12 @@ import {
   verbatimUpstreamUrl,
   extractProviderHeader,
   hasCopilotIntegrationHeader,
-  resolveLastSeenProvider,
   resolveProviderRoute,
+  extraHeadersForUpstream,
+  upstreamUrlForLog,
+  isUpstreamWithinBase,
+  isCallerUpstreamAllowed,
+  normalizeUpstreamBase,
   unattributedBucketPath,
   type ProjectPathResult,
 } from "./config";
@@ -136,6 +142,7 @@ import {
   extractKnownSessionHeader,
   learnHeaders,
   findRotationPredecessor,
+  isCredentialHeaderName,
 } from "./session";
 import {
   detectCompactionRequest,
@@ -225,6 +232,7 @@ import {
   updateAssistantMessageTokens,
   resolveToolResults,
   deterministicID,
+  legacyDeterministicID,
 } from "./temporal-adapter";
 import {
   canonicalWorkerProviderID,
@@ -242,19 +250,21 @@ import {
   boundedSettle,
 } from "./background-limiter";
 import {
+  copyProviderAuthHeaders,
   extractAuth,
   authFingerprint,
+  credentialTenantFingerprint,
   setLastSeenAuth,
   setSessionAuth,
   resolveAuth,
   isAuthStale,
+  hasConflictingAuthHeaders,
   workerKeyScheme,
   type AuthCredential,
 } from "./auth";
 import type { UpstreamInterceptor } from "./recorder";
 import { startIdleScheduler, buildIdleWorkHandler } from "./idle";
 import { flushPendingImport } from "./pending-import";
-import { upstreamErrorHint } from "./upstream-error-hint";
 import { makeTemporalBackfillGate } from "./backfill-gate";
 import { buildSessionMetadata } from "./session-metadata";
 import { hasWorkerSessionAuth } from "./worker-auth";
@@ -610,6 +620,8 @@ let upstreamRequestOrder = 0;
 let beforeUpstreamCaptureForTest:
   | ((req: GatewayRequest, state: SessionState) => Promise<void>)
   | undefined;
+/** Foreground request lifetimes cancelled when the pipeline is reset. */
+const activeForegroundAbortControllers = new Set<AbortController>();
 
 export function setBeforeUpstreamCaptureForTest(
   hook:
@@ -643,6 +655,16 @@ export function setUpstreamInterceptor(
 export async function resetPipelineState(opts?: {
   fast?: boolean;
 }): Promise<void> {
+  // Cancel client-facing request/stream work before clearing singleton state.
+  // Gateway shutdown starts listener closure first, then reaches this abort;
+  // active streams settle and allow node:http's server.close() to complete.
+  const foregroundControllers = [...activeForegroundAbortControllers];
+  activeForegroundAbortControllers.clear();
+  const resetReason = new DOMException("gateway pipeline reset", "AbortError");
+  for (const controller of foregroundControllers) {
+    if (!controller.signal.aborted) controller.abort(resetReason);
+  }
+
   // Quiesce background work before tearing anything down. Only the non-fast
   // path drains — today that's test/eval teardown (the fast process-exit path,
   // the sole production caller, skips this to keep Ctrl+C snappy). Stop the
@@ -769,17 +791,59 @@ export function rebindActiveSession(
 }
 
 /**
- * Reverse lookup: maps header-based session ID values to internal session IDs.
+ * Reverse lookup: maps tenant-scoped header values to internal session IDs.
  * Key: `credentialFingerprint\x1fheaderName\x1fheaderValue`.
- * Value: internal session ID (the key in `sessions`).
- *
- * Populated for both Tier 1 (known headers) and Tier 2 (learned headers).
  */
 const headerSessionIndex = new Map<string, string>();
 const SESSION_INDEX_SEPARATOR = "\x1f";
+const TENANT_FINGERPRINT_RE = /^[a-f0-9]{64}$/;
 
-function requestCredentialFingerprint(headers: Record<string, string>): string {
+/** Remote and hosted gateways treat the request credential as a tenant boundary. */
+function usesRemoteSessionBinding(config: GatewayConfig): boolean {
+  return config.remoteGateway || config.hostedMode;
+}
+
+/** Server-derived durable storage owner; client headers never select it. */
+function requestStorageTenant(
+  headers: Record<string, string>,
+  config: GatewayConfig,
+): string {
+  if (!usesRemoteSessionBinding(config)) return "";
   const credential = extractAuth(headers);
+  return credential
+    ? credentialTenantFingerprint(credential)
+    : `unauthenticated:${crypto.randomUUID()}`;
+}
+
+/** Run a request under the same server-derived storage owner as the main pipeline. */
+function withRequestStorageTenant<T>(
+  headers: Record<string, string>,
+  config: GatewayConfig,
+  fn: () => T,
+): T {
+  return withTenant(requestStorageTenant(headers, config), fn);
+}
+
+function requestHeaders(headers: Headers): Record<string, string> {
+  const rawHeaders: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    rawHeaders[key] = value;
+  });
+  return rawHeaders;
+}
+
+/**
+ * Resolve the credential scope used by every session-identity mechanism.
+ * `null` means an unauthenticated remote request and must never be correlated.
+ */
+function requestCredentialFingerprint(
+  headers: Record<string, string>,
+  config: GatewayConfig,
+): string | null {
+  const credential = extractAuth(headers);
+  if (usesRemoteSessionBinding(config)) {
+    return credential ? credentialTenantFingerprint(credential) : null;
+  }
   return credential ? authFingerprint(credential) : "";
 }
 
@@ -806,6 +870,67 @@ function parseSessionIndexKey(key: string): {
     headerName: key.slice(first + 1, second),
     headerValue: key.slice(second + 1),
   };
+}
+
+/**
+ * Restore persisted header mappings under the current gateway trust policy.
+ * Remote mode accepts only full tenant-bound rows; local mode never interprets
+ * a remote tenant row as a local identity. Credential-shaped historical header
+ * mappings are cleared rather than merely ignored.
+ */
+function restoreHeaderSessionMappings(config: GatewayConfig): {
+  restored: number;
+  cleared: number;
+} {
+  let restored = 0;
+  let cleared = 0;
+  for (const entry of loadHeaderSessionIndex()) {
+    if (isCredentialHeaderName(entry.headerName)) {
+      saveSessionTracking(entry.sessionId, {
+        headerSessionId: null,
+        headerName: null,
+      });
+      cleared++;
+      continue;
+    }
+    const remoteFingerprint = TENANT_FINGERPRINT_RE.test(
+      entry.credentialFingerprint,
+    );
+    if (
+      usesRemoteSessionBinding(config) ? !remoteFingerprint : remoteFingerprint
+    ) {
+      continue;
+    }
+    headerSessionIndex.set(
+      sessionIndexKey(
+        entry.credentialFingerprint,
+        entry.headerName,
+        entry.headerSessionId,
+      ),
+      entry.sessionId,
+    );
+    restored++;
+  }
+  return { restored, cleared };
+}
+
+/** Resolve an active header-bound session under the current tenant policy. */
+function activeSessionForKnownHeader(
+  req: GatewayRequest,
+  allSessions: ReadonlyMap<string, SessionState>,
+  config: GatewayConfig,
+): SessionState | undefined {
+  const known = extractKnownSessionHeader(req.rawHeaders);
+  if (!known) return undefined;
+  const credentialFingerprint = requestCredentialFingerprint(
+    req.rawHeaders,
+    config,
+  );
+  if (credentialFingerprint === null) return undefined;
+  const sid = headerSessionIndex.get(
+    sessionIndexKey(credentialFingerprint, known.headerName, known.sessionId),
+  );
+  return sid ? allSessions.get(sid) : undefined;
 }
 
 /**
@@ -3082,19 +3207,14 @@ async function initIfNeeded(
   // with a known session header generates a new session ID and orphans the
   // old session's persisted state.
   try {
-    const headerEntries = loadHeaderSessionIndex();
-    for (const entry of headerEntries) {
-      const indexKey = sessionIndexKey(
-        entry.credentialFingerprint,
-        entry.headerName,
-        entry.headerSessionId,
+    const restored = restoreHeaderSessionMappings(config);
+    if (restored.cleared > 0) {
+      log.warn(
+        `cleared ${restored.cleared} unsafe persisted header→session mapping(s)`,
       );
-      headerSessionIndex.set(indexKey, entry.sessionId);
     }
-    if (headerEntries.length > 0) {
-      log.info(
-        `restored ${headerEntries.length} header→session mappings from DB`,
-      );
+    if (restored.restored > 0) {
+      log.info(`restored ${restored.restored} header→session mappings from DB`);
     }
   } catch (e) {
     log.warn("header session index restore failed:", e);
@@ -3119,10 +3239,11 @@ async function initIfNeeded(
     // session tracking) so the resume turn reads it from cache instead. The
     // compute is single-flighted per session; a concurrent turn's
     // `singleFlightStableLtm` shares the same in-flight promise.
-    const idleHandler = async (sessionID: string, state: SessionState) => {
-      void precomputeStableLtmForIdleSession(sessionID, state);
-      await baseIdleHandler(sessionID, state);
-    };
+    const idleHandler = async (sessionID: string, state: SessionState) =>
+      withTenant(state.storageTenantId ?? "", async () => {
+        void precomputeStableLtmForIdleSession(sessionID, state);
+        await baseIdleHandler(sessionID, state);
+      });
     stopIdleScheduler = startIdleScheduler(
       config,
       sessions,
@@ -3155,7 +3276,7 @@ async function initIfNeeded(
   // Start background cloud sync (no-op until the user runs `lore sync enable`).
   if (!stopSyncScheduler) {
     const { startSyncScheduler } = await import("./sync");
-    stopSyncScheduler = startSyncScheduler();
+    stopSyncScheduler = startSyncScheduler(config);
   }
 
   log.info(`gateway pipeline initialized: ${projectPath}`);
@@ -3187,7 +3308,12 @@ function getLLMClient(config: GatewayConfig): LLMClient {
           scheme: workerKeyScheme(providerID),
           value: workerApiKey,
         })
-      : resolveAuth;
+      : (sessionID, providerID) => {
+          if (sessionID) return resolveAuth(sessionID, providerID);
+          return usesRemoteSessionBinding(config)
+            ? null
+            : resolveAuth(undefined, providerID);
+        };
 
     // Worker-specific upstream: when LORE_WORKER_UPSTREAM is set, all worker
     // calls route to this URL instead of the default upstream URLs.
@@ -3198,8 +3324,12 @@ function getLLMClient(config: GatewayConfig): LLMClient {
     if (config.workerApiKey || config.workerUpstream) {
       log.info(
         `worker routing: ` +
-          `auth=${config.workerApiKey ? "dedicated key" : "session"}, ` +
-          `upstream=${config.workerUpstream ?? "default"}`,
+          `source=${config.workerApiKey ? "dedicated key" : "session"}, ` +
+          `upstream=${
+            config.workerUpstream
+              ? upstreamUrlForLog(config.workerUpstream)
+              : "default"
+          }`,
       );
     }
 
@@ -3723,10 +3853,19 @@ function validatedUpstreamSnapshot(value: unknown): UpstreamSnapshot | null {
   }
   return freezeUpstreamSnapshot({
     url: value.url,
+    // Legacy snapshots predate provenance. Treat them as caller-selected so a
+    // remote gateway never revives a pre-policy arbitrary destination.
+    callerSelected:
+      typeof value.callerSelected === "boolean" ? value.callerSelected : true,
     protocol: value.protocol as UpstreamSnapshot["protocol"],
     ...(value.providerID ? { providerID: value.providerID } : {}),
     model: value.model,
-    headers: value.headers as Record<string, string>,
+    // Older persisted snapshots may contain credentials from before routing
+    // state became credential-safe. Re-run the current forwarding filter when
+    // hydrating instead of trusting those historical header bytes.
+    headers: buildUpstreamSnapshotHeaders(
+      value.headers as Record<string, string>,
+    ),
     ...(isPlainRecord(value.providerOptions)
       ? { providerOptions: value.providerOptions }
       : {}),
@@ -3781,19 +3920,23 @@ function serializeUpstreamState(state: SessionState): string {
   });
 }
 
-function deserializeUpstreamState(serialized: string): {
+function deserializeUpstreamState(
+  serialized: string,
+  config: GatewayConfig,
+): {
   lastUpstream?: UpstreamSnapshot;
   upstreamByProvider: Map<string, UpstreamSnapshot>;
 } {
   const parsed = JSON.parse(serialized) as unknown;
   const legacy = validatedUpstreamSnapshot(parsed);
   if (legacy) {
-    return {
+    const restored = {
       lastUpstream: legacy,
       upstreamByProvider: new Map(
         legacy.providerID ? [[legacy.providerID, legacy]] : [],
       ),
     };
+    return filterRestoredUpstreamState(restored, config);
   }
   if (
     !isPlainRecord(parsed) ||
@@ -3828,6 +3971,7 @@ function deserializeUpstreamState(serialized: string): {
       if (
         !providerSnapshot ||
         providerSnapshot.url !== lastUpstream.url ||
+        providerSnapshot.callerSelected !== lastUpstream.callerSelected ||
         providerSnapshot.protocol !== lastUpstream.protocol ||
         providerSnapshot.model !== lastUpstream.model ||
         JSON.stringify(providerSnapshot.providerOptions) !==
@@ -3837,12 +3981,57 @@ function deserializeUpstreamState(serialized: string): {
       }
     }
   }
-  return { lastUpstream, upstreamByProvider };
+  return filterRestoredUpstreamState(
+    { lastUpstream, upstreamByProvider },
+    config,
+  );
+}
+
+/**
+ * Re-apply the current remote-gateway origin policy to persisted route state.
+ * Legacy snapshots are marked caller-selected by validation above, so an
+ * upgrade cannot revive an arbitrary pre-policy URL for workers or warmups.
+ */
+function filterRestoredUpstreamState(
+  restored: {
+    lastUpstream?: UpstreamSnapshot;
+    upstreamByProvider: Map<string, UpstreamSnapshot>;
+  },
+  config: GatewayConfig,
+): {
+  lastUpstream?: UpstreamSnapshot;
+  upstreamByProvider: Map<string, UpstreamSnapshot>;
+} {
+  if (!usesRemoteSessionBinding(config)) return restored;
+  const allowed = (snapshot: UpstreamSnapshot): boolean =>
+    snapshot.callerSelected === false ||
+    (snapshot.callerSelected === true &&
+      isCallerUpstreamAllowed(config, snapshot.url));
+  return {
+    ...(restored.lastUpstream && allowed(restored.lastUpstream)
+      ? { lastUpstream: restored.lastUpstream }
+      : {}),
+    upstreamByProvider: new Map(
+      [...restored.upstreamByProvider].filter(([, snapshot]) =>
+        allowed(snapshot),
+      ),
+    ),
+  };
+}
+
+/** Test-only access to persisted-route policy revalidation. */
+export function restoreUpstreamStateForTest(
+  serialized: string,
+  config: GatewayConfig,
+): {
+  lastUpstream?: UpstreamSnapshot;
+  upstreamByProvider: Map<string, UpstreamSnapshot>;
+} {
+  return deserializeUpstreamState(serialized, config);
 }
 
 function buildRequestUpstreamSnapshot(
   req: GatewayRequest,
-  config: GatewayConfig,
   route: ResolvedRequestUpstreamRoute,
 ): UpstreamSnapshot {
   const providerRouting = providerRoutingValue(req);
@@ -3864,13 +4053,13 @@ function buildRequestUpstreamSnapshot(
   }
   const snapshot: UpstreamSnapshot = {
     url: route.effectiveUpstreamBase,
+    callerSelected: route.headerUpstream !== undefined,
     protocol: route.effectiveProtocol,
     ...(route.providerID ? { providerID: route.providerID } : {}),
     model: req.model,
-    headers: forwardClientHeaders(req.rawHeaders),
+    headers: buildUpstreamSnapshotHeaders(req.rawHeaders),
     ...(providerOptions ? { providerOptions } : {}),
   };
-  applyUpstreamExtraHeaders(snapshot.headers, config.upstreamExtraHeaders);
   return freezeUpstreamSnapshot(snapshot);
 }
 
@@ -3886,16 +4075,28 @@ function captureRequestUpstream(
   requestOrder: number,
 ): ResolvedRequestUpstreamRoute {
   const route = resolveRequestUpstreamRoute(req, config);
-  const snapshot = buildRequestUpstreamSnapshot(req, config, route);
+  const snapshot = buildRequestUpstreamSnapshot(req, route);
   let changed = false;
 
   if (requestOrder >= (state._upstreamRequestOrder ?? 0)) {
     const previous = state.lastUpstream;
     if (
-      previous &&
-      (previous.model !== snapshot.model ||
-        previous.providerID !== snapshot.providerID)
+      (previous &&
+        (previous.url !== snapshot.url ||
+          previous.protocol !== snapshot.protocol ||
+          previous.model !== snapshot.model ||
+          previous.providerID !== snapshot.providerID ||
+          !isDeepStrictEqual(
+            previous.providerOptions,
+            snapshot.providerOptions,
+          ))) ||
+      (Object.keys(config.upstreamExtraHeaders).length > 0 &&
+        Object.keys(extraHeadersForUpstream(config, snapshot.url)).length === 0)
     ) {
+      // The cached body is route-specific and may contain a prior turn's full
+      // transcript. Clear it synchronously with route capture so a failed or
+      // in-flight policy-tightening request cannot let the idle warmer replay
+      // that body (or admin extras) to the newly selected destination.
       state.cacheAnalytics.lastRequestBody = null;
     }
     state.lastUpstream = snapshot;
@@ -3935,16 +4136,54 @@ function captureRequestUpstream(
   return route;
 }
 
+class SessionTenantMismatchError extends Error {
+  constructor() {
+    super("Session storage tenant does not match the authenticated request");
+    this.name = "SessionTenantMismatchError";
+  }
+}
+
 function getOrCreateSession(
   sessionID: string,
   projectPath: string,
-  pathSource: ProjectPathResult["source"] = "cwd",
-  credentialFingerprint = "",
+  pathSource: ProjectPathResult["source"],
+  credentialFingerprint: string,
+  config: GatewayConfig,
 ): SessionState {
+  const storageTenantId = currentTenantId();
   let state = sessions.get(sessionID);
+  if (state) {
+    // A session's storage owner is immutable. Reassigning it to whichever
+    // request happened to touch it most recently turns an isolation failure
+    // into durable cross-tenant background work. Missing ownership is accepted
+    // only for the historical local namespace.
+    if (
+      (state.storageTenantId === undefined && storageTenantId !== "") ||
+      (state.storageTenantId !== undefined &&
+        state.storageTenantId !== storageTenantId) ||
+      (usesRemoteSessionBinding(config) &&
+        credentialFingerprint !== "" &&
+        state.credentialFingerprint !== credentialFingerprint)
+    ) {
+      throw new SessionTenantMismatchError();
+    }
+    state.storageTenantId ??= "";
+  }
   if (!state) {
     // Restore persisted tracking state from DB (survives process restarts)
     const persisted = loadSessionTracking(sessionID);
+    // In remote mode the full credential fingerprint is both the authenticated
+    // session owner and the durable storage tenant. A corrupt/stale index must
+    // never hydrate a row owned by a different credential.
+    if (
+      usesRemoteSessionBinding(config) &&
+      credentialFingerprint !== "" &&
+      (storageTenantId !== credentialFingerprint ||
+        (persisted !== null &&
+          persisted.credentialFingerprint !== credentialFingerprint))
+    ) {
+      throw new SessionTenantMismatchError();
+    }
     // Project binding (v36): a persisted binding must survive restart so the
     // session's project_id never splits. A persisted CONFIDENT binding wins
     // over the current request's path — otherwise a path-less first
@@ -3980,6 +4219,7 @@ function getOrCreateSession(
       fingerprint: persisted?.fingerprint || "",
       credentialFingerprint:
         persisted?.credentialFingerprint || credentialFingerprint,
+      storageTenantId,
       lastRequestTime: Date.now(),
       lastUserTurnTime: 0,
       messageCount: persisted?.messageCount ?? 0,
@@ -4076,7 +4316,10 @@ function getOrCreateSession(
     }
     if (persisted?.lastUpstream != null) {
       try {
-        const restored = deserializeUpstreamState(persisted.lastUpstream);
+        const restored = deserializeUpstreamState(
+          persisted.lastUpstream,
+          config,
+        );
         state.lastUpstream = restored.lastUpstream;
         state.upstreamByProvider = restored.upstreamByProvider;
       } catch {
@@ -4123,6 +4366,9 @@ function getOrCreateSession(
   // Ensure upstreamByProvider exists (upgrade from older session state)
   if (!state.upstreamByProvider) {
     state.upstreamByProvider = new Map();
+  }
+  if (credentialFingerprint) {
+    state.credentialFingerprint = credentialFingerprint;
   }
 
   return state;
@@ -4274,23 +4520,41 @@ async function adoptByFingerprint(input: {
   projectPath: string;
   known: { headerName: string; sessionId: string } | null;
   msgCount: number;
+  config: GatewayConfig;
+  credentialFingerprint: string;
 }): Promise<{ sessionID: string; isNew: false; tier: 3 } | null> {
-  const { req, headers, projectPath, known, msgCount } = input;
+  const {
+    req,
+    headers,
+    projectPath,
+    known,
+    msgCount,
+    config,
+    credentialFingerprint,
+  } = input;
   if (!projectPath) return null;
 
   const cred = extractAuth(req.rawHeaders);
-  const credentialFingerprint = cred ? authFingerprint(cred) : "";
   const fingerprintInput = req.messages.map((m) => ({
     role: m.role,
     content: m.content,
   }));
-  const fingerprint = await fingerprintMessages(fingerprintInput, {
-    authSuffix: cred ? authFingerprint(cred) : "",
-  });
+  const remoteBinding = usesRemoteSessionBinding(config);
+  const fingerprint = await fingerprintMessages(
+    fingerprintInput,
+    remoteBinding
+      ? { tenantFingerprint: credentialFingerprint }
+      : { authSuffix: cred ? authFingerprint(cred) : "" },
+  );
 
   const reqIsSubagent = !!headers["x-parent-session-id"];
-  const candidates = findSessionStatesByFingerprint(fingerprint);
-  if (cred) {
+  const candidates = findSessionStatesByFingerprint(fingerprint).filter(
+    (candidate) =>
+      !remoteBinding ||
+      loadSessionTracking(candidate.session_id)?.credentialFingerprint ===
+        credentialFingerprint,
+  );
+  if (cred && !remoteBinding) {
     // v78 added the credential suffix to conversation fingerprints. Legacy
     // candidates have the old unsuffixed fingerprint and no persisted owner;
     // they still require the same project-scoped multi-message overlap below.
@@ -4314,21 +4578,21 @@ async function adoptByFingerprint(input: {
   // an early message only lowers overlap (graceful miss → no adoption), never a
   // false positive. The primary target (opencode x-lore-session-id) sends no
   // such markers, and marker clients carry them on the latest turn only.
-  const probeIDs: string[] = [];
+  const probeMessages: Array<{ index: number; message: GatewayMessage }> = [];
   let probedUsers = 0;
   const probeLimit = Math.min(req.messages.length, ADOPT_PROBE_MESSAGES);
   for (let i = 0; i < probeLimit; i++) {
     const m = req.messages[i];
     if (m.role !== "user") continue;
     probedUsers++;
-    probeIDs.push(deterministicID(m.role, i, m.content));
+    probeMessages.push({ index: i, message: m });
   }
-  if (probeIDs.length < ADOPT_MIN_OVERLAP) return null;
+  if (probeMessages.length < ADOPT_MIN_OVERLAP) return null;
 
   const pid = ensureProject(projectPath);
   const minOverlap = Math.max(ADOPT_MIN_OVERLAP, Math.ceil(probedUsers * 0.5));
   let best: { sid: string; overlap: number; countDiff: number } | null = null;
-  // temporal_messages.id is globally unique, so valid rows cannot give two
+  // Source IDs include the candidate session, so valid rows cannot give two
   // sessions the same positive overlap set. Keep the tie guard as defense in
   // depth for a corrupt/imported database rather than selecting by row order.
   let ambiguousBest = false;
@@ -4338,6 +4602,24 @@ async function adoptByFingerprint(input: {
     if (msgCount - c.message_count < -MESSAGE_COUNT_PROXIMITY_THRESHOLD) {
       continue;
     }
+    const probeIDs = probeMessages.map(({ index, message }) => {
+      const sourceID = deterministicID(
+        c.session_id,
+        message.role,
+        index,
+        message.content,
+      );
+      return temporal.storedMessageId({
+        projectPath,
+        sessionID: c.session_id,
+        sourceID,
+        legacySourceID: legacyDeterministicID(
+          message.role,
+          index,
+          message.content,
+        ),
+      });
+    });
     const overlap = countMatchingTemporalIds(pid, c.session_id, probeIDs);
     if (overlap < minOverlap) continue;
     const countDiff = Math.abs(msgCount - c.message_count);
@@ -4378,9 +4660,17 @@ async function adoptByFingerprint(input: {
 async function identifySession(
   req: GatewayRequest,
   projectPath: string,
+  config: GatewayConfig,
 ): Promise<{ sessionID: string; isNew: boolean; tier: 1 | 2 | 2.5 | 3 }> {
   const headers = req.rawHeaders;
-  const credentialFingerprint = requestCredentialFingerprint(headers);
+  const credentialFingerprint = requestCredentialFingerprint(headers, config);
+
+  // Remote correlation is authenticated. Without a usable credential, every
+  // request receives an unindexed session rather than inheriting another
+  // client's header, marker, fingerprint, or worker credential.
+  if (credentialFingerprint === null) {
+    return { sessionID: generateSessionID(), isNew: true, tier: 3 };
+  }
 
   // --- Tier 1: Known headers ---
   // Sub-agent requests (carrying x-parent-session-id) are NOT merged into the
@@ -4397,16 +4687,7 @@ async function identifySession(
     );
     let existingSid = headerSessionIndex.get(indexKey);
     if (!existingSid) {
-      for (const entry of loadHeaderSessionIndex()) {
-        headerSessionIndex.set(
-          sessionIndexKey(
-            entry.credentialFingerprint,
-            entry.headerName,
-            entry.headerSessionId,
-          ),
-          entry.sessionId,
-        );
-      }
+      restoreHeaderSessionMappings(config);
       existingSid = headerSessionIndex.get(indexKey);
     }
     if (existingSid) {
@@ -4567,6 +4848,8 @@ async function identifySession(
       projectPath,
       known,
       msgCount: req.messages.length,
+      config,
+      credentialFingerprint,
     });
     if (adopted) return adopted;
 
@@ -4620,15 +4903,19 @@ async function identifySession(
     content: m.content,
   }));
   const cred = extractAuth(req.rawHeaders);
-  const fingerprint = await fingerprintMessages(rawMessages, {
-    authSuffix: cred ? authFingerprint(cred) : "",
-  });
+  const fingerprint = await fingerprintMessages(
+    rawMessages,
+    usesRemoteSessionBinding(config)
+      ? { tenantFingerprint: credentialFingerprint }
+      : { authSuffix: cred ? authFingerprint(cred) : "" },
+  );
   const msgCount = req.messages.length;
 
   // Find the best matching session: same fingerprint + closest message count
   let bestMatch: { sid: string; countDiff: number } | null = null;
 
   for (const [sid, state] of sessions) {
+    if ((state.credentialFingerprint ?? "") !== credentialFingerprint) continue;
     if (state.fingerprint !== fingerprint) continue;
 
     const diff = msgCount - state.messageCount;
@@ -4686,6 +4973,8 @@ async function identifySession(
     projectPath,
     known: null,
     msgCount,
+    config,
+    credentialFingerprint,
   });
   if (adopted) return adopted;
 
@@ -4715,6 +5004,45 @@ type ResolvedRequestUpstreamRoute = {
 };
 
 /**
+ * Preserve the legacy process-global credential only for a local, unambiguous
+ * direct-provider request to the exact configured base. Remote/hosted gateways,
+ * explicit provider selection, and client-selected URLs never populate it.
+ */
+function captureLegacyGlobalAuth(
+  req: GatewayRequest,
+  config: GatewayConfig,
+  cred: AuthCredential,
+): string | undefined {
+  if (usesRemoteSessionBinding(config)) return undefined;
+  if (
+    req.rawHeaders["x-lore-provider"] ||
+    req.rawHeaders["x-lore-upstream-url"]
+  ) {
+    return undefined;
+  }
+  const route = resolveRequestUpstreamRoute(req, config);
+  const providerID =
+    route.effectiveProtocol === "anthropic"
+      ? "anthropic"
+      : route.effectiveProtocol === "openai" ||
+          route.effectiveProtocol === "openai-responses"
+        ? "openai"
+        : undefined;
+  if (!providerID) return undefined;
+  const configuredBase =
+    providerID === "anthropic"
+      ? config.upstreamAnthropic
+      : config.upstreamOpenAI;
+  const routeBase = normalizeUpstreamBase(route.effectiveUpstreamBase);
+  const trustedBase = normalizeUpstreamBase(configuredBase);
+  if (!routeBase || !trustedBase || routeBase !== trustedBase) {
+    return undefined;
+  }
+  setLastSeenAuth(cred, providerID);
+  return providerID;
+}
+
+/**
  * Single source of truth for foreground routing and its durable snapshot.
  * This is deliberately synchronous: dynamic models.dev lookup is cache-only,
  * so capture can run before any fetch/interceptor and failed requests still
@@ -4727,10 +5055,23 @@ function resolveRequestUpstreamRoute(
   const headerUpstream = extractUpstreamUrlHeader(req.rawHeaders);
   const headerUpstreamPath = extractUpstreamPathHeader(req.rawHeaders);
   const providerHeader = extractProviderHeader(req.rawHeaders);
+  if (req.rawHeaders["x-lore-provider"] && !providerHeader) {
+    throw new Error("Unsupported or invalid X-Lore-Provider");
+  }
+  if (req.rawHeaders["x-lore-upstream-url"] && !headerUpstream) {
+    throw new Error("Invalid X-Lore-Upstream-URL");
+  }
+  if (headerUpstream && !isCallerUpstreamAllowed(config, headerUpstream)) {
+    throw new Error(
+      "X-Lore-Upstream-URL origin is not allowed by this remote gateway",
+    );
+  }
   let providerID = providerHeader;
   let providerRoute = providerID ? resolveProviderRoute(providerID) : null;
   if (!providerRoute && providerID) {
-    providerRoute = lookupProviderRoute(providerID);
+    // Explicit request routing is cache-only. An unknown untrusted provider
+    // must fail closed without triggering side-channel network activity.
+    providerRoute = lookupProviderRoute(providerID, false);
   }
   if (
     !providerRoute &&
@@ -4744,6 +5085,32 @@ function resolveRequestUpstreamRoute(
   const selfUrlBuildingProtocol =
     providerRoute?.bedrockMantle === true ||
     providerRoute?.protocol === "vertex";
+  if (headerUpstream && !extractAuth(req.rawHeaders)) {
+    throw new Error("An explicit upstream URL requires client authentication");
+  }
+  if (
+    headerUpstream &&
+    headerUpstreamPath &&
+    !isUpstreamWithinBase(
+      new URL(headerUpstreamPath, new URL(headerUpstream).origin).href,
+      headerUpstream,
+    )
+  ) {
+    throw new Error("Explicit upstream path escapes its upstream base");
+  }
+  if (providerID && !providerRoute && !headerUpstream) {
+    throw new Error(`Unsupported provider "${providerID}"`);
+  }
+  if (
+    providerID &&
+    providerRoute?.url == null &&
+    !headerUpstream &&
+    !selfUrlBuildingProtocol
+  ) {
+    throw new Error(
+      `Provider "${providerID}" requires an explicit upstream URL`,
+    );
+  }
   const providerRouteUsable =
     providerRoute &&
     (providerRoute.url != null || headerUpstream || selfUrlBuildingProtocol)
@@ -4865,13 +5232,13 @@ async function forwardToUpstream(
   // provider routing issues without guessing.
   const routingAuth = extractAuth(req.rawHeaders);
   log.info(
-    `upstream: ${effectiveUpstreamBase} ` +
+    `upstream: ${upstreamUrlForLog(effectiveUpstreamBase)} ` +
       `(provider=${providerID ?? "none"}, ` +
-      `providerURL=${providerRoute?.url ?? "none"}, ` +
-      `modelRoute=${modelRoute?.url ?? "none"}, ` +
+      `providerURL=${upstreamUrlForLog(providerRoute?.url)}, ` +
+      `modelRoute=${upstreamUrlForLog(modelRoute?.url)}, ` +
       `headerUpstream=${headerUpstream ? "yes" : "no"}, ` +
       `protocol=${effectiveProtocol}, ` +
-      `auth=${routingAuth ? `${routingAuth.scheme}:${routingAuth.value.slice(0, 8)}…` : "none"})`,
+      `scheme=${routingAuth?.scheme ?? "none"})`,
   );
 
   // Defense-in-depth: warn when a bearer token prefix clearly mismatches
@@ -4882,7 +5249,7 @@ async function forwardToUpstream(
     !effectiveUpstreamBase.includes("githubcopilot")
   ) {
     log.error(
-      `auth/upstream mismatch: GitHub OAuth token (gho_) routed to ${effectiveUpstreamBase} — ` +
+      `auth/upstream mismatch: GitHub OAuth token (gho_) routed to ${upstreamUrlForLog(effectiveUpstreamBase)} — ` +
         `provider: ${providerID ?? "none"}`,
     );
   }
@@ -5052,7 +5419,7 @@ async function forwardToUpstream(
   // corporate proxies, LiteLLM team-routing tokens, Cloudflare AI Gateway
   // auth, and service-account scenarios can override any header — including
   // the gateway-reconstructed `x-api-key` / `Authorization`.
-  applyUpstreamExtraHeaders(headers, config.upstreamExtraHeaders);
+  applyUpstreamExtraHeaders(headers, extraHeadersForUpstream(config, url));
 
   let serializedBody = JSON.stringify(body);
 
@@ -5506,13 +5873,17 @@ export function buildStreamingResponse(
               recallDepth++;
               const { result, input } = await promiseAgainstAbort(
                 () =>
-                  executeRecall(
-                    recallBlock,
-                    recallContext.sessionState.projectPath,
-                    recallContext.sessionState.sessionID,
-                    getLLMClient(recallContext.config),
-                    alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
-                    streamSignal,
+                  withTenant(
+                    recallContext.sessionState.storageTenantId ?? "",
+                    () =>
+                      executeRecall(
+                        recallBlock,
+                        recallContext.sessionState.projectPath,
+                        recallContext.sessionState.sessionID,
+                        getLLMClient(recallContext.config),
+                        alreadyInLtmIds.size > 0 ? alreadyInLtmIds : undefined,
+                        streamSignal,
+                      ),
                   ),
                 streamSignal,
               );
@@ -5755,10 +6126,9 @@ export function buildStreamingResponse(
                   recallBlock,
                   streamSignal,
                 );
-              } catch (fetchErr) {
+              } catch {
                 log.error(
-                  `recall follow-up fetch error (depth=${recallDepth}) for session ${recallContext.sessionState.sessionID.slice(0, 16)}:`,
-                  fetchErr,
+                  `recall follow-up fetch failed (depth=${recallDepth}) for session ${recallContext.sessionState.sessionID.slice(0, 16)}`,
                 );
                 // takeHeldBackEvents() — for Anthropic this is a no-op
                 // (already consumed before the marker envelope emission
@@ -5780,7 +6150,7 @@ export function buildStreamingResponse(
 
               if (!streamingFollowUp.ok) {
                 log.error(
-                  `recall follow-up upstream error: ${streamingFollowUp.status ?? "?"} ${streamingFollowUp.detail}`,
+                  `recall follow-up upstream error: ${streamingFollowUp.status ?? "?"}`,
                   new Error(
                     `recall follow-up upstream ${streamingFollowUp.status ?? "?"}`,
                   ),
@@ -9532,7 +9902,7 @@ export function recordCacheTurnUsage(
  * is pure in-memory (temporal-adapter.ts) and MUST run BETWEEN the two stores —
  * the user message is stored with its ORIGINAL tool_result content, before
  * resolveToolResults strips it — so it stays inside the same savepoint. The
- * stores are idempotent UPSERTs keyed by message id, so the all-or-nothing
+ * stores are idempotent UPSERTs keyed by owned message identity, so the all-or-nothing
  * rollback on a mid-batch error is recoverable: the next turn re-includes and
  * re-stores these messages.
  *
@@ -9554,7 +9924,16 @@ export function storeTurnTemporal(input: {
 
   if (noStore) {
     // Still resolve tool results in-memory (needed downstream), but write nothing.
-    resolveToolResults(loreMessages);
+    resolveToolResults(
+      loreMessages,
+      (message) =>
+        temporal.storedMessageIdIfProjectExists({
+          projectPath,
+          sessionID: message.info.sessionID,
+          sourceID: message.info.id,
+          legacySourceID: message.legacySourceID,
+        }) ?? message.info.id,
+    );
     return;
   }
 
@@ -9576,6 +9955,7 @@ export function storeTurnTemporal(input: {
           projectPath,
           info: loreMessages[i].info,
           parts: loreMessages[i].parts,
+          legacySourceID: loreMessages[i].legacySourceID,
         });
         // The latest user message carries tool_result blocks that resolve the
         // PRIOR assistant turn's tool calls — record their outcomes
@@ -9584,6 +9964,7 @@ export function storeTurnTemporal(input: {
           projectPath,
           info: loreMessages[i].info,
           parts: loreMessages[i].parts,
+          legacySourceID: loreMessages[i].legacySourceID,
         });
         break;
       }
@@ -9592,7 +9973,14 @@ export function storeTurnTemporal(input: {
     // Resolve tool results for gradient transform (merges tool_result into
     // assistant parts, strips from user messages — needed for reconstruct-
     // after-eviction pattern but not for temporal storage above).
-    resolveToolResults(loreMessages);
+    resolveToolResults(loreMessages, (message) =>
+      temporal.storedMessageId({
+        projectPath,
+        sessionID: message.info.sessionID,
+        sourceID: message.info.id,
+        legacySourceID: message.legacySourceID,
+      }),
+    );
 
     // Build and store the assistant response message.
     // Strip recall marker text blocks — they contain the raw query string and
@@ -9603,6 +9991,7 @@ export function storeTurnTemporal(input: {
     const assistantMsg = gatewayMessagesToLore(
       [{ role: "assistant", content: assistantContent }],
       sessionID,
+      loreMessages.length,
     )[0];
     updateAssistantMessageTokens(assistantMsg, input.usage, input.model);
     if (assistantContent.length > 0) {
@@ -9610,6 +9999,7 @@ export function storeTurnTemporal(input: {
         projectPath,
         info: assistantMsg.info,
         parts: assistantMsg.parts,
+        legacySourceID: assistantMsg.legacySourceID,
       });
     }
     // Always record structured tool-call traces — even when the assistant
@@ -9620,6 +10010,7 @@ export function storeTurnTemporal(input: {
       projectPath,
       info: assistantMsg.info,
       parts: assistantMsg.parts,
+      legacySourceID: assistantMsg.legacySourceID,
     });
   });
 }
@@ -9628,7 +10019,7 @@ export function storeTurnTemporal(input: {
  * Run after a successful response: calibrate, store temporal messages,
  * and schedule background work (distillation, curation).
  */
-function postResponse(
+function postResponseForTenant(
   req: GatewayRequest,
   resp: GatewayResponse,
   sessionState: SessionState,
@@ -9690,6 +10081,19 @@ function postResponse(
       requestBody,
       genAiSpan,
     );
+    // Admin credentials are authorized at dispatch time and never retained in
+    // session snapshots. The idle warmer still receives gateway-global extras,
+    // so prevent it from replaying a cached body to a client-selected endpoint
+    // that is outside every configured trusted base.
+    if (
+      Object.keys(config.upstreamExtraHeaders).length > 0 &&
+      sessionState.lastUpstream &&
+      Object.keys(
+        extraHeadersForUpstream(config, sessionState.lastUpstream.url),
+      ).length === 0
+    ) {
+      sessionState.cacheAnalytics.lastRequestBody = null;
+    }
 
     // Capture previous stop reason before it's overwritten below (line ~1667).
     // Used to detect tool-use continuation turns for gap recording filtering.
@@ -9904,6 +10308,26 @@ function postResponse(
   }
 }
 
+function postResponse(
+  req: GatewayRequest,
+  resp: GatewayResponse,
+  sessionState: SessionState,
+  config: GatewayConfig,
+  requestBody?: string,
+  genAiSpan?: Sentry.Span,
+): void {
+  withTenant(sessionState.storageTenantId ?? "", () =>
+    postResponseForTenant(
+      req,
+      resp,
+      sessionState,
+      config,
+      requestBody,
+      genAiSpan,
+    ),
+  );
+}
+
 /**
  * Schedule background distillation and curation (fire-and-forget).
  */
@@ -9919,7 +10343,7 @@ function trackBackground(p: Promise<unknown>): void {
   void p.finally(() => inFlightBackground.delete(p));
 }
 
-export function scheduleBackgroundWork(
+function scheduleBackgroundWorkForTenant(
   sessionState: SessionState,
   config: GatewayConfig,
 ): void {
@@ -10001,23 +10425,25 @@ export function scheduleBackgroundWork(
   }
   if (urgentFromGradient || urgentFromCompaction) {
     trackBackground(
-      distillation
-        .run({
-          llm,
-          projectPath,
-          sessionID,
-          model,
-          force: true,
-          urgent: true,
-          callType: "direct",
-          // Never run meta-distillation while the conversation cache is warm.
-          // Meta archives gen-0 rows and creates a gen-1 row, rewriting the
-          // synthetic distilled prefix at messages[0/1] on the next turn. That
-          // early-message rewrite is a real prompt-cache bust. Idle-time meta in
-          // idle.ts remains enabled because the cache is already cold there.
-          skipMeta: true,
-        })
-        .catch((e) => log.error("background distillation failed:", e)),
+      withTenant(sessionState.storageTenantId ?? "", () =>
+        distillation
+          .run({
+            llm,
+            projectPath,
+            sessionID,
+            model,
+            force: true,
+            urgent: true,
+            callType: "direct",
+            // Never run meta-distillation while the conversation cache is warm.
+            // Meta archives gen-0 rows and creates a gen-1 row, rewriting the
+            // synthetic distilled prefix at messages[0/1] on the next turn. That
+            // early-message rewrite is a real prompt-cache bust. Idle-time meta in
+            // idle.ts remains enabled because the cache is already cold there.
+            skipMeta: true,
+          })
+          .catch((e) => log.error("background distillation failed:", e)),
+      ),
     );
   } else if (
     !isBackgroundPaused(workerProviderID) &&
@@ -10045,17 +10471,19 @@ export function scheduleBackgroundWork(
         );
         runBackground(
           () =>
-            distillation.run({
-              llm,
-              projectPath,
-              sessionID,
-              model,
-              skipMeta: true,
-              callType: batchQueueEnabled ? "batch" : "direct",
-              workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
-              // #627 Phase 1: stamp the session's gitHead on every distilled row.
-              metadata: buildSessionMetadata(sessionState.gitHead),
-            }),
+            withTenant(sessionState.storageTenantId ?? "", () =>
+              distillation.run({
+                llm,
+                projectPath,
+                sessionID,
+                model,
+                skipMeta: true,
+                callType: batchQueueEnabled ? "batch" : "direct",
+                workerHealth: makeWorkerHealth(sessionID, "lore-distill"),
+                // #627 Phase 1: stamp the session's gitHead on every distilled row.
+                metadata: buildSessionMetadata(sessionState.gitHead),
+              }),
+            ),
           `incremental-distill session=${sessionID.slice(0, 16)}`,
           workerProviderID,
         ).catch((e) => log.error("background distillation failed:", e));
@@ -10120,22 +10548,24 @@ export function scheduleBackgroundWork(
     trackBackground(
       runBackground(
         () =>
-          Sentry.startSpan(
-            {
-              name: "lore.curator",
-              op: "lore.curation",
-              attributes: { trigger: "in-flight" },
-            },
-            () =>
-              curator.run({
-                llm,
-                projectPath,
-                sessionID,
-                model,
-                workerHealth: makeWorkerHealth(sessionID, "lore-curator"),
-                // #627 Phase 1: stamp the session's gitHead on curator entries.
-                metadata: buildSessionMetadata(sessionState.gitHead),
-              }),
+          withTenant(sessionState.storageTenantId ?? "", () =>
+            Sentry.startSpan(
+              {
+                name: "lore.curator",
+                op: "lore.curation",
+                attributes: { trigger: "in-flight" },
+              },
+              () =>
+                curator.run({
+                  llm,
+                  projectPath,
+                  sessionID,
+                  model,
+                  workerHealth: makeWorkerHealth(sessionID, "lore-curator"),
+                  // #627 Phase 1: stamp the session's gitHead on curator entries.
+                  metadata: buildSessionMetadata(sessionState.gitHead),
+                }),
+            ),
           ),
         `in-flight-curation session=${sessionID.slice(0, 16)}`,
         workerProviderID,
@@ -10168,6 +10598,15 @@ export function scheduleBackgroundWork(
         }),
     );
   }
+}
+
+export function scheduleBackgroundWork(
+  sessionState: SessionState,
+  config: GatewayConfig,
+): void {
+  withTenant(sessionState.storageTenantId ?? "", () =>
+    scheduleBackgroundWorkForTenant(sessionState, config),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -10288,13 +10727,14 @@ async function handleCompactionInner(
   }
   const pathResult = getProjectPath(req.system, req.rawHeaders);
 
-  const { sessionID } = await identifySession(req, pathResult.path);
+  const { sessionID } = await identifySession(req, pathResult.path, config);
   stripContextMarkers(req.messages);
   const sessionState = getOrCreateSession(
     sessionID,
     pathResult.path,
     pathResult.source,
-    requestCredentialFingerprint(req.rawHeaders),
+    requestCredentialFingerprint(req.rawHeaders, config) ?? "",
+    config,
   );
   const projectPath = resolveSessionProjectPath(
     pathResult,
@@ -10515,13 +10955,20 @@ async function handleCompactEndpointInner(
   req: Request,
   config: GatewayConfig,
   signal: AbortSignal,
+  rawHeaders: Record<string, string>,
 ): Promise<Response> {
+  if (hasConflictingAuthHeaders(rawHeaders)) {
+    return new Response(
+      JSON.stringify({
+        error: "invalid_request",
+        message:
+          "Conflicting authentication headers: send either x-api-key or Authorization, not both",
+      }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
   // Authenticate from headers before touching a potentially unbounded or
   // stalled upload. This endpoint always requires a provider credential.
-  const rawHeaders: Record<string, string> = {};
-  req.headers.forEach((value, key) => {
-    rawHeaders[key] = value;
-  });
   const credential = extractAuth(rawHeaders);
   if (!credential) {
     return new Response(
@@ -10580,7 +11027,11 @@ async function handleCompactEndpointInner(
     rawHeaders,
   };
 
-  const { sessionID, isNew } = await identifySession(minimalReq, projectPath);
+  const { sessionID, isNew } = await identifySession(
+    minimalReq,
+    projectPath,
+    config,
+  );
 
   if (isNew) {
     // No prior session found — the caller's session header didn't match any
@@ -10597,14 +11048,28 @@ async function handleCompactEndpointInner(
     );
   }
 
-  const state = getOrCreateSession(
-    sessionID,
-    projectPath,
-    "header",
-    authFingerprint(credential),
-  );
+  let state: SessionState;
+  try {
+    state = getOrCreateSession(
+      sessionID,
+      projectPath,
+      "header",
+      requestCredentialFingerprint(rawHeaders, config) ?? "",
+      config,
+    );
+  } catch (error) {
+    if (error instanceof SessionTenantMismatchError) {
+      return new Response(
+        JSON.stringify({
+          error: "session_not_found",
+          message: "No session found for the authenticated storage tenant",
+        }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      );
+    }
+    throw error;
+  }
   if (
-    !state ||
     state.projectPathProvisional === true ||
     state.projectPath !== projectPath
   ) {
@@ -10710,18 +11175,26 @@ export async function handleCompactEndpoint(
   req: Request,
   config: GatewayConfig,
 ): Promise<Response> {
-  const abortScope = createForegroundAbortScope(req.signal);
-  try {
-    const response = await handleCompactEndpointInner(
-      req,
-      config,
-      abortScope.signal,
-    );
-    return wrapBodyWithCleanup(response, abortScope.dispose, abortScope.signal);
-  } catch (error) {
-    abortScope.dispose();
-    throw error;
-  }
+  const rawHeaders = requestHeaders(req.headers);
+  return withRequestStorageTenant(rawHeaders, config, async () => {
+    const abortScope = createForegroundAbortScope(req.signal);
+    try {
+      const response = await handleCompactEndpointInner(
+        req,
+        config,
+        abortScope.signal,
+        rawHeaders,
+      );
+      return wrapBodyWithCleanup(
+        response,
+        abortScope.dispose,
+        abortScope.signal,
+      );
+    } catch (error) {
+      abortScope.dispose();
+      throw error;
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -10745,7 +11218,28 @@ async function handleResponsesCompactEndpointInner(
   req: Request,
   config: GatewayConfig,
   signal: AbortSignal,
+  rawHeaders: Record<string, string>,
 ): Promise<Response> {
+  if (hasConflictingAuthHeaders(rawHeaders)) {
+    return new Response(
+      JSON.stringify({
+        error: "invalid_request",
+        message:
+          "Conflicting authentication headers: send either x-api-key or Authorization, not both",
+      }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+  const credential = extractAuth(rawHeaders);
+  if (usesRemoteSessionBinding(config) && !credential) {
+    return new Response(
+      JSON.stringify({
+        error: "unauthorized",
+        message: "A provider credential is required",
+      }),
+      { status: 401, headers: { "content-type": "application/json" } },
+    );
+  }
   // Read the body as text so we can both parse it and replay it for passthrough.
   // Decode any Content-Encoding (Codex sends zstd by default) first — otherwise
   // the raw compressed bytes fail to JSON.parse and the passthrough replays
@@ -10775,11 +11269,6 @@ async function handleResponsesCompactEndpointInner(
     );
   }
 
-  const rawHeaders: Record<string, string> = {};
-  req.headers.forEach((value, key) => {
-    rawHeaders[key] = value;
-  });
-
   // Parse the body as a Responses API request to get messages for session
   // fingerprinting. The compact request body has the same shape as a normal
   // /v1/responses request (model, instructions, input, tools, etc.).
@@ -10802,22 +11291,60 @@ async function handleResponsesCompactEndpointInner(
   const pathResult = getProjectPath(gatewayReq.system, rawHeaders);
   const gitRemote = extractGitRemoteHeader(rawHeaders);
 
-  await initIfNeeded(pathResult.path, config, gitRemote);
-
   const { sessionID, isNew } = await identifySession(
     gatewayReq,
     pathResult.path,
+    config,
   );
 
   // If no prior session, skip Lore compaction and passthrough to upstream.
   if (!isNew) {
+    let state: SessionState;
+    try {
+      state = getOrCreateSession(
+        sessionID,
+        pathResult.path,
+        pathResult.source,
+        requestCredentialFingerprint(rawHeaders, config) ?? "",
+        config,
+      );
+    } catch (error) {
+      if (error instanceof SessionTenantMismatchError) {
+        return new Response(
+          JSON.stringify({
+            error: "session_not_found",
+            message: "No session found for the authenticated storage tenant",
+          }),
+          { status: 404, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw error;
+    }
+    if (
+      usesRemoteSessionBinding(config) &&
+      (state.projectPathProvisional === true ||
+        state.projectPath !== pathResult.path)
+    ) {
+      return new Response(
+        JSON.stringify({
+          error: "project_mismatch",
+          message: "project path does not match the authenticated session",
+        }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      );
+    }
+    const compactProjectPath = usesRemoteSessionBinding(config)
+      ? state.projectPath
+      : pathResult.path;
+    await initIfNeeded(compactProjectPath, config, gitRemote);
+
     log.info(
       `responses/compact: generating Lore summary for session ${sessionID.slice(0, 16)}`,
     );
 
     try {
       const summary = await generateCompactionSummary({
-        projectPath: pathResult.path,
+        projectPath: compactProjectPath,
         sessionID,
         config,
         signal,
@@ -10872,6 +11399,7 @@ async function handleResponsesCompactEndpointInner(
     rawHeaders,
     config,
     signal,
+    gatewayReq,
   );
 }
 
@@ -10879,18 +11407,26 @@ export async function handleResponsesCompactEndpoint(
   req: Request,
   config: GatewayConfig,
 ): Promise<Response> {
-  const abortScope = createForegroundAbortScope(req.signal);
-  try {
-    const response = await handleResponsesCompactEndpointInner(
-      req,
-      config,
-      abortScope.signal,
-    );
-    return wrapBodyWithCleanup(response, abortScope.dispose, abortScope.signal);
-  } catch (error) {
-    abortScope.dispose();
-    throw error;
-  }
+  const rawHeaders = requestHeaders(req.headers);
+  return withRequestStorageTenant(rawHeaders, config, async () => {
+    const abortScope = createForegroundAbortScope(req.signal);
+    try {
+      const response = await handleResponsesCompactEndpointInner(
+        req,
+        config,
+        abortScope.signal,
+        rawHeaders,
+      );
+      return wrapBodyWithCleanup(
+        response,
+        abortScope.dispose,
+        abortScope.signal,
+      );
+    } catch (error) {
+      abortScope.dispose();
+      throw error;
+    }
+  });
 }
 
 /**
@@ -10901,18 +11437,155 @@ export async function passthroughResponsesCompact(
   rawHeaders: Record<string, string>,
   config: GatewayConfig,
   callerSignal?: AbortSignal,
+  parsedRequest?: GatewayRequest,
 ): Promise<Response> {
   const abortScope = createForegroundAbortScope(callerSignal);
-  const upstreamUrl = `${config.upstreamOpenAI}/v1/responses/compact`;
+  if (hasConflictingAuthHeaders(rawHeaders)) {
+    abortScope.dispose();
+    return errorResponse(
+      400,
+      "Conflicting authentication headers: send either x-api-key or Authorization, not both",
+    );
+  }
+
+  // Resolve with the same provider/header/model priority chain as a normal
+  // Responses request. If parsing failed, an explicit validated URL override is
+  // the only safe custom route; an explicit provider without a compatible URL
+  // fails closed because model routing is unavailable.
+  const headerUpstream = extractUpstreamUrlHeader(rawHeaders);
+  if (headerUpstream && !extractAuth(rawHeaders)) {
+    abortScope.dispose();
+    return new Response(
+      JSON.stringify({
+        error: "compaction_routing_failed",
+        message: "An explicit upstream URL requires client authentication",
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+  let route: ResolvedRequestUpstreamRoute | undefined;
+  if (parsedRequest) {
+    try {
+      route = resolveRequestUpstreamRoute(parsedRequest, config);
+    } catch (error) {
+      abortScope.dispose();
+      return new Response(
+        JSON.stringify({
+          error: "compaction_routing_failed",
+          message:
+            error instanceof Error ? error.message : "Invalid compact route",
+        }),
+        { status: 502, headers: { "content-type": "application/json" } },
+      );
+    }
+  }
+  const fallbackProviderID = route
+    ? route.providerID
+    : extractProviderHeader(rawHeaders);
+  if (rawHeaders["x-lore-provider"] && !fallbackProviderID) {
+    abortScope.dispose();
+    return new Response(
+      JSON.stringify({
+        error: "compaction_routing_failed",
+        message: "Unsupported or invalid X-Lore-Provider",
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+  if (rawHeaders["x-lore-upstream-url"] && !headerUpstream) {
+    abortScope.dispose();
+    return new Response(
+      JSON.stringify({
+        error: "compaction_routing_failed",
+        message: "Invalid X-Lore-Upstream-URL",
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+  if (headerUpstream && !isCallerUpstreamAllowed(config, headerUpstream)) {
+    abortScope.dispose();
+    return new Response(
+      JSON.stringify({
+        error: "compaction_routing_failed",
+        message:
+          "X-Lore-Upstream-URL origin is not allowed by this remote gateway",
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+  const fallbackProviderRoute =
+    !route && fallbackProviderID
+      ? (resolveProviderRoute(fallbackProviderID) ??
+        lookupProviderRoute(fallbackProviderID, false))
+      : null;
+  if (
+    route?.providerID &&
+    !route.headerUpstream &&
+    (!route.providerRoute?.url ||
+      (route.providerRoute.protocol !== null &&
+        route.providerRoute.protocol !== "openai-responses"))
+  ) {
+    abortScope.dispose();
+    return new Response(
+      JSON.stringify({
+        error: "compaction_routing_failed",
+        message: `Cannot safely resolve a Responses compact endpoint for provider "${route.providerID}"`,
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+  if (
+    !route &&
+    fallbackProviderID &&
+    !headerUpstream &&
+    (!fallbackProviderRoute?.url ||
+      (fallbackProviderRoute.protocol !== null &&
+        fallbackProviderRoute.protocol !== "openai-responses"))
+  ) {
+    abortScope.dispose();
+    return new Response(
+      JSON.stringify({
+        error: "compaction_routing_failed",
+        message: `Cannot safely resolve a Responses compact endpoint for provider "${fallbackProviderID}"`,
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+  const effectiveUpstreamBase =
+    route?.effectiveUpstreamBase ??
+    headerUpstream ??
+    fallbackProviderRoute?.url ??
+    config.upstreamOpenAI;
+  const effectiveProtocol =
+    route?.effectiveProtocol ??
+    fallbackProviderRoute?.protocol ??
+    "openai-responses";
+  if (effectiveProtocol !== "openai-responses") {
+    abortScope.dispose();
+    return new Response(
+      JSON.stringify({
+        error: "compaction_routing_failed",
+        message:
+          "The resolved upstream does not support the OpenAI Responses compact protocol",
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+  const upstreamPath = extractUpstreamPathHeader(rawHeaders);
+  const compactPath = upstreamPath?.endsWith("/responses/compact")
+    ? upstreamPath
+    : undefined;
+  const upstreamUrl = compactPath
+    ? new URL(compactPath, `${effectiveUpstreamBase.replace(/\/+$/, "")}/`).href
+    : fallbackProviderID === "openai-codex"
+      ? `${effectiveUpstreamBase}/codex/responses/compact`
+      : `${effectiveUpstreamBase}/v1/responses/compact`;
   const headers: Record<string, string> = {
     "content-type": "application/json",
   };
 
-  // Forward auth headers (keys are lowercase — Fetch API normalizes them).
-  const auth = rawHeaders.authorization;
-  if (auth) headers.authorization = auth;
-  const apiKey = rawHeaders["x-api-key"];
-  if (apiKey) headers["x-api-key"] = apiKey;
+  // Preserve the one centrally-approved provider-auth scheme exactly.
+  Object.assign(headers, copyProviderAuthHeaders(rawHeaders));
 
   // Forward OpenAI-specific headers
   const openAiBeta = rawHeaders["openai-beta"];
@@ -10928,12 +11601,12 @@ export async function passthroughResponsesCompact(
     bodyText,
     rawHeaders["content-encoding"],
     buildUpstreamRouteContext({
-      upstreamUrlHeader: undefined,
-      providerHeader: undefined,
+      upstreamUrlHeader: headerUpstream,
+      providerHeader: fallbackProviderID,
       ingressProtocol: "openai-responses",
-      effectiveProtocol: "openai-responses",
+      effectiveProtocol,
       ingressUpstreamBase: config.upstreamOpenAI,
-      effectiveUpstreamBase: config.upstreamOpenAI,
+      effectiveUpstreamBase,
     }),
   );
   if (contentEncoding) headers["content-encoding"] = contentEncoding;
@@ -10941,7 +11614,10 @@ export async function passthroughResponsesCompact(
   // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS as a final overlay so
   // corporate proxies / LiteLLM team-routing tokens / Cloudflare AI Gateway
   // / service-account scenarios work for compaction-passthrough calls too.
-  applyUpstreamExtraHeaders(headers, config.upstreamExtraHeaders);
+  applyUpstreamExtraHeaders(
+    headers,
+    extraHeadersForUpstream(config, upstreamUrl),
+  );
 
   try {
     const upstream = await responseAgainstAbort(
@@ -10955,14 +11631,13 @@ export async function passthroughResponsesCompact(
       abortScope.signal,
     );
     return wrapBodyWithCleanup(upstream, abortScope.dispose, abortScope.signal);
-  } catch (err) {
+  } catch {
     abortScope.dispose();
-    const msg = err instanceof Error ? err.message : "Upstream unreachable";
-    log.error("responses/compact upstream passthrough error:", err);
+    log.error("responses/compact upstream passthrough failed");
     return new Response(
       JSON.stringify({
         error: "compaction_failed",
-        message: `Failed to reach upstream: ${msg}`,
+        message: "Failed to reach upstream",
       }),
       { status: 502, headers: { "content-type": "application/json" } },
     );
@@ -11013,6 +11688,7 @@ export function createForegroundAbortScope(caller?: AbortSignal): {
   dispose: () => void;
 } {
   const controller = new AbortController();
+  activeForegroundAbortControllers.add(controller);
   const onCallerAbort = () => controller.abort(caller?.reason);
   caller?.addEventListener("abort", onCallerAbort, { once: true });
   if (caller?.aborted) onCallerAbort();
@@ -11026,6 +11702,7 @@ export function createForegroundAbortScope(caller?: AbortSignal): {
   return {
     signal: controller.signal,
     dispose: () => {
+      activeForegroundAbortControllers.delete(controller);
       clearTimeout(timer);
       caller?.removeEventListener("abort", onCallerAbort);
     },
@@ -11528,19 +12205,15 @@ async function handleConversationTurn(
 
   // --- 2. Capture auth credentials for background workers ---
   const cred = extractAuth(req.rawHeaders);
-  if (cred) {
-    // Tag the global fallback with the request's provider so a worker for a
-    // different provider can't borrow this credential (cross-contamination,
-    // #829). Falls back to the upstream destination URL when no x-lore-provider
-    // header is present — e.g. credentialed title/summary-gen requests that
-    // bypass the per-turn chat.headers hook (#942).
-    setLastSeenAuth(cred, resolveLastSeenProvider(req.rawHeaders));
-  }
+  const legacyGlobalProvider = cred
+    ? captureLegacyGlobalAuth(req, config, cred)
+    : undefined;
 
   // --- 3. Session identification ---
   const { sessionID, isNew, tier } = await identifySession(
     req,
     pathResult.path,
+    config,
   );
 
   // Strip [lore:session-id=...] and [lore:project=...] context markers from
@@ -11552,7 +12225,8 @@ async function handleConversationTurn(
     sessionID,
     pathResult.path,
     pathResult.source,
-    cred ? authFingerprint(cred) : "",
+    requestCredentialFingerprint(req.rawHeaders, config) ?? "",
+    config,
   );
   let projectPath = resolveSessionProjectPath(pathResult, sessionState, config);
 
@@ -11667,8 +12341,13 @@ async function handleConversationTurn(
   // and a warning is logged.
   {
     const parentClientId = req.rawHeaders["x-parent-session-id"];
+    const credentialFingerprint = requestCredentialFingerprint(
+      req.rawHeaders,
+      config,
+    );
     if (
       parentClientId &&
+      credentialFingerprint !== null &&
       (!sessionState.isSubagent || !sessionState.parentSessionId)
     ) {
       if (!sessionState.isSubagent) {
@@ -11679,8 +12358,7 @@ async function handleConversationTurn(
       for (const [key, loreId] of headerSessionIndex) {
         const parsed = parseSessionIndexKey(key);
         if (
-          parsed?.credentialFingerprint ===
-            (sessionState.credentialFingerprint ?? "") &&
+          parsed?.credentialFingerprint === credentialFingerprint &&
           parsed.headerValue === parentClientId
         ) {
           resolvedParent = loreId;
@@ -11717,8 +12395,17 @@ async function handleConversationTurn(
   // cross-contamination when a session switches providers mid-conversation
   // (e.g. Anthropic → MiniMax → Anthropic).
   if (cred) {
-    const reqProviderID = extractProviderHeader(req.rawHeaders);
-    setSessionAuth(sessionID, cred, reqProviderID || undefined);
+    const reqProviderID =
+      requestUpstreamRoute.providerID ??
+      (requestUpstreamRoute.effectiveProtocol === "anthropic"
+        ? "anthropic"
+        : requestUpstreamRoute.effectiveProtocol === "openai" ||
+            requestUpstreamRoute.effectiveProtocol === "openai-responses"
+          ? "openai"
+          : requestUpstreamRoute.effectiveProtocol === "gemini"
+            ? "google"
+            : undefined);
+    setSessionAuth(sessionID, cred, reqProviderID);
     clearWarmupAuthDisabled(sessionID); // Re-enable cache warming on fresh credential
 
     // One-time "it's working" signal. A fresh user has no easy way to tell
@@ -11731,18 +12418,12 @@ async function handleConversationTurn(
       );
     }
 
-    // A credential just landed. If `lore run` deferred a conversation import
-    // (no credential existed at startup), run it now — this is the first
-    // authenticated turn. Forward the provider the GLOBAL fallback was tagged
-    // with — resolveLastSeenProvider (x-lore-provider ?? URL inference), the
-    // same value setLastSeenAuth used above — because the session-less import
-    // job resolves auth against that global. Using the bare header
-    // (extractProviderHeader) here would pass undefined when the provider was
-    // URL-inferred, re-introducing the silent cross-provider drop. One-shot and
-    // self-guarded; a no-op otherwise.
-    trackBackground(
-      flushPendingImport(resolveLastSeenProvider(req.rawHeaders)),
-    );
+    // A session-less import may use only the deliberately captured local,
+    // configured direct-provider credential. Remote/custom routes never expose
+    // their credential through the process-global fallback.
+    if (legacyGlobalProvider) {
+      trackBackground(flushPendingImport(legacyGlobalProvider));
+    }
   }
 
   // Capture billing header prefix for worker cch computation, scoped to
@@ -11759,15 +12440,17 @@ async function handleConversationTurn(
 
   // Track fingerprint for future correlation
   if (isNew) {
+    const credentialFingerprint =
+      requestCredentialFingerprint(req.rawHeaders, config) ?? "";
     const fingerprint = await fingerprintMessages(
       req.messages.map((m) => ({ role: m.role, content: m.content })),
-      {
-        authSuffix: cred ? authFingerprint(cred) : "",
-      },
+      usesRemoteSessionBinding(config)
+        ? { tenantFingerprint: credentialFingerprint }
+        : { authSuffix: cred ? authFingerprint(cred) : "" },
     );
     sessionState.fingerprint = fingerprint;
     // Persist fingerprint immediately — rare event (new session only)
-    saveSessionTracking(sessionID, { fingerprint });
+    saveSessionTracking(sessionID, { fingerprint, credentialFingerprint });
 
     // Seed header learning for new sessions (Tier 2 bootstrap).
     // Even Tier 1 sessions don't need this, but it's harmless and
@@ -11829,6 +12512,7 @@ async function handleConversationTurn(
     consecutiveTextOnlyTurns: sessionState.consecutiveTextOnlyTurns,
     projectPath: sessionState.projectPath || null,
     projectPathProvisional: sessionState.projectPathProvisional === true,
+    credentialFingerprint: sessionState.credentialFingerprint ?? "",
     // v37: persist the compaction anomaly flag so a gateway restart between
     // detection (this turn) and consumption (next turn's scheduleBackgroundWork)
     // doesn't lose the urgent-distillation signal.
@@ -12144,7 +12828,14 @@ async function handleConversationTurn(
     req.messages,
     loreMessages,
   );
-  resolveToolResults(loreMessages);
+  resolveToolResults(loreMessages, (message) =>
+    temporal.storedMessageId({
+      projectPath,
+      sessionID: message.info.sessionID,
+      sourceID: message.info.id,
+      legacySourceID: message.legacySourceID,
+    }),
+  );
 
   // --- 6. LTM injection (system[1] stable prefix + durable-delta context LTM) ---
   // system[0]: Host prompt              [no cache_control]
@@ -13274,21 +13965,7 @@ async function handleConversationTurn(
         foregroundAbort.signal,
       ),
     );
-    // Friendly diagnostic suffix for a pass-through 429 misread as a Lore bug.
-    // 🔴 credScheme is the LOAD-BEARING exclusion for Bedrock: Bedrock also
-    // reports effectiveProtocol === "anthropic", so the protocol gate does NOT
-    // exclude it — only its "api-key" scheme (x-api-key) does. Never drop the
-    // credScheme arg or hardcode it, or Bedrock 429s would misfire the
-    // "your Anthropic subscription's rate limit" hint.
-    const errorHint = upstreamErrorHint({
-      status: upstreamResponse.status,
-      body: errorBody,
-      protocol: effectiveProtocol,
-      credScheme: resolveAuth(sessionID)?.scheme,
-    });
-    log.error(
-      `upstream error: ${upstreamResponse.status} ${errorBody.slice(0, 500)}${errorHint}`,
-    );
+    log.error(`upstream error: ${upstreamResponse.status}`);
 
     // When the API rejects with a context-length error, escalate the compression
     // layer for the next turn so the session doesn't get stuck in a loop.
@@ -13521,10 +14198,9 @@ async function handleConversationTurn(
               recallBlock,
               foregroundAbort.signal,
             );
-      } catch (fetchErr) {
+      } catch {
         log.error(
-          `recall follow-up fetch error (non-stream, depth=${recallDepth}) for session ${sessionState.sessionID.slice(0, 16)}:`,
-          fetchErr,
+          `recall follow-up fetch failed (non-stream, depth=${recallDepth}) for session ${sessionState.sessionID.slice(0, 16)}`,
         );
         // Fall back to response with marker (no continuation)
         markerResp.usage = cumulativeUsage;
@@ -13549,7 +14225,7 @@ async function handleConversationTurn(
 
       if (!jsonFollowUp.ok) {
         log.error(
-          `recall follow-up upstream error: ${jsonFollowUp.status ?? "?"} ${jsonFollowUp.detail}`,
+          `recall follow-up upstream error: ${jsonFollowUp.status ?? "?"}`,
           new Error(`recall follow-up upstream ${jsonFollowUp.status ?? "?"}`),
         );
         captureToolPairing400({
@@ -13716,18 +14392,22 @@ async function handleConversationTurn(
                   stableLtmText,
                   pendingKnowledgeDelta,
                 );
-                const { result, input } = await executeRecall(
-                  {
-                    type: "tool_use",
-                    id: `recall_stream_${query}_${scope ?? ""}_${id ?? ""}`,
-                    name: RECALL_TOOL_NAME,
-                    input: { query, scope, id },
-                  },
-                  sessionState.projectPath,
-                  sessionState.sessionID,
-                  getLLMClient(config),
-                  alreadyInLtm.size > 0 ? alreadyInLtm : undefined,
-                  signal,
+                const { result, input } = await withTenant(
+                  sessionState.storageTenantId ?? "",
+                  () =>
+                    executeRecall(
+                      {
+                        type: "tool_use",
+                        id: `recall_stream_${query}_${scope ?? ""}_${id ?? ""}`,
+                        name: RECALL_TOOL_NAME,
+                        input: { query, scope, id },
+                      },
+                      sessionState.projectPath,
+                      sessionState.sessionID,
+                      getLLMClient(config),
+                      alreadyInLtm.size > 0 ? alreadyInLtm : undefined,
+                      signal,
+                    ),
                 );
                 const recallBlock = acc.content[contentPosition];
                 if (
@@ -14302,13 +14982,13 @@ async function handleLoreSlashCommand(
   if (!text.toLowerCase().startsWith("/lore:")) return null;
 
   // Route to specific handlers
-  const warmupResult = handleWarmupSlashCommand(req, allSessions);
+  const warmupResult = handleWarmupSlashCommand(req, allSessions, config);
   if (warmupResult) return warmupResult;
 
   const curateResult = await handleCurateSlashCommand(req, allSessions, config);
   if (curateResult) return curateResult;
 
-  const amnesiaResult = handleAmnesiaSlashCommand(req, allSessions);
+  const amnesiaResult = handleAmnesiaSlashCommand(req, allSessions, config);
   if (amnesiaResult) return amnesiaResult;
 
   // Unknown /lore:* command — return error instead of forwarding upstream
@@ -14335,6 +15015,7 @@ async function handleLoreSlashCommand(
 function handleAmnesiaSlashCommand(
   req: GatewayRequest,
   allSessions: Map<string, SessionState>,
+  config: GatewayConfig,
 ): Response | null {
   const text = lastUserTextTrimmed(req);
   const lower = text.toLowerCase();
@@ -14347,13 +15028,19 @@ function handleAmnesiaSlashCommand(
   const known = extractKnownSessionHeader(req.rawHeaders);
   let state: SessionState | undefined;
   if (known) {
-    const indexKey = sessionIndexKey(
-      requestCredentialFingerprint(req.rawHeaders),
-      known.headerName,
-      known.sessionId,
+    const credentialFingerprint = requestCredentialFingerprint(
+      req.rawHeaders,
+      config,
     );
-    const sid = headerSessionIndex.get(indexKey);
-    if (sid) state = allSessions.get(sid);
+    if (credentialFingerprint !== null) {
+      const indexKey = sessionIndexKey(
+        credentialFingerprint,
+        known.headerName,
+        known.sessionId,
+      );
+      const sid = headerSessionIndex.get(indexKey);
+      if (sid) state = allSessions.get(sid);
+    }
   }
 
   if (state) {
@@ -14391,6 +15078,7 @@ function handleAmnesiaSlashCommand(
 function handleWarmupSlashCommand(
   req: GatewayRequest,
   allSessions: Map<string, SessionState>,
+  config: GatewayConfig,
 ): Response | null {
   const text = lastUserTextTrimmed(req);
   const lower = text.toLowerCase();
@@ -14402,6 +15090,16 @@ function handleWarmupSlashCommand(
   const isOff = lower === "/lore:warm:off";
   const isOn = lower === "/lore:warm:on";
   if (!isStop && !isKeep && !isAuto && !isReset && !isOff && !isOn) return null;
+
+  if (
+    (isReset || isOff || isOn) &&
+    (config.remoteGateway || config.hostedMode)
+  ) {
+    return errorResponse(
+      403,
+      "Global cache-warming administration is unavailable on remote gateways",
+    );
+  }
 
   // Reset is a breaker-wide admin action — clear every tripped bucket and
   // return immediately (it does not depend on resolving this session).
@@ -14437,13 +15135,19 @@ function handleWarmupSlashCommand(
   const known = extractKnownSessionHeader(req.rawHeaders);
   let state: SessionState | undefined;
   if (known) {
-    const indexKey = sessionIndexKey(
-      requestCredentialFingerprint(req.rawHeaders),
-      known.headerName,
-      known.sessionId,
+    const credentialFingerprint = requestCredentialFingerprint(
+      req.rawHeaders,
+      config,
     );
-    const sid = headerSessionIndex.get(indexKey);
-    if (sid) state = allSessions.get(sid);
+    if (credentialFingerprint !== null) {
+      const indexKey = sessionIndexKey(
+        credentialFingerprint,
+        known.headerName,
+        known.sessionId,
+      );
+      const sid = headerSessionIndex.get(indexKey);
+      if (sid) state = allSessions.get(sid);
+    }
   }
 
   // Update session warmup state
@@ -14508,15 +15212,21 @@ async function handleCurateSlashCommand(
   let state: SessionState | undefined;
   let sessionID: string | undefined;
   if (known) {
-    const indexKey = sessionIndexKey(
-      requestCredentialFingerprint(req.rawHeaders),
-      known.headerName,
-      known.sessionId,
+    const credentialFingerprint = requestCredentialFingerprint(
+      req.rawHeaders,
+      config,
     );
-    const sid = headerSessionIndex.get(indexKey);
-    if (sid) {
-      state = allSessions.get(sid);
-      sessionID = sid;
+    if (credentialFingerprint !== null) {
+      const indexKey = sessionIndexKey(
+        credentialFingerprint,
+        known.headerName,
+        known.sessionId,
+      );
+      const sid = headerSessionIndex.get(indexKey);
+      if (sid) {
+        state = allSessions.get(sid);
+        sessionID = sid;
+      }
     }
   }
 
@@ -14524,11 +15234,16 @@ async function handleCurateSlashCommand(
   if (!sessionID) {
     // Use the most recently active session
     let latest: SessionState | undefined;
-    const credentialFingerprint = requestCredentialFingerprint(req.rawHeaders);
-    for (const s of allSessions.values()) {
-      if ((s.credentialFingerprint ?? "") !== credentialFingerprint) continue;
-      if (!latest || s.lastRequestTime > latest.lastRequestTime) {
-        latest = s;
+    const credentialFingerprint = requestCredentialFingerprint(
+      req.rawHeaders,
+      config,
+    );
+    if (credentialFingerprint !== null) {
+      for (const s of allSessions.values()) {
+        if ((s.credentialFingerprint ?? "") !== credentialFingerprint) continue;
+        if (!latest || s.lastRequestTime > latest.lastRequestTime) {
+          latest = s;
+        }
       }
     }
     if (latest) {
@@ -14842,7 +15557,7 @@ export function earlyFlushStreamingResponse(
  * Returns a standard `Response` object — either a streaming SSE response
  * or a JSON response, depending on the client's `stream` setting.
  */
-export async function handleRequest(
+async function handleRequestForTenant(
   req: GatewayRequest,
   config: GatewayConfig,
 ): Promise<Response> {
@@ -14857,27 +15572,35 @@ export async function handleRequest(
       return errorResponse(400, "Malformed request: missing headers");
     }
 
-    // Capture auth credentials early for background workers. Tag by the
-    // explicit x-lore-provider header, falling back to the upstream URL for
-    // header-less credentialed requests (#829/#942).
+    if (hasConflictingAuthHeaders(req.rawHeaders)) {
+      return errorResponse(
+        400,
+        "Conflicting authentication headers: send either x-api-key or Authorization, not both",
+      );
+    }
+
+    // Validate explicit provider/upstream selection before slash, side-channel,
+    // compaction, and meta branches can take alternate paths. This resolver is
+    // synchronous and performs no network I/O.
+    try {
+      resolveRequestUpstreamRoute(req, config);
+    } catch (error) {
+      return errorResponse(
+        400,
+        error instanceof Error ? error.message : "Invalid upstream route",
+      );
+    }
+
+    // Preserve the process-global legacy credential only for a local,
+    // header-less request to the exact configured provider base.
     const earlyAuth = extractAuth(req.rawHeaders);
     if (earlyAuth) {
-      setLastSeenAuth(earlyAuth, resolveLastSeenProvider(req.rawHeaders));
+      captureLegacyGlobalAuth(req, config, earlyAuth);
     }
 
     // --- Quick Tier-1 session lookup for structural compaction detection ---
     // O(1) header + map lookup — lets us compare message counts before routing.
-    let priorState: SessionState | undefined;
-    const known = extractKnownSessionHeader(req.rawHeaders);
-    if (known) {
-      const indexKey = sessionIndexKey(
-        earlyAuth ? authFingerprint(earlyAuth) : "",
-        known.headerName,
-        known.sessionId,
-      );
-      const sid = headerSessionIndex.get(indexKey);
-      if (sid) priorState = sessions.get(sid);
-    }
+    const priorState = activeSessionForKnownHeader(req, sessions, config);
 
     // --- Case 0: Slash command interception (/lore:*) ---
     // All /lore:* commands are intercepted here and never forwarded upstream.
@@ -14962,8 +15685,18 @@ export async function handleRequest(
         route: "request",
       });
     } else {
-      log.error("pipeline error:", err);
+      log.error("pipeline request failed");
     }
     return errorResponse(502, message);
   }
+}
+
+export async function handleRequest(
+  req: GatewayRequest,
+  config: GatewayConfig,
+): Promise<Response> {
+  if (!req?.rawHeaders) return handleRequestForTenant(req, config);
+  return withRequestStorageTenant(req.rawHeaders, config, () =>
+    handleRequestForTenant(req, config),
+  );
 }

--- a/packages/gateway/src/portfile.ts
+++ b/packages/gateway/src/portfile.ts
@@ -9,21 +9,42 @@
  * harmless — plugins probe `/health` after reading the port and ignore
  * unresponsive ports.
  */
+import { randomBytes } from "node:crypto";
 import { join } from "node:path";
-import { writeFileSync, unlinkSync, readFileSync, mkdirSync } from "node:fs";
+import { linkSync, renameSync, rmSync } from "node:fs";
 import { dataDir } from "@loreai/core";
+import { atomicWriteRuntimeFile, readRuntimeFile } from "./runtime-files";
 
 const PORTFILE_NAME = "gateway.port";
+
+export interface GatewayPortRecord {
+  version: 1;
+  port: number;
+  token: string;
+}
+
+export type PortFileInspection =
+  | { state: "absent" }
+  | { state: "valid"; record: GatewayPortRecord }
+  | { state: "invalid"; reason: string };
 
 function portfilePath(): string {
   return join(dataDir(), PORTFILE_NAME);
 }
 
 /** Write the actual port to disk so plugins can discover it. */
-export function writePortFile(port: number): void {
-  const dir = dataDir();
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(portfilePath(), String(port), "utf8");
+export function writePortFile(port: number, token?: string): void {
+  if (token === undefined) {
+    atomicWriteRuntimeFile(PORTFILE_NAME, String(port));
+    return;
+  }
+  if (!validPort(port) || !validToken(token)) {
+    throw new Error("Invalid gateway port record");
+  }
+  atomicWriteRuntimeFile(
+    PORTFILE_NAME,
+    `${JSON.stringify({ version: 1, port, token })}\n`,
+  );
 }
 
 /**
@@ -31,24 +52,108 @@ export function writePortFile(port: number): void {
  * port this instance wrote. This prevents a concurrent gateway instance
  * from losing its port file when a different instance shuts down.
  */
-export function removePortFile(expectedPort: number): void {
+export function removePortFile(
+  expectedPort: number,
+  expectedToken?: string,
+): void {
+  const path = portfilePath();
+  const claimName = `.gateway.port.cleanup-${process.pid}-${randomBytes(8).toString("hex")}`;
+  const claimPath = join(dataDir(), claimName);
   try {
-    const current = readPortFile();
-    if (current === expectedPort) {
-      unlinkSync(portfilePath());
+    renameSync(path, claimPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  const claimed = inspectPortFile(claimName);
+  if (expectedToken === undefined && claimed.state === "invalid") {
+    try {
+      const legacyPort = Number.parseInt(readRuntimeFile(claimName).trim(), 10);
+      if (legacyPort === expectedPort) {
+        rmSync(claimPath, { force: true });
+        return;
+      }
+    } catch {
+      // Preserve unrecognized evidence below.
     }
-  } catch {
-    /* already gone or unreadable */
+  }
+  if (
+    claimed.state === "valid" &&
+    claimed.record.port === expectedPort &&
+    (expectedToken === undefined || claimed.record.token === expectedToken)
+  ) {
+    rmSync(claimPath, { force: true });
+    return;
+  }
+  try {
+    linkSync(claimPath, path);
+    rmSync(claimPath, { force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    // Preserve the displaced unknown generation as a recovery artifact.
   }
 }
 
 /** Read the port file. Returns the port number or null if not found/invalid. */
 export function readPortFile(): number | null {
   try {
-    const content = readFileSync(portfilePath(), "utf8").trim();
+    const content = readRuntimeFile(PORTFILE_NAME).trim();
+    if (content.startsWith("{")) {
+      const value = JSON.parse(content) as unknown;
+      return validPortRecord(value) ? value.port : null;
+    }
     const port = Number.parseInt(content, 10);
-    return port > 0 && port <= 65535 ? port : null;
+    return validPort(port) ? port : null;
   } catch {
     return null;
+  }
+}
+
+function validPort(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    value <= 65535
+  );
+}
+
+function validToken(value: unknown): value is string {
+  return typeof value === "string" && value.length >= 32 && value.length <= 256;
+}
+
+function validPortRecord(value: unknown): value is GatewayPortRecord {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Partial<GatewayPortRecord>;
+  return (
+    record.version === 1 && validPort(record.port) && validToken(record.token)
+  );
+}
+
+/** Strict discovery API; unlike readPortFile it preserves invalid evidence. */
+export function inspectPortFile(
+  runtimeName: string = PORTFILE_NAME,
+): PortFileInspection {
+  try {
+    let value: unknown;
+    try {
+      value = JSON.parse(readRuntimeFile(runtimeName, { ownerOnly: true }));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { state: "absent" };
+      }
+      return {
+        state: "invalid",
+        reason: `port record is malformed, unreadable, or unsafe: ${String(error)}`,
+      };
+    }
+    return validPortRecord(value)
+      ? { state: "valid", record: value }
+      : { state: "invalid", reason: "port record has invalid fields" };
+  } catch (error) {
+    return {
+      state: "invalid",
+      reason: `port record is unreadable or unsafe: ${String(error)}`,
+    };
   }
 }

--- a/packages/gateway/src/quota.ts
+++ b/packages/gateway/src/quota.ts
@@ -236,11 +236,20 @@ export async function fetchOAuthQuotaSnapshot(
       return null;
     }
 
-    const body = (await response.json()) as unknown;
+    let body: unknown;
+    try {
+      body = (await response.json()) as unknown;
+    } catch {
+      log.warn(
+        `quota: endpoint returned malformed JSON with status ${response.status}`,
+      );
+      return null;
+    }
     return parseSnapshot(body);
-  } catch (err) {
-    // Timeout / network / JSON parse — expected, non-fatal. Warn only.
-    log.warn("quota: fetch error", err);
+  } catch {
+    // Timeout / network failure — expected, non-fatal. Fetch error messages can
+    // contain credential-bearing request URLs, so omit them.
+    log.warn("quota: fetch failed before receiving a usable response");
     return null;
   } finally {
     // Space out the next call by the serial gap, then release the gate.
@@ -339,8 +348,8 @@ export function maybeFetchQuota(sessionID: string, cred: AuthCredential): void {
       // background limiter; leave the short retry window in place.)
       if (snap) quotaFetchCooldown.set(fp, Date.now());
     })
-    .catch((err) => {
-      log.warn("quota: background fetch failed", err);
+    .catch(() => {
+      log.warn("quota: background fetch failed");
     });
 }
 

--- a/packages/gateway/src/runtime-files.ts
+++ b/packages/gateway/src/runtime-files.ts
@@ -1,0 +1,565 @@
+import { randomBytes } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  type Stats,
+} from "node:fs";
+import { basename, join, win32 } from "node:path";
+import { dataDir } from "@loreai/core";
+
+const DIRECTORY_MODE = 0o700;
+const FILE_MODE = 0o600;
+const WINDOWS_PRIVATE_MARKER = "LORE_RUNTIME_ACL_PRIVATE";
+const WINDOWS_ACL_TIMEOUT_MS = 15_000;
+
+type RuntimeFileKind = "directory" | "file";
+type RuntimeFileWindowsSecurityAction = "secure" | "verify";
+
+export interface RuntimeFileWindowsSecurityRequest {
+  path: string;
+  kind: RuntimeFileKind;
+  action: RuntimeFileWindowsSecurityAction;
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+}
+
+export interface RuntimeFileWindowsSecurityResult {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+interface RuntimeFileWindowsSecurityTestHooks {
+  platform?: NodeJS.Platform;
+  powershellPath?: string;
+  run?: (
+    request: RuntimeFileWindowsSecurityRequest,
+  ) => RuntimeFileWindowsSecurityResult;
+}
+
+let windowsSecurityTestHooks: RuntimeFileWindowsSecurityTestHooks | undefined;
+
+/** @internal Deterministic Windows-security seam for non-Windows unit tests. */
+export function _setRuntimeFileWindowsSecurityForTest(
+  hooks: RuntimeFileWindowsSecurityTestHooks | null,
+): void {
+  windowsSecurityTestHooks = hooks ?? undefined;
+}
+
+/*
+ * Windows ignores POSIX creation modes. Use Windows' supported ACL APIs to
+ * replace inheritance with one full-control ACE for the current user's SID,
+ * then independently verify the resulting descriptor. The path is supplied in
+ * the child environment rather than interpolated into this script, so spaces,
+ * quotes, metacharacters, and non-ASCII usernames remain data rather than code.
+ *
+ * The ancestor checks reject reparse points and any non-privileged principal
+ * that can delete, replace, or rewrite an ancestor ACL. Once those checks pass,
+ * another local user cannot swap the validated object during the remaining
+ * lstat/ACL/open sequence; same-user and administrator attacks are outside an
+ * owner-only confidentiality boundary on both Windows and Unix.
+ */
+const WINDOWS_ACL_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$path = [Environment]::GetEnvironmentVariable('LORE_RUNTIME_ACL_PATH', 'Process')
+$kind = [Environment]::GetEnvironmentVariable('LORE_RUNTIME_ACL_KIND', 'Process')
+$action = [Environment]::GetEnvironmentVariable('LORE_RUNTIME_ACL_ACTION', 'Process')
+if ([String]::IsNullOrWhiteSpace($path)) { throw 'runtime ACL path is missing' }
+if ($kind -ne 'directory' -and $kind -ne 'file') { throw 'runtime ACL kind is invalid' }
+if ($action -ne 'secure' -and $action -ne 'verify') { throw 'runtime ACL action is invalid' }
+
+$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User
+if ($null -eq $sid) { throw 'current Windows SID is unavailable' }
+$trustedSids = @(
+  $sid.Value,
+  'S-1-5-18',
+  'S-1-5-32-544',
+  'S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464'
+)
+$dangerousAncestorRights =
+  [Security.AccessControl.FileSystemRights]::Delete -bor
+  [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+  [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+  [Security.AccessControl.FileSystemRights]::TakeOwnership
+
+function Assert-NotReparsePoint($item) {
+  if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "runtime path contains a reparse point: $($item.FullName)"
+  }
+}
+
+function Assert-StableAncestors($leaf) {
+  $item = $leaf.Parent
+  while ($null -ne $item) {
+    Assert-NotReparsePoint $item
+    $acl = [IO.Directory]::GetAccessControl($item.FullName)
+    $owner = $acl.GetOwner([Security.Principal.SecurityIdentifier]).Value
+    if ($trustedSids -notcontains $owner) {
+      throw "runtime path has an untrusted ancestor owner: $($item.FullName)"
+    }
+    $rules = @($acl.GetAccessRules(
+      $true,
+      $true,
+      [Security.Principal.SecurityIdentifier]
+    ))
+    foreach ($rule in $rules) {
+      $inheritOnly =
+        ($rule.PropagationFlags -band [Security.AccessControl.PropagationFlags]::InheritOnly) -ne 0
+      if (
+        -not $inheritOnly -and
+        $rule.AccessControlType -eq [Security.AccessControl.AccessControlType]::Allow -and
+        $trustedSids -notcontains $rule.IdentityReference.Value -and
+        ($rule.FileSystemRights -band $dangerousAncestorRights) -ne 0
+      ) {
+        throw "runtime path has a replaceable ancestor: $($item.FullName)"
+      }
+    }
+    $item = $item.Parent
+  }
+}
+
+function Get-RuntimeItem {
+  $item = if ($kind -eq 'directory') {
+    [IO.DirectoryInfo]::new($path)
+  } else {
+    [IO.FileInfo]::new($path)
+  }
+  $item.Refresh()
+  if (-not $item.Exists) { throw 'runtime ACL path does not exist' }
+  return $item
+}
+
+$item = Get-RuntimeItem
+Assert-NotReparsePoint $item
+Assert-StableAncestors $item
+
+if ($action -eq 'secure') {
+  if ($kind -eq 'directory') {
+    $newAcl = [Security.AccessControl.DirectorySecurity]::new()
+    $inheritance =
+      [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+      [Security.AccessControl.InheritanceFlags]::ObjectInherit
+  } else {
+    $newAcl = [Security.AccessControl.FileSecurity]::new()
+    $inheritance = [Security.AccessControl.InheritanceFlags]::None
+  }
+  $newAcl.SetAccessRuleProtection($true, $false)
+  $newAcl.SetOwner($sid)
+  $rule = [Security.AccessControl.FileSystemAccessRule]::new(
+    $sid,
+    [Security.AccessControl.FileSystemRights]::FullControl,
+    $inheritance,
+    [Security.AccessControl.PropagationFlags]::None,
+    [Security.AccessControl.AccessControlType]::Allow
+  )
+  [void]$newAcl.AddAccessRule($rule)
+  if ($kind -eq 'directory') {
+    [IO.Directory]::SetAccessControl($path, $newAcl)
+  } else {
+    [IO.File]::SetAccessControl($path, $newAcl)
+  }
+}
+
+$item = Get-RuntimeItem
+Assert-NotReparsePoint $item
+Assert-StableAncestors $item
+$actual = if ($kind -eq 'directory') {
+  [IO.Directory]::GetAccessControl($path)
+} else {
+  [IO.File]::GetAccessControl($path)
+}
+$owner = $actual.GetOwner([Security.Principal.SecurityIdentifier]).Value
+if ($owner -ne $sid.Value) { throw 'runtime ACL owner is not the current user' }
+if (-not $actual.AreAccessRulesProtected) { throw 'runtime ACL remains inherited' }
+$rules = @($actual.GetAccessRules(
+  $true,
+  $true,
+  [Security.Principal.SecurityIdentifier]
+))
+if ($rules.Count -ne 1) { throw 'runtime ACL contains a broad access rule' }
+$rule = $rules[0]
+if ($rule.IsInherited) { throw 'runtime ACL contains an inherited access rule' }
+if ($rule.IdentityReference.Value -ne $sid.Value) { throw 'runtime ACL grants another principal' }
+if ($rule.AccessControlType -ne [Security.AccessControl.AccessControlType]::Allow) {
+  throw 'runtime ACL contains a non-allow rule'
+}
+if ($rule.FileSystemRights -ne [Security.AccessControl.FileSystemRights]::FullControl) {
+  throw 'runtime ACL does not grant current-user full control'
+}
+$expectedInheritance = if ($kind -eq 'directory') {
+  [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+  [Security.AccessControl.InheritanceFlags]::ObjectInherit
+} else {
+  [Security.AccessControl.InheritanceFlags]::None
+}
+if ($rule.InheritanceFlags -ne $expectedInheritance) {
+  throw 'runtime ACL has unexpected inheritance flags'
+}
+if ($rule.PropagationFlags -ne [Security.AccessControl.PropagationFlags]::None) {
+  throw 'runtime ACL has unexpected propagation flags'
+}
+[Console]::Out.WriteLine('${WINDOWS_PRIVATE_MARKER}')
+`;
+
+const WINDOWS_ACL_ARGS = [
+  "-NoLogo",
+  "-NoProfile",
+  "-NonInteractive",
+  "-ExecutionPolicy",
+  "Bypass",
+  "-EncodedCommand",
+  Buffer.from(WINDOWS_ACL_SCRIPT, "utf16le").toString("base64"),
+];
+
+function runtimePlatform(): NodeJS.Platform {
+  return windowsSecurityTestHooks?.platform ?? process.platform;
+}
+
+function noFollowFlag(): number {
+  return runtimePlatform() === "win32" ? 0 : constants.O_NOFOLLOW;
+}
+
+function windowsPowerShellPath(): string {
+  if (windowsSecurityTestHooks?.powershellPath) {
+    return windowsSecurityTestHooks.powershellPath;
+  }
+  const windowsRoot = process.env.SystemRoot ?? process.env.WINDIR;
+  if (!windowsRoot || !win32.isAbsolute(windowsRoot)) {
+    throw new Error(
+      "Windows runtime ACL enforcement is unavailable: SystemRoot is missing or invalid",
+    );
+  }
+  return win32.join(
+    windowsRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+function windowsSecurityEnvironment(
+  path: string,
+  kind: RuntimeFileKind,
+  action: RuntimeFileWindowsSecurityAction,
+): NodeJS.ProcessEnv {
+  const reserved = new Set([
+    "LORE_RUNTIME_ACL_PATH",
+    "LORE_RUNTIME_ACL_KIND",
+    "LORE_RUNTIME_ACL_ACTION",
+  ]);
+  const env: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!reserved.has(name.toUpperCase())) env[name] = value;
+  }
+  env.LORE_RUNTIME_ACL_PATH = path;
+  env.LORE_RUNTIME_ACL_KIND = kind;
+  env.LORE_RUNTIME_ACL_ACTION = action;
+  return env;
+}
+
+function runWindowsSecurityCommand(
+  request: RuntimeFileWindowsSecurityRequest,
+): RuntimeFileWindowsSecurityResult {
+  if (windowsSecurityTestHooks?.run) {
+    return windowsSecurityTestHooks.run(request);
+  }
+  const result = spawnSync(request.command, request.args, {
+    env: request.env,
+    encoding: "utf8",
+    windowsHide: true,
+    shell: false,
+    timeout: WINDOWS_ACL_TIMEOUT_MS,
+  });
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+function commandFailureDetail(
+  result: RuntimeFileWindowsSecurityResult,
+): string {
+  return (result.stderr || result.stdout)
+    .trim()
+    .replace(/\s+/g, " ")
+    .slice(0, 500);
+}
+
+function enforceWindowsPrivacy(
+  path: string,
+  kind: RuntimeFileKind,
+  action: RuntimeFileWindowsSecurityAction,
+): void {
+  const request: RuntimeFileWindowsSecurityRequest = {
+    path,
+    kind,
+    action,
+    command: windowsPowerShellPath(),
+    args: [...WINDOWS_ACL_ARGS],
+    env: windowsSecurityEnvironment(path, kind, action),
+  };
+  const result = runWindowsSecurityCommand(request);
+  if (result.error) {
+    throw new Error(
+      `Windows runtime ACL command failed for ${path}: ${result.error.message}`,
+      { cause: result.error },
+    );
+  }
+  if (result.status !== 0 || result.signal !== null) {
+    const detail = commandFailureDetail(result);
+    throw new Error(
+      `Windows runtime ACL ${action} failed for ${path}${detail ? `: ${detail}` : ""}`,
+    );
+  }
+  if (result.stdout.trim() !== WINDOWS_PRIVATE_MARKER) {
+    throw new Error(
+      `Windows runtime ACL ${action} returned unverifiable output for ${path}`,
+    );
+  }
+}
+
+function assertRuntimeFileName(name: string): void {
+  if (name.length === 0 || name !== basename(name) || name === ".") {
+    throw new Error(`Invalid runtime file name: ${name}`);
+  }
+}
+
+function assertCurrentOwner(info: Stats, path: string): void {
+  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+    throw new Error(
+      `Refusing runtime path not owned by the current user: ${path}`,
+    );
+  }
+}
+
+function assertRegularFile(info: Stats, path: string): void {
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error(`Refusing non-regular runtime file: ${path}`);
+  }
+  assertCurrentOwner(info, path);
+}
+
+function assertSameFile(before: Stats, after: Stats, path: string): void {
+  if (before.dev !== after.dev || before.ino !== after.ino) {
+    throw new Error(`Runtime file changed while opening: ${path}`);
+  }
+}
+
+function validateRuntimeDataDir(
+  dir: string,
+  windowsAction: RuntimeFileWindowsSecurityAction = "verify",
+): void {
+  const pathInfo = lstatSync(dir);
+  if (pathInfo.isSymbolicLink() || !pathInfo.isDirectory()) {
+    throw new Error(`Refusing non-directory runtime data path: ${dir}`);
+  }
+  assertCurrentOwner(pathInfo, dir);
+
+  if (runtimePlatform() === "win32") {
+    enforceWindowsPrivacy(dir, "directory", windowsAction);
+    const finalInfo = lstatSync(dir);
+    if (finalInfo.isSymbolicLink() || !finalInfo.isDirectory()) {
+      throw new Error(`Refusing non-directory runtime data path: ${dir}`);
+    }
+    assertCurrentOwner(finalInfo, dir);
+    assertSameFile(pathInfo, finalInfo, dir);
+    return;
+  }
+
+  // Validate and tighten through an open descriptor. O_NOFOLLOW closes the
+  // lstat/open race for the final path component, while O_DIRECTORY ensures a
+  // replacement non-directory cannot be chmodded or subsequently trusted.
+  const fd = openSync(
+    dir,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    const info = fstatSync(fd);
+    if (!info.isDirectory()) {
+      throw new Error(`Refusing non-directory runtime data path: ${dir}`);
+    }
+    assertCurrentOwner(info, dir);
+    assertSameFile(pathInfo, info, dir);
+    if ((info.mode & 0o777) !== DIRECTORY_MODE) {
+      fchmodSync(fd, DIRECTORY_MODE);
+    }
+    const finalInfo = fstatSync(fd);
+    if ((finalInfo.mode & 0o077) !== 0) {
+      throw new Error(`Runtime data directory is not owner-only: ${dir}`);
+    }
+    assertSameFile(lstatSync(dir), finalInfo, dir);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Create, validate, and tighten the gateway runtime data directory. */
+export function ensureRuntimeDataDir(): string {
+  const dir = dataDir();
+  mkdirSync(dir, { recursive: true, mode: DIRECTORY_MODE });
+  validateRuntimeDataDir(dir, "secure");
+  return dir;
+}
+
+/** Validate an existing runtime directory without creating one. */
+function existingRuntimeDataDir(): string {
+  const dir = dataDir();
+  validateRuntimeDataDir(dir);
+  return dir;
+}
+
+/** Atomically replace a runtime record with an owner-only regular file. */
+export function atomicWriteRuntimeFile(name: string, content: string): void {
+  assertRuntimeFileName(name);
+  const dir = ensureRuntimeDataDir();
+  const path = join(dir, name);
+  const temp = join(
+    dir,
+    `.${name}.${process.pid}.${randomBytes(12).toString("hex")}.tmp`,
+  );
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      temp,
+      constants.O_WRONLY |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        noFollowFlag(),
+      FILE_MODE,
+    );
+    const info = fstatSync(fd);
+    assertRegularFile(info, temp);
+    validateRuntimeDataDir(dir);
+    if (runtimePlatform() === "win32") {
+      enforceWindowsPrivacy(temp, "file", "secure");
+      const securedInfo = lstatSync(temp);
+      assertRegularFile(securedInfo, temp);
+      assertSameFile(info, securedInfo, temp);
+    } else {
+      fchmodSync(fd, FILE_MODE);
+    }
+    writeFileSync(fd, content, "utf8");
+    fsyncSync(fd);
+    const completedFd = fd;
+    fd = undefined;
+    closeSync(completedFd);
+
+    // The directory privacy and identity must still hold immediately before
+    // the private temporary generation becomes the published record.
+    validateRuntimeDataDir(dir);
+    assertSameFile(info, lstatSync(temp), temp);
+
+    // rename replaces a final symlink itself rather than following it and is
+    // atomic because the temporary file lives in the same directory.
+    renameSync(temp, path);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+    rmSync(temp, { force: true });
+  }
+}
+
+/** Read an owned regular runtime record without following its final symlink. */
+export function readRuntimeFile(
+  name: string,
+  options: { ownerOnly?: boolean } = {},
+): string {
+  assertRuntimeFileName(name);
+  const path = join(existingRuntimeDataDir(), name);
+  const pathInfo = lstatSync(path);
+  assertRegularFile(pathInfo, path);
+
+  const fd = openSync(path, constants.O_RDONLY | noFollowFlag());
+  try {
+    const info = fstatSync(fd);
+    assertRegularFile(info, path);
+    validateRuntimeDataDir(dataDir());
+    assertSameFile(pathInfo, info, path);
+    if (runtimePlatform() === "win32") {
+      enforceWindowsPrivacy(path, "file", "verify");
+      const securedInfo = lstatSync(path);
+      assertRegularFile(securedInfo, path);
+      assertSameFile(info, securedInfo, path);
+    }
+    if (
+      options.ownerOnly &&
+      runtimePlatform() !== "win32" &&
+      (info.mode & 0o077) !== 0
+    ) {
+      throw new Error(`Runtime file is not owner-only: ${path}`);
+    }
+    return readFileSync(fd, "utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Open an owner-only regular runtime file for append without following its
+ * final symlink. The returned descriptor is owned by the caller.
+ */
+export function openRuntimeFileForAppend(name: string): number {
+  assertRuntimeFileName(name);
+  const path = join(ensureRuntimeDataDir(), name);
+  try {
+    const existing = lstatSync(path);
+    assertRegularFile(existing, path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  // O_NONBLOCK prevents a raced-in FIFO from blocking before fstat rejects it.
+  const fd = openSync(
+    path,
+    constants.O_WRONLY |
+      constants.O_APPEND |
+      constants.O_CREAT |
+      constants.O_NONBLOCK |
+      noFollowFlag(),
+    FILE_MODE,
+  );
+  try {
+    const info = fstatSync(fd);
+    assertRegularFile(info, path);
+    validateRuntimeDataDir(dataDir());
+    try {
+      assertSameFile(lstatSync(path), info, path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(`Runtime file changed while opening: ${path}`);
+      }
+      throw error;
+    }
+    if (runtimePlatform() === "win32") {
+      enforceWindowsPrivacy(path, "file", "secure");
+      const securedInfo = lstatSync(path);
+      assertRegularFile(securedInfo, path);
+      assertSameFile(info, securedInfo, path);
+    } else {
+      fchmodSync(fd, FILE_MODE);
+    }
+    return fd;
+  } catch (error) {
+    closeSync(fd);
+    throw error;
+  }
+}

--- a/packages/gateway/src/sentry.ts
+++ b/packages/gateway/src/sentry.ts
@@ -41,7 +41,7 @@ export function setSentryRequestContext(opts: {
     Sentry.setTag("auth_fingerprint", opts.authFingerprint);
   }
   Sentry.setTag("model", opts.model);
-  Sentry.setTag("upstream_url", opts.upstreamUrl);
+  Sentry.setTag("upstream_origin", safeTelemetryOrigin(opts.upstreamUrl));
   Sentry.setTag("port", String(opts.port));
 
   // Hash project path — sensitive info for secret projects
@@ -53,6 +53,17 @@ export function setSentryRequestContext(opts: {
 
   // Link to Sentry AI monitoring conversation tracking
   Sentry.setConversationId(opts.sessionID);
+}
+
+function safeTelemetryOrigin(value: string): string {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.origin
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 /**
@@ -702,6 +713,12 @@ import { setBustSpiralHook, type BustSpiralInfo } from "@loreai/core";
  * `bustSpiralAlerted` flag in core, cleared on recovery.
  */
 export function setupBustSpiralCapture(): void {
+  const safeInfo = (info: BustSpiralInfo) => ({
+    consecutiveBusts: info.consecutiveBusts,
+    transformCount: info.transformCount,
+    layer: info.layer,
+    capFit: info.capFit,
+  });
   setBustSpiralHook({
     onColdStart: (info: BustSpiralInfo) => {
       if (!Sentry.isInitialized()) return;
@@ -710,7 +727,7 @@ export function setupBustSpiralCapture(): void {
         level: "info",
         message:
           "Cold-start bust spiral observed (within grace window) — expected per #796/#804",
-        data: info,
+        data: safeInfo(info),
       });
     },
     onSpiral: (info: BustSpiralInfo) => {
@@ -725,7 +742,7 @@ export function setupBustSpiralCapture(): void {
           // One grouped issue per fingerprint, not per session/event.
           fingerprint: ["bust-spiral-past-grace"],
           contexts: {
-            bust_spiral: info as unknown as Record<string, unknown>,
+            bust_spiral: safeInfo(info),
           },
         },
       );
@@ -736,7 +753,7 @@ export function setupBustSpiralCapture(): void {
         category: "lore.cache.bust_spiral",
         level: "info",
         message: "Bust spiral recovered",
-        data: info,
+        data: safeInfo(info),
       });
     },
   });
@@ -776,7 +793,13 @@ export function captureEmptyCompletion(info: EmptyCompletionInfo): void {
       level: "warning",
       fingerprint: ["empty-completion", info.protocol],
       contexts: {
-        empty_completion: info as unknown as Record<string, unknown>,
+        empty_completion: {
+          protocol: info.protocol,
+          model: info.model,
+          stopReason: info.stopReason,
+          outputTokens: info.outputTokens,
+          recallDepth: info.recallDepth,
+        },
       },
     },
   );
@@ -1062,7 +1085,6 @@ export function captureClientAbortUnderPressure(ctx: {
       contexts: {
         abort_pressure: {
           route: ctx.route,
-          session_id: ctx.sessionID ?? "unknown",
           time_in_flight_ms: Date.now() - ctx.startMs,
           event_loop_lag_p99_ms: Math.round(lagP99Ms),
           rss_bytes: mem.rss,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -16,11 +16,18 @@
  * code runs under both Bun and the Node.js npm distribution.
  */
 import { createServer as createHttpServer } from "node:http";
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { Server } from "node:http";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { BlockList, isIP, type Socket } from "node:net";
 import { Readable } from "node:stream";
-import { embedding, log } from "@loreai/core";
-import { DEFAULT_PORT, type GatewayConfig } from "./config";
+import { embedding, GATEWAY_AUTH_HEADER, log } from "@loreai/core";
+import {
+  assertGatewayAccessConfigured,
+  DEFAULT_PORT,
+  extraHeadersForUpstream,
+  type GatewayConfig,
+} from "./config";
 import { bootstrapDailySpend, getDailyBudget } from "./cost-tracker";
 import { workerHealthSummary } from "./worker-health";
 import {
@@ -30,6 +37,12 @@ import {
   setupVecReadLatencyCapture,
 } from "./sentry";
 import type { GatewayRequest } from "./translate/types";
+import { applyUpstreamExtraHeaders } from "./translate/types";
+import {
+  copyProviderAuthHeaders,
+  hasConflictingAuthHeaders,
+  PROVIDER_AUTH_HEADER_NAMES,
+} from "./auth";
 import { parseAnthropicRequest } from "./translate/anthropic";
 import { parseOpenAIRequest } from "./translate/openai";
 import { parseGeminiRequest } from "./translate/gemini";
@@ -48,6 +61,7 @@ import { upstreamFetch } from "./fetch";
 import { responseAgainstAbort } from "./abort-race";
 import { cancelAndReleaseReader, readStreamChunk } from "./stream/anthropic";
 import { decodeRequestBody } from "./http-body";
+import { SHUTDOWN_DEADLINE_MS } from "./shutdown-deadline";
 import {
   BEDROCK_RUNTIME_PATH_RE,
   proxyBedrockRuntimeRequest,
@@ -68,20 +82,47 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// CORS headers — permissive for localhost development
+// Browser-origin policy
 // ---------------------------------------------------------------------------
 
-const CORS_HEADERS: Record<string, string> = {
-  "access-control-allow-origin": "*",
-  "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
-  "access-control-allow-headers": "*",
-  "access-control-max-age": "86400",
-};
+const CORS_METHODS = "GET, POST, DELETE, OPTIONS";
 
-function withCors(response: Response): Response {
-  for (const [key, value] of Object.entries(CORS_HEADERS)) {
-    response.headers.set(key, value);
+/**
+ * Data-plane responses are intentionally not CORS-enabled. Clone the response
+ * while removing upstream-supplied CORS headers too, so a cached no-Origin
+ * response cannot make model output readable to a later browser request.
+ */
+function withoutCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+  // Snapshot before deleting so iterator invalidation cannot skip a header.
+  for (const name of Array.from(headers.keys())) {
+    if (name.startsWith("access-control-")) headers.delete(name);
   }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function withManagementCors(
+  response: Response,
+  origin: string | null,
+): Response {
+  // The dashboard contains destructive forms. Prevent an untrusted site from
+  // embedding it and clickjacking a loopback browser into submitting them.
+  response.headers.set("content-security-policy", "frame-ancestors 'none'");
+  response.headers.set("x-frame-options", "DENY");
+
+  // Same-origin browser requests and non-browser clients do not need CORS.
+  // For an explicitly cross-origin request, reflect only the already-validated
+  // loopback origin; a wildcard would let an arbitrary website drive localhost.
+  if (!origin) return response;
+  response.headers.set("access-control-allow-origin", origin);
+  response.headers.set("access-control-allow-methods", CORS_METHODS);
+  response.headers.set("access-control-allow-headers", "content-type");
+  response.headers.set("access-control-max-age", "600");
+  response.headers.append("vary", "Origin");
   return response;
 }
 
@@ -98,12 +139,28 @@ function headersToRecord(headers: Headers): Record<string, string> {
   return record;
 }
 
+function jsonResponseWithoutCors(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
-  return withCors(
-    new Response(JSON.stringify(body), {
-      status,
-      headers: { "content-type": "application/json" },
-    }),
+  return withoutCors(jsonResponseWithoutCors(body, status));
+}
+
+function errorResponseWithoutCors(
+  status: number,
+  type: string,
+  message: string,
+): Response {
+  return jsonResponseWithoutCors(
+    {
+      type: "error",
+      error: { type, message },
+    },
+    status,
   );
 }
 
@@ -112,13 +169,192 @@ function errorResponse(
   type: string,
   message: string,
 ): Response {
-  return jsonResponse(
-    {
-      type: "error",
-      error: { type, message },
-    },
-    status,
+  return withoutCors(errorResponseWithoutCors(status, type, message));
+}
+
+// ---------------------------------------------------------------------------
+// Management access policy
+// ---------------------------------------------------------------------------
+
+const LOOPBACK_ADDRESSES = new BlockList();
+LOOPBACK_ADDRESSES.addSubnet("127.0.0.0", 8, "ipv4");
+LOOPBACK_ADDRESSES.addAddress("::1", "ipv6");
+
+/** True only for a numeric loopback socket address. Hostnames are not trusted. */
+export function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  const family = isIP(address);
+  if (family === 4) return LOOPBACK_ADDRESSES.check(address, "ipv4");
+  if (family === 6) return LOOPBACK_ADDRESSES.check(address, "ipv6");
+  return false;
+}
+
+function isManagementPath(pathname: string): boolean {
+  return (
+    pathname === "/" ||
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname === "/ui" ||
+    pathname.startsWith("/ui/")
   );
+}
+
+function isDataPlanePath(pathname: string): boolean {
+  return (
+    pathname === "/v1/messages" ||
+    pathname === "/v1/chat/completions" ||
+    pathname === "/chat/completions" ||
+    pathname === "/v1/responses" ||
+    pathname === "/v1/codex/responses" ||
+    pathname === "/v1/responses/compact" ||
+    pathname === "/v1/compact" ||
+    pathname === "/v1/models" ||
+    GEMINI_PATH_RE.test(pathname) ||
+    BEDROCK_RUNTIME_PATH_RE.test(pathname)
+  );
+}
+
+/** Deliberately carries no route details or CORS headers. */
+function browserOriginDeniedResponse(): Response {
+  // Do not wait for or drain an attacker-controlled body after rejecting it.
+  return new Response(null, {
+    status: 403,
+    headers: { "cache-control": "no-store", connection: "close" },
+  });
+}
+
+/** Uniform remote data-plane denial: no body, challenge, or config detail. */
+function gatewayAccessDeniedResponse(): Response {
+  return new Response(null, {
+    status: 401,
+    headers: { "cache-control": "no-store", connection: "close" },
+  });
+}
+
+function conflictingProviderAuthResponse(): Response {
+  const response = errorResponseWithoutCors(
+    400,
+    "invalid_request_error",
+    "Conflicting provider authentication headers",
+  );
+  response.headers.set("cache-control", "no-store");
+  response.headers.set("connection", "close");
+  return response;
+}
+
+function rawHeaderCount(
+  rawHeaders: readonly string[] | undefined,
+  target: string,
+): number {
+  if (!rawHeaders) return 1;
+  let count = 0;
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    if (rawHeaders[index]?.toLowerCase() === target) count++;
+  }
+  return count;
+}
+
+function singleRawHeaderValue(
+  rawHeaders: readonly string[],
+  target: string,
+): string | null {
+  let value: string | null = null;
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    if (rawHeaders[index]?.toLowerCase() !== target) continue;
+    if (value !== null) return null;
+    value = rawHeaders[index + 1] ?? "";
+  }
+  return value;
+}
+
+function constantTimeTokenMatches(actual: string, expected: string): boolean {
+  const digest = (value: string): Buffer =>
+    createHash("sha256")
+      .update("lore.gateway-access.v1\0")
+      .update(value)
+      .digest();
+  return timingSafeEqual(digest(actual), digest(expected));
+}
+
+function gatewayAccessMatches(
+  headers: Headers,
+  expected: string,
+  rawHeaders?: readonly string[],
+): boolean {
+  if (rawHeaderCount(rawHeaders, GATEWAY_AUTH_HEADER) !== 1) return false;
+  const actual = rawHeaders
+    ? singleRawHeaderValue(rawHeaders, GATEWAY_AUTH_HEADER)
+    : headers.get(GATEWAY_AUTH_HEADER);
+  return actual !== null && constantTimeTokenMatches(actual, expected);
+}
+
+function hasRawConflictingProviderAuth(rawHeaders: readonly string[]): boolean {
+  const present = new Set<string>();
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index]?.toLowerCase();
+    if (!PROVIDER_AUTH_HEADER_NAMES.some((candidate) => candidate === name)) {
+      continue;
+    }
+    if (present.has(name)) return true;
+    present.add(name);
+    if (present.size > 1) return true;
+  }
+  return false;
+}
+
+/** Remove the access credential before any downstream request processing. */
+function withoutGatewayAccessHeader(req: Request): Request {
+  if (!req.headers.has(GATEWAY_AUTH_HEADER)) return req;
+  const headers = new Headers(req.headers);
+  headers.delete(GATEWAY_AUTH_HEADER);
+  return new Request(req.url, {
+    method: req.method,
+    headers,
+    body: req.body,
+    signal: req.signal,
+    ...(req.body ? { duplex: "half" } : {}),
+  });
+}
+
+/**
+ * Return an allowed CORS origin, null when Origin is absent, or false when an
+ * untrusted web origin supplied the header. Only numeric loopback hosts and the
+ * special-use `localhost` name are valid browser origins for management.
+ */
+function managementCorsOrigin(req: Request): string | null | false {
+  const origin = req.headers.get("origin");
+  if (!origin) return null;
+  try {
+    const parsed = new URL(origin);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+    if (
+      parsed.username ||
+      parsed.password ||
+      parsed.pathname !== "/" ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return false;
+    }
+    const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+    if (hostname !== "localhost" && !isLoopbackAddress(hostname)) return false;
+    return origin;
+  } catch {
+    return false;
+  }
+}
+
+/** Deliberately carries no route details or CORS headers. */
+function hiddenManagementResponse(): Response {
+  // Close rather than leave a keep-alive socket waiting on an unauthorized,
+  // deliberately unread request body (request timeouts are disabled for LLM
+  // streaming routes).
+  return new Response(null, {
+    status: 404,
+    headers: { connection: "close" },
+  });
 }
 
 function requestWithSignal(req: Request, signal: AbortSignal): Request {
@@ -179,7 +415,7 @@ function isWebSocketUpgrade(req: Request): boolean {
  * client not to keep retrying on the same socket.
  */
 function rejectWebSocketUpgrade(pathname: string): Response {
-  const resp = errorResponse(
+  const resp = errorResponseWithoutCors(
     426,
     "websocket_not_supported",
     `WebSocket transport is not supported for ${pathname}; use HTTP.`,
@@ -217,7 +453,7 @@ async function handleAnthropicMessages(
   try {
     const result = await handleRequest(gatewayReq, config);
     // Pipeline returns a Response directly (streaming or non-streaming)
-    return withCors(result);
+    return withoutCors(result);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
     log.error(`pipeline error: ${msg}`);
@@ -240,34 +476,36 @@ export async function handleModelsPassthrough(
     const headers: Record<string, string> = {
       "content-type": "application/json",
     };
-    const apiKey = req.headers.get("x-api-key");
-    const auth = req.headers.get("authorization");
-    if (apiKey) headers["x-api-key"] = apiKey;
-    if (auth) headers.authorization = auth;
+    Object.assign(
+      headers,
+      copyProviderAuthHeaders(headersToRecord(req.headers)),
+    );
     // Anthropic requires the version header
     const anthropicVersion = req.headers.get("anthropic-version");
     if (anthropicVersion) headers["anthropic-version"] = anthropicVersion;
-    // Apply user-supplied LORE_UPSTREAM_EXTRA_HEADERS (corporate proxies,
-    // Cloudflare AI Gateway auth, etc.) as a final overlay.
-    for (const [key, value] of Object.entries(config.upstreamExtraHeaders)) {
-      headers[key] = value;
-    }
+    // Apply administrator credentials as one auth overlay: if configured auth
+    // is present it replaces every client auth variant rather than competing.
+    const upstreamUrl = `${config.upstreamAnthropic}/v1/models`;
+    applyUpstreamExtraHeaders(
+      headers,
+      extraHeadersForUpstream(config, upstreamUrl),
+    );
 
     const upstream = await responseAgainstAbort(
       () =>
-        upstreamFetch(`${config.upstreamAnthropic}/v1/models`, {
+        upstreamFetch(upstreamUrl, {
           headers,
           signal: abortScope.signal,
         }),
       abortScope.signal,
     );
-    // Clone to a new Response so we can append CORS headers
+    // Clone to attach foreground cleanup and strip any upstream CORS headers.
     const response = wrapBodyWithCleanup(
       upstream,
       abortScope.dispose,
       abortScope.signal,
     );
-    return withCors(response);
+    return withoutCors(response);
   } catch (e) {
     abortScope.dispose();
     const msg = e instanceof Error ? e.message : "Upstream unreachable";
@@ -298,6 +536,17 @@ function handleHealth(): Response {
   });
 }
 
+function controlTokenMatches(req: Request, token: string): boolean {
+  const authorization = req.headers.get("authorization") ?? "";
+  const expected = `Bearer ${token}`;
+  const actualBytes = Buffer.from(authorization);
+  const expectedBytes = Buffer.from(expected);
+  return (
+    actualBytes.length === expectedBytes.length &&
+    timingSafeEqual(actualBytes, expectedBytes)
+  );
+}
+
 async function handleOpenAIChatCompletions(
   req: Request,
   config: GatewayConfig,
@@ -325,7 +574,7 @@ async function handleOpenAIChatCompletions(
     // (OpenAI Chat Completions JSON or SSE), so no server-side translation
     // is needed. This prevents the class of bugs where the stream flag is
     // forgotten during format conversion.
-    return withCors(await handleRequest(gatewayReq, config));
+    return withoutCors(await handleRequest(gatewayReq, config));
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
     log.error(`pipeline error: ${msg}`);
@@ -379,7 +628,7 @@ async function handleGeminiGenerateContent(
   try {
     // Pipeline returns the response in the client's native Gemini wire format
     // (generateContent JSON or streamGenerateContent SSE).
-    return withCors(await handleRequest(gatewayReq, config));
+    return withoutCors(await handleRequest(gatewayReq, config));
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
     log.error(`pipeline error: ${msg}`);
@@ -416,7 +665,7 @@ async function handleOpenAIResponses(
     // Pipeline returns the response in the client's native wire format
     // (OpenAI Responses API JSON or SSE), so no server-side translation
     // is needed.
-    return withCors(await handleRequest(gatewayReq, config));
+    return withoutCors(await handleRequest(gatewayReq, config));
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
     log.error(`pipeline error: ${msg}`);
@@ -454,7 +703,7 @@ async function handleOpenAICodexResponses(
   }
 
   try {
-    return withCors(await handleRequest(gatewayReq, config));
+    return withoutCors(await handleRequest(gatewayReq, config));
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Pipeline error";
     log.error(`pipeline error: ${msg}`);
@@ -466,13 +715,32 @@ async function handleOpenAICodexResponses(
 // Server
 // ---------------------------------------------------------------------------
 
-export async function startServer(config: GatewayConfig): Promise<{
-  stop: () => void;
+const responseCompletionCallbacks = new WeakMap<Response, () => void>();
+
+export async function startServer(
+  config: GatewayConfig,
+  options: {
+    controlToken?: string;
+    /** Invoked asynchronously after an authenticated shutdown response flushes. */
+    onShutdown?: () => void | Promise<void>;
+    /** Focused lifecycle seam for exercising listener-close failures. */
+    closeServer?: (server: Server) => Promise<void>;
+    /** Focused lifecycle seam for bounded-drain regression tests. */
+    shutdownDeadlineMs?: number;
+    /** Focused access-control seam for simulating a socket peer in tests. */
+    peerAddressForRequest?: (request: IncomingMessage) => string | undefined;
+  } = {},
+): Promise<{
+  stop: () => Promise<void>;
   port: number;
   hosts: string[];
   /** Resolves when all bound servers are listening. */
   ready: Promise<void>;
 }> {
+  const closeBoundServer =
+    options.closeServer ??
+    ((server: Server) =>
+      closeServer(server, options.shutdownDeadlineMs ?? SHUTDOWN_DEADLINE_MS));
   // Defensive defaults for public API consumers who may pass incomplete config.
   // loadConfig() always provides these, but startServer is a public export.
   config = config ?? ({} as GatewayConfig);
@@ -486,6 +754,7 @@ export async function startServer(config: GatewayConfig): Promise<{
   if (!Number.isFinite(config.port) || config.port < 0) {
     config = { ...config, port: DEFAULT_PORT };
   }
+  assertGatewayAccessConfigured(config);
 
   // Bootstrap the daily spend counter from DB (recovers today's spend after restart)
   if (getDailyBudget() > 0) {
@@ -509,14 +778,72 @@ export async function startServer(config: GatewayConfig): Promise<{
   setupVecReadLatencyCapture();
 
   // Shared fetch handler for all server instances.
-  const fetch = async (req: Request): Promise<Response> => {
+  const fetch = async (
+    req: Request,
+    peerAddress: string | undefined,
+    rawHeaders?: readonly string[],
+  ): Promise<Response> => {
     const url = new URL(req.url);
     const { pathname } = url;
     const method = req.method;
+    const managementPath = isManagementPath(pathname);
+    const dataPlanePath = isDataPlanePath(pathname);
+    let allowedManagementOrigin: string | null = null;
 
-    // CORS preflight
+    if (managementPath) {
+      // Authorize from node:http's socket metadata, never from Forwarded,
+      // X-Forwarded-For, Host, or another client-controlled header. Keep this
+      // before preflight handling, lazy imports, and request body consumption.
+      if (!isLoopbackAddress(peerAddress)) return hiddenManagementResponse();
+
+      const origin = managementCorsOrigin(req);
+      if (origin === false) return hiddenManagementResponse();
+      allowedManagementOrigin = origin;
+
+      if (method === "OPTIONS") {
+        return withManagementCors(
+          new Response(null, { status: 204 }),
+          allowedManagementOrigin,
+        );
+      }
+    }
+
+    // Provider credentials authorize an upstream, not this gateway. Browser
+    // origins therefore cannot invoke any model/data-plane route, even from a
+    // loopback origin. Keep this ahead of preflight handling, body reads,
+    // authentication, session/storage setup, and upstream/interceptor work.
+    if (dataPlanePath && req.headers.has("origin")) {
+      return browserOriginDeniedResponse();
+    }
+
+    // Provider keys authorize model providers, never this gateway. Enforce the
+    // separate access credential and all mixed-provider-auth pairs centrally,
+    // before OPTIONS handling, body reads, session/storage/cost state, auth
+    // learning, configured credential overlays, or upstream/interceptor calls.
+    if (dataPlanePath) {
+      if (
+        (config.remoteGateway || config.hostedMode) &&
+        (!config.gatewayAuthToken ||
+          !gatewayAccessMatches(
+            req.headers,
+            config.gatewayAuthToken,
+            rawHeaders,
+          ))
+      ) {
+        return gatewayAccessDeniedResponse();
+      }
+      if (
+        hasConflictingAuthHeaders(headersToRecord(req.headers)) ||
+        (rawHeaders !== undefined && hasRawConflictingProviderAuth(rawHeaders))
+      ) {
+        return conflictingProviderAuthResponse();
+      }
+      req = withoutGatewayAccessHeader(req);
+    }
+
+    // Preserve no-Origin OPTIONS behavior without enabling browser CORS.
     if (method === "OPTIONS") {
-      return withCors(new Response(null, { status: 204 }));
+      return withoutCors(new Response(null, { status: 204 }));
     }
 
     if (config.debug && !log.isStderrSilenced()) {
@@ -533,7 +860,10 @@ export async function startServer(config: GatewayConfig): Promise<{
           `[lore] rejecting WebSocket upgrade for ${pathname} (HTTP-only gateway)`,
         );
       }
-      return withCors(rejectWebSocketUpgrade(pathname));
+      const response = rejectWebSocketUpgrade(pathname);
+      return managementPath
+        ? withManagementCors(response, allowedManagementOrigin)
+        : withoutCors(response);
     }
 
     try {
@@ -577,7 +907,7 @@ export async function startServer(config: GatewayConfig): Promise<{
 
       // POST /v1/responses/compact — Codex compaction (Responses API)
       if (method === "POST" && pathname === "/v1/responses/compact") {
-        return withCors(
+        return withoutCors(
           await handleForegroundBodyRoute(req, (scoped) =>
             handleResponsesCompactEndpoint(scoped, config),
           ),
@@ -605,7 +935,7 @@ export async function startServer(config: GatewayConfig): Promise<{
 
       // POST /v1/compact — explicit compaction summary (Pi plugin, etc.)
       if (method === "POST" && pathname === "/v1/compact") {
-        return withCors(
+        return withoutCors(
           await handleForegroundBodyRoute(req, (scoped) =>
             handleCompactEndpoint(scoped, config),
           ),
@@ -619,7 +949,7 @@ export async function startServer(config: GatewayConfig): Promise<{
       // already owns retries, streaming, and credential rotation). Region
       // comes from LORE_BEDROCK_REGION / AWS_REGION (loaded into config).
       if (method === "POST" && BEDROCK_RUNTIME_PATH_RE.test(pathname)) {
-        return withCors(
+        return withoutCors(
           await proxyBedrockRuntimeRequest(req, config.bedrockRegion),
         );
       }
@@ -634,10 +964,51 @@ export async function startServer(config: GatewayConfig): Promise<{
         return handleHealth();
       }
 
+      // Owner-only process control used by `lore stop`. Public health omits the
+      // PID because a public response cannot prove process ownership. Every
+      // unauthorized method is the same 404 as an absent route.
+      if (
+        (method === "GET" || method === "POST") &&
+        pathname === "/_lore/control"
+      ) {
+        if (
+          !options.controlToken ||
+          !controlTokenMatches(req, options.controlToken) ||
+          (method === "POST" && !options.onShutdown)
+        ) {
+          return errorResponse(
+            404,
+            "not_found",
+            `No route for ${method} /_lore/control`,
+          );
+        }
+        const response = jsonResponse({
+          status: "ok",
+          service: "lore",
+          pid: process.pid,
+          ...(method === "POST" ? { shutdown: "requested" } : {}),
+        });
+        if (method === "POST") {
+          responseCompletionCallbacks.set(response, () => {
+            try {
+              void Promise.resolve(options.onShutdown?.()).catch((error) => {
+                log.error("remote shutdown callback failed:", error);
+              });
+            } catch (error) {
+              log.error("remote shutdown callback failed:", error);
+            }
+          });
+        }
+        return response;
+      }
+
       // GET/POST/DELETE /api/* — REST API (lazy-imported to keep proxy hot path fast)
       if (pathname.startsWith("/api/")) {
         const { handleAPIRequest } = await import("./api");
-        return withCors(await handleAPIRequest(req, url, config));
+        return withManagementCors(
+          await handleAPIRequest(req, url, config),
+          allowedManagementOrigin,
+        );
       }
 
       // GET/POST /ui/* — Web dashboard (lazy-imported to keep proxy hot path fast)
@@ -664,31 +1035,43 @@ export async function startServer(config: GatewayConfig): Promise<{
             30_000,
           ),
         );
-        return withCors(await Promise.race([uiPromise, timeoutPromise]));
+        return withManagementCors(
+          await Promise.race([uiPromise, timeoutPromise]),
+          allowedManagementOrigin,
+        );
       }
 
       // GET / — redirect to dashboard. Build the redirect manually instead of
-      // via Response.redirect(), whose headers are immutable: withCors() would
-      // throw "immutable" while adding CORS headers and the root path would 500
-      // instead of redirecting.
+      // via Response.redirect(), whose headers are immutable: management CORS
+      // could not be applied and the root path would 500 instead of redirecting.
       if (method === "GET" && pathname === "/") {
-        return withCors(
+        return withManagementCors(
           new Response(null, {
             status: 302,
             headers: { location: new URL("/ui", url).toString() },
           }),
+          allowedManagementOrigin,
         );
       }
 
       // 404 for everything else
-      return errorResponse(
+      const notFound = errorResponseWithoutCors(
         404,
         "not_found",
         `No route for ${method} ${pathname}`,
       );
+      return managementPath
+        ? withManagementCors(notFound, allowedManagementOrigin)
+        : withoutCors(notFound);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Internal server error";
       log.error(`uncaught error: ${msg}`);
+      if (managementPath) {
+        return withManagementCors(
+          errorResponseWithoutCors(500, "api_error", msg),
+          allowedManagementOrigin,
+        );
+      }
       return errorResponse(500, "api_error", msg);
     }
   };
@@ -707,8 +1090,16 @@ export async function startServer(config: GatewayConfig): Promise<{
   try {
     for (const host of config.hosts) {
       const s = createHttpServer((nodeReq, nodeRes) => {
-        void handleNodeRequest(nodeReq, nodeRes, fetch, host, resolvedPort);
+        void handleNodeRequest(
+          nodeReq,
+          nodeRes,
+          fetch,
+          host,
+          resolvedPort,
+          options.peerAddressForRequest,
+        );
       });
+      trackServerSockets(s);
       // LLM streaming responses can be very long-lived — disable Node's
       // default timeouts (request/headers/keep-alive/socket) that would
       // otherwise kill idle streaming connections. 0 means "no timeout".
@@ -722,6 +1113,57 @@ export async function startServer(config: GatewayConfig): Promise<{
       // install a dedicated listener that writes a 426 + closes the socket.
       // Mirrors the `isWebSocketUpgrade` rejection in the fetch handler.
       s.on("upgrade", (req, socket) => {
+        const pathname = new URL(req.url ?? "/", "http://gateway.local")
+          .pathname;
+        if (isDataPlanePath(pathname) && req.headers.origin !== undefined) {
+          socket.end(
+            "HTTP/1.1 403 Forbidden\r\n" +
+              "Content-Length: 0\r\n" +
+              "Connection: close\r\n" +
+              "\r\n",
+          );
+          return;
+        }
+        if (isDataPlanePath(pathname)) {
+          const accessHeader = singleRawHeaderValue(
+            req.rawHeaders,
+            GATEWAY_AUTH_HEADER,
+          );
+          const accessAllowed =
+            !(config.remoteGateway || config.hostedMode) ||
+            (typeof config.gatewayAuthToken === "string" &&
+              accessHeader !== null &&
+              constantTimeTokenMatches(accessHeader, config.gatewayAuthToken));
+          if (!accessAllowed) {
+            socket.end(
+              "HTTP/1.1 401 Unauthorized\r\n" +
+                "Content-Length: 0\r\n" +
+                "Cache-Control: no-store\r\n" +
+                "Connection: close\r\n" +
+                "\r\n",
+            );
+            return;
+          }
+          if (hasRawConflictingProviderAuth(req.rawHeaders)) {
+            const body = JSON.stringify({
+              type: "error",
+              error: {
+                type: "invalid_request_error",
+                message: "Conflicting provider authentication headers",
+              },
+            });
+            socket.end(
+              "HTTP/1.1 400 Bad Request\r\n" +
+                "Content-Type: application/json\r\n" +
+                `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+                "Cache-Control: no-store\r\n" +
+                "Connection: close\r\n" +
+                "\r\n" +
+                body,
+            );
+            return;
+          }
+        }
         if (config.debug && !log.isStderrSilenced()) {
           console.error(
             `[lore] rejecting WebSocket upgrade for ${req.url ?? "/"} (HTTP-only gateway)`,
@@ -744,10 +1186,6 @@ export async function startServer(config: GatewayConfig): Promise<{
             "Content-Type: application/json\r\n" +
             `Content-Length: ${Buffer.byteLength(body)}\r\n` +
             "Connection: close\r\n" +
-            "Access-Control-Allow-Origin: *\r\n" +
-            "Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\n" +
-            "Access-Control-Allow-Headers: *\r\n" +
-            "Access-Control-Max-Age: 86400\r\n" +
             "\r\n" +
             body,
         );
@@ -769,7 +1207,7 @@ export async function startServer(config: GatewayConfig): Promise<{
         // error still propagate to startGateway()'s port-fallback/reuse logic.
         if (isUnavailableAddressError(e)) {
           // Close this never-listening server to avoid leaking the handle.
-          s.close();
+          await closeBoundServer(s);
           // Always warn (not just in debug): silently degrading to loopback-only
           // when an explicitly-configured host is dropped is surprising, and the
           // event is low-frequency and actionable.
@@ -793,7 +1231,7 @@ export async function startServer(config: GatewayConfig): Promise<{
     // A later host failed to bind (e.g. EADDRINUSE) after earlier hosts
     // already bound — close the successfully-bound servers so we don't leak
     // file descriptors, then re-throw for startGateway() to handle.
-    for (const s of servers) s.close();
+    await Promise.all(servers.map(closeBoundServer));
     throw e;
   }
 
@@ -810,9 +1248,11 @@ export async function startServer(config: GatewayConfig): Promise<{
     .map((s) => serverReadyPromises.get(s))
     .filter((p): p is Promise<void> => p !== undefined);
 
+  let stopPromise: Promise<void> | undefined;
   const result = {
-    stop: () => {
-      for (const s of servers) s.close();
+    stop: (): Promise<void> => {
+      stopPromise ??= Promise.all(servers.map(closeBoundServer)).then(() => {});
+      return stopPromise;
     },
     port: resolvedPort,
     // Report the hosts we actually bound (unavailable ones were skipped), so
@@ -843,6 +1283,45 @@ export async function startServer(config: GatewayConfig): Promise<{
   }
 
   return promise;
+}
+
+const serverSockets = new WeakMap<Server, Set<Socket>>();
+
+function trackServerSockets(server: Server): void {
+  const sockets = new Set<Socket>();
+  serverSockets.set(server, sockets);
+  server.on("connection", (socket: Socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+}
+
+/**
+ * Stop accepting work, drain established requests, then destroy any sockets
+ * that still prevent `server.close()` from settling (including partial HTTP
+ * headers that never become an IncomingMessage).
+ */
+function closeServer(server: Server, deadlineMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      // Node's helpers cover parsed HTTP connections; explicit tracking also
+      // covers sockets still stalled in the HTTP parser and upgraded sockets.
+      server.closeIdleConnections();
+      server.closeAllConnections();
+      for (const socket of serverSockets.get(server) ?? []) socket.destroy();
+    }, deadlineMs);
+    server.close((error) => {
+      clearTimeout(timer);
+      if (
+        !error ||
+        (error as NodeJS.ErrnoException).code === "ERR_SERVER_NOT_RUNNING"
+      ) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    });
+  });
 }
 
 /**
@@ -1031,12 +1510,18 @@ export function waitForNodeResponseCompletion(
 export async function handleNodeRequest(
   nodeReq: IncomingMessage,
   nodeRes: ServerResponse,
-  fetch: (req: Request) => Response | Promise<Response>,
+  fetch: (
+    req: Request,
+    peerAddress: string | undefined,
+    rawHeaders?: readonly string[],
+  ) => Response | Promise<Response>,
   host: string,
   port: number,
+  peerAddressForRequest?: (request: IncomingMessage) => string | undefined,
 ): Promise<void> {
   const ingressAbort = bindNodeIngressAbort(nodeReq, nodeRes);
   let responseStarted = false;
+  let responseCompleted = false;
   try {
     const url = `http://${bracketHost(host)}:${port}${nodeReq.url ?? "/"}`;
 
@@ -1055,7 +1540,16 @@ export async function handleNodeRequest(
     });
 
     const response = await responseAgainstAbort(
-      () => Promise.resolve(fetch(req)),
+      () =>
+        Promise.resolve(
+          fetch(
+            req,
+            peerAddressForRequest
+              ? peerAddressForRequest(nodeReq)
+              : nodeReq.socket.remoteAddress,
+            nodeReq.rawHeaders,
+          ),
+        ),
       ingressAbort.signal,
     );
 
@@ -1095,6 +1589,11 @@ export async function handleNodeRequest(
       );
       nodeRes.end();
       await completed;
+      responseCompleted = true;
+    }
+    if (responseCompleted) {
+      const onResponseComplete = responseCompletionCallbacks.get(response);
+      if (onResponseComplete) setImmediate(onResponseComplete);
     }
   } catch (err) {
     if (!ingressAbort.signal.aborted) log.error("request handler error:", err);

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -10,22 +10,30 @@
  *    legacy name). Checked in priority order; first match wins.
  *
  *  **Tier 2 — Learned headers** (bootstrapped via fingerprint):
- *    During the first few fingerprinted turns, collect candidate `x-`
- *    headers with ID-like values. Promote a header after it is stable
+ *    During the first few fingerprinted turns, collect non-credential
+ *    candidate `x-` headers with ID-like values. Promote a header after it is stable
  *    within a session (same value across 3 turns) AND varies across
  *    different sessions (not a global constant like client version).
  *
  *  **Tier 3 — Fingerprint fallback** (bootstrap + unknown clients):
- *    SHA-256 of the first user message + auth suffix. Used to bootstrap
- *    Tier 2 learning and as permanent fallback for headerless clients.
+ *    SHA-256 of the first user message + auth suffix. Remote gateways use a
+ *    domain-separated full tenant fingerprint instead. Used to bootstrap Tier
+ *    2 learning and as permanent fallback for headerless clients.
  *    Model is intentionally excluded (model strings change mid-session).
  *
  * The session ID packs 8 random bytes + 4 bytes of unix timestamp
  * (seconds, big-endian) into 12 bytes, then base62-encodes them to a
  * compact alphanumeric string (~17 chars).
  *
- * This module has zero dependencies on `@loreai/core` — pure utility.
+ * This module depends only on the shared credential-header policy from core.
  */
+
+import {
+  isCredentialHeaderName,
+  KNOWN_SESSION_HEADERS,
+} from "./credential-headers";
+
+export { isCredentialHeaderName, KNOWN_SESSION_HEADERS };
 
 // ---------------------------------------------------------------------------
 // Base62 encoding
@@ -169,9 +177,10 @@ export function scanForMarker(
  * Compute a SHA-256 fingerprint from the first user message's content,
  * optionally incorporating an auth credential suffix.
  *
- * Returns the first 16 hex characters of the hash. Used as the Tier 3
- * (fallback) session correlator — combined with message-count proximity
- * to disambiguate forked sessions that share the same first message.
+ * Local mode returns the historical first 16 hex characters of the hash.
+ * Remote mode prefixes that correlator with the full server-derived tenant
+ * fingerprint so the persisted lookup retains an exact tenant boundary. Used
+ * as the Tier 3 fallback with message-count proximity to disambiguate forks.
  *
  * Model is intentionally excluded: model strings change mid-session
  * (e.g. `claude-opus-4-7` → `opus-4-6`) and including them caused
@@ -179,7 +188,7 @@ export function scanForMarker(
  */
 export async function fingerprintMessages(
   messages: Array<{ role: string; content: unknown }>,
-  extras?: { authSuffix?: string },
+  extras?: { authSuffix?: string; tenantFingerprint?: string },
 ): Promise<string> {
   let firstUserContent = "";
   for (const msg of messages) {
@@ -190,17 +199,28 @@ export async function fingerprintMessages(
     }
   }
 
-  const material = firstUserContent + (extras?.authSuffix ?? "");
+  // Preserve the historical/local fingerprint byte-for-byte. Remote mode uses
+  // an explicitly versioned encoding so pre-binding historical rows cannot be
+  // adopted across tenants after an upgrade. Delimiters also remove the
+  // concatenation ambiguity of the legacy firstMessage+suffix format.
+  const material = extras?.tenantFingerprint
+    ? `lore.remote-session-fingerprint.v1\0${extras.tenantFingerprint}\0${firstUserContent}`
+    : firstUserContent + (extras?.authSuffix ?? "");
   const encoded = new TextEncoder().encode(material);
   const hash = await crypto.subtle.digest("SHA-256", encoded);
   const bytes = new Uint8Array(hash);
 
-  // First 16 hex chars (8 bytes)
+  // First 16 hex chars (8 bytes) for message correlation. In remote mode the
+  // full tenant fingerprint is retained as a separate, exact-match component:
+  // a truncated combined hash would make a theoretical cross-tenant collision
+  // adoptable after restart, violating the tenant boundary.
   let hex = "";
   for (let i = 0; i < 8; i++) {
     hex += bytes[i].toString(16).padStart(2, "0");
   }
-  return hex;
+  return extras?.tenantFingerprint
+    ? `lore-tenant-fingerprint-v1:${extras.tenantFingerprint}:${hex}`
+    : hex;
 }
 
 // ---------------------------------------------------------------------------
@@ -244,17 +264,6 @@ export function isClaudeCodeClient(
 // ---------------------------------------------------------------------------
 // Session identification
 // ---------------------------------------------------------------------------
-
-/**
- * Well-known HTTP headers that carry a persistent, unique session ID.
- * Checked in order — first match wins.
- */
-export const KNOWN_SESSION_HEADERS = [
-  "x-lore-session-id", // Lore plugins (stable, deterministic) — checked first
-  "x-claude-code-session-id", // Claude Code (fresh UUID per conversation — never rotates)
-  "x-session-id", // Generic session ID (e.g. OpenCode v1.17+, stable per session)
-  "x-session-affinity", // OpenCode (nanoid, regenerated on process restart — MAY rotate)
-] as const;
 
 /**
  * Headers whose values may change on a client process restart while the
@@ -369,16 +378,18 @@ export function isIdLikeValue(value: string): boolean {
 /**
  * Collect candidate headers from a request that could carry session IDs.
  *
- * Returns all `x-` prefixed headers with ID-like values — both those
+ * Returns non-credential `x-` prefixed headers with ID-like values — both those
  * matching the session/affinity name patterns and generic ones. The
- * learning algorithm will filter by stability over time.
+ * learning algorithm will filter by stability over time. Credential names are
+ * rejected here, before their raw values can enter either promotion pass.
  */
 export function collectCandidateHeaders(
   rawHeaders: Record<string, string>,
 ): Map<string, string> {
   const candidates = new Map<string, string>();
   for (const [name, value] of Object.entries(rawHeaders)) {
-    if (!name.startsWith("x-")) continue;
+    if (isCredentialHeaderName(name)) continue;
+    if (!name.toLowerCase().startsWith("x-")) continue;
     if (!isIdLikeValue(value)) continue;
 
     // Accept if name matches session/affinity pattern, or if the value

--- a/packages/gateway/src/shutdown-deadline.ts
+++ b/packages/gateway/src/shutdown-deadline.ts
@@ -1,0 +1,25 @@
+const DEFAULT_SHUTDOWN_DEADLINE_MS = 4000;
+const MIN_SHUTDOWN_DEADLINE_MS = 10;
+const MAX_SHUTDOWN_DEADLINE_MS = 2_147_483_647;
+
+/** Parse a Node-safe integer shutdown deadline, falling back on invalid input. */
+export function parseShutdownDeadline(
+  raw: string | undefined,
+  fallback: number = DEFAULT_SHUTDOWN_DEADLINE_MS,
+): number {
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    value > MAX_SHUTDOWN_DEADLINE_MS
+  ) {
+    return fallback;
+  }
+  return Math.max(value, MIN_SHUTDOWN_DEADLINE_MS);
+}
+
+/** Shared bound for signal-driven and authenticated-control shutdown. */
+export const SHUTDOWN_DEADLINE_MS = parseShutdownDeadline(
+  process.env.LORE_SHUTDOWN_TIMEOUT_MS,
+);

--- a/packages/gateway/src/sync.ts
+++ b/packages/gateway/src/sync.ts
@@ -35,6 +35,7 @@ import {
   convergeProjectsByRemote,
 } from "@loreai/core";
 import { getAuthedClient, getCurrentUser } from "./supabase";
+import type { GatewayConfig } from "./config";
 
 const PAGE = 200;
 const pushKey = (t: string) => `sync.push.${t}`;
@@ -75,6 +76,13 @@ export interface SyncProgress {
   pulled: number;
 }
 export type SyncProgressFn = (p: SyncProgress) => void;
+
+const emptySyncResult = (): SyncResult => ({
+  pushed: 0,
+  pulled: 0,
+  conflicts: 0,
+  skipped: 0,
+});
 
 type PushErrorKind = "quota" | "poison" | "transient";
 
@@ -344,6 +352,7 @@ export async function pushOnce(
   client: SupabaseClient,
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
+  if (!syncData.isLocalSyncContext()) return emptySyncResult();
   const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
   const enc = makeEncryptionResolver();
   for (const meta of syncData.syncedTablesFor(syncData.currentSyncTier())) {
@@ -741,6 +750,7 @@ export async function pullOnce(
   client: SupabaseClient,
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
+  if (!syncData.isLocalSyncContext()) return emptySyncResult();
   const res: SyncResult = { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
   const encResolver = makeEncryptionResolver();
 
@@ -1054,6 +1064,16 @@ function applyRemote(
   enc: EncSnapshot,
 ): void {
   const rowId = syncData.rowIdOf(meta.table, remote);
+  const isDeleted = remote.is_deleted === true || remote.is_deleted === 1;
+
+  // Local SQLite FKs key only by id and therefore accept a child that points
+  // at a request tenant's same-database parent. Validate the complete registry
+  // before ANY apply/state side effect. Missing upsert parents use the existing
+  // FK-orphan quarantine path; tombstones may outlive a missing parent but may
+  // never target a parent that exists under non-local ownership.
+  syncData.assertLocalSyncParents(meta.table, remote, {
+    allowMissing: isDeleted,
+  });
 
   // A2 sub-PR 3b-2: the CRDT counter table is a grow-only join-semilattice — its
   // per-key MAX merge is idempotent + monotonic, so a remote row is ALWAYS safe to
@@ -1061,7 +1081,7 @@ function applyRemote(
   // (no hash classify, never a skip/conflict). Track sync_state from the MERGED LOCAL
   // row so the push side sees the post-merge value as in-sync and never re-pushes a
   // peer's counter (this device only pushes its OWN replica's rows).
-  if (meta.table === "knowledge_meta_crdt") {
+  if (meta.table === "knowledge_meta_crdt" && !isDeleted) {
     syncData.applyRemoteMetaCrdt(stripSyncCols(remote));
     const localRow = syncData.getRowById(meta.table, rowId);
     syncData.setSyncState(meta.table, rowId, {
@@ -1074,8 +1094,6 @@ function applyRemote(
     res.pulled++;
     return;
   }
-
-  const isDeleted = remote.is_deleted === true || remote.is_deleted === 1;
 
   // classifyRemoteRow's contract: "remoteHash is null for a tombstone". A delete
   // has no content to compare, so a tombstone is NEVER a content-match "skip".
@@ -1253,6 +1271,7 @@ async function reportDeviceProgress(client: SupabaseClient): Promise<void> {
 export async function refreshRegistryMirror(
   client: SupabaseClient,
 ): Promise<void> {
+  if (!syncData.isLocalSyncContext()) return;
   const PAGE = 1000; // registry tables are tiny; a page cap is pure defense-in-depth.
   for (const meta of syncData.syncedTablesFor(syncData.currentSyncTier())) {
     if (!meta.mirrorSnapshot) continue;
@@ -1301,6 +1320,7 @@ const IDENTITY_PUB_KV = "sync.identityPub"; // base64 of the last-published publ
 export async function publishIdentityPub(
   client: SupabaseClient,
 ): Promise<void> {
+  if (!syncData.isLocalSyncContext()) return;
   try {
     if (keystore.encryptionState() !== "on") return; // no unlocked identity to publish
     const pub = Buffer.from(keystore.getAccountIdentity().publicKey).toString(
@@ -1365,6 +1385,7 @@ async function fetchMemberPubKey(
 export async function reconcileScopeWraps(
   client: SupabaseClient,
 ): Promise<{ wrapped: number }> {
+  if (!syncData.isLocalSyncContext()) return { wrapped: 0 };
   const u = await getCurrentUser();
   if (!u) return { wrapped: 0 };
   const self = u.user_id;
@@ -1420,8 +1441,12 @@ export async function syncOnce(
   onProgress?: SyncProgressFn,
 ): Promise<SyncResult> {
   if (!syncData.isSyncEnabled()) {
-    return { pushed: 0, pulled: 0, conflicts: 0, skipped: 0 };
+    return emptySyncResult();
   }
+  // v81 quarantines pre-provenance outbox/state rows. Recover every live local
+  // upsert exactly once before the first post-upgrade cycle; ambiguous legacy
+  // deletes remain quarantined rather than crossing an account boundary.
+  syncData.reconcileTenantIsolationMigration();
   const client = await getAuthedClient();
   if (!client)
     return { pushed: 0, pulled: 0, conflicts: 0, skipped: 0, notAuthed: true };
@@ -1497,6 +1522,15 @@ export async function syncOnce(
 
 const DEFAULT_SYNC_INTERVAL_MS = 60_000;
 
+export type SyncSchedulerMode = Pick<
+  GatewayConfig,
+  "remoteGateway" | "hostedMode"
+>;
+
+function schedulerAllowed(mode: SyncSchedulerMode): boolean {
+  return !mode.remoteGateway && !mode.hostedMode;
+}
+
 /**
  * Start periodic background sync. Self-contained (owns its interval). Runs one
  * cycle ~5s after startup, then every `intervalMs`. Best-effort. The returned
@@ -1504,12 +1538,19 @@ const DEFAULT_SYNC_INTERVAL_MS = 60_000;
  * shutdown push never races a periodic push (which would corrupt cursors).
  */
 export function startSyncScheduler(
+  mode: SyncSchedulerMode,
   intervalMs = DEFAULT_SYNC_INTERVAL_MS,
 ): () => Promise<void> {
+  // Do not even allocate timers in a multi-tenant gateway. `mode` is retained
+  // by reference and re-checked below so an in-process local→remote/hosted
+  // transition also stops cycles and suppresses the shutdown flush.
+  if (!schedulerAllowed(mode)) return async () => {};
+
   let inflight: Promise<unknown> | null = null;
 
   const tick = () => {
-    if (inflight || !syncData.isSyncEnabled()) return;
+    if (inflight || !schedulerAllowed(mode) || !syncData.isSyncEnabled())
+      return;
     inflight = syncOnce()
       // A quota pause is already reported once per table by pushEntry (deduped) — no
       // per-cycle scheduler summary, which would re-spam the same state every interval.
@@ -1533,7 +1574,7 @@ export function startSyncScheduler(
     clearTimeout(startupTimer);
     clearInterval(timer);
     if (inflight) await inflight.catch(() => {}); // don't race the in-flight cycle
-    if (!syncData.isSyncEnabled()) return;
+    if (!schedulerAllowed(mode) || !syncData.isSyncEnabled()) return;
     try {
       const client = await getAuthedClient();
       if (client) await pushOnce(client); // final best-effort flush

--- a/packages/gateway/src/telemetry-privacy.ts
+++ b/packages/gateway/src/telemetry-privacy.ts
@@ -1,0 +1,330 @@
+import type { Event } from "@sentry/bun";
+import {
+  isCredentialHeaderName,
+  redactCredentialHeaderAssignments,
+} from "./credential-headers";
+
+export const SENTRY_DATA_COLLECTION = {
+  userInfo: false,
+  cookies: false,
+  httpHeaders: { request: false, response: false },
+  httpBodies: [],
+  queryParams: false,
+  genAI: { inputs: false, outputs: false },
+  stackFrameVariables: false,
+  frameContextLines: 0,
+};
+
+const FILTERED = "[Filtered]";
+const QUERY_VALUE_KEY =
+  /(?:^|[._-])(?:query[._-]?string|http[._-]?query|url[._-]?query|request[._-]?query)(?:$|[._-])/i;
+const URL_KEY = /(?:^|[._-])(?:url|uri|href)(?:$|[._-])/i;
+const SENSITIVE_TEXT_KEY = String.raw`(?:proxy[\s._-]*authorization|authorization|x[\s._-]*api[\s._-]*key|api[\s._-]*key|(?:api|access|auth|bearer|client|consumer|identity|private|refresh|security|subscription)[\s._-]*(?:id|key|secret|token)|ocp[\s._-]*apim[\s._-]*subscription[\s._-]*key|cf[\s._-]*access[\s._-]*client[\s._-]*id|set[\s._-]*cookie|(?:[a-z0-9]+[\s._-]+)*signatures?|token|secret|password|passwd|passphrase|credentials?|cookies?)`;
+const PRIVATE_CONTENT_KEYS = new Set([
+  "alias",
+  "body",
+  "bodysnippet",
+  "command",
+  "cwd",
+  "detail",
+  "entityalias",
+  "entityname",
+  "error",
+  "errorbody",
+  "errormessage",
+  "filepath",
+  "path",
+  "projectpath",
+  "prompt",
+  "prompttitle",
+  "rawbody",
+  "requestbody",
+  "responsebody",
+  "slashcommand",
+  "snippet",
+  "title",
+  "upstreambody",
+]);
+const SAFE_ERROR_TELEMETRY_MESSAGES = [
+  /^Batch item failed$/,
+  /^Cache bust spiral past cold-start grace — investigate caching bug$/,
+  /^Client abort under host pressure$/,
+  /^Empty completion returned to client \(no content blocks\)$/,
+  /^Embedding worker OOM:/,
+  /^Worker health critical: sustained worker failure$/,
+  /^Worker health degraded$/,
+  /^Worker upstream auth error: HTTP \d+$/,
+  /^Worker upstream exhausted \d+ retries: HTTP \d+(?: embedded \d+)?$/,
+  /^cch: multiple billing-header sentinels in request body/,
+  /^tool-pairing 400 \(tool_use\/tool_result concurrency\)$/,
+];
+
+function canonicalKey(key: string): { words: string[]; canonical: string } {
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  return { words, canonical: words.join("") };
+}
+
+/**
+ * Classify structured keys after splitting camelCase/PascalCase and separators.
+ * Telemetry is intentionally conservative: a false positive loses one
+ * diagnostic attribute, while a false negative can disclose a credential.
+ */
+export function isSensitiveTelemetryKey(key: string): boolean {
+  const { words, canonical } = canonicalKey(key);
+
+  if (isCredentialHeaderName(key)) return true;
+
+  if (
+    [
+      "authorization",
+      "proxyauthorization",
+      "apikey",
+      "xapikey",
+      "clientsecret",
+      "accesstoken",
+      "refreshtoken",
+      "sessiontoken",
+      "securitytoken",
+      "idtoken",
+      "authtoken",
+      "bearertoken",
+      "privatekey",
+      "setcookie",
+      "token",
+      "secret",
+      "password",
+      "passwd",
+      "passphrase",
+      "credential",
+      "credentials",
+      "cookie",
+      "cookies",
+      "signature",
+      "signatures",
+    ].some((name) => canonical.endsWith(name))
+  ) {
+    return true;
+  }
+
+  return words.some((word) =>
+    [
+      "authorization",
+      "token",
+      "secret",
+      "password",
+      "passwd",
+      "passphrase",
+      "credential",
+      "credentials",
+      "cookie",
+      "cookies",
+      "signature",
+      "signatures",
+    ].includes(word),
+  );
+}
+
+function isPrivateContentKey(key: string): boolean {
+  const { words, canonical } = canonicalKey(key);
+  return (
+    PRIVATE_CONTENT_KEYS.has(canonical) ||
+    words.includes("snippet") ||
+    canonical.endsWith("snippet")
+  );
+}
+
+function scrubErrorTelemetryMessage(value: string): string {
+  const scrubbed = scrubTelemetryText(value);
+  return SAFE_ERROR_TELEMETRY_MESSAGES.some((pattern) => pattern.test(scrubbed))
+    ? scrubbed
+    : "Application error";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Remove userinfo, query values, and fragments from an HTTP(S) URL. */
+export function scrubTelemetryUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return value;
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+/** Redact credentials and query-bearing URLs embedded in free-form text. */
+export function scrubTelemetryText(value: string): string {
+  return redactCredentialHeaderAssignments(value, FILTERED)
+    .replace(
+      /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi,
+      (match, scheme: string, offset: number, source: string) =>
+        /(?:^|[\s._-])scheme\s*=\s*$/i.test(
+          source.slice(Math.max(0, offset - 32), offset),
+        )
+          ? match
+          : `${scheme} ${FILTERED}`,
+    )
+    .replace(
+      new RegExp(
+        String.raw`(^|[\r\n])([\t ]*(?:${SENSITIVE_TEXT_KEY})[\t ]*:[\t ]*)[^\r\n]*`,
+        "gi",
+      ),
+      `$1$2${FILTERED}`,
+    )
+    .replace(/https?:\/\/[^\s"'<>]+/gi, (url) => scrubTelemetryUrl(url))
+    .replace(/\bfile:\/\/\/[^\s"'<>]+/gi, FILTERED)
+    .replace(/\b[A-Za-z]:[\\/][^\s"'<>]+/g, FILTERED)
+    .replace(
+      /(^|[\s"'(=])(?:~?\/[^\s"'<>]+)/g,
+      (_match, prefix: string) => `${prefix}${FILTERED}`,
+    )
+    .replace(/([?&][^\s=&#]+)=([^\s&#]*)/g, `$1=${FILTERED}`);
+}
+
+function scrubRequest(value: Record<string, unknown>): Record<string, unknown> {
+  const request: Record<string, unknown> = {};
+  if (typeof value.method === "string") request.method = value.method;
+  if (typeof value.url === "string") {
+    request.url = scrubTelemetryUrl(value.url);
+  }
+  return request;
+}
+
+function scrubValue(
+  value: unknown,
+  seen: WeakMap<object, unknown>,
+  parentKey?: string,
+): unknown {
+  if (typeof value === "string") {
+    return URL_KEY.test(parentKey ?? "")
+      ? scrubTelemetryUrl(scrubTelemetryText(value))
+      : scrubTelemetryText(value);
+  }
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    value instanceof Date ||
+    ArrayBuffer.isView(value)
+  ) {
+    return value;
+  }
+
+  const existing = seen.get(value);
+  if (existing !== undefined) return existing;
+
+  if (Array.isArray(value)) {
+    const copy: unknown[] = [];
+    seen.set(value, copy);
+    for (const item of value) copy.push(scrubValue(item, seen));
+    return copy;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (parentKey?.toLowerCase() === "request") {
+    return scrubRequest(record);
+  }
+
+  const copy: Record<string, unknown> = {};
+  seen.set(value, copy);
+  for (const [key, child] of Object.entries(record)) {
+    if (
+      isSensitiveTelemetryKey(key) ||
+      isPrivateContentKey(key) ||
+      QUERY_VALUE_KEY.test(key)
+    ) {
+      copy[key] = FILTERED;
+    } else if (key.toLowerCase() === "breadcrumbs") {
+      copy[key] = [];
+    } else if (key.toLowerCase() === "request" && isRecord(child)) {
+      copy[key] = scrubRequest(child);
+    } else {
+      copy[key] = scrubValue(child, seen, key);
+    }
+  }
+  return copy;
+}
+
+/** Deep-copy and redact an arbitrary telemetry payload or envelope. */
+export function scrubTelemetryValue<T>(value: T): T {
+  return scrubValue(value, new WeakMap()) as T;
+}
+
+/** Apply event-specific privacy rules while retaining non-sensitive diagnostics. */
+export function scrubTelemetryEvent<T extends Event>(event: T): T {
+  const originalMessage = event.message;
+  const originalExceptions = event.exception?.values;
+  const scrubbed = scrubTelemetryValue(event);
+  if (typeof originalMessage === "string") {
+    scrubbed.message = scrubErrorTelemetryMessage(originalMessage);
+  }
+  for (const [index, exception] of (
+    scrubbed.exception?.values ?? []
+  ).entries()) {
+    const originalValue = originalExceptions?.[index]?.value;
+    if (typeof originalValue === "string") {
+      exception.value = scrubErrorTelemetryMessage(originalValue);
+    }
+  }
+  scrubbed.breadcrumbs = undefined;
+  if (scrubbed.user) {
+    scrubbed.user = scrubbed.user.id ? { id: scrubbed.user.id } : undefined;
+  }
+  return scrubbed;
+}
+
+/** Add a final privacy boundary around a Sentry-compatible transport. */
+export function wrapTelemetryTransport<Envelope, Response>(transport: {
+  send(envelope: Envelope): PromiseLike<Response>;
+  flush(timeout?: number): PromiseLike<boolean>;
+}): {
+  send(envelope: Envelope): PromiseLike<Response>;
+  flush(timeout?: number): PromiseLike<boolean>;
+} {
+  return {
+    send: (envelope) => transport.send(scrubEnvelope(envelope)),
+    flush: (timeout) => transport.flush(timeout),
+  };
+}
+
+/** Scrub a complete Sentry envelope and drop disabled item types. */
+export function scrubTelemetryEnvelope<T>(envelope: T): T {
+  return scrubEnvelope(envelope);
+}
+
+function scrubEnvelope<T>(envelope: T): T {
+  return scrubTelemetryValue(scrubEnvelopeEvents(envelope));
+}
+
+/** Drop Sentry log envelope items at the final transport boundary. */
+function scrubEnvelopeEvents<T>(envelope: T): T {
+  if (!Array.isArray(envelope) || !Array.isArray(envelope[1])) return envelope;
+  const copy = [...envelope];
+  copy[1] = envelope[1]
+    .filter((item) => {
+      if (!Array.isArray(item) || !isRecord(item[0])) return true;
+      return item[0].type !== "log";
+    })
+    .map((item) => {
+      if (
+        !Array.isArray(item) ||
+        !isRecord(item[0]) ||
+        !isRecord(item[1]) ||
+        (item[0].type !== "event" && item[0].type !== "transaction")
+      ) {
+        return item;
+      }
+      return [item[0], scrubTelemetryEvent(item[1] as Event)];
+    });
+  return copy as T;
+}

--- a/packages/gateway/src/temporal-adapter.ts
+++ b/packages/gateway/src/temporal-adapter.ts
@@ -33,11 +33,24 @@ import { blocksToText } from "./translate/types";
 // ---------------------------------------------------------------------------
 
 /**
- * Generate a deterministic UUID-like ID from message content.
- * Same message at the same position produces the same ID across requests,
- * which is critical for gradient prefix fingerprinting and cache-bust detection.
+ * Generate a deterministic UUID-like source ID from message content.
+ * Same message at the same position in the same session produces the same ID
+ * across requests, while another session gets an independent identity.
  */
 export function deterministicID(
+  sessionID: string,
+  role: string,
+  index: number,
+  content: GatewayContentBlock[],
+): string {
+  const h = createHash("sha256");
+  h.update(JSON.stringify(["lore-gateway-message-v2", sessionID, role, index]));
+  hashBlocks(h, content);
+  return h.digest("hex").slice(0, 32);
+}
+
+/** Pre-v82 source identity, retained only to find already-persisted local rows. */
+export function legacyDeterministicID(
   role: string,
   index: number,
   content: GatewayContentBlock[],
@@ -212,13 +225,19 @@ function contentBlockToPart(
 export function gatewayMessagesToLore(
   messages: GatewayMessage[],
   sessionID: string,
+  startIndex = 0,
 ): LoreMessageWithParts[] {
   const out: LoreMessageWithParts[] = [];
   const now = Date.now();
 
   for (let i = 0; i < messages.length; i++) {
     const m = messages[i];
-    const id = deterministicID(m.role, i, m.content);
+    const id = deterministicID(sessionID, m.role, startIndex + i, m.content);
+    // The old adapter hashed the index within the array passed to this call.
+    // Keep that exact invocation-relative index: full request histories use
+    // absolute indexes (startIndex=0), while the single assistant-response call
+    // historically used index 0 even though its modern ID uses startIndex.
+    const legacySourceID = legacyDeterministicID(m.role, i, m.content);
     const parts: LorePart[] = m.content.map((block, pi) =>
       contentBlockToPart(block, sessionID, id, pi),
     );
@@ -242,6 +261,7 @@ export function gatewayMessagesToLore(
       out.push({
         info,
         parts,
+        legacySourceID,
         ...(hiddenInputTokens ? { hiddenInputTokens } : {}),
       });
     } else {
@@ -266,6 +286,7 @@ export function gatewayMessagesToLore(
       out.push({
         info,
         parts,
+        legacySourceID,
         ...(hiddenInputTokens ? { hiddenInputTokens } : {}),
       });
     }
@@ -317,7 +338,10 @@ export function updateAssistantMessageTokens(
  *
  * Mutates messages in place.
  */
-export function resolveToolResults(messages: LoreMessageWithParts[]): void {
+export function resolveToolResults(
+  messages: LoreMessageWithParts[],
+  recallMessageId?: (message: LoreMessageWithParts) => string,
+): void {
   // --- Pass 1: Index all tool_result parts by callID ---
   const resultsByCallID = new Map<
     string,
@@ -399,15 +423,17 @@ export function resolveToolResults(messages: LoreMessageWithParts[]): void {
     // add a recall-able placeholder so the model can fetch the original
     // tool output via recall using the temporal message ID (t:xxx).
     // The original content is stored in temporal BEFORE resolveToolResults
-    // runs, so `t:<messageID>` retrieves the full tool_result text.
+    // runs. The optional resolver maps the caller-facing source ID to the
+    // namespaced storage ID used by recall.
     if (msg.parts.length === 0 && before > 0) {
+      const messageID = recallMessageId?.(msg) ?? msg.info.id;
       msg.parts = [
         {
           id: randomUUID(),
           sessionID: "",
           messageID: msg.info.id,
           type: "text" as const,
-          text: `[tool results provided] (t:${msg.info.id})`,
+          text: `[tool results provided] (t:${messageID})`,
           time: { start: 0, end: 0 },
         } satisfies LoreTextPart,
       ];

--- a/packages/gateway/src/translate/gemini.ts
+++ b/packages/gateway/src/translate/gemini.ts
@@ -28,6 +28,7 @@ import type {
 } from "./types";
 import { blocksToText, forwardClientHeaders, ZERO_USAGE } from "./types";
 import { asString } from "@loreai/core";
+import { extractAuth } from "../auth";
 import { safeTokenSum, validateGeminiUsageMetadata } from "../usage-validation";
 
 /** Default Gemini API version segment used when building upstream URLs. */
@@ -344,6 +345,12 @@ export function buildGeminiUpstreamRequest(
     ...forwardClientHeaders(req.rawHeaders),
     "content-type": "application/json",
   };
+  const credential = extractAuth(req.rawHeaders);
+  if (credential?.scheme === "api-key") {
+    headers["x-goog-api-key"] = credential.value;
+  } else if (credential?.scheme === "bearer") {
+    headers.authorization = `Bearer ${credential.value}`;
+  }
 
   const contents: Array<Record<string, unknown>> = [];
   for (const msg of req.messages) {

--- a/packages/gateway/src/translate/openai-responses.ts
+++ b/packages/gateway/src/translate/openai-responses.ts
@@ -131,10 +131,7 @@ export function parseOpenAIResponsesRequest(
     stream,
     maxTokens,
     metadata: {},
-    rawHeaders: {
-      ...headers,
-      "x-api-key": headers["x-api-key"] ?? "",
-    },
+    rawHeaders: { ...headers },
     extras,
   };
 }

--- a/packages/gateway/src/translate/openai.ts
+++ b/packages/gateway/src/translate/openai.ts
@@ -198,10 +198,7 @@ export function parseOpenAIRequest(
     stream,
     maxTokens,
     metadata: {},
-    rawHeaders: {
-      ...headers,
-      "x-api-key": headers["x-api-key"] ?? "",
-    },
+    rawHeaders: { ...headers },
     extras,
   };
 }

--- a/packages/gateway/src/translate/types.ts
+++ b/packages/gateway/src/translate/types.ts
@@ -12,6 +12,14 @@
  */
 
 import { asString } from "@loreai/core";
+import {
+  GATEWAY_AUTH_HEADER,
+  isCredentialHeaderName,
+  KNOWN_SESSION_HEADERS,
+} from "../credential-headers";
+import { hasConflictingAuthHeaders, PROVIDER_AUTH_HEADER_NAMES } from "../auth";
+
+export { isCredentialHeaderName } from "../credential-headers";
 
 // ---------------------------------------------------------------------------
 // Content blocks — discriminated union on `type`
@@ -466,6 +474,8 @@ export type CacheAnalytics = {
 export interface UpstreamSnapshot {
   /** Resolved upstream base URL (e.g., "https://api.minimax.io/anthropic"). */
   url: string;
+  /** Whether X-Lore-Upstream-URL, rather than administrator routing, selected it. */
+  callerSelected?: boolean;
   /** Wire protocol used for the request. */
   protocol: "anthropic" | "openai" | "openai-responses" | "vertex" | "gemini";
   /** Provider ID from X-Lore-Provider header (for worker model selection). */
@@ -597,8 +607,12 @@ export type SessionState = {
   headerSessionId?: string;
   /** Name of the header that provided `headerSessionId`. */
   headerName?: string;
-  /** Privacy-safe credential scope for header/marker session identity. */
+  /** Privacy-safe credential scope for header/marker session identity. Remote
+   *  gateways must use the full domain-separated tenant fingerprint; local
+   *  gateways retain the historical short diagnostic fingerprint. */
   credentialFingerprint?: string;
+  /** Opaque server-derived owner used to re-enter tenant scope in delayed work. */
+  storageTenantId?: string;
   /** Candidate headers being tracked during the Tier 2 learning phase.
    *  Key: header name. Value: last seen value + consecutive stable turn count. */
   candidateHeaders?: Map<string, { value: string; seenCount: number }>;
@@ -763,6 +777,10 @@ const GATEWAY_MANAGED_HEADERS = new Set([
   // upstream request to match the bytes it actually sends. Forwarding the
   // client's raw value would mislabel the re-serialized body (issue #1032).
   "content-encoding",
+  // Origin-bound browser credentials, including Lore's management cookie.
+  // Never forward these to a model-provider origin.
+  "cookie",
+  "proxy-authorization",
   // Lore-specific (injected by fetch interceptor / plugin hooks)
   "x-lore-provider",
   "x-lore-upstream-url",
@@ -772,15 +790,16 @@ const GATEWAY_MANAGED_HEADERS = new Set([
   "x-lore-git-remote",
   "x-lore-agent",
   "x-lore-no-store",
+  GATEWAY_AUTH_HEADER,
   "x-lore-recall-invoked",
   // Protocol version — set explicitly by each builder
   "anthropic-version",
   // Session identification — consumed by gateway, not meaningful to upstream
   "x-parent-session-id",
-  "x-session-affinity",
-  "x-claude-code-session-id",
+  ...KNOWN_SESSION_HEADERS,
   // Auth — handled separately by each builder (extractAuth + authHeaders)
   "x-api-key",
+  "x-goog-api-key",
   "authorization",
 ]);
 
@@ -790,7 +809,8 @@ const GATEWAY_MANAGED_HEADERS = new Set([
  * The fetch interceptor preserves all original headers (including provider-
  * specific ones like `anthropic-beta`, `OpenAI-Organization`, etc.) on the
  * request to the gateway. This function extracts them for forwarding to the
- * upstream, filtering out headers the gateway sets itself.
+ * upstream, filtering out headers the gateway sets itself and any credentials
+ * whose destination cannot be safely inferred here.
  *
  * User-supplied `extraHeaders` (from `LORE_UPSTREAM_EXTRA_HEADERS`) are
  * applied separately at the end of each request builder so they overlay
@@ -805,7 +825,11 @@ export function forwardClientHeaders(
   const forwarded: Record<string, string> = {};
   for (const [key, value] of Object.entries(rawHeaders)) {
     const lower = key.toLowerCase();
-    if (!lower.startsWith("x-lore-") && !GATEWAY_MANAGED_HEADERS.has(lower)) {
+    if (
+      !lower.startsWith("x-lore-") &&
+      !GATEWAY_MANAGED_HEADERS.has(lower) &&
+      !isCredentialHeaderName(lower)
+    ) {
       forwarded[lower] = value;
     }
   }
@@ -817,10 +841,8 @@ export function forwardClientHeaders(
  * built upstream `headers` object. Keys are already lowercased by
  * `parseCurlHeaders`. Empty input is a no-op.
  *
- * Used by every upstream-headers construction site (anthropic/openai/openai-
- * responses builders, the upstream snapshot in `pipeline.ts`, and the
- * passthrough endpoints in `server.ts` / `cache-warmer.ts` /
- * `passthroughResponsesCompact`) to keep precedence consistent:
+ * Used by upstream dispatch sites (anthropic/openai/openai-responses builders
+ * and passthrough/cache-warmer paths) to keep precedence consistent:
  * client-forwarded headers → gateway-managed overlay → user extras.
  */
 export function applyUpstreamExtraHeaders(
@@ -828,7 +850,38 @@ export function applyUpstreamExtraHeaders(
   extras?: Record<string, string>,
 ): void {
   if (!extras) return;
-  for (const [key, value] of Object.entries(extras)) {
+  const normalized = new Map(
+    Object.entries(extras).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  if (normalized.has(GATEWAY_AUTH_HEADER)) {
+    throw new Error(
+      "Configured upstream headers cannot contain the gateway access header",
+    );
+  }
+  if (hasConflictingAuthHeaders(extras)) {
+    throw new Error(
+      "Configured upstream headers contain conflicting authentication mechanisms",
+    );
+  }
+  const authHeaders = new Set<string>(PROVIDER_AUTH_HEADER_NAMES);
+  const replacesAuth = [...normalized.keys()].some((key) =>
+    authHeaders.has(key),
+  );
+
+  for (const key of Object.keys(headers)) {
+    const lower = key.toLowerCase();
+    if (normalized.has(lower) || (replacesAuth && authHeaders.has(lower))) {
+      delete headers[key];
+    }
+  }
+  for (const [key, value] of normalized) {
     headers[key] = value;
   }
+}
+
+/** Build the credential-safe client-header snapshot reused by workers/warmers. */
+export function buildUpstreamSnapshotHeaders(
+  rawHeaders: Record<string, string>,
+): Record<string, string> {
+  return forwardClientHeaders(rawHeaders);
 }

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -360,13 +360,19 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
       clearTimeout(timeout);
 
       if (!response.ok) {
-        log.warn(
-          `models.dev API failed: ${response.status} ${response.statusText}`,
-        );
+        log.warn(`models.dev API failed: ${response.status}`);
         return cachedModelData ?? new Map();
       }
 
-      const data = (await response.json()) as ModelsDevResponse;
+      let data: ModelsDevResponse;
+      try {
+        data = (await response.json()) as ModelsDevResponse;
+      } catch {
+        log.warn(
+          `models.dev API returned malformed JSON with status ${response.status}`,
+        );
+        return cachedModelData ?? new Map();
+      }
       const modelData = new Map<string, ModelsDevEntry>();
       const modelDataByProvider = new Map<string, ModelsDevEntry>();
       const providerModelsIndex = new Map<string, string[]>();
@@ -427,7 +433,7 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
       // Warn if core providers are missing (likely API change)
       for (const required of SUPPORTED_PROVIDERS) {
         if (!loadedProviders.includes(required)) {
-          log.warn(`models.dev API: no ${required} provider found`);
+          log.warn("models.dev API: required provider data missing");
         }
       }
 
@@ -441,8 +447,10 @@ export function fetchModelData(): Promise<Map<string, ModelsDevEntry>> {
         `models.dev: loaded data for ${modelData.size} models across ${loadedProviders.length} providers`,
       );
       return modelData;
-    } catch (e) {
-      log.warn("models.dev API error:", e);
+    } catch {
+      // Fetch errors can embed credential-bearing request URLs. The endpoint is
+      // fixed, so a categorical diagnostic is sufficient and safe.
+      log.warn("models.dev API request failed");
       return cachedModelData ?? new Map();
     } finally {
       inflightFetch = null;
@@ -476,17 +484,20 @@ function npmToProtocol(
  * stale cache, triggers a background refresh and returns stale data (or
  * null) — never blocks the hot request path on a network call.
  */
-export function lookupProviderRoute(providerID: string): ProviderRoute | null {
+export function lookupProviderRoute(
+  providerID: string,
+  refreshOnMiss = true,
+): ProviderRoute | null {
   // Return from cache (fresh or stale) — never block the request.
   if (cachedProviderRoutes) {
     // If stale, trigger a background refresh (fire-and-forget).
-    if (Date.now() - cachedModelDataAt >= CACHE_TTL_MS) {
+    if (refreshOnMiss && Date.now() - cachedModelDataAt >= CACHE_TTL_MS) {
       fetchModelData().catch(() => {});
     }
     return cachedProviderRoutes.get(providerID) ?? null;
   }
   // No cache at all — trigger a background fetch for next request.
-  fetchModelData().catch(() => {});
+  if (refreshOnMiss) fetchModelData().catch(() => {});
   return null;
 }
 
@@ -802,11 +813,6 @@ function findCheaperSameProviderModel(
       // narrows the type without a non-null assertion.
       if (best) {
         const resolvedId = best.newestId;
-        log.info(
-          `dynamic worker model: ${providerID}/${resolvedId} ($${best.tierCost}/M, ` +
-            `lineage ${sessionLineage}, family ${best.family}, closest cheaper tier) ` +
-            `instead of ${sessionModelID} ($${sessionInputCost}/M)`,
-        );
         memo.set(memoKey, resolvedId);
         return resolvedId;
       }
@@ -869,13 +875,6 @@ function findCheaperSameProviderModel(
       }
     }
   }
-
-  const resolvedCost = cachedModelData.get(resolvedId)?.cost?.input;
-  log.info(
-    `dynamic worker model: ${providerID}/${resolvedId} ($${resolvedCost}/M` +
-      `${cheapestFamily ? `, family ${cheapestFamily}` : ""}) ` +
-      `instead of ${sessionModelID} ($${sessionInputCost}/M)`,
-  );
 
   memo.set(memoKey, resolvedId);
   return resolvedId;
@@ -951,11 +950,6 @@ function resolveNewestInFamily(
     }
   }
 
-  if (bestId) {
-    log.info(
-      `worker model: newest in family ${providerID}/${family} → ${bestId}`,
-    );
-  }
   memo.set(memoKey, bestId);
   return bestId;
 }

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -233,6 +233,30 @@ describe("Codex agent cliArgs", () => {
       );
       expect(hasProviderHeaders).toBe(false);
     });
+
+    test("never places gateway access in Codex CLI arguments", () => {
+      const codex = AGENTS.find((a) => a.name === "codex");
+      if (!codex) throw new Error("codex agent not registered");
+      process.env.LORE_UPSTREAM_EXTRA_HEADERS =
+        "X-Lore-Gateway-Token: must-not-enter-argv\nX-Team: acme";
+      const args = codex.cliArgs?.("https://lore.example", "/tmp/test") ?? [];
+      expect(args.join(" ")).not.toContain("must-not-enter-argv");
+      expect(args.join(" ")).toContain("X-Team");
+    });
+
+    test("does not duplicate configured provider auth onto the Codex-to-gateway hop", () => {
+      const codex = AGENTS.find((a) => a.name === "codex");
+      if (!codex) throw new Error("codex agent not registered");
+      process.env.LORE_UPSTREAM_EXTRA_HEADERS =
+        "Authorization: Bearer admin\nX-Api-Key: admin-api\nX-Goog-Api-Key: admin-google\nX-Team: acme";
+      const args = codex.cliArgs?.("http://127.0.0.1:3207", "/tmp/test") ?? [];
+      const serialized = args.join(" ").toLowerCase();
+
+      expect(serialized).not.toContain("authorization");
+      expect(serialized).not.toContain("x-api-key");
+      expect(serialized).not.toContain("x-goog-api-key");
+      expect(serialized).toContain("x-team");
+    });
   });
 });
 

--- a/packages/gateway/test/anthropic-client-openai-upstream-stream.test.ts
+++ b/packages/gateway/test/anthropic-client-openai-upstream-stream.test.ts
@@ -27,6 +27,8 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { request as httpRequest } from "node:http";
+import { Readable } from "node:stream";
 
 function sseChunk(obj: unknown): string {
   return `data: ${JSON.stringify(obj)}\n\n`;
@@ -94,10 +96,58 @@ function openAICopilotStream(): Response {
   });
 }
 
-let teardownFn: (() => void) | undefined;
+async function postJson(
+  baseURL: string,
+  projectDir: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const url = new URL("/v1/messages", baseURL);
+  const serialized = JSON.stringify(body);
+  return new Promise<Response>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(serialized)),
+          "x-api-key": "test-key",
+          "anthropic-version": "2023-06-01",
+          "x-lore-agent": "coder",
+          "x-lore-project": projectDir,
+        },
+      },
+      (incoming) => {
+        const responseHeaders = new Headers();
+        for (let i = 0; i < incoming.rawHeaders.length; i += 2) {
+          responseHeaders.append(
+            incoming.rawHeaders[i],
+            incoming.rawHeaders[i + 1],
+          );
+        }
+        resolve(
+          new Response(
+            Readable.toWeb(incoming) as unknown as ReadableStream<Uint8Array>,
+            {
+              status: incoming.statusCode ?? 500,
+              statusText: incoming.statusMessage,
+              headers: responseHeaders,
+            },
+          ),
+        );
+      },
+    );
+    request.once("error", reject);
+    request.end(serialized);
+  });
+}
 
-afterEach(() => {
-  teardownFn?.();
+let teardownFn: (() => Promise<void>) | undefined;
+
+afterEach(async () => {
+  await teardownFn?.();
   teardownFn = undefined;
 });
 
@@ -138,14 +188,16 @@ describe("Anthropic client + OpenAI upstream (streaming re-emission, #1052)", ()
     // race window server.port could surface as 0 → "bad port" fetch (#1429).
     config.port = 0;
     config.portExplicit = false;
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     // Fail loudly at the source if the bind didn't resolve a real port, instead
     // of leaking an invalid port into a downstream "bad port" fetch error.
     expect(server.port).toBeGreaterThan(0);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       setUpstreamInterceptor(undefined);
       for (const suffix of ["", "-shm", "-wal"]) {
@@ -163,30 +215,20 @@ describe("Anthropic client + OpenAI upstream (streaming re-emission, #1052)", ()
       }
     };
 
-    const resp = await fetch(`${baseURL}/v1/messages`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": "test-key",
-        "anthropic-version": "2023-06-01",
-        // Force a primary (conversation) turn — otherwise the small request is
-        // treated as a meta request and takes the passthrough path.
-        "x-lore-agent": "coder",
-        "x-lore-project": projectDir,
-      },
-      body: JSON.stringify({
-        model: "gpt-4o",
-        max_tokens: 1024,
-        stream: true,
-        tools: [
-          {
-            name: "read",
-            description: "read a file",
-            input_schema: { type: "object", properties: {} },
-          },
-        ],
-        messages: [{ role: "user", content: "read a.txt please" }],
-      }),
+    const resp = await postJson(baseURL, projectDir, {
+      // Force a primary (conversation) turn — otherwise the small request is
+      // treated as a meta request and takes the passthrough path.
+      model: "gpt-4o",
+      max_tokens: 1024,
+      stream: true,
+      tools: [
+        {
+          name: "read",
+          description: "read a file",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+      messages: [{ role: "user", content: "read a.txt please" }],
     });
 
     expect(resp.ok).toBe(true);

--- a/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
+++ b/packages/gateway/test/anthropic-recall-continuation-abort.test.ts
@@ -15,6 +15,13 @@ import type { GatewayRequest, SessionState } from "../src/translate/types";
 
 const mockedRecall = vi.mocked(executeRecall);
 
+function loadLocalConfig() {
+  const config = loadConfig();
+  config.remoteGateway = false;
+  config.hostedMode = false;
+  return config;
+}
+
 function event(type: string, data: Record<string, unknown>): string {
   return `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`;
 }
@@ -180,7 +187,7 @@ describe("Anthropic recall continuation abort", () => {
         {
           clientMessages: req.messages,
           modifiedReq: req,
-          config: loadConfig(),
+          config: loadLocalConfig(),
           sessionState: state,
           cacheOptions: { cacheConversation: false },
           clientSpeaksAnthropic: true,

--- a/packages/gateway/test/api.test.ts
+++ b/packages/gateway/test/api.test.ts
@@ -14,7 +14,7 @@ import { zstdCompressSync } from "node:zlib";
 
 let baseURL: string;
 let dbPath: string;
-let server: { stop: () => void; port: number; hosts: string[] };
+let server: { stop: () => Promise<void>; port: number; hosts: string[] };
 let closeDB: () => void;
 let resetPipelineState: () => Promise<void>;
 
@@ -39,12 +39,14 @@ beforeAll(async () => {
   await resetPipelineState();
 
   const config = loadConfig();
+  config.remoteGateway = false;
+  config.hostedMode = false;
   server = await startServer(config);
   baseURL = `http://127.0.0.1:${server.port}`;
 });
 
 afterAll(async () => {
-  if (server) server.stop();
+  if (server) await server.stop();
   if (closeDB) closeDB();
   if (resetPipelineState) await resetPipelineState();
 

--- a/packages/gateway/test/auth.test.ts
+++ b/packages/gateway/test/auth.test.ts
@@ -2,11 +2,16 @@ import { describe, test, expect, beforeEach, vi } from "vitest";
 import { log } from "@loreai/core";
 import {
   extractAuth,
+  copyProviderAuthHeaders,
+  hasConflictingAuthHeaders,
+  authFingerprint,
+  credentialTenantFingerprint,
   setSessionAuth,
   getSessionAuth,
   deleteSessionAuth,
   setLastSeenAuth,
   resolveAuth,
+  resolveSessionProviderAuth,
   markAuthStale,
   isAuthStale,
   clearAuthStale,
@@ -51,6 +56,16 @@ describe("extractAuth", () => {
     });
   });
 
+  test.each(["x-goog-api-key", "X-gOoG-aPi-KeY"])(
+    "extracts a single %s as api-key credential",
+    (headerName) => {
+      expect(extractAuth({ [headerName]: "goog-123" })).toEqual({
+        scheme: "api-key",
+        value: "goog-123",
+      });
+    },
+  );
+
   test("extracts Bearer token as bearer credential", () => {
     expect(extractAuth({ authorization: "Bearer tok-abc" })).toEqual({
       scheme: "bearer",
@@ -62,12 +77,147 @@ describe("extractAuth", () => {
     expect(extractAuth({})).toBeNull();
   });
 
+  test("never treats gateway access as provider authentication", () => {
+    const headers = {
+      "x-lore-gateway-token": "gateway-access-token",
+      "x-goog-api-key": "google-provider-key",
+    };
+    expect(extractAuth(headers)).toEqual({
+      scheme: "api-key",
+      value: "google-provider-key",
+    });
+    expect(hasConflictingAuthHeaders(headers)).toBe(false);
+    expect(copyProviderAuthHeaders(headers)).toEqual({
+      "x-goog-api-key": "google-provider-key",
+    });
+  });
+
   // Regression: a fuzzer (/opt/audit/fuzz-exports.js) called extractAuth()
   // with undefined, triggering "Cannot read properties of undefined
   // (reading 'x-api-key')" (Sentry LOREAI-GATEWAY-28). Guard returns null.
   test("returns null for null/undefined headers instead of throwing", () => {
     expect(extractAuth(null)).toBeNull();
     expect(extractAuth(undefined)).toBeNull();
+  });
+
+  test.each<Record<string, string>>([
+    { "x-api-key": "" },
+    { "x-api-key": "   " },
+    { "x-goog-api-key": "" },
+    { "x-goog-api-key": "   " },
+    { authorization: "" },
+    { authorization: "Basic basic-token" },
+    { authorization: "Bearer " },
+  ])("returns null for an empty or malformed credential %#", (headers) => {
+    expect(extractAuth(headers)).toBeNull();
+  });
+});
+
+describe("credential fingerprints", () => {
+  test("tenant fingerprint is full SHA-256, deterministic, and domain-separated", () => {
+    const tenant = credentialTenantFingerprint(apiKeyCred);
+    expect(tenant).toMatch(/^[a-f0-9]{64}$/);
+    expect(credentialTenantFingerprint(apiKeyCred)).toBe(tenant);
+    expect(tenant).not.toContain(apiKeyCred.value);
+    expect(tenant.startsWith(authFingerprint(apiKeyCred))).toBe(false);
+  });
+
+  test("tenant fingerprint separates credentials and auth schemes", () => {
+    expect(credentialTenantFingerprint(apiKeyCred)).not.toBe(
+      credentialTenantFingerprint({
+        scheme: "bearer",
+        value: apiKeyCred.value,
+      }),
+    );
+    expect(credentialTenantFingerprint(apiKeyCred)).not.toBe(
+      credentialTenantFingerprint({
+        scheme: "api-key",
+        value: `${apiKeyCred.value}-other`,
+      }),
+    );
+  });
+});
+
+describe("hasConflictingAuthHeaders", () => {
+  test.each<{ label: string; headers: Record<string, string> }>([
+    {
+      label: "generic and Google API keys",
+      headers: {
+        "X-aPi-KeY": "same-api-key",
+        "x-GoOg-aPi-kEy": "same-api-key",
+      },
+    },
+    {
+      label: "generic API key and bearer",
+      headers: {
+        "X-Api-Key": "api-key",
+        Authorization: "Bearer token",
+      },
+    },
+    {
+      label: "Google API key and bearer",
+      headers: {
+        "X-Goog-Api-Key": "google-key",
+        aUtHoRiZaTiOn: "Bearer token",
+      },
+    },
+  ])("rejects $label without choosing a credential", ({ headers }) => {
+    expect(hasConflictingAuthHeaders(headers)).toBe(true);
+    expect(extractAuth(headers)).toBeNull();
+
+    const reversedHeaders = Object.fromEntries(
+      Object.entries(headers).reverse(),
+    );
+    expect(hasConflictingAuthHeaders(reversedHeaders)).toBe(true);
+    expect(extractAuth(reversedHeaders)).toBeNull();
+  });
+
+  test("rejects all three authentication mechanisms without choosing a credential", () => {
+    const headers = {
+      "x-api-key": "api-key",
+      "x-goog-api-key": "google-key",
+      authorization: "Bearer token",
+    };
+
+    expect(hasConflictingAuthHeaders(headers)).toBe(true);
+    expect(extractAuth(headers)).toBeNull();
+
+    const reversedHeaders = Object.fromEntries(
+      Object.entries(headers).reverse(),
+    );
+    expect(hasConflictingAuthHeaders(reversedHeaders)).toBe(true);
+    expect(extractAuth(reversedHeaders)).toBeNull();
+  });
+
+  test.each<Record<string, string>>([
+    {
+      "x-api-key": "",
+      "x-goog-api-key": "",
+    },
+    {
+      "x-api-key": "",
+      authorization: "Basic malformed-token",
+    },
+    {
+      "x-goog-api-key": "",
+      authorization: "Bearer ",
+    },
+  ])(
+    "treats empty or malformed values as present when detecting conflicts %#",
+    (headers) => {
+      expect(hasConflictingAuthHeaders(headers)).toBe(true);
+      expect(extractAuth(headers)).toBeNull();
+    },
+  );
+
+  test("does not reject a single authentication mechanism", () => {
+    expect(hasConflictingAuthHeaders({ "x-api-key": "api-key" })).toBe(false);
+    expect(hasConflictingAuthHeaders({ "x-goog-api-key": "google-key" })).toBe(
+      false,
+    );
+    expect(hasConflictingAuthHeaders({ authorization: "Bearer token" })).toBe(
+      false,
+    );
   });
 });
 
@@ -231,14 +381,13 @@ describe("resolveAuth with staleness", () => {
     expect(result).toEqual(bearerCred);
   });
 
-  test("skips stale session credential and falls through to global", () => {
+  test("stale session credential never falls through to another client's global", () => {
     setSessionAuth("sess-1", bearerCred);
     setLastSeenAuth(apiKeyCred);
     markAuthStale("sess-1");
 
     const result = resolveAuth("sess-1");
-    // Should skip the stale session credential and return global
-    expect(result).toEqual(apiKeyCred);
+    expect(result).toBeNull();
   });
 
   test("returns null when session is stale and no global set", () => {
@@ -272,14 +421,22 @@ describe("resolveAuth with staleness", () => {
     expect(resolveAuth("sess-1")).toBe(null);
   });
 
-  test("returns global when stale session and global hold different tokens", () => {
+  test("returns null when stale session and global hold different tokens", () => {
     // Multi-session setup: another client refreshed the global credential
     setSessionAuth("sess-1", bearerCred);
     setLastSeenAuth(bearerCred2);
     markAuthStale("sess-1");
 
-    // Global has a different (potentially fresh) token — return it
-    expect(resolveAuth("sess-1")).toEqual(bearerCred2);
+    expect(resolveAuth("sess-1")).toBeNull();
+  });
+
+  test("provider-agnostic resolution follows the session's latest provider switch", () => {
+    setSessionAuth("sess-switch", bearerCred, "anthropic");
+    setSessionAuth("sess-switch", bearerCred2, "openai");
+    setLastSeenAuth(apiKeyCred, "anthropic");
+
+    expect(resolveAuth("sess-switch")).toEqual(bearerCred2);
+    expect(resolveAuth("sess-switch")).not.toEqual(apiKeyCred);
   });
 
   // -------------------------------------------------------------------------
@@ -308,11 +465,11 @@ describe("resolveAuth with staleness", () => {
     expect(resolveAuth("sess-1", "anthropic")).toEqual(apiKeyCred);
   });
 
-  test("still allows global fallback for cold-start sessions with no provider store", () => {
+  test("cold-start sessions never inherit a process-global credential", () => {
     // No setSessionAuth at all — a cold-start worker before the first turn's
-    // credential was registered. The global fallback is still legitimate here.
+    // credential was registered. A named session remains an isolation boundary.
     setLastSeenAuth(apiKeyCred);
-    expect(resolveAuth("sess-cold", "anthropic")).toEqual(apiKeyCred);
+    expect(resolveAuth("sess-cold", "anthropic")).toBeNull();
   });
 
   // -------------------------------------------------------------------------
@@ -338,27 +495,18 @@ describe("resolveAuth with staleness", () => {
 
   test("a _default-only session does not leak a cross-provider global (#829)", () => {
     // Foreground request arrived WITHOUT x-lore-provider → stored under
-    // _default — while the global was tagged with the real provider. A
-    // _default store does not satisfy a specific-provider lookup, and
-    // sessionHasProviderStore() is false, so the 359 guard cannot fire: the
-    // provider-aware global is the only thing standing between the OpenAI
-    // worker and the Anthropic key.
+    // _default — while the global was tagged with the real provider. A named
+    // provider lookup does not reinterpret either source as session-owned.
     setSessionAuth("sess-1", apiKeyCred); // no providerID → _default
     setLastSeenAuth(apiKeyCred, "anthropic");
 
     expect(resolveAuth("sess-1", "openai")).toBe(null);
-    // The captured provider still resolves through the global fallback.
-    expect(resolveAuth("sess-1", "anthropic")).toEqual(apiKeyCred);
+    expect(resolveAuth("sess-1", "anthropic")).toBeNull();
   });
 
   test("end-to-end #829: Anthropic session + OpenAI worker resolves null, not the Anthropic key", () => {
     // Mixed-provider setup: chat on Anthropic, a worker/aux model on OpenAI.
-    // NOTE: this scenario is actually closed by the pre-existing 359 guard
-    // (the session has a non-_default "anthropic" store, so
-    // sessionHasProviderStore() is true and the global fallback is never
-    // reached) — it passes even WITHOUT the provider-aware tag. It documents
-    // the full #829 shape; the provider-tag logic itself is guarded by the
-    // session-less and _default-only tests above.
+    // A named session lookup is strict, so it cannot reach process-global auth.
     setSessionAuth("sess-1", apiKeyCred, "anthropic");
     setLastSeenAuth(apiKeyCred, "anthropic");
 
@@ -367,12 +515,12 @@ describe("resolveAuth with staleness", () => {
     expect(workerCred).not.toEqual(apiKeyCred);
   });
 
-  test("an UNTAGGED global still serves any provider (legacy single-provider client)", () => {
+  test("an UNTAGGED global is sessionless only", () => {
     // A client that sends no x-lore-provider produces a null tag. Single-
     // provider setups must keep working: the global is the only credential and
     // is necessarily the right one — suppressing it would break their workers.
     setLastSeenAuth(minimaxCred); // no providerID → null tag
-    expect(resolveAuth("sess-cold", "openai")).toEqual(minimaxCred);
+    expect(resolveAuth("sess-cold", "openai")).toBeNull();
     expect(resolveAuth(undefined, "anthropic")).toEqual(minimaxCred);
   });
 
@@ -381,14 +529,43 @@ describe("resolveAuth with staleness", () => {
     setLastSeenAuth(apiKeyCred);
     markAuthStale("sess-1");
 
-    // Stale — returns global
-    expect(resolveAuth("sess-1")).toEqual(apiKeyCred);
+    expect(resolveAuth("sess-1")).toBeNull();
 
     // Fresh credential arrives, clears staleness
     setSessionAuth("sess-1", bearerCred2);
 
     // Now returns the fresh session credential
     expect(resolveAuth("sess-1")).toEqual(bearerCred2);
+  });
+});
+
+describe("resolveSessionProviderAuth", () => {
+  test("uses only the requested session and never the process-global fallback", () => {
+    setSessionAuth("anthropic-session", bearerCred, "anthropic");
+    setSessionAuth("openai-session", bearerCred2, "openai");
+    setLastSeenAuth(bearerCred2, "openai");
+
+    expect(
+      resolveSessionProviderAuth("anthropic-session", "anthropic"),
+    ).toEqual(bearerCred);
+    expect(
+      resolveSessionProviderAuth("missing-session", "anthropic"),
+    ).toBeNull();
+  });
+
+  test("does not model-route a default credential after named lookup failure", () => {
+    setSessionAuth("claude-code", bearerCred);
+    setLastSeenAuth(bearerCred2, "openai");
+
+    expect(resolveSessionProviderAuth("claude-code", "anthropic")).toBeNull();
+  });
+
+  test("does not replace a stale named credential with the default credential", () => {
+    setSessionAuth("mixed", bearerCred2);
+    setSessionAuth("mixed", bearerCred, "anthropic");
+    markAuthStale("mixed", "anthropic");
+
+    expect(resolveSessionProviderAuth("mixed", "anthropic")).toBeNull();
   });
 });
 
@@ -408,8 +585,7 @@ describe("resolveAuth per-provider staleness", () => {
 
     // Anthropic credential should still resolve normally
     expect(resolveAuth("sess-1", "anthropic")).toEqual(apiKeyCred);
-    // MiniMax should fall through to global
-    expect(resolveAuth("sess-1", "minimax")).toEqual(apiKeyCred);
+    expect(resolveAuth("sess-1", "minimax")).toBeNull();
   });
 
   test("stale Anthropic does not poison MiniMax credential", () => {
@@ -421,21 +597,21 @@ describe("resolveAuth per-provider staleness", () => {
 
     // MiniMax credential should still resolve
     expect(resolveAuth("sess-1", "minimax")).toEqual(minimaxCred);
-    // Anthropic falls through to global (same value → null)
+    // The stale Anthropic slot fails closed without consulting global auth.
     expect(resolveAuth("sess-1", "anthropic")).toBe(null);
   });
 
-  test("named provider does NOT contaminate _default slot", () => {
+  test("provider-agnostic resolution follows the current named provider without contaminating _default", () => {
     // Storing a named provider credential must NOT set _default — this
     // prevents cross-contamination (e.g. MiniMax key leaking to Anthropic
     // workers that resolve auth without a providerID).
     setSessionAuth("sess-1", minimaxCred, "minimax");
     setLastSeenAuth(apiKeyCred);
 
-    // _default was never set (no dual-write), so resolveAuth without
-    // providerID falls through to global.
+    // _default was never set (no dual-write), while provider-agnostic callers
+    // follow the session's current authenticated turn rather than global state.
     expect(getSessionAuth("sess-1")).toBe(null);
-    expect(resolveAuth("sess-1")).toEqual(apiKeyCred);
+    expect(resolveAuth("sess-1")).toEqual(minimaxCred);
 
     // minimax credential resolves correctly via its providerID
     expect(resolveAuth("sess-1", "minimax")).toEqual(minimaxCred);
@@ -454,10 +630,8 @@ describe("resolveAuth per-provider staleness", () => {
     expect(isAuthStale("sess-1", "minimax")).toBe(true);
     // _default should NOT be stale — it holds a different credential
     expect(isAuthStale("sess-1", "_default")).toBe(false);
-    // resolveAuth without providerID returns _default — not stale
-    expect(resolveAuth("sess-1")).toEqual(apiKeyCred);
-    // MiniMax stale → falls to global
-    expect(resolveAuth("sess-1", "minimax")).toEqual(bearerCred);
+    expect(resolveAuth("sess-1")).toBeNull();
+    expect(resolveAuth("sess-1", "minimax")).toBeNull();
   });
 
   test("refreshing one provider clears only that provider staleness", () => {
@@ -473,8 +647,7 @@ describe("resolveAuth per-provider staleness", () => {
 
     // Anthropic is fresh — resolves to new credential
     expect(resolveAuth("sess-1", "anthropic")).toEqual(bearerCred2);
-    // MiniMax still stale — falls through to global
-    expect(resolveAuth("sess-1", "minimax")).toEqual(apiKeyCred);
+    expect(resolveAuth("sess-1", "minimax")).toBeNull();
     // _default was never set (named providers don't dual-write to _default)
     expect(isAuthStale("sess-1", "_default")).toBe(false);
     // But session-level still stale (minimax)

--- a/packages/gateway/test/batch-queue.test.ts
+++ b/packages/gateway/test/batch-queue.test.ts
@@ -11,6 +11,7 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   createBatchLLMClient,
+  createAnthropicBatchProvider,
   extractAnthropicError,
 } from "../src/batch-queue";
 
@@ -21,6 +22,7 @@ vi.mock("../src/fetch", () => ({
     globalThis.fetch(...args),
 }));
 import type { LLMClient } from "@loreai/core";
+import { log } from "@loreai/core";
 import type { AuthCredential } from "../src/auth";
 import {
   _resetTemperatureUnsupportedModels,
@@ -978,7 +980,7 @@ describe("BatchLLMClient", () => {
   // -------------------------------------------------------------------------
 
   describe("extractAnthropicError", () => {
-    test("reads the nested ErrorResponse envelope (real Anthropic shape)", () => {
+    test("does not retain the nested ErrorResponse message", () => {
       // Anthropic wraps the cause in `{ type: "error", request_id, error: { type, message } }`.
       expect(
         extractAnthropicError(
@@ -992,16 +994,16 @@ describe("BatchLLMClient", () => {
           },
           "errored",
         ),
-      ).toBe("invalid_request_error: max_tokens: too large");
+      ).toBe("errored");
     });
 
-    test("tolerates a flattened envelope ({ type, message } at top level)", () => {
+    test("does not retain a flattened envelope message", () => {
       expect(
         extractAnthropicError(
           { type: "overloaded_error", message: "Overloaded" },
           "errored",
         ),
-      ).toBe("overloaded_error: Overloaded");
+      ).toBe("errored");
     });
 
     test("falls back to the outcome string, never yields 'error: undefined'", () => {
@@ -1017,7 +1019,7 @@ describe("BatchLLMClient", () => {
     });
   });
 
-  test("anthropic errored result surfaces the real message, not 'error: undefined'", async () => {
+  test("anthropic errored result excludes the upstream error body from logs", async () => {
     const inner = createMockLLMClient();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -1120,7 +1122,8 @@ describe("BatchLLMClient", () => {
     const logged = errorSpy.mock.calls
       .map((c) => c.map((a) => String(a)).join(" "))
       .join("\n");
-    expect(logged).toContain("invalid_request_error: max_tokens: too large");
+    expect(logged).toContain("batch item");
+    expect(logged).not.toContain("max_tokens: too large");
     expect(logged).not.toContain("errored: error: undefined");
 
     const s = client.stats();
@@ -1131,7 +1134,7 @@ describe("BatchLLMClient", () => {
     await client.shutdown();
   });
 
-  test("openai errored result includes the response body error message", async () => {
+  test("openai errored result logs status but excludes the response body", async () => {
     const inner = createMockLLMClient();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -1246,11 +1249,171 @@ describe("BatchLLMClient", () => {
       .map((c) => c.map((a) => String(a)).join(" "))
       .join("\n");
     expect(logged).toContain("HTTP 400");
-    expect(logged).toContain("context_length_exceeded");
+    expect(logged).not.toContain("context_length_exceeded");
 
     errorSpy.mockRestore();
     globalThis.fetch = prevFetch;
     await client.shutdown();
+  });
+
+  test("malformed batch JSON logs a body-independent diagnostic", async () => {
+    const bodyMarker = "PRIVATE_BATCH_MALFORMED_PREFIX";
+    const reasonMarker = "PRIVATE_BATCH_REASON_MARKER";
+    const messages: string[] = [];
+    const errorSpy = vi.spyOn(log, "error").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(`${bodyMarker} not-json`, {
+          status: 200,
+          statusText: reasonMarker,
+        }),
+    ) as unknown as typeof fetch;
+    try {
+      const provider = createAnthropicBatchProvider(UPSTREAMS.anthropic);
+      const result = await provider.submit(TEST_AUTH, [
+        {
+          customId: "safe-id",
+          providerID: "anthropic",
+          params: {
+            model: "claude-test",
+            max_tokens: 8,
+            system: "sys",
+            messages: [{ role: "user", content: "user" }],
+          },
+        },
+      ]);
+
+      expect(result).toBeNull();
+      const output = messages.join("\n");
+      expect(output).toContain("malformed JSON");
+      expect(output).not.toContain(bodyMarker);
+      expect(output).not.toContain(reasonMarker);
+    } finally {
+      errorSpy.mockRestore();
+      globalThis.fetch = prevFetch;
+    }
+  });
+
+  test("provider batch IDs from response bodies never reach logs", async () => {
+    const batchIdMarker = "PRIVATE_PROVIDER_BATCH_ID_MARKER";
+    const messages: string[] = [];
+    const infoSpy = vi.spyOn(log, "info").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ id: batchIdMarker }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const client = createBatchLLMClient(
+      createMockLLMClient(),
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      { flushIntervalMs: 60_000, maxQueueSize: 1, pollIntervalMs: 60_000 },
+    );
+    try {
+      void client.prompt("sys", "user msg", { workerID: "lore-distill" });
+      await vi.waitFor(() => expect(client.stats().inflightBatches).toBe(1));
+      expect(messages.join("\n")).toContain("batch created");
+      expect(messages.join("\n")).not.toContain(batchIdMarker);
+    } finally {
+      infoSpy.mockRestore();
+      globalThis.fetch = prevFetch;
+      await client.shutdown({ drainQueue: false });
+    }
+  });
+
+  test("batch create catches never log thrown URL secrets", async () => {
+    const userinfoMarker = "PRIVATE_BATCH_THROWN_USERINFO";
+    const queryMarker = "PRIVATE_BATCH_THROWN_QUERY";
+    const fragmentMarker = "PRIVATE_BATCH_THROWN_FRAGMENT";
+    const messages: string[] = [];
+    const errorSpy = vi.spyOn(log, "error").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error(
+        `fetch https://user:${userinfoMarker}@example.com/batch?token=${queryMarker}#${fragmentMarker} failed`,
+      );
+    }) as unknown as typeof fetch;
+    const client = createBatchLLMClient(
+      createMockLLMClient(),
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      { flushIntervalMs: 60_000, maxQueueSize: 1, pollIntervalMs: 50 },
+    );
+    try {
+      await client.prompt("sys", "user msg", { workerID: "lore-distill" });
+      const output = messages.join("\n");
+      expect(output).toContain("batch create error");
+      expect(output).not.toContain(userinfoMarker);
+      expect(output).not.toContain(queryMarker);
+      expect(output).not.toContain(fragmentMarker);
+    } finally {
+      errorSpy.mockRestore();
+      globalThis.fetch = prevFetch;
+      await client.shutdown();
+    }
+  });
+
+  test("body-controlled batch outcome and status fields never reach logs", async () => {
+    const bodyMarker = "PRIVATE_BATCH_STATUS_FIELD_MARKER";
+    const messages: string[] = [];
+    const errorSpy = vi.spyOn(log, "error").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    let capturedCustomId = "";
+    let callIndex = 0;
+    const prevFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (_url, init) => {
+      const index = callIndex++;
+      if (index === 0) {
+        const body = JSON.parse(String(init?.body)) as {
+          requests: Array<{ custom_id: string }>;
+        };
+        capturedCustomId = body.requests[0]?.custom_id ?? "";
+        return new Response(JSON.stringify({ id: "safe-batch-id" }), {
+          status: 200,
+        });
+      }
+      if (index === 1) {
+        return new Response(
+          JSON.stringify({ processing_status: "ended", results_url: null }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          custom_id: capturedCustomId,
+          result: { type: bodyMarker },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    const client = createBatchLLMClient(
+      createMockLLMClient(),
+      UPSTREAMS,
+      getTestAuth,
+      DEFAULT_MODEL,
+      { flushIntervalMs: 60_000, maxQueueSize: 1, pollIntervalMs: 10 },
+    );
+    try {
+      await expect(
+        client.prompt("sys", "user msg", { workerID: "lore-distill" }),
+      ).resolves.toBeNull();
+      expect(messages.join("\n")).toContain("batch item failed");
+      expect(messages.join("\n")).not.toContain(bodyMarker);
+    } finally {
+      errorSpy.mockRestore();
+      globalThis.fetch = prevFetch;
+      await client.shutdown();
+    }
   });
 });
 

--- a/packages/gateway/test/bedrock-routing.test.ts
+++ b/packages/gateway/test/bedrock-routing.test.ts
@@ -33,10 +33,10 @@ function mantleJSONResponse(): Response {
   );
 }
 
-let teardownFn: (() => void) | undefined;
+let teardownFn: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  teardownFn?.();
+afterEach(async () => {
+  await teardownFn?.();
   teardownFn = undefined;
 });
 
@@ -68,11 +68,13 @@ describe("X-Lore-Provider: bedrock routing (bedrock-mantle)", () => {
     });
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       setUpstreamInterceptor(undefined);
       delete process.env.LORE_BEDROCK_REGION;

--- a/packages/gateway/test/bedrock-runtime.test.ts
+++ b/packages/gateway/test/bedrock-runtime.test.ts
@@ -457,11 +457,11 @@ describe("proxyBedrockRuntimeRequest — handler logic", () => {
 // via undici MockAgent. Fully hermetic: no real network, DNS, or TLS.
 // ---------------------------------------------------------------------------
 
-let teardownFn: (() => void) | undefined;
+let teardownFn: (() => Promise<void>) | undefined;
 let mock: MockAgent | undefined;
 
-afterEach(() => {
-  teardownFn?.();
+afterEach(async () => {
+  await teardownFn?.();
   teardownFn = undefined;
   if (mock) {
     void mock.close();
@@ -533,11 +533,13 @@ describe("POST /v1/model/{modelId}/{verb} — Bedrock Runtime API passthrough", 
     await resetPipelineState();
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       for (const suffix of ["", "-shm", "-wal"]) {
         const f = `${dbPath}${suffix}`;
@@ -653,11 +655,13 @@ describe("POST /v1/model/{modelId}/{verb} — Bedrock Runtime API passthrough", 
     await resetPipelineState();
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       for (const suffix of ["", "-shm", "-wal"]) {
         const f = `${dbPath}${suffix}`;
@@ -725,11 +729,13 @@ describe("POST /v1/model/{modelId}/{verb} — Bedrock Runtime API passthrough", 
     await resetPipelineState();
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       for (const suffix of ["", "-shm", "-wal"]) {
         const f = `${dbPath}${suffix}`;
@@ -777,11 +783,13 @@ describe("POST /v1/model/{modelId}/{verb} — Bedrock Runtime API passthrough", 
     closeDB();
     await resetPipelineState();
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       for (const suffix of ["", "-shm", "-wal"]) {
         const f = `${dbPath}${suffix}`;

--- a/packages/gateway/test/browser-origin-data-plane.test.ts
+++ b/packages/gateway/test/browser-origin-data-plane.test.ts
@@ -1,0 +1,598 @@
+import { request as httpRequest } from "node:http";
+import { connect } from "node:net";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { MockAgent } from "undici";
+import { db } from "@loreai/core";
+import type { GatewayConfig } from "../src/config";
+import {
+  getAllSessionCosts,
+  getDailySpend,
+  resetDailyBudgetState,
+} from "../src/cost-tracker";
+import { setUpstreamDispatcherForTest } from "../src/fetch";
+import { getActiveSessions, setUpstreamInterceptor } from "../src/pipeline";
+import type { Harness } from "./helpers/harness";
+import { createHarness, TEST_GATEWAY_AUTH_TOKEN } from "./helpers/harness";
+
+const ATTACK_PROJECT = `/tmp/lore-browser-origin-${process.pid}`;
+const SERVER_ANTHROPIC_ORIGIN = "https://browser-security-anthropic.invalid";
+const SERVER_OPENAI_ORIGIN = "https://browser-security-openai.invalid";
+const BEDROCK_ORIGIN =
+  "https://bedrock-runtime.browser-security-1.amazonaws.com";
+
+type DataPlaneRoute = {
+  name: string;
+  path: string;
+  method: "GET" | "POST";
+  headers: Record<string, string>;
+  body?: string;
+};
+
+const projectHeaders = { "x-lore-project": ATTACK_PROJECT };
+const anthropicBody = JSON.stringify({
+  model: "claude-sonnet-4-6",
+  max_tokens: 32,
+  messages: [{ role: "user", content: "steal local memory" }],
+});
+const openAIChatBody = JSON.stringify({
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "steal local memory" }],
+});
+const responsesBody = JSON.stringify({
+  model: "gpt-5.4",
+  input: [{ role: "user", content: "steal local memory" }],
+});
+const geminiBody = JSON.stringify({
+  contents: [{ role: "user", parts: [{ text: "steal local memory" }] }],
+});
+const bedrockBody = JSON.stringify({
+  messages: [{ role: "user", content: [{ text: "steal local memory" }] }],
+});
+
+const DATA_PLANE_ROUTES: DataPlaneRoute[] = [
+  {
+    name: "Anthropic messages",
+    path: "/v1/messages",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      "anthropic-version": "2023-06-01",
+      "x-api-key": "attacker-anthropic-key",
+    },
+    body: anthropicBody,
+  },
+  ...["/v1/chat/completions", "/chat/completions"].map(
+    (path): DataPlaneRoute => ({
+      name: `OpenAI chat ${path}`,
+      path,
+      method: "POST",
+      headers: {
+        ...projectHeaders,
+        authorization: "Bearer attacker-openai-token",
+      },
+      body: openAIChatBody,
+    }),
+  ),
+  {
+    name: "OpenAI responses",
+    path: "/v1/responses",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      authorization: "Bearer attacker-openai-token",
+    },
+    body: responsesBody,
+  },
+  {
+    name: "Codex responses",
+    path: "/v1/codex/responses",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      authorization: "Bearer attacker-codex-token",
+      "x-lore-provider": "openai-codex",
+    },
+    body: responsesBody,
+  },
+  {
+    name: "Responses compaction",
+    path: "/v1/responses/compact",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      authorization: "Bearer attacker-openai-token",
+      "x-lore-provider": "openai",
+    },
+    body: responsesBody,
+  },
+  {
+    name: "Explicit compaction",
+    path: "/v1/compact",
+    method: "POST",
+    headers: { "x-api-key": "attacker-anthropic-key" },
+    body: JSON.stringify({ project_path: ATTACK_PROJECT }),
+  },
+  {
+    name: "Models passthrough",
+    path: "/v1/models",
+    method: "GET",
+    headers: {
+      "x-api-key": "attacker-anthropic-key",
+      authorization: "Bearer attacker-openai-token",
+    },
+  },
+  ...["/v1beta", "/v1", ""].flatMap((prefix) =>
+    ["generateContent", "streamGenerateContent"].map(
+      (verb): DataPlaneRoute => ({
+        name: `Gemini ${prefix || "bare"} ${verb}`,
+        path: `${prefix}/models/gemini-2.5-flash:${verb}`,
+        method: "POST",
+        headers: {
+          ...projectHeaders,
+          "x-goog-api-key": "attacker-gemini-key",
+        },
+        body: geminiBody,
+      }),
+    ),
+  ),
+  ...[
+    "converse",
+    "converse-stream",
+    "invoke",
+    "invoke-with-response-stream",
+  ].map(
+    (verb): DataPlaneRoute => ({
+      name: `Bedrock Runtime ${verb}`,
+      path: `/v1/model/anthropic.claude-sonnet-4-6-v1/${verb}`,
+      method: "POST",
+      headers: { authorization: "Bearer attacker-bedrock-token" },
+      body: bedrockBody,
+    }),
+  ),
+];
+
+const BROWSER_ATTEMPTS = DATA_PLANE_ROUTES.flatMap((route) =>
+  ["https://attacker.example", "null"].flatMap((origin) => [
+    { ...route, origin, requestKind: "credentialed request" as const },
+    {
+      ...route,
+      origin,
+      requestKind: "simple request" as const,
+      headers: {},
+    },
+    {
+      ...route,
+      origin,
+      requestKind: "preflight" as const,
+      method: "OPTIONS" as const,
+      headers: {},
+      body: undefined,
+    },
+  ]),
+);
+
+const STORAGE_TABLES = [
+  "projects",
+  "temporal_messages",
+  "distillations",
+  "knowledge",
+  "session_state",
+  "daily_costs",
+  "session_prompt_deltas",
+  "session_rollup",
+] as const;
+
+function storageSnapshot(): Record<string, number> {
+  return Object.fromEntries(
+    STORAGE_TABLES.map((table) => {
+      const row = db()
+        .query(`SELECT COUNT(*) AS count FROM ${table}`)
+        .get() as { count: number };
+      return [table, row.count];
+    }),
+  );
+}
+
+function assertNoCors(response: Response): void {
+  expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  expect(response.headers.get("access-control-allow-headers")).toBeNull();
+  expect(response.headers.get("access-control-allow-methods")).toBeNull();
+  for (const name of response.headers.keys()) {
+    expect(name.startsWith("access-control-")).toBe(false);
+  }
+}
+
+function mockedUpstreamResponse(model: string): Response {
+  let body: unknown;
+  if (model.startsWith("claude")) {
+    body = {
+      id: "msg_browser_security",
+      type: "message",
+      role: "assistant",
+      model,
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+  } else if (model.startsWith("gemini")) {
+    body = {
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: "ok" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+      modelVersion: model,
+    };
+  } else {
+    body = {
+      id: "chatcmpl_browser_security",
+      object: "chat.completion",
+      created: 1,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+  }
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "access-control-allow-origin": "*",
+      "access-control-allow-headers": "*",
+    },
+  });
+}
+
+describe("browser-origin data-plane isolation", () => {
+  let harness: Harness;
+  let mockAgent: MockAgent;
+  let pipelineInterceptorCalls = 0;
+  let dispatcherCalls = 0;
+  let initialStorage: Record<string, number>;
+  let initialSpend = 0;
+
+  beforeAll(async () => {
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+
+    const interceptedOrigins = [
+      SERVER_ANTHROPIC_ORIGIN,
+      SERVER_OPENAI_ORIGIN,
+      "https://generativelanguage.googleapis.com",
+      "https://chatgpt.com",
+      BEDROCK_ORIGIN,
+    ];
+    for (const origin of interceptedOrigins) {
+      for (const method of ["GET", "POST"] as const) {
+        mockAgent
+          .get(origin)
+          .intercept({ path: () => true, method })
+          .reply(() => {
+            dispatcherCalls += 1;
+            return {
+              statusCode: 200,
+              data: JSON.stringify({ data: [], output: [] }),
+              responseOptions: {
+                headers: {
+                  "content-type": "application/json",
+                  "access-control-allow-origin": "*",
+                  "access-control-allow-headers": "*",
+                },
+              },
+            };
+          })
+          .persist();
+      }
+    }
+    setUpstreamDispatcherForTest(mockAgent);
+
+    const configOverrides: Partial<GatewayConfig> = {
+      upstreamAnthropic: SERVER_ANTHROPIC_ORIGIN,
+      upstreamOpenAI: SERVER_OPENAI_ORIGIN,
+      remoteGateway: true,
+      gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      bedrockRegion: "browser-security-1",
+      workerApiKey: "victim-server-worker-key",
+      upstreamExtraHeaders: {
+        authorization: "Bearer victim-server-upstream-token",
+      },
+      upstreamExtraHeaderBases: [SERVER_ANTHROPIC_ORIGIN, SERVER_OPENAI_ORIGIN],
+    };
+    harness = await createHarness({ fixtures: [], configOverrides });
+
+    setUpstreamInterceptor(async (_body, model) => {
+      pipelineInterceptorCalls += 1;
+      return mockedUpstreamResponse(model);
+    });
+    resetDailyBudgetState();
+    initialStorage = storageSnapshot();
+    initialSpend = getDailySpend().spend;
+  });
+
+  afterAll(async () => {
+    if (harness) await harness.teardown();
+    setUpstreamDispatcherForTest(null);
+    if (mockAgent) await mockAgent.close();
+  });
+
+  function gatewayRequest(
+    path: string,
+    options: {
+      method: string;
+      headers?: Record<string, string>;
+      body?: string;
+    },
+  ): Promise<Response> {
+    const gateway = new URL(harness.baseURL);
+    return new Promise<Response>((resolve, reject) => {
+      const request = httpRequest(
+        {
+          hostname: gateway.hostname,
+          port: gateway.port,
+          path,
+          method: options.method,
+          headers: options.headers,
+        },
+        (incoming) => {
+          const chunks: Buffer[] = [];
+          incoming.on("data", (chunk: Buffer) => chunks.push(chunk));
+          incoming.once("end", () => {
+            const headers = new Headers();
+            for (
+              let index = 0;
+              index < incoming.rawHeaders.length;
+              index += 2
+            ) {
+              headers.append(
+                incoming.rawHeaders[index],
+                incoming.rawHeaders[index + 1],
+              );
+            }
+            const body = Buffer.concat(chunks);
+            resolve(
+              new Response(body.length === 0 ? null : body, {
+                status: incoming.statusCode ?? 500,
+                statusText: incoming.statusMessage,
+                headers,
+              }),
+            );
+          });
+        },
+      );
+      request.once("error", reject);
+      request.end(options.body);
+    });
+  }
+
+  describe("route and preflight battery", () => {
+    test.each(BROWSER_ATTEMPTS)(
+      "rejects $requestKind for $name with Origin $origin",
+      async ({ path, method, headers, body, origin, requestKind }) => {
+        const requestHeaders: Record<string, string> = {
+          origin,
+          ...headers,
+        };
+        if (requestKind === "preflight") {
+          requestHeaders["access-control-request-method"] =
+            DATA_PLANE_ROUTES.find((route) => route.path === path)?.method ??
+            "POST";
+          requestHeaders["access-control-request-headers"] =
+            "authorization, content-type, x-api-key, x-goog-api-key";
+        } else if (body !== undefined) {
+          // text/plain is CORS-safelisted. The simple-request cases carry no
+          // other non-safelisted headers; credentialed cases separately cover
+          // attacker-supplied provider authentication.
+          requestHeaders["content-type"] = "text/plain;charset=UTF-8";
+          requestHeaders["content-length"] = String(Buffer.byteLength(body));
+        }
+
+        const response = await gatewayRequest(path, {
+          method,
+          headers: requestHeaders,
+          body,
+        });
+
+        expect(response.status).toBe(403);
+        expect(await response.text()).toBe("");
+        expect(response.headers.get("cache-control")).toBe("no-store");
+        assertNoCors(response);
+        expect(pipelineInterceptorCalls).toBe(0);
+        expect(dispatcherCalls).toBe(0);
+        expect(getActiveSessions().size).toBe(0);
+        expect(getAllSessionCosts().size).toBe(0);
+        expect(getDailySpend().spend).toBe(initialSpend);
+        expect(storageSnapshot()).toEqual(initialStorage);
+      },
+    );
+  });
+
+  test("rejects before waiting for or parsing a data-plane body", async () => {
+    const port = Number(new URL(harness.baseURL).port);
+    const rawResponse = await new Promise<string>((resolve, reject) => {
+      const socket = connect(port, "127.0.0.1");
+      let received = "";
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error("browser-origin denial waited for the request body"));
+      }, 2_000);
+      const finish = (): void => {
+        clearTimeout(timer);
+        socket.destroy();
+        resolve(received);
+      };
+      socket.once("connect", () => {
+        socket.write(
+          "POST /v1/messages HTTP/1.1\r\n" +
+            `Host: 127.0.0.1:${port}\r\n` +
+            "Origin: https://attacker.example\r\n" +
+            "Content-Type: text/plain\r\n" +
+            "X-Api-Key: attacker-key\r\n" +
+            "Content-Length: 100000\r\n" +
+            "\r\n" +
+            "{",
+        );
+      });
+      socket.on("data", (chunk) => {
+        received += chunk.toString();
+        if (received.includes("\r\n\r\n")) finish();
+      });
+      socket.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      socket.once("close", () => {
+        if (received) finish();
+      });
+    });
+
+    expect(rawResponse).toContain("403 Forbidden");
+    expect(rawResponse.toLowerCase()).toContain("connection: close");
+    expect(rawResponse.toLowerCase()).not.toContain("access-control-");
+    expect(pipelineInterceptorCalls).toBe(0);
+    expect(dispatcherCalls).toBe(0);
+    expect(getActiveSessions().size).toBe(0);
+    expect(storageSnapshot()).toEqual(initialStorage);
+  });
+
+  test.each(["https://attacker.example", "null"])(
+    "rejects browser WebSocket upgrade with Origin %s before route handling",
+    async (origin) => {
+      const port = Number(new URL(harness.baseURL).port);
+      const rawResponse = await new Promise<string>((resolve, reject) => {
+        const socket = connect(port, "127.0.0.1", () => {
+          socket.write(
+            "GET /v1/responses HTTP/1.1\r\n" +
+              `Host: 127.0.0.1:${port}\r\n` +
+              `Origin: ${origin}\r\n` +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              "Sec-WebSocket-Version: 13\r\n" +
+              "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+              "\r\n",
+          );
+        });
+        let received = "";
+        socket.on("data", (chunk) => {
+          received += chunk.toString();
+        });
+        socket.once("close", () => resolve(received));
+        socket.once("error", reject);
+      });
+
+      expect(rawResponse).toContain("403 Forbidden");
+      expect(rawResponse.toLowerCase()).not.toContain("access-control-");
+      expect(pipelineInterceptorCalls).toBe(0);
+      expect(dispatcherCalls).toBe(0);
+    },
+  );
+
+  test("rejects an Origin matching the gateway itself on data-plane routes", async () => {
+    const response = await gatewayRequest("/v1/messages", {
+      method: "POST",
+      headers: {
+        ...projectHeaders,
+        origin: harness.baseURL,
+        "content-type": "text/plain;charset=UTF-8",
+        "x-api-key": "attacker-anthropic-key",
+      },
+      body: anthropicBody,
+    });
+
+    expect(response.status).toBe(403);
+    assertNoCors(response);
+    expect(pipelineInterceptorCalls).toBe(0);
+    expect(dispatcherCalls).toBe(0);
+    expect(getActiveSessions().size).toBe(0);
+    expect(storageSnapshot()).toEqual(initialStorage);
+  });
+
+  test.each(["https://attacker.example", "null"])(
+    "keeps health public for Origin %s without granting CORS read access",
+    async (origin) => {
+      const response = await gatewayRequest("/health", {
+        method: "GET",
+        headers: { origin },
+      });
+
+      expect(response.status).toBe(200);
+      assertNoCors(response);
+    },
+  );
+
+  test("keeps no-Origin Anthropic and OpenAI SDK requests working", async () => {
+    const anthropicCallsBefore = pipelineInterceptorCalls;
+    const anthropic = await gatewayRequest("/v1/messages", {
+      method: "POST",
+      headers: {
+        ...projectHeaders,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+        "x-api-key": "cli-anthropic-key",
+        "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+      },
+      body: anthropicBody,
+    });
+    expect(anthropic.status).toBe(200);
+    expect(pipelineInterceptorCalls).toBe(anthropicCallsBefore + 1);
+    assertNoCors(anthropic);
+
+    const openAICallsBefore = pipelineInterceptorCalls;
+    const openAI = await gatewayRequest("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        ...projectHeaders,
+        authorization: "Bearer cli-openai-token",
+        "content-type": "application/json",
+        "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+      },
+      body: openAIChatBody,
+    });
+    expect(openAI.status).toBe(200);
+    expect(pipelineInterceptorCalls).toBe(openAICallsBefore + 1);
+    assertNoCors(openAI);
+  });
+
+  test("keeps no-Origin model passthrough clients working and strips upstream CORS", async () => {
+    const modelsCallsBefore = dispatcherCalls;
+    const models = await gatewayRequest("/v1/models", {
+      method: "GET",
+      headers: {
+        "x-api-key": "cli-anthropic-key",
+        "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+    expect(models.status).toBe(200);
+    expect(dispatcherCalls).toBe(modelsCallsBefore + 1);
+    assertNoCors(models);
+
+    const bedrockCallsBefore = dispatcherCalls;
+    const bedrock = await gatewayRequest(
+      "/v1/model/anthropic.claude-sonnet-4-6-v1/converse",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer sdk-bedrock-token",
+          "content-type": "application/json",
+          "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+        },
+        body: bedrockBody,
+      },
+    );
+    expect(bedrock.status).toBe(200);
+    expect(dispatcherCalls).toBe(bedrockCallsBefore + 1);
+    assertNoCors(bedrock);
+  });
+});

--- a/packages/gateway/test/cache-warmer.test.ts
+++ b/packages/gateway/test/cache-warmer.test.ts
@@ -807,6 +807,23 @@ describe("circuit breaker", () => {
     expect(warmupBucketKey(switched)).not.toBe(key);
   });
 
+  test("warmupBucketKey strips URL userinfo, query, and fragment", () => {
+    const state = makeSessionState({
+      lastUpstream: {
+        url: "https://user:PRIVATE_BUCKET_USERINFO@example.com/custom?token=PRIVATE_BUCKET_QUERY#PRIVATE_BUCKET_FRAGMENT",
+        protocol: "anthropic",
+        model: "claude-test",
+        headers: {},
+      },
+    });
+
+    const key = warmupBucketKey(state);
+    expect(key).toContain("https://example.com/custom");
+    expect(key).not.toContain("PRIVATE_BUCKET_USERINFO");
+    expect(key).not.toContain("PRIVATE_BUCKET_QUERY");
+    expect(key).not.toContain("PRIVATE_BUCKET_FRAGMENT");
+  });
+
   test("getCircuitBreakerSummary lists tripped buckets", () => {
     const bad = makeWarmupResult({
       cacheReadTokens: 0,

--- a/packages/gateway/test/cli-bundle-smoke.test.ts
+++ b/packages/gateway/test/cli-bundle-smoke.test.ts
@@ -25,21 +25,26 @@ const TEST_TIMEOUT_MS = 45_000;
 
 async function runBundle(
   args: string[],
-  env: Record<string, string> = {},
+  env: NodeJS.ProcessEnv = {},
 ): Promise<{ stdout: string; stderr: string; code: number | null }> {
   if (!existsSync(BUNDLE)) {
     throw new Error(
       `Bundle not found at ${BUNDLE} — run \`pnpm --filter @loreai/gateway run bundle\` first.`,
     );
   }
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    // Suppress any background update check noise.
+    LORE_NO_UPDATE_CHECK: "1",
+  };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete childEnv[key];
+    else childEnv[key] = value;
+  }
+
   return new Promise((resolveRun, reject) => {
     const child = spawn(process.execPath, [BUNDLE, ...args], {
-      env: {
-        ...process.env,
-        // Suppress any background update check noise.
-        LORE_NO_UPDATE_CHECK: "1",
-        ...env,
-      },
+      env: childEnv,
       timeout: BUNDLE_TIMEOUT_MS,
     });
     const stdoutChunks: Buffer[] = [];
@@ -107,6 +112,29 @@ describe("Phase 1 — bundled CLI reaches the typed commands", () => {
       expect(code).toBe(0);
       // The version is a semver string from build-injected VERSION.
       expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "`lore --version` starts the production bundle with Sentry enabled by default",
+    async () => {
+      const { stdout, stderr, code } = await runBundle(["--version"], {
+        NODE_ENV: "production",
+        // Vitest sets SENTRY_ENABLED=0 globally. Remove it so this subprocess
+        // exercises the production bundle's default-enabled initialization.
+        SENTRY_ENABLED: undefined,
+        // If initialization ever emits an envelope, fail it quickly through a
+        // loopback-only proxy instead of making this regression depend on DNS
+        // or external network availability.
+        http_proxy: "http://127.0.0.1:1",
+        https_proxy: "http://127.0.0.1:1",
+        no_proxy: "",
+      });
+
+      expect(code).toBe(0);
+      expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+      expect(stderr).toBe("");
     },
     TEST_TIMEOUT_MS,
   );

--- a/packages/gateway/test/cli-stop-contract.test.ts
+++ b/packages/gateway/test/cli-stop-contract.test.ts
@@ -35,6 +35,54 @@ const state = vi.hoisted(() => ({
 
 vi.mock("../src/pidfile", () => ({
   readPidFile: () => state.pid,
+  inspectPidFile: () => {
+    if (state.pid === null) return { state: "absent" };
+    if (state.pidAlive) {
+      return {
+        state: "process",
+        record: {
+          version: 2,
+          pid: state.pid,
+          port: state.port ?? 3207,
+          hosts: ["127.0.0.1"],
+          token: "contract-token".repeat(3),
+          processIdentity: "contract-process-generation",
+        },
+      };
+    }
+    return {
+      state: "legacy",
+      record: {
+        pid: state.pid,
+        identity: {
+          device: 1n,
+          inode: 2n,
+          size: 3n,
+          mtimeNs: 4n,
+          ctimeNs: 5n,
+          birthtimeNs: 6n,
+        },
+      },
+    };
+  },
+  readGatewayProcessFile: () => {
+    if (state.pid === null || !state.pidAlive) return null;
+    return {
+      version: 2,
+      pid: state.pid,
+      port: state.port ?? 3207,
+      hosts: ["127.0.0.1"],
+      token: "contract-token".repeat(3),
+      processIdentity: "contract-process-generation",
+    };
+  },
+  removeGatewayProcessFile: (record: { pid: number }) => {
+    state.removed.push(record.pid);
+  },
+  removeLegacyPidFile: (record: { pid: number }) => {
+    state.removed.push(record.pid);
+    return "removed";
+  },
   removePidFile: (pid: number) => {
     state.removed.push(pid);
   },
@@ -50,6 +98,21 @@ vi.mock("../src/cli/start", () => ({
     if (!state.port) return false;
     return state.portAlive && url.endsWith(`:${state.port}`);
   },
+  probeGatewayProcess: async (record: { pid: number }) =>
+    state.pidAlive && record.pid === state.pid,
+  requestGatewayShutdown: async () => "unsupported",
+  probeUrlFor: (host: string, port: number) => `http://${host}:${port}`,
+}));
+
+vi.mock("../src/lifecycle-lock", () => ({
+  inspectProcessGeneration: (pid: number) =>
+    pid === state.pid && state.pidAlive
+      ? { state: "alive", identity: "contract-process-generation" }
+      : { state: "dead" },
+  withLifecycleLock: async (
+    _operation: string,
+    action: (lock: { assertOwned: () => void }) => unknown,
+  ) => action({ assertOwned: () => {} }),
 }));
 
 import { runCli } from "../src/cli/cli";

--- a/packages/gateway/test/cli-uninstall-contract.test.ts
+++ b/packages/gateway/test/cli-uninstall-contract.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const commandUninstall = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("../src/cli/uninstall", () => ({ commandUninstall }));
+
+import { LEGACY_ROUTES } from "../src/cli/app";
+import { runCli } from "../src/cli/cli";
+import { KNOWN_ROOT_COMMANDS, STRICLI_ROUTES } from "../src/cli/lib/argv";
+
+describe("lore uninstall CLI contract", () => {
+  const originalArgv = process.argv;
+  const originalExitCode = process.exitCode;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exitCode = originalExitCode;
+    commandUninstall.mockClear();
+  });
+
+  test("is registered as a typed root command", () => {
+    expect(STRICLI_ROUTES.has("uninstall")).toBe(true);
+    expect(KNOWN_ROOT_COMMANDS.has("uninstall")).toBe(true);
+    expect(LEGACY_ROUTES.has("uninstall")).toBe(false);
+  });
+
+  test("forwards the destructive flags explicitly", async () => {
+    process.argv = [
+      "node",
+      "lore",
+      "uninstall",
+      "--purge",
+      "--yes",
+      "--dry-run",
+    ];
+
+    await runCli();
+
+    expect(commandUninstall).toHaveBeenCalledWith([], {
+      purge: true,
+      yes: true,
+      "dry-run": true,
+    });
+  });
+
+  test("defaults to data-preserving behavior", async () => {
+    process.argv = ["node", "lore", "uninstall"];
+
+    await runCli();
+
+    expect(commandUninstall).toHaveBeenCalledWith([], {
+      purge: false,
+      yes: false,
+      "dry-run": false,
+    });
+  });
+});

--- a/packages/gateway/test/compact-endpoint-tenant-isolation.e2e.test.ts
+++ b/packages/gateway/test/compact-endpoint-tenant-isolation.e2e.test.ts
@@ -1,0 +1,366 @@
+import { request as httpRequest } from "node:http";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, test } from "vitest";
+import { credentialTenantFingerprint } from "../src/auth";
+import { setBeforeUpstreamCaptureForTest } from "../src/pipeline";
+import type { SessionState } from "../src/translate/types";
+import {
+  createHarness,
+  TEST_GATEWAY_AUTH_TOKEN,
+  type Harness,
+} from "./helpers/harness";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  makeFixtureEntry,
+  STANDARD_TOOLS,
+} from "./helpers/fixtures";
+
+const PROJECT_PATH = "/remote/compact-tenant-isolation";
+const SESSION_HEADER = "compact-tenant-b-session";
+const TENANT_A_KEY = "compact-tenant-a-key";
+const TENANT_B_KEY = "compact-tenant-b-key";
+const TENANT_A = credentialTenantFingerprint({
+  scheme: "api-key",
+  value: TENANT_A_KEY,
+});
+const TENANT_B = credentialTenantFingerprint({
+  scheme: "api-key",
+  value: TENANT_B_KEY,
+});
+const LOCAL_SECRET = "LOCAL_COMPACT_SECRET_malachite_71";
+const TENANT_A_SECRET = "TENANT_A_COMPACT_SECRET_cinnabar_83";
+const TENANT_B_SECRET = "TENANT_B_COMPACT_SECRET_sapphire_97";
+
+type CompactEndpoint = "/v1/compact" | "/v1/responses/compact";
+
+function conversationBody(content: string): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages: [{ role: "user", content }],
+    tools: STANDARD_TOOLS,
+  };
+}
+
+function compactBody(endpoint: CompactEndpoint): Record<string, unknown> {
+  if (endpoint === "/v1/compact") {
+    return { project_path: PROJECT_PATH };
+  }
+  return {
+    model: "gpt-5.4",
+    input: [{ type: "message", role: "user", content: "compact now" }],
+  };
+}
+
+async function postJson(
+  baseURL: string,
+  endpoint: CompactEndpoint,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const url = new URL(endpoint, baseURL);
+  const serialized = JSON.stringify(body);
+  return new Promise<Response>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(serialized)),
+          ...headers,
+        },
+      },
+      (incoming) => {
+        const responseHeaders = new Headers();
+        for (let i = 0; i < incoming.rawHeaders.length; i += 2) {
+          responseHeaders.append(
+            incoming.rawHeaders[i],
+            incoming.rawHeaders[i + 1],
+          );
+        }
+        resolve(
+          new Response(
+            Readable.toWeb(incoming) as unknown as ReadableStream<Uint8Array>,
+            {
+              status: incoming.statusCode ?? 500,
+              statusText: incoming.statusMessage,
+              headers: responseHeaders,
+            },
+          ),
+        );
+      },
+    );
+    request.once("error", reject);
+    request.end(serialized);
+  });
+}
+
+async function seedKnowledge(tenantId: string, secret: string): Promise<void> {
+  const { ensureProject, ltm, withTenant } = await import("@loreai/core");
+  withTenant(tenantId, () => {
+    ensureProject(PROJECT_PATH);
+    ltm.create({
+      projectPath: PROJECT_PATH,
+      scope: "project",
+      category: "architecture",
+      title: `Compact isolation ${secret}`,
+      content: `${secret} belongs only to its storage tenant.`,
+    });
+  });
+}
+
+async function createTenantBSession(
+  harness: Harness,
+  capture?: (state: SessionState) => void,
+): Promise<string> {
+  if (capture) {
+    setBeforeUpstreamCaptureForTest(async (_request, state) => capture(state));
+  }
+  try {
+    const response = await harness.chat(
+      conversationBody("tenant B conversation used to establish the session"),
+      TENANT_B_KEY,
+      {
+        "x-lore-session-id": SESSION_HEADER,
+        "x-lore-project": PROJECT_PATH,
+        "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+      },
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+  } finally {
+    setBeforeUpstreamCaptureForTest(undefined);
+  }
+
+  const sessions = harness.queryDB<{
+    session_id: string;
+    credential_fingerprint: string;
+  }>(
+    "SELECT session_id, credential_fingerprint FROM session_state WHERE credential_fingerprint = ?",
+    [TENANT_B],
+  );
+  expect(sessions).toHaveLength(1);
+
+  // Keep compaction deterministic and offline: the tenant-specific knowledge
+  // rows below are enough to build a summary, so no urgent worker call is needed.
+  const { db } = await import("@loreai/core");
+  db()
+    .query("UPDATE temporal_messages SET distilled = 1 WHERE session_id = ?")
+    .run(sessions[0].session_id);
+  return sessions[0].session_id;
+}
+
+function storageSnapshot(harness: Harness) {
+  return {
+    projects: harness.queryDB(
+      "SELECT id, path, tenant_id FROM projects ORDER BY tenant_id, id",
+    ),
+    knowledge: harness.queryDB(
+      `SELECT id, logical_id, project_id, tenant_id, title, content
+         FROM knowledge ORDER BY tenant_id, id`,
+    ),
+    temporal: harness.queryDB(
+      `SELECT id, project_id, session_id, role, content, distilled
+         FROM temporal_messages ORDER BY id`,
+    ),
+    sessions: harness.queryDB(
+      `SELECT session_id, credential_fingerprint, header_name,
+              header_session_id, project_path, project_path_provisional
+         FROM session_state ORDER BY session_id`,
+    ),
+  };
+}
+
+function summaryFromResponse(
+  endpoint: CompactEndpoint,
+  body: Record<string, unknown>,
+): string {
+  if (endpoint === "/v1/compact") {
+    return typeof body.summary === "string" ? body.summary : "";
+  }
+  const output = body.output as Array<{
+    content?: Array<{ text?: string }>;
+  }>;
+  return String(output?.[0]?.content?.[0]?.text ?? "");
+}
+
+describe("compact endpoint remote tenant isolation", () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    setBeforeUpstreamCaptureForTest(undefined);
+    await harness?.teardown();
+    harness = undefined;
+  });
+
+  test.each([
+    {
+      endpoint: "/v1/compact" as const,
+      seedWrongTenantsFirst: true,
+      restartBeforeCompact: false,
+    },
+    {
+      endpoint: "/v1/responses/compact" as const,
+      seedWrongTenantsFirst: false,
+      restartBeforeCompact: true,
+    },
+  ])(
+    "$endpoint reads only tenant B in adversarial order",
+    async ({ endpoint, seedWrongTenantsFirst, restartBeforeCompact }) => {
+      harness = await createHarness({
+        fixtures: [
+          makeFixtureEntry({
+            seq: 0,
+            requestMessages: [],
+            responseText: "tenant B response",
+          }),
+        ],
+        configOverrides: {
+          remoteGateway: true,
+          gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+        },
+        projectPath: PROJECT_PATH,
+      });
+
+      if (seedWrongTenantsFirst) {
+        await seedKnowledge("", LOCAL_SECRET);
+        await seedKnowledge(TENANT_A, TENANT_A_SECRET);
+      }
+
+      await createTenantBSession(harness);
+      await seedKnowledge(TENANT_B, TENANT_B_SECRET);
+
+      if (!seedWrongTenantsFirst) {
+        await seedKnowledge(TENANT_A, TENANT_A_SECRET);
+        await seedKnowledge("", LOCAL_SECRET);
+      }
+
+      if (restartBeforeCompact) await harness.restartPipeline();
+
+      const before = storageSnapshot(harness);
+      expect(
+        (before.projects as Array<{ tenant_id: string }>).map(
+          (row) => row.tenant_id,
+        ),
+      ).toEqual(["", TENANT_A, TENANT_B].sort());
+
+      const response = await postJson(
+        harness.baseURL,
+        endpoint,
+        compactBody(endpoint),
+        {
+          "x-api-key": TENANT_B_KEY,
+          "x-lore-session-id": SESSION_HEADER,
+          "x-lore-project": PROJECT_PATH,
+          "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+        },
+      );
+      expect(response.status).toBe(200);
+      const responseBody = (await response.json()) as Record<string, unknown>;
+      const summary = summaryFromResponse(endpoint, responseBody).replaceAll(
+        "\\",
+        "",
+      );
+      expect(summary).toContain(TENANT_B_SECRET);
+      expect(summary).not.toContain(TENANT_A_SECRET);
+      expect(summary).not.toContain(LOCAL_SECRET);
+
+      // Compaction is a read/assembly operation. In particular, it must not
+      // create a local/A project row or rebind tenant B's persisted session.
+      expect(storageSnapshot(harness)).toEqual(before);
+    },
+  );
+
+  test.each(["/v1/compact" as const, "/v1/responses/compact" as const])(
+    "$endpoint fails closed on an in-memory tenant mismatch",
+    async (endpoint) => {
+      harness = await createHarness({
+        fixtures: [
+          makeFixtureEntry({
+            seq: 0,
+            requestMessages: [],
+            responseText: "tenant B response",
+          }),
+        ],
+        configOverrides: {
+          remoteGateway: true,
+          gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+        },
+        projectPath: PROJECT_PATH,
+      });
+
+      let sessionState: SessionState | undefined;
+      await createTenantBSession(harness, (state) => {
+        sessionState = state;
+      });
+      await seedKnowledge(TENANT_B, TENANT_B_SECRET);
+      if (!sessionState)
+        throw new Error("conversation did not expose session state");
+
+      // Models the exact stale-owner state created by the old unscoped compact
+      // path. The real HTTP route must reject it, never silently adopt/rewrite it.
+      sessionState.storageTenantId = TENANT_A;
+      const before = storageSnapshot(harness);
+      const response = await postJson(
+        harness.baseURL,
+        endpoint,
+        compactBody(endpoint),
+        {
+          "x-api-key": TENANT_B_KEY,
+          "x-lore-session-id": SESSION_HEADER,
+          "x-lore-project": PROJECT_PATH,
+          "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+        },
+      );
+      expect(response.status).toBe(404);
+      expect(await response.json()).toMatchObject({
+        error: "session_not_found",
+      });
+      expect(storageSnapshot(harness)).toEqual(before);
+      expect(sessionState.storageTenantId).toBe(TENANT_A);
+    },
+  );
+
+  test.each(["/v1/compact" as const, "/v1/responses/compact" as const])(
+    "$endpoint rejects mixed auth before storage access",
+    async (endpoint) => {
+      harness = await createHarness({
+        fixtures: [],
+        configOverrides: {
+          remoteGateway: true,
+          gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+        },
+        projectPath: PROJECT_PATH,
+      });
+
+      const response = await postJson(
+        harness.baseURL,
+        endpoint,
+        compactBody(endpoint),
+        {
+          "x-api-key": TENANT_B_KEY,
+          "x-goog-api-key": "conflicting-google-key",
+          "x-lore-session-id": SESSION_HEADER,
+          "x-lore-project": PROJECT_PATH,
+          "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+        },
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain(
+        "Conflicting provider authentication headers",
+      );
+      expect(storageSnapshot(harness)).toEqual({
+        projects: [],
+        knowledge: [],
+        temporal: [],
+        sessions: [],
+      });
+    },
+  );
+});

--- a/packages/gateway/test/credential-header-contract.test.ts
+++ b/packages/gateway/test/credential-header-contract.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "vitest";
+import {
+  collectCandidateHeaders,
+  extractKnownSessionHeader,
+  isCredentialHeaderName as isLearningCredentialHeaderName,
+  KNOWN_SESSION_HEADERS,
+  learnHeaders,
+  _resetGlobalHeaderValues,
+} from "../src/session";
+import {
+  buildUpstreamSnapshotHeaders,
+  forwardClientHeaders,
+  isCredentialHeaderName as isForwardingCredentialHeaderName,
+} from "../src/translate/types";
+import { scrubTelemetryText } from "../src/telemetry-privacy";
+import { log } from "@loreai/core";
+
+const CREDENTIAL_HEADER_CORPUS = [
+  "Authorization",
+  "Proxy-Authorization",
+  "Cookie",
+  "Cookie2",
+  "api-key",
+  "cf-aig-authorization",
+  "cf-access-client-id",
+  "x-api-key",
+  "x-goog-api-key",
+  "x-lore-gateway-token",
+  "x-auth-token",
+  "x-authtoken",
+  "x-refresh-token",
+  "x-client-secret",
+  "x-access-key-id",
+  "x-custom-auth",
+  "x-credential-id",
+  "x-password",
+  "x-session-key",
+  "x-client-session-key",
+  "x-auth-session-id",
+  "x-oauth-session-id",
+  "x-secret-session-id",
+  "x-token-session-id",
+  "x-key-session-id",
+  "x-bearer-session-id",
+  "X-BEARER-SESSION-ID",
+  "x_bearer_session_id",
+  "x.bearer.session.id",
+  "xBearerSessionId",
+  "XBearerSessionID",
+  "x-bearer_sessionId",
+  "x-bearersessionid",
+  "xbearersessionid",
+] as const;
+
+const COLLAPSED_CREDENTIAL_HEADER_ALIASES = [
+  "xapikey",
+  "xApiKey",
+  "XAPIKEY",
+  "x-apikey",
+  "xapi-key",
+  "x_api.key",
+  "x.api_key",
+  "x-api_key",
+  "xApi_Key",
+  ...["auth", "oauth", "secret", "token", "key"].flatMap((kind) => {
+    const titleKind = `${kind[0].toUpperCase()}${kind.slice(1)}`;
+    return [
+      `x${kind}sessionid`,
+      `x-${kind}sessionid`,
+      `x.${kind}sessionid`,
+      `x_${kind}sessionid`,
+      `x${titleKind}SessionId`,
+      `x${titleKind}_session_id`,
+      `X${kind.toUpperCase()}SESSIONID`,
+      `x_${kind}.sessionId`,
+      `x-${kind}_session.id`,
+    ];
+  }),
+] as const;
+
+const REJECTED_CREDENTIAL_HEADER_NAMES = [
+  ...CREDENTIAL_HEADER_CORPUS,
+  ...COLLAPSED_CREDENTIAL_HEADER_ALIASES,
+] as const;
+
+describe("credential header classification contract", () => {
+  test("forwarding and learning expose the shared classifier", () => {
+    expect(isLearningCredentialHeaderName).toBe(
+      isForwardingCredentialHeaderName,
+    );
+  });
+
+  test.each(REJECTED_CREDENTIAL_HEADER_NAMES)(
+    "forwarding and learning reject credential-shaped header %s",
+    (name) => {
+      const value = "credential-value-aaaa1111";
+
+      expect(isForwardingCredentialHeaderName(name)).toBe(true);
+      expect(isLearningCredentialHeaderName(name)).toBe(
+        isForwardingCredentialHeaderName(name),
+      );
+      expect(forwardClientHeaders({ [name]: value })).toEqual({});
+      expect(buildUpstreamSnapshotHeaders({ [name]: value })).toEqual({});
+      expect(collectCandidateHeaders({ [name]: value }).has(name)).toBe(false);
+      const freeText = `diagnostic prefix: ${name}=${value} status=401`;
+      const expected = `diagnostic prefix: ${name}=[Filtered] status=401`;
+      expect(scrubTelemetryText(freeText)).toBe(expected);
+      expect(log.redactSensitiveLogText(freeText)).toBe(expected);
+
+      const compound =
+        `diagnostic prefix: ${name}: foo=first-secret; ` +
+        "bar=second-secret status=401";
+      const compoundExpected = `diagnostic prefix: ${name}: [Filtered] status=401`;
+      expect(scrubTelemetryText(compound)).toBe(compoundExpected);
+      expect(log.redactSensitiveLogText(compound)).toBe(compoundExpected);
+    },
+  );
+
+  test("x-bearer-session-id cannot promote from historical candidate state", () => {
+    _resetGlobalHeaderValues();
+    const name = "x-bearer-session-id";
+    const value = "credential-value-aaaa1111";
+
+    learnHeaders(undefined, { [name]: "credential-value-bbbb2222" });
+    const result = learnHeaders(new Map([[name, { value, seenCount: 2 }]]), {
+      [name]: value,
+    });
+
+    expect(result.updatedCandidates.has(name)).toBe(false);
+    expect(result.promoted).toBeNull();
+  });
+
+  test.each(KNOWN_SESSION_HEADERS)(
+    "established session header %s remains safe and usable",
+    (name) => {
+      const value = "legitimate-session-value-1234";
+
+      expect(isForwardingCredentialHeaderName(name)).toBe(false);
+      expect(isLearningCredentialHeaderName(name)).toBe(false);
+      expect(collectCandidateHeaders({ [name]: value }).get(name)).toBe(value);
+      expect(extractKnownSessionHeader({ [name]: value })).toEqual({
+        headerName: name,
+        sessionId: value,
+      });
+      expect(forwardClientHeaders({ [name]: value })).toEqual({});
+    },
+  );
+
+  test.each([
+    "x-client-session-id",
+    "x-keyboard-session-id",
+    "x-monkey-session-id",
+  ])("safe learned session header %s remains eligible", (name) => {
+    const value = "legitimate-session-value-1234";
+
+    expect(isForwardingCredentialHeaderName(name)).toBe(false);
+    expect(isLearningCredentialHeaderName(name)).toBe(false);
+    expect(collectCandidateHeaders({ [name]: value }).get(name)).toBe(value);
+    expect(forwardClientHeaders({ [name]: value })).toEqual({ [name]: value });
+  });
+
+  test.each([
+    ...KNOWN_SESSION_HEADERS,
+    "idempotency-key",
+    "sec-websocket-key",
+    "session-id",
+    "x-client-session-id",
+    "x-keyboard-session-id",
+    "x-monkey-session-id",
+  ])("safe diagnostic header %s remains visible in free text", (name) => {
+    const diagnostic = `diagnostic prefix: ${name}=safe-diagnostic-value`;
+
+    expect(isForwardingCredentialHeaderName(name)).toBe(false);
+    expect(scrubTelemetryText(diagnostic)).toBe(diagnostic);
+    expect(log.redactSensitiveLogText(diagnostic)).toBe(diagnostic);
+  });
+
+  test("does not redact a bearer scheme diagnostic without an assignment credential", () => {
+    const diagnostic = "routing decision scheme=bearer provider=anthropic";
+
+    expect(scrubTelemetryText(diagnostic)).toBe(diagnostic);
+    expect(log.redactSensitiveLogText(diagnostic)).toBe(diagnostic);
+  });
+});

--- a/packages/gateway/test/daemon-args.test.ts
+++ b/packages/gateway/test/daemon-args.test.ts
@@ -1,267 +1,259 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildStartChildArgs,
+  daemonLogPath,
   daemonProbeHost,
   daemonSpawnSpec,
-  daemonLogPath,
-  runDaemon,
   realDaemonIO,
+  runDaemon,
   type DaemonIO,
 } from "../src/cli/start";
-import { readPortFile } from "../src/portfile";
+import { removePortFile } from "../src/portfile";
+import {
+  readGatewayProcessFile,
+  removeGatewayProcessFile,
+  type GatewayProcessRecord,
+} from "../src/pidfile";
 
-/** Build a DaemonIO with sensible defaults, overridable per test. */
-function makeDaemonIO(overrides: Partial<DaemonIO> = {}): {
-  io: DaemonIO;
-  info: string[];
-  errors: string[];
-  spawned: () => number;
-} {
+const RECORD: GatewayProcessRecord = {
+  version: 1,
+  pid: 4242,
+  port: 3207,
+  hosts: ["127.0.0.1"],
+  token: "a".repeat(32),
+};
+
+function makeDaemonIO(overrides: Partial<DaemonIO> = {}) {
   const info: string[] = [];
   const errors: string[] = [];
   let spawnCount = 0;
   const io: DaemonIO = {
-    readPort: () => null,
-    probe: async () => false,
+    readProcess: () => null,
+    authenticate: async () => null,
+    probeHealth: async () => false,
     spawnDaemon: () => {
-      spawnCount++;
+      spawnCount += 1;
       return 4242;
     },
+    inspectProcess: () => ({
+      state: "alive",
+      identity: "child-generation",
+    }),
+    terminate: () => {},
+    removeProcess: () => {},
+    removePort: () => {},
     sleep: async () => {},
     now: () => 0,
-    logInfo: (m) => info.push(m),
-    logError: (m) => errors.push(m),
+    logInfo: (message) => info.push(message),
+    logError: (message) => errors.push(message),
     ...overrides,
   };
   return { io, info, errors, spawned: () => spawnCount };
 }
 
-describe("buildStartChildArgs", () => {
-  it("always starts with the `start` command", () => {
-    expect(buildStartChildArgs({})[0]).toBe("start");
-  });
-
-  it("never includes the daemonize flag (--bg / --daemon)", () => {
-    // Even though the parent was invoked with --bg, the detached child must
-    // run a plain foreground `start` or it would fork forever.
-    const args = buildStartChildArgs({ bg: true, port: 3207 });
-    expect(args).not.toContain("--bg");
-    expect(args).not.toContain("--daemon");
-  });
-
-  it("reconstructs --port", () => {
-    expect(buildStartChildArgs({ port: 8080 })).toEqual([
-      "start",
-      "--port",
-      "8080",
-    ]);
-  });
-
-  it("reconstructs multiple --host flags (one per host)", () => {
-    const args = buildStartChildArgs({ hosts: ["127.0.0.1", "100.64.0.1"] });
-    expect(args).toEqual([
-      "start",
-      "--host",
-      "127.0.0.1",
-      "--host",
-      "100.64.0.1",
-    ]);
-  });
-
-  it("reconstructs --debug only when true", () => {
-    expect(buildStartChildArgs({ debug: true })).toContain("--debug");
-    expect(buildStartChildArgs({ debug: false })).not.toContain("--debug");
-  });
-
-  it("reconstructs --local only when true", () => {
-    expect(buildStartChildArgs({ local: true })).toContain("--local");
-    expect(buildStartChildArgs({ local: false })).not.toContain("--local");
-  });
-
-  it("reconstructs --remote", () => {
-    expect(buildStartChildArgs({ remoteUrl: "http://remote:3207" })).toEqual([
-      "start",
-      "--remote",
-      "http://remote:3207",
-    ]);
-  });
-
-  it("combines all options in a stable order", () => {
-    const args = buildStartChildArgs({
-      bg: true,
-      port: 3207,
-      hosts: ["127.0.0.1"],
-      debug: true,
-      local: true,
-    });
-    expect(args).toEqual([
+describe("daemon arguments", () => {
+  it("reconstructs stable child arguments without daemonizing recursively", () => {
+    expect(
+      buildStartChildArgs({
+        bg: true,
+        port: 3207,
+        hosts: ["127.0.0.1", "100.64.0.1"],
+        debug: true,
+        local: true,
+        remoteUrl: "http://remote:3207",
+      }),
+    ).toEqual([
       "start",
       "--port",
       "3207",
       "--host",
       "127.0.0.1",
+      "--host",
+      "100.64.0.1",
       "--debug",
       "--local",
+      "--remote",
+      "http://remote:3207",
     ]);
+    expect(buildStartChildArgs({ bg: true })).not.toContain("--bg");
   });
 
-  it("emits just `start` for empty options", () => {
-    expect(buildStartChildArgs({})).toEqual(["start"]);
-  });
-});
-
-describe("daemonProbeHost", () => {
-  it("defaults to loopback when no host is configured", () => {
-    expect(daemonProbeHost({})).toBe("127.0.0.1");
-    expect(daemonProbeHost({ hosts: [] })).toBe("127.0.0.1");
-  });
-
-  it("uses the first configured host (Seer #875: non-loopback bind)", () => {
-    expect(daemonProbeHost({ hosts: ["100.64.0.1"] })).toBe("100.64.0.1");
-  });
-
-  it("skips empty host entries", () => {
-    expect(daemonProbeHost({ hosts: ["", "10.0.0.5"] })).toBe("10.0.0.5");
-  });
-});
-
-describe("daemonSpawnSpec", () => {
-  it("uses process.execPath and includes the reconstructed start args", () => {
+  it("uses process.execPath and prepends the script outside SEA", () => {
     const spec = daemonSpawnSpec({ port: 3299 });
     expect(spec.command).toBe(process.execPath);
-    // In dev/test (not a SEA binary) the script path is prepended.
     expect(spec.args[0]).toBe(process.argv[1]);
     expect(spec.args).toContain("start");
-    expect(spec.args).toContain("3299");
-    expect(spec.args).not.toContain("--bg");
+  });
+
+  it("retains the host and log-path compatibility helpers", () => {
+    expect(daemonProbeHost({})).toBe("127.0.0.1");
+    expect(daemonProbeHost({ hosts: ["", "10.0.0.5"] })).toBe("10.0.0.5");
+    expect(daemonLogPath()).toMatch(/gateway\.log$/);
   });
 });
 
-describe("daemonLogPath", () => {
-  it("points at gateway.log in the data dir", () => {
-    expect(daemonLogPath().endsWith("gateway.log")).toBe(true);
-  });
-});
-
-describe("runDaemon", () => {
-  it("reuses an already-running gateway without spawning", async () => {
+describe("runDaemon authenticated lifecycle", () => {
+  it("reuses only an authenticated process record", async () => {
     const { io, info, spawned } = makeDaemonIO({
-      readPort: () => 3207,
-      probe: async () => true,
+      readProcess: () => RECORD,
+      authenticate: async () => "127.0.0.1",
     });
-    const code = await runDaemon({}, io);
-    expect(code).toBe(0);
+    expect(await runDaemon({}, io)).toBe(0);
     expect(spawned()).toBe(0);
     expect(info.join("\n")).toContain("already running");
   });
 
-  it("probes the configured non-loopback host (Seer #875)", async () => {
-    const { io, info } = makeDaemonIO({
-      readPort: () => 3207,
-      probe: async (url) => url.includes("100.64.0.1"),
-    });
-    const code = await runDaemon({ hosts: ["100.64.0.1"] }, io);
-    expect(code).toBe(0);
-    expect(info.join("\n")).toContain("100.64.0.1:3207");
-  });
-
-  it("reuses a loopback gateway when configured for a non-overlapping host (issue #908)", async () => {
-    // The existing gateway is reachable on 127.0.0.1 only; we asked for a
-    // Tailscale/LAN IP nothing is bound to. The reuse-check must probe 127.0.0.1
-    // in ADDITION to the configured host, find the gateway, and adopt it WITHOUT
-    // spawning a child — otherwise the child's own pre-bind probe would
-    // reuse-and-exit, leaving us polling 100.64.0.1 until the deadline.
-    let t = 0;
+  it("spawns, polls, and reports an authenticated child record", async () => {
+    let reads = 0;
     const { io, info, spawned } = makeDaemonIO({
-      readPort: () => 3207,
-      probe: async (url) => url.includes("127.0.0.1"),
-      // Advance the clock so that a *regressed* spawn+poll path terminates
-      // (times out) instead of hanging the test on a constant now() === 0.
-      now: () => (t += 5000),
-      timeoutMs: 10_000,
+      readProcess: () => (reads++ === 0 ? null : { ...RECORD, port: 3299 }),
+      authenticate: async (record) => record.hosts[0],
     });
-    const code = await runDaemon({ hosts: ["100.64.0.1"] }, io);
-    expect(code).toBe(0);
-    expect(spawned()).toBe(0);
-    expect(info.join("\n")).toContain("already running");
-    expect(info.join("\n")).toContain("127.0.0.1:3207");
-
-    // Regression guard: a single-host reuse-check (probing only the configured
-    // 100.64.0.1) returns false → spawns a child → polls 100.64.0.1 forever →
-    // times out (code 1, spawned 1), failing the assertions above.
-  });
-
-  it("spawns, polls, and reports the healthy gateway", async () => {
-    let portCalls = 0;
-    const { io, info, spawned } = makeDaemonIO({
-      // existing-check → no port yet; first poll → port present
-      readPort: () => (portCalls++ === 0 ? null : 3299),
-      probe: async () => true,
-    });
-    const code = await runDaemon({ port: 3299 }, io);
-    expect(code).toBe(0);
+    expect(await runDaemon({ port: 3299 }, io)).toBe(0);
     expect(spawned()).toBe(1);
     expect(info.join("\n")).toContain("pid 4242");
     expect(info.join("\n")).toContain("3299");
   });
 
-  it("brackets IPv6 hosts in the health-poll URL (Seer, PR #920)", async () => {
-    // The post-spawn polling loop must bracket IPv6 literals via probeUrlFor:
-    // a raw `http://${host}:${port}` template yields the malformed
-    // `http://::1:3207`, the probe never connects, and the daemon times out.
-    let t = 0;
-    let portCalls = 0;
-    let probedUrl = "";
-    const { io, spawned } = makeDaemonIO({
-      // existing-check → no port yet; first poll → port present
-      readPort: () => (portCalls++ === 0 ? null : 3207),
-      probe: async (url) => {
-        probedUrl = url;
-        return url.includes("[::1]");
-      },
-      // Advance the clock so the regressed (unbracketed) path times out
-      // instead of hanging on a constant now() === 0.
-      now: () => (t += 5000),
-      timeoutMs: 10_000,
+  it("does not reuse public-health spoofing on an explicit port", async () => {
+    const { io, spawned, errors } = makeDaemonIO({
+      readProcess: () => null,
+      probeHealth: async () => true,
     });
-    const code = await runDaemon({ hosts: ["::1"] }, io);
-    expect(code).toBe(0);
-    expect(spawned()).toBe(1);
-    expect(probedUrl).toBe("http://[::1]:3207");
+    expect(await runDaemon({ port: 3207 }, io)).toBe(1);
+    expect(spawned()).toBe(0);
+    expect(errors.join("\n")).toContain("not an authenticated lore gateway");
   });
 
-  it("returns 1 and logs an error on health-poll timeout", async () => {
-    let t = 0;
-    const { io, errors, spawned } = makeDaemonIO({
-      readPort: () => 3299,
-      probe: async () => false, // never healthy
-      now: () => (t += 5000), // 5000, 10000, 15000 → past the 10s deadline
+  it("terminates a timed-out child and cleans only its exact record", async () => {
+    let now = 0;
+    let alive = true;
+    const signals: string[] = [];
+    let removedProcess = false;
+    let removedPort = false;
+    const childRecord = {
+      ...RECORD,
+      version: 2 as const,
+      processIdentity: "child-generation",
+    };
+    const { io, errors } = makeDaemonIO({
+      readProcess: () => childRecord,
+      authenticate: async () => null,
+      now: () => (now += 5000),
       timeoutMs: 10_000,
+      inspectProcess: () =>
+        alive
+          ? { state: "alive", identity: "child-generation" }
+          : { state: "dead" },
+      terminate: (_pid, signal) => {
+        signals.push(signal);
+        alive = false;
+      },
+      removeProcess: () => {
+        removedProcess = true;
+      },
+      removePort: () => {
+        removedPort = true;
+      },
     });
-    const code = await runDaemon({}, io);
-    expect(code).toBe(1);
-    expect(spawned()).toBe(1);
-    expect(errors.join("\n")).toContain("did not become healthy");
+    expect(await runDaemon({}, io)).toBe(1);
+    expect(signals).toEqual(["SIGTERM"]);
+    expect(removedProcess).toBe(true);
+    expect(removedPort).toBe(true);
+    expect(errors.join("\n")).toContain("terminated background pid 4242");
+  });
+
+  it("reports unknown state when SIGTERM/SIGKILL cannot confirm exit", async () => {
+    let now = 0;
+    const signals: string[] = [];
+    const { io, errors } = makeDaemonIO({
+      now: () => (now += 5000),
+      timeoutMs: 10_000,
+      cleanupTimeoutMs: 1000,
+      inspectProcess: () => ({
+        state: "alive",
+        identity: "child-generation",
+      }),
+      terminate: (_pid, signal) => signals.push(signal),
+    });
+    expect(await runDaemon({}, io)).toBe(1);
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(errors.join("\n")).toContain("unknown child state");
+  });
+
+  it("does not signal a reused PID before SIGTERM", async () => {
+    let now = 0;
+    let inspections = 0;
+    const signals: string[] = [];
+    const { io, errors } = makeDaemonIO({
+      now: () => (now += 5000),
+      timeoutMs: 10_000,
+      inspectProcess: () => ({
+        state: "alive",
+        identity: inspections++ === 0 ? "child-generation" : "successor",
+      }),
+      terminate: (_pid, signal) => signals.push(signal),
+    });
+
+    expect(await runDaemon({}, io)).toBe(1);
+    expect(signals).toEqual([]);
+    expect(errors.join("\n")).toContain("spawned process generation");
+  });
+
+  it("revalidates generation before SIGKILL and never signals a successor", async () => {
+    let now = 0;
+    let inspections = 0;
+    const signals: string[] = [];
+    const { io } = makeDaemonIO({
+      now: () => (now += 5000),
+      timeoutMs: 10_000,
+      cleanupTimeoutMs: 0,
+      inspectProcess: () => ({
+        state: "alive",
+        identity: inspections++ < 4 ? "child-generation" : "successor",
+      }),
+      terminate: (_pid, signal) => signals.push(signal),
+    });
+
+    expect(await runDaemon({}, io)).toBe(1);
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
+  it("fails closed when the spawned process generation is unverifiable", async () => {
+    let now = 0;
+    const signals: string[] = [];
+    const { io, errors } = makeDaemonIO({
+      now: () => (now += 5000),
+      timeoutMs: 10_000,
+      inspectProcess: () => ({ state: "alive", identity: null }),
+      terminate: (_pid, signal) => signals.push(signal),
+    });
+
+    expect(await runDaemon({}, io)).toBe(1);
+    expect(signals).toEqual([]);
+    expect(errors.join("\n")).toContain("unknown child state");
   });
 });
 
 describe("realDaemonIO", () => {
-  it("wires real dependencies (without spawning)", async () => {
+  it("wires production discovery and cleanup dependencies", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const io = realDaemonIO({ port: 3299 });
-      expect(io.readPort).toBe(readPortFile);
-      expect(typeof io.spawnDaemon).toBe("function"); // not invoked here
-      expect(io.now()).toBeGreaterThan(0);
+      expect(io.readProcess).toBe(readGatewayProcessFile);
+      expect(io.removeProcess).toBe(removeGatewayProcessFile);
+      expect(io.removePort).toBe(removePortFile);
+      expect(typeof io.spawnDaemon).toBe("function");
+      expect(typeof io.terminate).toBe("function");
       await io.sleep(0);
       io.logInfo("hello");
       io.logError("oops");
       expect(log).toHaveBeenCalledWith("[lore] hello");
-      expect(err).toHaveBeenCalledWith("[lore] oops");
+      expect(error).toHaveBeenCalledWith("[lore] oops");
     } finally {
       log.mockRestore();
-      err.mockRestore();
+      error.mockRestore();
     }
   });
 });

--- a/packages/gateway/test/doctor.test.ts
+++ b/packages/gateway/test/doctor.test.ts
@@ -538,11 +538,11 @@ describe("fetchMemoryHealth", () => {
         { status: 200 },
       ),
     );
-    const h = await fetchMemoryHealth("http://127.0.0.1:3207");
+    const h = await fetchMemoryHealth("http://gateway.example.test:3207");
     expect(h?.embeddings?.available).toBe(true);
     expect(h?.worker?.ok).toBe(true);
     expect(fetchSpy).toHaveBeenCalledWith(
-      "http://127.0.0.1:3207/health",
+      "http://gateway.example.test:3207/health",
       expect.anything(),
     );
   });
@@ -551,7 +551,9 @@ describe("fetchMemoryHealth", () => {
     fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response("nope", { status: 500 }));
-    expect(await fetchMemoryHealth("http://127.0.0.1:3207")).toBeNull();
+    expect(
+      await fetchMemoryHealth("http://gateway.example.test:3207"),
+    ).toBeNull();
   });
 
   it("returns null when the gateway predates the fields (no embeddings/worker)", async () => {
@@ -560,13 +562,17 @@ describe("fetchMemoryHealth", () => {
         status: 200,
       }),
     );
-    expect(await fetchMemoryHealth("http://127.0.0.1:3207")).toBeNull();
+    expect(
+      await fetchMemoryHealth("http://gateway.example.test:3207"),
+    ).toBeNull();
   });
 
   it("returns null when the request throws", async () => {
     fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockRejectedValue(new Error("connection refused"));
-    expect(await fetchMemoryHealth("http://127.0.0.1:3207")).toBeNull();
+    expect(
+      await fetchMemoryHealth("http://gateway.example.test:3207"),
+    ).toBeNull();
   });
 });

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -39,6 +39,7 @@ function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
     hosts: ["127.0.0.1"],
     upstreamAnthropic: "https://api.anthropic.com",
     upstreamOpenAI: "https://api.openai.com",
+    callerUpstreamAllowlist: [],
     bedrockRegion: "us-east-1",
     vertexProject: "",
     vertexRegion: "us-central1",

--- a/packages/gateway/test/fetch.test.ts
+++ b/packages/gateway/test/fetch.test.ts
@@ -2,6 +2,23 @@ import { describe, test, expect, vi, afterEach } from "vitest";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import { EventEmitter } from "node:events";
 
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as { port: number }).port);
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
 class FakeIncomingMessage extends EventEmitter {
   paused = 0;
   resumed = 0;
@@ -253,8 +270,10 @@ describe("upstreamFetch runtime split", () => {
     vi.resetModules();
 
     const undiciFetch = vi.fn(
-      async (_input: unknown, _init?: { dispatcher?: unknown }) =>
-        new Response("ok"),
+      async (
+        _input: unknown,
+        _init?: { dispatcher?: unknown; redirect?: RequestRedirect },
+      ) => new Response("ok"),
     );
     const agentArgs: unknown[] = [];
     class FakeAgent {
@@ -278,5 +297,51 @@ describe("upstreamFetch runtime split", () => {
     expect(agentArgs[0]).toEqual({ bodyTimeout: 0, headersTimeout: 0 });
     const init = undiciFetch.mock.calls[0][1];
     expect(init?.dispatcher).toBeInstanceOf(FakeAgent);
+    expect(init?.redirect).toBe("manual");
   });
+
+  test.each(["x-api-key", "api-key", "cf-aig-authorization"])(
+    "Node: never replays %s across a live cross-origin redirect",
+    async (credentialHeader) => {
+      delete (globalThis as { Bun?: unknown }).Bun;
+      vi.resetModules();
+      vi.doUnmock("undici");
+
+      let initialCredential: string | undefined;
+      let destinationRequests = 0;
+      let destinationCredential: string | undefined;
+      const destination = createServer((req, res) => {
+        destinationRequests++;
+        destinationCredential = req.headers[credentialHeader] as
+          | string
+          | undefined;
+        res.end("credential reached redirect destination");
+      });
+      const destinationPort = await listen(destination);
+      const redirector = createServer((req, res) => {
+        initialCredential = req.headers[credentialHeader] as string | undefined;
+        res.writeHead(307, {
+          location: `http://127.0.0.1:${destinationPort}/destination`,
+        });
+        res.end();
+      });
+      const redirectorPort = await listen(redirector);
+
+      try {
+        const { upstreamFetch } = await import("../src/fetch");
+        await expect(
+          upstreamFetch(`http://127.0.0.1:${redirectorPort}/initial`, {
+            headers: { [credentialHeader]: "credential-secret" },
+            redirect: "follow",
+          }),
+        ).rejects.toThrow(/redirect/i);
+
+        expect(initialCredential).toBe("credential-secret");
+        expect(destinationCredential).toBeUndefined();
+        expect(destinationRequests).toBe(0);
+      } finally {
+        await Promise.all([close(redirector), close(destination)]);
+      }
+    },
+  );
 });

--- a/packages/gateway/test/foreground-routes-abort.test.ts
+++ b/packages/gateway/test/foreground-routes-abort.test.ts
@@ -4,13 +4,15 @@ import {
   passthroughResponsesCompact,
   resetPipelineState,
 } from "../src/pipeline";
-import { handleModelsPassthrough } from "../src/server";
+import { handleModelsPassthrough, startServer } from "../src/server";
 import { upstreamFetch } from "../src/fetch";
 
 vi.mock("../src/fetch", () => ({ upstreamFetch: vi.fn() }));
 
 const mockedFetch = vi.mocked(upstreamFetch);
 const config = loadConfig();
+config.remoteGateway = false;
+config.hostedMode = false;
 
 function fetchUrl(input: RequestInfo | URL): string {
   if (typeof input === "string") return input;
@@ -49,6 +51,79 @@ afterEach(async () => {
 });
 
 describe("foreground passthrough route aborts", () => {
+  test("pipeline reset aborts an actual Bedrock streaming route and unblocks listener close", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    let markUpstreamStarted!: () => void;
+    const upstreamStarted = new Promise<void>((resolve) => {
+      markUpstreamStarted = resolve;
+    });
+    let upstreamCancelled = false;
+    mockedFetch.mockImplementation(async (_url, init) => {
+      upstreamSignal = init?.signal ?? undefined;
+      markUpstreamStarted();
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("partial"));
+          },
+          pull() {
+            return new Promise(() => {});
+          },
+          cancel() {
+            upstreamCancelled = true;
+          },
+        }),
+        {
+          headers: {
+            "content-type": "application/vnd.amazon.eventstream",
+          },
+        },
+      );
+    });
+
+    const server = await startServer({
+      ...config,
+      port: 0,
+      hosts: ["127.0.0.1"],
+      remoteGateway: false,
+      hostedMode: false,
+      bedrockRegion: "us-east-1",
+    });
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${server.port}/v1/model/test/converse-stream`,
+        { method: "POST", body: "{}" },
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe(
+        "application/vnd.amazon.eventstream",
+      );
+      await upstreamStarted;
+
+      const responseBody = response.body;
+      if (!responseBody) throw new Error("expected a streaming response body");
+      const reader = responseBody.getReader();
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe(
+        "partial",
+      );
+      const stalledRead = reader.read();
+
+      // Match production shutdown ordering: stop accepting requests first,
+      // then abort registered foreground work so server.close() can settle.
+      const listenerClose = server.stop();
+      await resetPipelineState({ fast: true });
+
+      // The Web-stream AbortError crosses node:http as a terminated socket;
+      // either transport surface is acceptable, but the read must settle.
+      await expect(stalledRead).rejects.toBeDefined();
+      await expect(listenerClose).resolves.toBeUndefined();
+      expect(upstreamSignal?.aborted).toBe(true);
+      expect(upstreamCancelled).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
   test.each(ROUTES)(
     "caller abort settles $name when fetch ignores signal",
     async ({ invoke, target }) => {

--- a/packages/gateway/test/gateway-access-auth.e2e.test.ts
+++ b/packages/gateway/test/gateway-access-auth.e2e.test.ts
@@ -1,0 +1,733 @@
+import { request as httpRequest } from "node:http";
+import { connect } from "node:net";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { db } from "@loreai/core";
+import { MockAgent } from "undici";
+import {
+  getAllSessionCosts,
+  getDailySpend,
+  resetDailyBudgetState,
+} from "../src/cost-tracker";
+import { setUpstreamDispatcherForTest } from "../src/fetch";
+import {
+  getActiveSessions,
+  setBeforeUpstreamCaptureForTest,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+import {
+  createHarness,
+  TEST_GATEWAY_AUTH_TOKEN,
+  type Harness,
+} from "./helpers/harness";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  STANDARD_TOOLS,
+} from "./helpers/fixtures";
+
+const ACCESS_HEADER = "x-lore-gateway-token";
+const PROJECT = `/tmp/lore-gateway-access-${process.pid}`;
+const SESSION = "gateway-access-session";
+const COMPACT_SESSION = "gateway-access-compact-session";
+const ADMIN_ANTHROPIC_ORIGIN = "https://gateway-access-admin.invalid";
+const BEDROCK_ORIGIN = "https://bedrock-runtime.gateway-access-1.amazonaws.com";
+
+type HeaderValue = string | string[];
+
+type DataPlaneRoute = {
+  name: string;
+  path: string;
+  method: "GET" | "POST" | "WS";
+  headers: Record<string, HeaderValue>;
+  body?: string;
+  expectedStatus?: number;
+};
+
+const anthropicBody = JSON.stringify({
+  model: DEFAULT_MODEL,
+  max_tokens: 32,
+  system: DEFAULT_SYSTEM,
+  messages: [{ role: "user", content: "authorized request" }],
+  tools: STANDARD_TOOLS,
+});
+const chatBody = JSON.stringify({
+  model: "gpt-4o-mini",
+  messages: [{ role: "user", content: "authorized request" }],
+});
+const responsesBody = JSON.stringify({
+  model: "gpt-5.4",
+  input: [{ role: "user", content: "authorized request" }],
+});
+const geminiBody = JSON.stringify({
+  contents: [{ role: "user", parts: [{ text: "authorized request" }] }],
+});
+const bedrockBody = JSON.stringify({
+  messages: [{ role: "user", content: [{ text: "authorized request" }] }],
+});
+
+const projectHeaders = {
+  "x-lore-project": PROJECT,
+  "x-lore-session-id": SESSION,
+};
+
+const DATA_PLANE_ROUTES: DataPlaneRoute[] = [
+  {
+    name: "Anthropic messages",
+    path: "/v1/messages",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+      "x-api-key": "client-anthropic-key",
+    },
+    body: anthropicBody,
+  },
+  ...["/v1/chat/completions", "/chat/completions"].map(
+    (path): DataPlaneRoute => ({
+      name: `OpenAI chat ${path}`,
+      path,
+      method: "POST",
+      headers: {
+        ...projectHeaders,
+        authorization: "Bearer client-openai-token",
+        "content-type": "application/json",
+      },
+      body: chatBody,
+    }),
+  ),
+  {
+    name: "OpenAI Responses",
+    path: "/v1/responses",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      authorization: "Bearer client-openai-token",
+      "content-type": "application/json",
+    },
+    body: responsesBody,
+  },
+  {
+    name: "Codex Responses",
+    path: "/v1/codex/responses",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      authorization: "Bearer client-codex-token",
+      "content-type": "application/json",
+      "x-lore-provider": "openai-codex",
+    },
+    body: responsesBody,
+  },
+  {
+    name: "Responses compact",
+    path: "/v1/responses/compact",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      authorization: "Bearer client-openai-token",
+      "content-type": "application/json",
+      "x-lore-provider": "openai",
+    },
+    body: responsesBody,
+  },
+  {
+    name: "Explicit compact",
+    path: "/v1/compact",
+    method: "POST",
+    headers: {
+      ...projectHeaders,
+      "content-type": "application/json",
+      "x-api-key": "client-anthropic-key",
+      "x-lore-session-id": COMPACT_SESSION,
+    },
+    body: JSON.stringify({ project_path: PROJECT, tokens_before: 1 }),
+  },
+  {
+    name: "Models passthrough",
+    path: "/v1/models",
+    method: "GET",
+    headers: { "x-api-key": "client-anthropic-key" },
+  },
+  {
+    name: "Models passthrough with Google key",
+    path: "/v1/models",
+    method: "GET",
+    headers: { "x-goog-api-key": "client-google-key" },
+  },
+  ...["/v1beta", "/v1", ""].flatMap((prefix) =>
+    ["generateContent", "streamGenerateContent"].map(
+      (verb): DataPlaneRoute => ({
+        name: `Gemini ${prefix || "bare"} ${verb}`,
+        path: `${prefix}/models/gemini-2.5-flash:${verb}`,
+        method: "POST",
+        headers: {
+          ...projectHeaders,
+          "content-type": "application/json",
+          "x-goog-api-key": "client-google-key",
+        },
+        body: geminiBody,
+      }),
+    ),
+  ),
+  ...[
+    "converse",
+    "converse-stream",
+    "invoke",
+    "invoke-with-response-stream",
+  ].map(
+    (verb): DataPlaneRoute => ({
+      name: `Bedrock Runtime ${verb}`,
+      path: `/v1/model/anthropic.claude-sonnet-4-6-v1/${verb}`,
+      method: "POST",
+      headers: {
+        authorization: "Bearer client-bedrock-token",
+        "content-type": "application/json",
+      },
+      body: bedrockBody,
+    }),
+  ),
+  {
+    name: "Responses WebSocket upgrade",
+    path: "/v1/responses",
+    method: "WS",
+    headers: { authorization: "Bearer client-openai-token" },
+    expectedStatus: 426,
+  },
+];
+
+const ACCESS_FAILURES = [
+  { name: "missing", value: undefined },
+  { name: "wrong", value: "wrong-gateway-token-with-32-characters" },
+  { name: "malformed", value: "malformed gateway token with spaces" },
+  {
+    name: "duplicate-equivalent",
+    value: [TEST_GATEWAY_AUTH_TOKEN, TEST_GATEWAY_AUTH_TOKEN] as string[],
+  },
+] as const;
+
+const MIXED_AUTH_PAIRS = [
+  {
+    name: "x-api-key + x-goog-api-key",
+    headers: { "x-api-key": "api-key", "x-goog-api-key": "google-key" },
+  },
+  {
+    name: "x-api-key + bearer",
+    headers: {
+      "x-api-key": "api-key",
+      authorization: "Bearer bearer-token",
+    },
+  },
+  {
+    name: "x-goog-api-key + bearer",
+    headers: {
+      "x-goog-api-key": "google-key",
+      authorization: "Bearer bearer-token",
+    },
+  },
+] as const;
+
+const STORAGE_TABLES = [
+  "projects",
+  "temporal_messages",
+  "distillations",
+  "knowledge",
+  "session_state",
+  "daily_costs",
+  "session_prompt_deltas",
+  "session_rollup",
+] as const;
+
+function storageSnapshot(): Record<string, number> {
+  return Object.fromEntries(
+    STORAGE_TABLES.map((table) => {
+      const row = db()
+        .query(`SELECT COUNT(*) AS count FROM ${table}`)
+        .get() as { count: number };
+      return [table, row.count];
+    }),
+  );
+}
+
+function statusFromRawResponse(response: string): number {
+  const match = /^HTTP\/1\.1 (\d{3})/.exec(response);
+  return match ? Number(match[1]) : 0;
+}
+
+function websocketRequest(
+  baseURL: string,
+  route: DataPlaneRoute,
+  headers: Record<string, HeaderValue>,
+): Promise<{ status: number; body: string; headers: Headers }> {
+  const url = new URL(baseURL);
+  return new Promise((resolve, reject) => {
+    const socket = connect(Number(url.port), url.hostname);
+    let received = "";
+    socket.once("connect", () => {
+      const lines = [
+        `GET ${route.path} HTTP/1.1`,
+        `Host: ${url.host}`,
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        "Sec-WebSocket-Version: 13",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+      ];
+      for (const [name, value] of Object.entries(headers)) {
+        for (const item of Array.isArray(value) ? value : [value]) {
+          lines.push(`${name}: ${item}`);
+        }
+      }
+      socket.end(`${lines.join("\r\n")}\r\n\r\n`);
+    });
+    socket.on("data", (chunk) => {
+      received += chunk.toString();
+    });
+    socket.once("close", () => {
+      const [headerText, body = ""] = received.split("\r\n\r\n", 2);
+      const responseHeaders = new Headers();
+      for (const line of headerText.split("\r\n").slice(1)) {
+        const separator = line.indexOf(":");
+        if (separator > 0) {
+          responseHeaders.append(
+            line.slice(0, separator),
+            line.slice(separator + 1).trim(),
+          );
+        }
+      }
+      resolve({
+        status: statusFromRawResponse(received),
+        body,
+        headers: responseHeaders,
+      });
+    });
+    socket.once("error", reject);
+  });
+}
+
+function httpDataPlaneRequest(
+  baseURL: string,
+  route: DataPlaneRoute,
+  headers: Record<string, HeaderValue>,
+): Promise<{ status: number; body: string; headers: Headers }> {
+  const url = new URL(baseURL);
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: route.path,
+        method: route.method,
+        headers,
+      },
+      (incoming) => {
+        const chunks: Buffer[] = [];
+        incoming.on("data", (chunk: Buffer) => chunks.push(chunk));
+        incoming.once("end", () => {
+          const responseHeaders = new Headers();
+          for (let index = 0; index < incoming.rawHeaders.length; index += 2) {
+            responseHeaders.append(
+              incoming.rawHeaders[index],
+              incoming.rawHeaders[index + 1],
+            );
+          }
+          resolve({
+            status: incoming.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString(),
+            headers: responseHeaders,
+          });
+        });
+      },
+    );
+    request.once("error", reject);
+    request.end(route.body);
+  });
+}
+
+function sendRoute(
+  baseURL: string,
+  route: DataPlaneRoute,
+  headers: Record<string, HeaderValue>,
+) {
+  return route.method === "WS"
+    ? websocketRequest(baseURL, route, headers)
+    : httpDataPlaneRequest(baseURL, route, headers);
+}
+
+function withoutProviderAuth(
+  headers: Record<string, HeaderValue>,
+): Record<string, HeaderValue> {
+  const copy = { ...headers };
+  delete copy.authorization;
+  delete copy["x-api-key"];
+  delete copy["x-goog-api-key"];
+  return copy;
+}
+
+function mockedPipelineResponse(
+  body: unknown,
+  model: string,
+  streaming: boolean,
+): Response {
+  if (model.startsWith("gemini")) {
+    const payload = JSON.stringify({
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: "ok" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+        totalTokenCount: 2,
+      },
+      modelVersion: model,
+    });
+    return new Response(streaming ? `data: ${payload}\n\n` : payload, {
+      status: 200,
+      headers: {
+        "content-type": streaming ? "text/event-stream" : "application/json",
+      },
+    });
+  }
+  if (model.startsWith("gpt")) {
+    const isResponses =
+      typeof body === "object" && body !== null && "input" in body;
+    return new Response(
+      JSON.stringify(
+        isResponses
+          ? {
+              id: "resp_gateway_access",
+              object: "response",
+              status: "completed",
+              model,
+              output: [],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }
+          : {
+              id: "chatcmpl_gateway_access",
+              object: "chat.completion",
+              created: 1,
+              model,
+              choices: [
+                {
+                  index: 0,
+                  message: { role: "assistant", content: "ok" },
+                  finish_reason: "stop",
+                },
+              ],
+              usage: {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+              },
+            },
+      ),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+  return new Response(
+    JSON.stringify({
+      id: "msg_gateway_access",
+      type: "message",
+      role: "assistant",
+      model,
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function installDispatcher(
+  mock: MockAgent,
+  onRequest: (headers: unknown) => void,
+) {
+  for (const origin of [
+    ADMIN_ANTHROPIC_ORIGIN,
+    "https://api.openai.com",
+    "https://chatgpt.com",
+    BEDROCK_ORIGIN,
+  ]) {
+    for (const method of ["GET", "POST"] as const) {
+      mock
+        .get(origin)
+        .intercept({ path: () => true, method })
+        .reply((options) => {
+          onRequest(options.headers);
+          return {
+            statusCode: 200,
+            data: JSON.stringify({
+              data: [],
+              id: "resp_compact_gateway_access",
+              object: "response.compaction",
+              output: [],
+              usage: { input_tokens: 1, output_tokens: 1 },
+            }),
+            responseOptions: {
+              headers: { "content-type": "application/json" },
+            },
+          };
+        })
+        .persist();
+    }
+  }
+  setUpstreamDispatcherForTest(mock);
+}
+
+describe("remote gateway central access and mixed-auth enforcement", () => {
+  let harness: Harness;
+  let mock: MockAgent;
+  let pipelineCalls = 0;
+  let dispatcherCalls = 0;
+  let initialStorage: Record<string, number>;
+  let initialSpend = 0;
+
+  beforeAll(async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    installDispatcher(mock, () => {
+      dispatcherCalls++;
+    });
+    harness = await createHarness({
+      fixtures: [],
+      projectPath: PROJECT,
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+        upstreamAnthropic: ADMIN_ANTHROPIC_ORIGIN,
+        bedrockRegion: "gateway-access-1",
+        workerApiKey: "server-owned-worker-credential",
+        upstreamExtraHeaders: {
+          authorization: "Bearer server-owned-foreground-credential",
+        },
+        upstreamExtraHeaderBases: [ADMIN_ANTHROPIC_ORIGIN],
+      },
+    });
+    setUpstreamInterceptor(async (body, model, streaming) => {
+      pipelineCalls++;
+      return mockedPipelineResponse(body, model, streaming);
+    });
+    resetDailyBudgetState();
+    initialStorage = storageSnapshot();
+    initialSpend = getDailySpend().spend;
+  });
+
+  afterAll(async () => {
+    setBeforeUpstreamCaptureForTest(undefined);
+    setUpstreamDispatcherForTest(null);
+    await harness?.teardown();
+    await mock?.close();
+  });
+
+  test.each(
+    DATA_PLANE_ROUTES.flatMap((route) =>
+      ACCESS_FAILURES.map((failure) => ({ route, failure })),
+    ),
+  )(
+    "$route.name rejects $failure.name gateway access uniformly before work",
+    async ({ route, failure }) => {
+      const headers: Record<string, HeaderValue> = { ...route.headers };
+      if (failure.value !== undefined) headers[ACCESS_HEADER] = failure.value;
+
+      const response = await sendRoute(harness.baseURL, route, headers);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toBe("");
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(pipelineCalls).toBe(0);
+      expect(dispatcherCalls).toBe(0);
+      expect(getActiveSessions().size).toBe(0);
+      expect(getAllSessionCosts().size).toBe(0);
+      expect(getDailySpend().spend).toBe(initialSpend);
+      expect(storageSnapshot()).toEqual(initialStorage);
+    },
+  );
+
+  test.each(
+    DATA_PLANE_ROUTES.flatMap((route) =>
+      MIXED_AUTH_PAIRS.map((pair) => ({ route, pair })),
+    ),
+  )(
+    "$route.name rejects mixed provider auth $pair.name before work",
+    async ({ route, pair }) => {
+      const headers = {
+        ...withoutProviderAuth(route.headers),
+        [ACCESS_HEADER]: TEST_GATEWAY_AUTH_TOKEN,
+        ...pair.headers,
+      };
+      const response = await sendRoute(harness.baseURL, route, headers);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toContain("Conflicting provider authentication");
+      expect(pipelineCalls).toBe(0);
+      expect(dispatcherCalls).toBe(0);
+      expect(getActiveSessions().size).toBe(0);
+      expect(getAllSessionCosts().size).toBe(0);
+      expect(getDailySpend().spend).toBe(initialSpend);
+      expect(storageSnapshot()).toEqual(initialStorage);
+    },
+  );
+
+  test("rejects a stalled body before parsing or waiting for it", async () => {
+    const port = Number(new URL(harness.baseURL).port);
+    const rawResponse = await new Promise<string>((resolve, reject) => {
+      const socket = connect(port, "127.0.0.1");
+      let received = "";
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error("gateway access denial waited for the request body"));
+      }, 2_000);
+      socket.once("connect", () => {
+        socket.write(
+          "POST /v1/messages HTTP/1.1\r\n" +
+            `Host: 127.0.0.1:${port}\r\n` +
+            "Content-Type: application/json\r\n" +
+            "X-Api-Key: fake-client-key\r\n" +
+            "Content-Length: 100000\r\n" +
+            "\r\n" +
+            "{",
+        );
+      });
+      socket.on("data", (chunk) => {
+        received += chunk.toString();
+        if (received.includes("\r\n\r\n")) {
+          clearTimeout(timer);
+          socket.destroy();
+          resolve(received);
+        }
+      });
+      socket.once("error", reject);
+    });
+
+    expect(rawResponse).toContain("401 Unauthorized");
+    expect(pipelineCalls).toBe(0);
+    expect(dispatcherCalls).toBe(0);
+    expect(getActiveSessions().size).toBe(0);
+    expect(storageSnapshot()).toEqual(initialStorage);
+  });
+});
+
+describe("authorized remote data-plane routes", () => {
+  let harness: Harness;
+  let mock: MockAgent;
+  let pipelineCalls = 0;
+  let dispatcherCalls = 0;
+  const downstreamHeaders: Array<Record<string, string>> = [];
+
+  beforeAll(async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    installDispatcher(mock, (headers) => {
+      dispatcherCalls++;
+      downstreamHeaders.push(headers as Record<string, string>);
+    });
+    harness = await createHarness({
+      fixtures: [],
+      projectPath: PROJECT,
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+        upstreamAnthropic: ADMIN_ANTHROPIC_ORIGIN,
+        bedrockRegion: "gateway-access-1",
+        workerApiKey: "server-owned-worker-credential",
+        upstreamExtraHeaders: {
+          authorization: "Bearer server-owned-foreground-credential",
+        },
+        upstreamExtraHeaderBases: [ADMIN_ANTHROPIC_ORIGIN],
+      },
+    });
+    setUpstreamInterceptor(async (body, model, streaming) => {
+      pipelineCalls++;
+      return mockedPipelineResponse(body, model, streaming);
+    });
+    const seeded = await harness.chat(
+      JSON.parse(anthropicBody),
+      "client-anthropic-key",
+      {
+        ...projectHeaders,
+        "x-lore-session-id": COMPACT_SESSION,
+        [ACCESS_HEADER]: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    );
+    if (seeded.status !== 200) {
+      throw new Error(
+        `failed to seed authorized compact session: ${seeded.status}`,
+      );
+    }
+    await seeded.text();
+    const seededSessions = harness.queryDB<{
+      header_session_id: string;
+      project_path: string;
+    }>(
+      "SELECT header_session_id, project_path FROM session_state WHERE header_session_id = ?",
+      [COMPACT_SESSION],
+    );
+    if (seededSessions.length !== 1) {
+      throw new Error(
+        `failed to persist compact session: ${JSON.stringify(seededSessions)}`,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    setBeforeUpstreamCaptureForTest(undefined);
+    setUpstreamDispatcherForTest(null);
+    await harness?.teardown();
+    await mock?.close();
+  });
+
+  test.each(DATA_PLANE_ROUTES)(
+    "$name accepts the gateway token plus one provider auth mechanism",
+    async (route) => {
+      const headers = {
+        ...route.headers,
+        [ACCESS_HEADER]: TEST_GATEWAY_AUTH_TOKEN,
+      };
+      let rawHeadersAtPipeline: Record<string, string> | undefined;
+      setBeforeUpstreamCaptureForTest(async (request) => {
+        rawHeadersAtPipeline = { ...request.rawHeaders };
+      });
+      const callsBefore = pipelineCalls + dispatcherCalls;
+      const response = await sendRoute(harness.baseURL, route, headers);
+      setBeforeUpstreamCaptureForTest(undefined);
+
+      if (response.status !== (route.expectedStatus ?? 200)) {
+        throw new Error(
+          `${route.name} returned ${response.status}: ${response.body}`,
+        );
+      }
+      expect(response).toMatchObject({ status: route.expectedStatus ?? 200 });
+      if (route.method !== "WS" && route.path !== "/v1/compact") {
+        expect(pipelineCalls + dispatcherCalls).toBeGreaterThan(callsBefore);
+      }
+      expect(rawHeadersAtPipeline?.[ACCESS_HEADER]).toBeUndefined();
+    },
+  );
+
+  test("configured foreground auth replaces client auth and never forwards gateway access", () => {
+    expect(dispatcherCalls).toBeGreaterThan(0);
+    const serialized = JSON.stringify(downstreamHeaders);
+    expect(serialized).not.toContain(TEST_GATEWAY_AUTH_TOKEN);
+
+    const modelsHeaders = downstreamHeaders.find(
+      (headers) =>
+        (headers.authorization ?? headers.Authorization) ===
+        "Bearer server-owned-foreground-credential",
+    );
+    expect(modelsHeaders).toBeDefined();
+    expect(modelsHeaders?.["x-api-key"]).toBeUndefined();
+    expect(modelsHeaders?.["x-goog-api-key"]).toBeUndefined();
+  });
+
+  test("gateway access token is not persisted or learned as session state", () => {
+    const serializedRows = JSON.stringify({
+      sessions: harness.queryDB("SELECT * FROM session_state"),
+      temporal: harness.queryDB("SELECT * FROM temporal_messages"),
+      projects: harness.queryDB("SELECT * FROM projects"),
+    });
+    expect(serializedRows).not.toContain(TEST_GATEWAY_AUTH_TOKEN);
+  });
+});

--- a/packages/gateway/test/gateway-auth-config.test.ts
+++ b/packages/gateway/test/gateway-auth-config.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  assertGatewayAccessConfigured,
+  GATEWAY_AUTH_TOKEN_MAX_LENGTH,
+  GATEWAY_AUTH_TOKEN_MIN_LENGTH,
+  loadConfig,
+  parseGatewayAuthToken,
+} from "../src/config";
+import { startServer } from "../src/server";
+
+const TOKEN = "gateway-auth-config-test-token-at-least-32";
+const ENV_KEYS = [
+  "LORE_GATEWAY_AUTH_TOKEN",
+  "LORE_HOSTED_MODE",
+  "LORE_LISTEN_HOST",
+  "LORE_REMOTE_GATEWAY",
+  "LORE_UPSTREAM_EXTRA_HEADERS",
+] as const;
+
+describe("gateway access configuration", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    saved.clear();
+  });
+
+  test("parses a strong header-safe token without transforming it", () => {
+    expect(parseGatewayAuthToken(TOKEN)).toBe(TOKEN);
+    expect(
+      parseGatewayAuthToken("a".repeat(GATEWAY_AUTH_TOKEN_MIN_LENGTH)),
+    ).toBe("a".repeat(GATEWAY_AUTH_TOKEN_MIN_LENGTH));
+    expect(
+      parseGatewayAuthToken("z".repeat(GATEWAY_AUTH_TOKEN_MAX_LENGTH)),
+    ).toBe("z".repeat(GATEWAY_AUTH_TOKEN_MAX_LENGTH));
+  });
+
+  test.each([
+    "short",
+    "a".repeat(GATEWAY_AUTH_TOKEN_MAX_LENGTH + 1),
+    `a${"b".repeat(GATEWAY_AUTH_TOKEN_MIN_LENGTH)} c`,
+    `a${"b".repeat(GATEWAY_AUTH_TOKEN_MIN_LENGTH)},c`,
+    `a${"b".repeat(GATEWAY_AUTH_TOKEN_MIN_LENGTH)}\n`,
+    "é".repeat(GATEWAY_AUTH_TOKEN_MIN_LENGTH),
+  ])("rejects weak or non-header-safe token %#", (token) => {
+    expect(() => parseGatewayAuthToken(token)).toThrow(
+      "LORE_GATEWAY_AUTH_TOKEN",
+    );
+  });
+
+  test("loads LORE_GATEWAY_AUTH_TOKEN separately from remote URL and provider auth", () => {
+    process.env.LORE_GATEWAY_AUTH_TOKEN = TOKEN;
+    process.env.LORE_REMOTE_GATEWAY = "1";
+    const config = loadConfig();
+
+    expect(config.gatewayAuthToken).toBe(TOKEN);
+    expect(config.remoteGateway).toBe(true);
+    expect(config.remoteUrl).toBeUndefined();
+    expect(config.upstreamExtraHeaders).toEqual({});
+    expect(() => assertGatewayAccessConfigured(config)).not.toThrow();
+  });
+
+  test.each([
+    { remoteGateway: true, hostedMode: false },
+    { remoteGateway: false, hostedMode: true },
+    { remoteGateway: true, hostedMode: true },
+  ])("fails closed for remote/hosted mode without a token %#", (mode) => {
+    expect(() =>
+      assertGatewayAccessConfigured({ ...mode, gatewayAuthToken: undefined }),
+    ).toThrow("LORE_GATEWAY_AUTH_TOKEN");
+  });
+
+  test("keeps local mode token-optional", () => {
+    expect(() =>
+      assertGatewayAccessConfigured({
+        remoteGateway: false,
+        hostedMode: false,
+        gatewayAuthToken: undefined,
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects a weak token supplied through a programmatic config", () => {
+    expect(() =>
+      assertGatewayAccessConfigured({
+        remoteGateway: true,
+        hostedMode: false,
+        gatewayAuthToken: "short",
+      }),
+    ).toThrow("LORE_GATEWAY_AUTH_TOKEN");
+  });
+
+  test("public server startup applies the same fail-closed invariant", async () => {
+    const config = loadConfig();
+    config.port = 0;
+    config.remoteGateway = true;
+    config.hostedMode = false;
+    config.gatewayAuthToken = undefined;
+
+    await expect(startServer(config)).rejects.toThrow(
+      "LORE_GATEWAY_AUTH_TOKEN",
+    );
+  });
+
+  test("rejects configured mixed provider auth at config load", () => {
+    process.env.LORE_UPSTREAM_EXTRA_HEADERS =
+      "Authorization: Bearer admin\nX-Api-Key: competing-admin";
+    expect(() => loadConfig()).toThrow(
+      "at most one provider authentication mechanism",
+    );
+  });
+
+  test("rejects attempts to configure the gateway access header as upstream auth", () => {
+    process.env.LORE_UPSTREAM_EXTRA_HEADERS =
+      "X-Lore-Gateway-Token: must-never-leave-the-gateway";
+    expect(() => loadConfig()).toThrow("gateway access header");
+  });
+
+  test("rejects a case-variant gateway access header in a programmatic config", () => {
+    expect(() =>
+      assertGatewayAccessConfigured({
+        remoteGateway: false,
+        hostedMode: false,
+        gatewayAuthToken: undefined,
+        upstreamExtraHeaders: {
+          "X-Lore-Gateway-Token": "must-never-leave-the-gateway",
+        },
+      }),
+    ).toThrow("gateway access header");
+  });
+});

--- a/packages/gateway/test/gemini-translate.test.ts
+++ b/packages/gateway/test/gemini-translate.test.ts
@@ -223,7 +223,7 @@ describe("buildGeminiUpstreamRequest", () => {
     expect(url).toBe(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent",
     );
-    // x-goog-api-key forwarded (not a managed header).
+    // Credential filtering strips raw auth; the Gemini builder reconstructs it.
     expect(headers["x-goog-api-key"]).toBe("key123");
     const b = body as Record<string, unknown>;
     expect(b.systemInstruction).toEqual({ parts: [{ text: "sys prompt" }] });

--- a/packages/gateway/test/ghcr-integrity.test.ts
+++ b/packages/gateway/test/ghcr-integrity.test.ts
@@ -1,0 +1,78 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { downloadNightlyBlob } from "../src/cli/lib/ghcr";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+describe("GHCR blob integrity", () => {
+  it("returns bytes that match the OCI manifest digest", async () => {
+    const content = "published nightly blob";
+    globalThis.fetch = vi.fn(
+      async () => new Response(content),
+    ) as unknown as typeof fetch;
+
+    const response = await downloadNightlyBlob(
+      "token",
+      `sha256:${sha256(content)}`,
+    );
+
+    expect(await response.text()).toBe(content);
+  });
+
+  it("rejects a tampered GHCR blob before returning it to a consumer", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { Location: "https://blob.test/nightly.gz" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("tampered blob"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      downloadNightlyBlob("token", `sha256:${sha256("published blob")}`),
+    ).rejects.toThrow(/OCI blob digest mismatch/i);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).not.toHaveProperty(
+      "Authorization",
+    );
+  });
+
+  it("rejects malformed manifest digests without downloading a blob", async () => {
+    const fetchMock = vi.fn(async () => new Response("blob"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      downloadNightlyBlob("token", "sha256:not-a-digest"),
+    ).rejects.toThrow(/invalid OCI blob digest/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-HTTPS blob redirect before following it", async () => {
+    const fetchMock = vi.fn(async () =>
+      Promise.resolve(
+        new Response(null, {
+          status: 307,
+          headers: { Location: "http://blob.test/nightly.gz" },
+        }),
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      downloadNightlyBlob("token", `sha256:${sha256("published blob")}`),
+    ).rejects.toThrow(/authenticated HTTPS URL/i);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gateway/test/helpers/harness.ts
+++ b/packages/gateway/test/helpers/harness.ts
@@ -12,14 +12,18 @@
  * Usage:
  *   const harness = await createHarness({ fixtures });
  *   const resp = await harness.chat(body);
- *   harness.teardown();
+ *   await harness.teardown();
  */
 import { unlinkSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { DatabaseSync, type SQLInputValue } from "node:sqlite";
 import { request as httpRequest } from "node:http";
 import { Readable } from "node:stream";
 import type { FixtureEntry } from "../../src/recorder";
+import type { GatewayConfig } from "../../src/config";
 import type { SimulatedCacheTurn } from "./simulated-cache";
+
+export const TEST_GATEWAY_AUTH_TOKEN =
+  "test-gateway-access-token-32-bytes-minimum";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -28,7 +32,7 @@ import type { SimulatedCacheTurn } from "./simulated-cache";
 export interface HarnessOptions {
   fixtures: FixtureEntry[];
   /** Override any config values */
-  configOverrides?: Partial<{ port: number; debug: boolean }>;
+  configOverrides?: Partial<GatewayConfig>;
   /**
    * Compute realistic prompt-cache usage (cache_read / cache_creation) from the
    * actual upstream body prefix-stability and inject it into each replayed
@@ -62,7 +66,7 @@ export interface Harness {
   /** Send a POST /v1/messages request, return the raw Response */
   chat(
     requestBody: unknown,
-    apiKey?: string,
+    apiKey?: string | null,
     extraHeaders?: Record<string, string>,
   ): Promise<Response>;
   /** Query the temporal DB directly via a read-only SQLite connection */
@@ -118,6 +122,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   const { withSimulatedCache } = await import("./simulated-cache");
   const { setUpstreamInterceptor, resetPipelineState } =
     await import("../../src/pipeline");
+  const { _resetAuthForTest } = await import("../../src/auth");
   const { startServer } = await import("../../src/server");
   const { loadConfig } = await import("../../src/config");
   // Import close() so we can reset the DB singleton between harnesses.
@@ -128,6 +133,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   // Must close the DB BEFORE resetting pipeline state (which may use the DB).
   closeDB();
   await resetPipelineState();
+  _resetAuthForTest();
 
   // --- 4. Wire in replay interceptor (streaming-aware: emits SSE for
   // streaming turns, JSON otherwise), wrapped to capture the exact upstream
@@ -171,7 +177,14 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
 
   // --- 5. Start gateway ---
   opts.beforeConfigLoad?.();
-  const config = loadConfig();
+  const config = {
+    ...loadConfig(),
+    // Harnesses are local unless a test opts into remote/hosted semantics.
+    // This keeps the suite independent of the developer machine's bind env.
+    remoteGateway: false,
+    hostedMode: false,
+    ...opts.configOverrides,
+  };
   // Vitest files share process.env within a worker. Another file can clobber
   // LORE_LISTEN_PORT between the assignment above and this loadConfig() call,
   // so pin the requested harness port on the config object itself.
@@ -179,7 +192,7 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   config.portExplicit = port !== 0;
   const server = await startServer(config);
   if (server.port <= 0) {
-    server.stop();
+    await server.stop();
     throw new Error(`test gateway resolved invalid port ${server.port}`);
   }
 
@@ -209,22 +222,22 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   // --- 7. chat() helper ---
   async function chat(
     requestBody: unknown,
-    apiKey = "test-key",
+    apiKey: string | null = "test-key",
     extraHeaders?: Record<string, string>,
   ): Promise<Response> {
     const body = JSON.stringify(requestBody);
-    const headers = {
+    const headers: Record<string, string> = {
       "content-type": "application/json",
       "content-length": String(Buffer.byteLength(body)),
-      "x-api-key": apiKey,
       "anthropic-version": "2023-06-01",
       // Provide a confident project binding by default so the synthetic
       // project-resolution probe is never triggered in harness-based tests.
       // Tests that intentionally test path-less sessions can override this
       // via extraHeaders (set to empty string to suppress).
       "x-lore-project": projectPath,
-      ...extraHeaders,
     };
+    if (apiKey !== null) headers["x-api-key"] = apiKey;
+    Object.assign(headers, extraHeaders);
     // WHATWG fetch rejects a browser-defined list of "bad ports". Port 0 can
     // legitimately assign one of those ports to the local test server, making
     // an otherwise valid harness request fail nondeterministically. Use Node's
@@ -266,11 +279,12 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
 
   // --- 8. teardown() ---
   async function teardown(): Promise<void> {
-    server.stop();
+    await server.stop();
     // Close the core DB singleton first so the next harness can open a fresh
     // DB at its own LORE_DB_PATH.
     closeDB();
     await resetPipelineState();
+    _resetAuthForTest();
     setUpstreamInterceptor(undefined);
 
     // Delete DB files (main + WAL + SHM)
@@ -295,6 +309,9 @@ export async function createHarness(opts: HarnessOptions): Promise<Harness> {
   async function restartPipeline(): Promise<void> {
     closeDB();
     await resetPipelineState({ fast: true });
+    // A real process restart loses the in-memory credential registry. Clear it
+    // here too so restart regressions cannot pass on a stale pre-restart key.
+    _resetAuthForTest();
     installReplayInterceptor();
   }
 

--- a/packages/gateway/test/install-script.test.ts
+++ b/packages/gateway/test/install-script.test.ts
@@ -1,0 +1,1133 @@
+import { createHash } from "node:crypto";
+import { spawn, spawnSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireLifecycleLock,
+  createUninstallTombstone,
+  LifecycleLockBusyError,
+  type LifecycleLockOwner,
+} from "../src/lifecycle-lock";
+import { standaloneInstallProvenance } from "../src/cli/uninstall";
+
+const installer = resolve(import.meta.dirname, "../../website/public/install");
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const path of temporaryDirectories.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function fixture(): { home: string; env: NodeJS.ProcessEnv } {
+  const root = mkdtempSync(join(tmpdir(), "lore-installer-"));
+  temporaryDirectories.push(root);
+  const home = join(root, "home");
+  const fakeBin = join(root, "fake-bin");
+  mkdirSync(home);
+  mkdirSync(fakeBin);
+
+  const binary = Buffer.from(
+    '#!/bin/sh\n[ "${1:-}" = "--version" ] && echo 1.2.3\n',
+  );
+  const archive = join(root, "lore.gz");
+  const compressed = gzipSync(binary);
+  writeFileSync(archive, compressed);
+  const checksums = join(root, "lore-checksums.txt");
+  const binarySha256 = createHash("sha256").update(binary).digest("hex");
+  const archiveSha256 = createHash("sha256").update(compressed).digest("hex");
+  writeFileSync(
+    checksums,
+    [
+      `${binarySha256}  lore-linux-x64`,
+      `${archiveSha256}  lore-linux-x64.gz`,
+      `${binarySha256}  lore-windows-x64.exe`,
+      `${archiveSha256}  lore-windows-x64.exe.gz`,
+      "",
+    ].join("\n"),
+  );
+  const releaseMetadata = join(root, "release.json");
+  writeFileSync(
+    releaseMetadata,
+    JSON.stringify({
+      tag_name: "1.2.3",
+      assets: [
+        {
+          name: "lore-checksums.txt",
+          digest: `sha256:${createHash("sha256")
+            .update(readFileSync(checksums))
+            .digest("hex")}`,
+          browser_download_url:
+            "https://github.com/BYK/loreai/releases/download/1.2.3/lore-checksums.txt",
+        },
+      ],
+    }),
+  );
+  writeExecutable(
+    join(fakeBin, "curl"),
+    [
+      "#!/bin/sh",
+      'case "$*" in',
+      '  *api.github.com*/releases/tags/*) cat "$LORE_TEST_RELEASE_METADATA" ;;',
+      '  *lore-checksums.txt*) cat "$LORE_TEST_CHECKSUMS" ;;',
+      '  *.gz*) cat "$LORE_TEST_ARCHIVE" ;;',
+      "  *) exit 1 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  writeExecutable(
+    join(fakeBin, "uname"),
+    [
+      "#!/bin/sh",
+      'case "${1:-}" in',
+      "  -s) printf '%s\\n' \"${LORE_TEST_UNAME_S:-Linux}\" ;;",
+      "  -m) printf '%s\\n' \"${LORE_TEST_UNAME_M:-x86_64}\" ;;",
+      "  *) exit 1 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  writeExecutable(
+    join(fakeBin, "cygpath"),
+    [
+      "#!/bin/sh",
+      '[ "${1:-}" = "-w" ] || exit 1',
+      "printf '%s\\n' \"$LORE_TEST_WINDOWS_PATH\"",
+      "",
+    ].join("\n"),
+  );
+
+  return {
+    home,
+    env: {
+      ...process.env,
+      HOME: home,
+      LORE_TEST_ARCHIVE: archive,
+      LORE_TEST_CHECKSUMS: checksums,
+      LORE_TEST_RELEASE_METADATA: releaseMetadata,
+      LORE_VERSION: "1.2.3",
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      SHELL: "/bin/bash",
+    },
+  };
+}
+
+function writeExecutable(path: string, contents: string): void {
+  writeFileSync(path, contents, { mode: 0o755 });
+}
+
+function realCommand(command: string): string {
+  const result = spawnSync("which", [command], {
+    env: process.env,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) throw new Error(`Could not locate ${command}`);
+  return result.stdout.trim();
+}
+
+function runInstaller(
+  home: string,
+  env: NodeJS.ProcessEnv,
+  ...args: string[]
+): SpawnSyncReturns<string> {
+  return spawnSync("bash", [installer, ...args], {
+    cwd: home,
+    env,
+    encoding: "utf8",
+  });
+}
+
+function uninstallTombstone(token: string): string {
+  return `${JSON.stringify({
+    version: 1,
+    token,
+    createdAt: "2026-08-12T00:00:00.000Z",
+  })}\n`;
+}
+
+function expectedReceipt(executable: string, pathInstallDir: string): string {
+  const info = lstatSync(executable, { bigint: true });
+  return [
+    "lore-install-receipt-v3",
+    `executable=${executable}`,
+    `path-install-dir=${pathInstallDir}`,
+    `sha256=${createHash("sha256").update(readFileSync(executable)).digest("hex")}`,
+    `device=${info.dev}`,
+    `inode=${info.ino}`,
+    `size=${info.size}`,
+    `mtime-ns=${info.mtimeNs}`,
+    "",
+  ].join("\n");
+}
+
+function processStartTicks(pid = process.pid): string {
+  const processStat = readFileSync(`/proc/${pid}/stat`, "utf8");
+  return (
+    processStat
+      .slice(processStat.lastIndexOf(")") + 2)
+      .trim()
+      .split(/\s+/)[19] ?? ""
+  );
+}
+
+describe("hosted installer", () => {
+  it("passes Bash syntax validation", () => {
+    const syntax = spawnSync("bash", ["-n", installer], {
+      encoding: "utf8",
+    });
+    expect(syntax.status, syntax.stderr).toBe(0);
+  });
+
+  it("publishes a v3 receipt bound to the executable generation", () => {
+    const { home, env } = fixture();
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status, install.stderr).toBe(0);
+    const executable = join(home, ".local", "bin", "lore");
+    expect(readFileSync(join(home, ".lore", "install-path"), "utf8")).toBe(
+      expectedReceipt(executable, join(home, ".local", "bin")),
+    );
+    expect(readFileSync(join(home, ".lore", "channel"), "utf8")).toBe("stable");
+    expect(
+      standaloneInstallProvenance(executable, { seaBinary: true, home }),
+    ).toMatchObject({
+      hostedInstall: true,
+      pathInstallDir: join(home, ".local", "bin"),
+      executableIdentity: {
+        sha256: createHash("sha256")
+          .update(readFileSync(executable))
+          .digest("hex"),
+      },
+      receiptIdentity: { sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
+    });
+  });
+
+  it("rejects a same-content replacement executable generation", () => {
+    const { home, env } = fixture();
+    const install = runInstaller(home, env, "--no-modify-path");
+    expect(install.status, install.stderr).toBe(0);
+
+    const executable = join(home, ".local", "bin", "lore");
+    const replacement = join(home, ".local", "bin", "replacement-lore");
+    writeFileSync(replacement, readFileSync(executable), { mode: 0o755 });
+    renameSync(replacement, executable);
+
+    expect(
+      standaloneInstallProvenance(executable, { seaBinary: true, home }),
+    ).toEqual({ hostedInstall: false });
+  });
+
+  it("clears the observed uninstall generation after a verified fresh install", async () => {
+    const { home, env } = fixture();
+    const stateDir = join(home, ".lore");
+    const tombstone = join(stateDir, "uninstalled.json");
+    const lock = await acquireLifecycleLock("uninstall", {
+      lockPath: join(stateDir, "lifecycle.lock"),
+    });
+    createUninstallTombstone(lock);
+    lock.release();
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status, install.stderr).toBe(0);
+    expect(existsSync(tombstone)).toBe(false);
+    expect(
+      standaloneInstallProvenance(join(home, ".local", "bin", "lore"), {
+        seaBinary: true,
+        home,
+      }),
+    ).toMatchObject({ hostedInstall: true });
+  });
+
+  it("publishes a lifecycle owner interoperable with the gateway lock", async () => {
+    const { home, env } = fixture();
+    const capturedOwner = join(dirname(home), "captured-owner.json");
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    writeExecutable(
+      join(fakeBin, "curl"),
+      [
+        "#!/bin/sh",
+        'cp "$HOME/.lore/lifecycle.lock/owner.json" "$LORE_TEST_OWNER_CAPTURE"',
+        'case "$*" in',
+        '  *api.github.com*/releases/tags/*) cat "$LORE_TEST_RELEASE_METADATA" ;;',
+        '  *lore-checksums.txt*) cat "$LORE_TEST_CHECKSUMS" ;;',
+        '  *.gz*) cat "$LORE_TEST_ARCHIVE" ;;',
+        "  *) exit 1 ;;",
+        "esac",
+        "",
+      ].join("\n"),
+    );
+    env.LORE_TEST_OWNER_CAPTURE = capturedOwner;
+
+    const install = runInstaller(home, env, "--no-modify-path");
+    expect(install.status, install.stderr).toBe(0);
+
+    const lockPath = join(home, ".lore", "lifecycle.lock");
+    const owner = JSON.parse(
+      readFileSync(capturedOwner, "utf8"),
+    ) as LifecycleLockOwner;
+    mkdirSync(lockPath, { mode: 0o700 });
+    writeFileSync(join(lockPath, "owner.json"), `${JSON.stringify(owner)}\n`, {
+      mode: 0o600,
+    });
+
+    await expect(
+      acquireLifecycleLock("uninstall", {
+        lockPath,
+        timeoutMs: 0,
+        now: () => 0,
+        pid: process.pid,
+        processIdentity: "test:contender",
+        processStartedAt: "2026-08-12T00:00:00.000Z",
+        inspectProcess: () => ({
+          state: "alive",
+          identity: owner.processIdentity,
+        }),
+      }),
+    ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+  });
+
+  it("clears only the uninstall generation observed before lock acquisition", () => {
+    const { home, env } = fixture();
+    const stateDir = join(home, ".lore");
+    const tombstone = join(stateDir, "uninstalled.json");
+    const lockPath = join(stateDir, "lifecycle.lock");
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    mkdirSync(stateDir, { mode: 0o700 });
+    writeFileSync(tombstone, uninstallTombstone("o".repeat(43)), {
+      mode: 0o600,
+    });
+
+    writeExecutable(
+      join(fakeBin, "mkdir"),
+      [
+        "#!/bin/sh",
+        "set -eu",
+        'last=""',
+        'for arg in "$@"; do last=$arg; done',
+        'if [ "$last" = "$LORE_TEST_LOCK_PATH" ]; then',
+        '  printf "%s" "$LORE_TEST_NEW_TOMBSTONE" > "$LORE_TEST_TOMBSTONE"',
+        '  chmod 600 "$LORE_TEST_TOMBSTONE"',
+        "fi",
+        'exec "$LORE_TEST_REAL_MKDIR" "$@"',
+        "",
+      ].join("\n"),
+    );
+    env.LORE_TEST_REAL_MKDIR = realCommand("mkdir");
+    env.LORE_TEST_LOCK_PATH = lockPath;
+    env.LORE_TEST_TOMBSTONE = tombstone;
+    env.LORE_TEST_NEW_TOMBSTONE = uninstallTombstone("n".repeat(43));
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status).not.toBe(0);
+    expect(install.stderr).toContain("stale hosted-install invocation");
+    expect(readFileSync(tombstone, "utf8")).toBe(
+      uninstallTombstone("n".repeat(43)),
+    );
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(false);
+  });
+
+  it("preserves a successor marker published during expected-token clearing", async () => {
+    const { home, env } = fixture();
+    const stateDir = join(home, ".lore");
+    const tombstone = join(stateDir, "uninstalled.json");
+    const lock = await acquireLifecycleLock("uninstall", {
+      lockPath: join(stateDir, "lifecycle.lock"),
+    });
+    createUninstallTombstone(lock);
+    lock.release();
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    writeExecutable(
+      join(fakeBin, "mv"),
+      [
+        "#!/bin/sh",
+        "set -eu",
+        '"$LORE_TEST_REAL_MV" "$@"',
+        'if [ "${1:-}" = "$LORE_TEST_TOMBSTONE" ]; then',
+        '  printf "%s" "$LORE_TEST_NEW_TOMBSTONE" > "$LORE_TEST_TOMBSTONE"',
+        '  chmod 600 "$LORE_TEST_TOMBSTONE"',
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    env.LORE_TEST_REAL_MV = realCommand("mv");
+    env.LORE_TEST_TOMBSTONE = tombstone;
+    env.LORE_TEST_NEW_TOMBSTONE = uninstallTombstone("s".repeat(43));
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status).not.toBe(0);
+    expect(install.stderr).toContain("successor uninstall marker");
+    expect(readFileSync(tombstone, "utf8")).toBe(
+      uninstallTombstone("s".repeat(43)),
+    );
+  });
+
+  it("fails lock contention before binary, receipt, channel, or profile mutation", () => {
+    const { home, env } = fixture();
+    const profile = join(home, ".bashrc");
+    const lock = join(home, ".lore", "lifecycle.lock");
+    mkdirSync(lock, { recursive: true, mode: 0o700 });
+    writeFileSync(profile, "export KEEP_ME=1\n");
+    const token = "o".repeat(43);
+    writeFileSync(
+      join(lock, "owner.json"),
+      `${JSON.stringify({
+        version: 1,
+        token,
+        pid: process.pid,
+        operation: "uninstall",
+        createdAt: "2000-01-01T00:00:00.000Z",
+        processStartedAt: "2000-01-01T00:00:00.000Z",
+        processIdentity: `unverified:${token}`,
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    const install = runInstaller(home, env);
+
+    expect(install.status).not.toBe(0);
+    expect(install.stderr).toContain("lifecycle is busy");
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(false);
+    expect(existsSync(join(home, ".lore", "install-path"))).toBe(false);
+    expect(existsSync(join(home, ".lore", "channel"))).toBe(false);
+    expect(readFileSync(profile, "utf8")).toBe("export KEEP_ME=1\n");
+  });
+
+  it("keeps a live unix owner busy when ps lstart renders in a different timezone", () => {
+    const { home, env } = fixture();
+    const lock = join(home, ".lore", "lifecycle.lock");
+    const token = "z".repeat(43);
+    const utcStart = spawnSync(
+      "ps",
+      ["-o", "lstart=", "-p", String(process.pid)],
+      {
+        encoding: "utf8",
+        env: { ...process.env, TZ: "UTC" },
+      },
+    ).stdout.trim();
+    const localStart = spawnSync(
+      "ps",
+      ["-o", "lstart=", "-p", String(process.pid)],
+      {
+        encoding: "utf8",
+        env: { ...process.env, TZ: "Pacific/Honolulu" },
+      },
+    ).stdout.trim();
+    expect(localStart).not.toBe(utcStart);
+    mkdirSync(lock, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(lock, "owner.json"),
+      `${JSON.stringify({
+        version: 1,
+        token,
+        pid: process.pid,
+        operation: "uninstall",
+        createdAt: "2026-08-12T00:00:00.000Z",
+        processStartedAt: utcStart,
+        processIdentity: `unix:${utcStart}`,
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    const install = runInstaller(
+      home,
+      { ...env, TZ: "Pacific/Honolulu" },
+      "--no-modify-path",
+    );
+
+    expect(install.status).not.toBe(0);
+    expect(install.stderr).toContain("lifecycle is busy");
+    expect(
+      JSON.parse(readFileSync(join(lock, "owner.json"), "utf8")).token,
+    ).toBe(token);
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(false);
+  });
+
+  it("fails closed when checksum metadata is missing for a new release", () => {
+    const { home, env } = fixture();
+    const metadata = env.LORE_TEST_RELEASE_METADATA;
+    if (!metadata) throw new Error("release metadata fixture is missing");
+    writeFileSync(metadata, JSON.stringify({ tag_name: "1.2.3", assets: [] }));
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status).not.toBe(0);
+    expect(install.stderr).toContain("checksum metadata");
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(false);
+  });
+
+  it("keeps a pre-checksum stable release installable without metadata", () => {
+    const { home, env } = fixture();
+    const metadata = env.LORE_TEST_RELEASE_METADATA;
+    if (!metadata) throw new Error("release metadata fixture is missing");
+    env.LORE_VERSION = "0.40.0";
+    writeFileSync(metadata, JSON.stringify({ tag_name: "0.40.0", assets: [] }));
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status, install.stderr).toBe(0);
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(true);
+  });
+
+  it("fails closed before execution when the stable binary checksum mismatches", () => {
+    const { home, env } = fixture();
+    const checksums = env.LORE_TEST_CHECKSUMS;
+    const metadata = env.LORE_TEST_RELEASE_METADATA;
+    if (!checksums || !metadata) throw new Error("checksum fixture is missing");
+    const contents = readFileSync(checksums, "utf8").replace(
+      /^[a-f0-9]{64}  lore-linux-x64$/m,
+      `${"0".repeat(64)}  lore-linux-x64`,
+    );
+    writeFileSync(checksums, contents);
+    const release: {
+      assets: Array<{ digest: string }>;
+    } = JSON.parse(readFileSync(metadata, "utf8"));
+    const checksumAsset = release.assets[0];
+    if (!checksumAsset) throw new Error("checksum asset fixture is missing");
+    checksumAsset.digest = `sha256:${createHash("sha256")
+      .update(contents)
+      .digest("hex")}`;
+    writeFileSync(metadata, JSON.stringify(release));
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status).not.toBe(0);
+    expect(install.stderr).toContain("checksum mismatch");
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(false);
+  });
+
+  it("rejects a tampered nightly blob against its OCI manifest digest", () => {
+    const { home, env } = fixture();
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    const publishedDigest = createHash("sha256")
+      .update("different published blob")
+      .digest("hex");
+    env.LORE_VERSION = "nightly";
+    env.LORE_TEST_NIGHTLY_MANIFEST = JSON.stringify({
+      schemaVersion: 2,
+      layers: [
+        {
+          digest: `sha256:${publishedDigest}`,
+          annotations: {
+            "org.opencontainers.image.title": "lore-linux-x64.gz",
+          },
+        },
+      ],
+      annotations: { version: "0.41.0-dev.1" },
+    });
+    writeExecutable(
+      join(fakeBin, "curl"),
+      [
+        "#!/bin/sh",
+        'case "$*" in',
+        "  *ghcr.io/token*) printf '%s' '{\"token\":\"test-token\"}' ;;",
+        "  *manifests/nightly*) printf '%s' \"$LORE_TEST_NIGHTLY_MANIFEST\" ;;",
+        "  *ghcr.io*/blobs/*) printf '\\n%s\\n' 'https://blob.test/lore.gz' ;;",
+        '  *blob.test/lore.gz*) cat "$LORE_TEST_ARCHIVE" ;;',
+        "  *) exit 1 ;;",
+        "esac",
+        "",
+      ].join("\n"),
+    );
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status).not.toBe(0);
+    expect(install.stderr).toContain("OCI blob digest mismatch");
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(false);
+  });
+
+  it("recovers an incomplete lock after its initialization lease", () => {
+    const { home, env } = fixture();
+    const lock = join(home, ".lore", "lifecycle.lock");
+    mkdirSync(lock, { recursive: true, mode: 0o700 });
+    const expired = new Date(Date.now() - 60_000);
+    utimesSync(lock, expired, expired);
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status, install.stderr).toBe(0);
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(true);
+  });
+
+  it("recovers a SIGKILL between lock mkdir and owner publication", async () => {
+    const { home, env } = fixture();
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    const stateDir = join(home, ".lore");
+    const lock = join(stateDir, "lifecycle.lock");
+    writeExecutable(
+      join(fakeBin, "mkdir"),
+      [
+        "#!/bin/sh",
+        "set -eu",
+        'last=""',
+        'for arg in "$@"; do last=$arg; done',
+        'if [ "$last" = "$LORE_TEST_LOCK_PATH" ] && [ "${LORE_TEST_KILL_AFTER_MKDIR:-}" = 1 ]; then',
+        '  "$LORE_TEST_REAL_MKDIR" "$@"',
+        '  kill -KILL "$LORE_TEST_INSTALLER_PID"',
+        "  exit 0",
+        "fi",
+        'exec "$LORE_TEST_REAL_MKDIR" "$@"',
+        "",
+      ].join("\n"),
+    );
+    env.LORE_TEST_REAL_MKDIR = realCommand("mkdir");
+    env.LORE_TEST_LOCK_PATH = lock;
+    env.LORE_TEST_KILL_AFTER_MKDIR = "1";
+
+    const killed = spawn(
+      "bash",
+      [
+        "-c",
+        'export LORE_TEST_INSTALLER_PID=$$; exec bash "$1" --no-modify-path',
+        "bash",
+        installer,
+      ],
+      { cwd: home, env, stdio: ["ignore", "ignore", "pipe"] },
+    );
+    await expect(
+      new Promise<NodeJS.Signals | null>((resolveExit, rejectExit) => {
+        killed.once("error", rejectExit);
+        killed.once("exit", (_code, signal) => resolveExit(signal));
+      }),
+    ).resolves.toBe("SIGKILL");
+
+    expect(existsSync(lock)).toBe(true);
+    expect(existsSync(join(lock, "owner.json"))).toBe(false);
+    const initClaims = readdirSync(stateDir).filter((entry) =>
+      entry.startsWith(".lifecycle.lock.init."),
+    );
+    expect(initClaims).toHaveLength(1);
+    const token = initClaims[0]?.slice(".lifecycle.lock.init.".length);
+    if (!token) throw new Error("initialization claim token is missing");
+    const expired = new Date(Date.now() - 60_000);
+    utimesSync(lock, expired, expired);
+
+    const install = runInstaller(
+      home,
+      { ...env, LORE_TEST_KILL_AFTER_MKDIR: "" },
+      "--no-modify-path",
+    );
+
+    expect(install.status, install.stderr).toBe(0);
+    expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(true);
+    expect(
+      existsSync(join(stateDir, `.lifecycle.lock.claim.init.${token}`)),
+    ).toBe(true);
+  });
+
+  it.skipIf(process.platform !== "linux")(
+    "reclaims a live PID whose process generation was reused",
+    () => {
+      const { home, env } = fixture();
+      const lock = join(home, ".lore", "lifecycle.lock");
+      const bootId = readFileSync(
+        "/proc/sys/kernel/random/boot_id",
+        "utf8",
+      ).trim();
+      mkdirSync(lock, { recursive: true, mode: 0o700 });
+      writeFileSync(
+        join(lock, "owner.json"),
+        `${JSON.stringify({
+          version: 1,
+          token: "r".repeat(43),
+          pid: process.pid,
+          operation: "uninstall",
+          createdAt: "2026-08-12T00:00:00.000Z",
+          processStartedAt: "2026-08-12T00:00:00.000Z",
+          processIdentity: `linux:${bootId}:1`,
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const install = runInstaller(home, env, "--no-modify-path");
+
+      expect(install.status, install.stderr).toBe(0);
+      expect(existsSync(join(home, ".local", "bin", "lore"))).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "reclaims an installer SIGKILLed after owner publication",
+    async () => {
+      const { home, env } = fixture();
+      const fakeBin = env.PATH?.split(":")[0];
+      if (!fakeBin) throw new Error("fixture PATH is missing");
+      const capturedOwner = join(dirname(home), "killed-owner.json");
+      writeExecutable(
+        join(fakeBin, "curl"),
+        [
+          "#!/bin/sh",
+          "set -eu",
+          'cp "$HOME/.lore/lifecycle.lock/owner.json" "$LORE_TEST_OWNER_CAPTURE"',
+          'if [ "${LORE_TEST_KILL_AFTER_OWNER:-}" = 1 ]; then kill -KILL "$LORE_TEST_INSTALLER_PID"; fi',
+          'case "$*" in',
+          '  *api.github.com*/releases/tags/*) cat "$LORE_TEST_RELEASE_METADATA" ;;',
+          '  *lore-checksums.txt*) cat "$LORE_TEST_CHECKSUMS" ;;',
+          '  *.gz*) cat "$LORE_TEST_ARCHIVE" ;;',
+          "  *) exit 1 ;;",
+          "esac",
+          "",
+        ].join("\n"),
+      );
+      env.LORE_TEST_OWNER_CAPTURE = capturedOwner;
+      env.LORE_TEST_KILL_AFTER_OWNER = "1";
+
+      const killed = spawn(
+        "bash",
+        [
+          "-c",
+          'export LORE_TEST_INSTALLER_PID=$$; exec bash "$1" --no-modify-path',
+          "bash",
+          installer,
+        ],
+        { cwd: home, env, stdio: ["ignore", "ignore", "pipe"] },
+      );
+      await expect(
+        new Promise<NodeJS.Signals | null>((resolveExit, rejectExit) => {
+          killed.once("error", rejectExit);
+          killed.once("exit", (_code, signal) => resolveExit(signal));
+        }),
+      ).resolves.toBe("SIGKILL");
+      const deadOwner = JSON.parse(readFileSync(capturedOwner, "utf8")) as {
+        token: string;
+      };
+
+      const install = runInstaller(
+        home,
+        { ...env, LORE_TEST_KILL_AFTER_OWNER: "" },
+        "--no-modify-path",
+      );
+
+      expect(install.status, install.stderr).toBe(0);
+      expect(
+        existsSync(
+          join(home, ".lore", `.lifecycle.lock.claim.${deadOwner.token}`),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "a delayed stale reclaimer cannot move a live successor",
+    () => {
+      const { home, env } = fixture();
+      const fakeBin = env.PATH?.split(":")[0];
+      if (!fakeBin) throw new Error("fixture PATH is missing");
+      const stateDir = join(home, ".lore");
+      const lock = join(stateDir, "lifecycle.lock");
+      const staleToken = "d".repeat(43);
+      const successorToken = "s".repeat(43);
+      const claim = join(stateDir, `.lifecycle.lock.claim.${staleToken}`);
+      const moveMarker = join(dirname(home), "stale-lock-moved");
+      const bootId = readFileSync(
+        "/proc/sys/kernel/random/boot_id",
+        "utf8",
+      ).trim();
+      mkdirSync(lock, { recursive: true, mode: 0o700 });
+      writeFileSync(
+        join(lock, "owner.json"),
+        `${JSON.stringify({
+          version: 1,
+          token: staleToken,
+          pid: process.pid,
+          operation: "uninstall",
+          createdAt: "2026-08-12T00:00:00.000Z",
+          processStartedAt: "2026-08-12T00:00:00.000Z",
+          processIdentity: `linux:${bootId}:1`,
+        })}\n`,
+        { mode: 0o600 },
+      );
+      writeExecutable(
+        join(fakeBin, "mv"),
+        [
+          "#!/bin/sh",
+          "set -eu",
+          'previous=""',
+          'current=""',
+          'for arg in "$@"; do previous=$current; current=$arg; done',
+          "source_path=$previous",
+          "destination_path=$current",
+          'if [ "$source_path" = "$LORE_TEST_LOCK" ] && [ ! -e "$LORE_TEST_MOVE_MARKER" ]; then',
+          '  : > "$LORE_TEST_MOVE_MARKER"',
+          '  "$LORE_TEST_REAL_MV" "$source_path" "$destination_path"',
+          '  "$LORE_TEST_REAL_MKDIR" -m 700 "$LORE_TEST_LOCK"',
+          '  printf \'{"version":1,"token":"%s","pid":%s,"operation":"gateway-start","createdAt":"2026-08-12T00:00:00.000Z","processStartedAt":"2026-08-12T00:00:00.000Z","processIdentity":"linux:%s:%s"}\\n\' "$LORE_TEST_SUCCESSOR_TOKEN" "$LORE_TEST_SUCCESSOR_PID" "$LORE_TEST_BOOT_ID" "$LORE_TEST_SUCCESSOR_START" > "$LORE_TEST_LOCK/owner.json"',
+          '  chmod 600 "$LORE_TEST_LOCK/owner.json"',
+          '  exec "$LORE_TEST_REAL_MV" "$source_path" "$destination_path/lock"',
+          "fi",
+          'exec "$LORE_TEST_REAL_MV" "$@"',
+          "",
+        ].join("\n"),
+      );
+      env.LORE_TEST_REAL_MV = realCommand("mv");
+      env.LORE_TEST_REAL_MKDIR = realCommand("mkdir");
+      env.LORE_TEST_LOCK = lock;
+      env.LORE_TEST_MOVE_MARKER = moveMarker;
+      env.LORE_TEST_SUCCESSOR_TOKEN = successorToken;
+      env.LORE_TEST_SUCCESSOR_PID = String(process.pid);
+      env.LORE_TEST_BOOT_ID = bootId;
+      env.LORE_TEST_SUCCESSOR_START = processStartTicks();
+
+      const install = runInstaller(home, env, "--no-modify-path");
+
+      expect(install.status).not.toBe(0);
+      expect(existsSync(moveMarker)).toBe(true);
+      expect(
+        JSON.parse(readFileSync(join(lock, "owner.json"), "utf8")).token,
+      ).toBe(successorToken);
+      expect(
+        JSON.parse(readFileSync(join(claim, "owner.json"), "utf8")).token,
+      ).toBe(staleToken);
+      expect(existsSync(join(claim, "lock", "lifecycle.lock"))).toBe(true);
+    },
+  );
+
+  it("does not overwrite a shell profile successor published after validation", () => {
+    const { home, env } = fixture();
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    const profile = join(home, ".bashrc");
+    writeFileSync(profile, "# original profile\n");
+    writeExecutable(
+      join(fakeBin, "mv"),
+      [
+        "#!/bin/sh",
+        "set -eu",
+        'previous=""',
+        'current=""',
+        'for arg in "$@"; do previous=$current; current=$arg; done',
+        '"$LORE_TEST_REAL_MV" "$@"',
+        'if [ "$previous" = "$LORE_TEST_PROFILE" ]; then',
+        "  printf '%s\\n' '# concurrent successor' > \"$LORE_TEST_PROFILE\"",
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    env.LORE_TEST_REAL_MV = realCommand("mv");
+    env.LORE_TEST_PROFILE = profile;
+
+    const install = runInstaller(home, env);
+
+    expect(install.status, install.stderr).toBe(0);
+    expect(install.stderr).toContain("automatic PATH setup failed");
+    expect(readFileSync(profile, "utf8")).toBe("# concurrent successor\n");
+    const originalClaims = readdirSync(home).filter((name) =>
+      name.startsWith(".bashrc.lore-original."),
+    );
+    expect(originalClaims).toHaveLength(1);
+    expect(readFileSync(join(home, originalClaims[0]), "utf8")).toBe(
+      "# original profile\n",
+    );
+  });
+
+  it.skipIf(process.platform !== "linux")(
+    "recovers a profile in a fresh process after SIGKILL immediately after its claim move",
+    async () => {
+      const { home, env } = fixture();
+      const fakeBin = env.PATH?.split(":")[0];
+      if (!fakeBin) throw new Error("fixture PATH is missing");
+      const profile = join(home, ".bashrc");
+      writeFileSync(profile, "# original profile\nexport KEEP_ME=1\n");
+      writeExecutable(
+        join(fakeBin, "mv"),
+        [
+          "#!/bin/sh",
+          "set -eu",
+          'previous=""',
+          'current=""',
+          'for arg in "$@"; do previous=$current; current=$arg; done',
+          '"$LORE_TEST_REAL_MV" "$@"',
+          'case "$current" in',
+          '  "$LORE_TEST_PROFILE".lore-original.*)',
+          '    if [ "${LORE_TEST_KILL_AFTER_PROFILE_CLAIM:-}" = 1 ]; then',
+          '      kill -KILL "$LORE_TEST_INSTALLER_PID"',
+          "    fi",
+          "    ;;",
+          "esac",
+          "",
+        ].join("\n"),
+      );
+      env.LORE_TEST_REAL_MV = realCommand("mv");
+      env.LORE_TEST_PROFILE = profile;
+      env.LORE_TEST_KILL_AFTER_PROFILE_CLAIM = "1";
+
+      const killed = spawn(
+        "bash",
+        [
+          "-c",
+          'export LORE_TEST_INSTALLER_PID=$$; exec bash "$1"',
+          "bash",
+          installer,
+        ],
+        { cwd: home, env, stdio: ["ignore", "ignore", "pipe"] },
+      );
+      await expect(
+        new Promise<NodeJS.Signals | null>((resolveExit, rejectExit) => {
+          killed.once("error", rejectExit);
+          killed.once("exit", (_code, signal) => resolveExit(signal));
+        }),
+      ).resolves.toBe("SIGKILL");
+
+      expect(existsSync(profile)).toBe(false);
+      expect(
+        readdirSync(home).filter((name) =>
+          name.startsWith(".bashrc.lore-original."),
+        ),
+      ).toHaveLength(1);
+
+      const recovered = runInstaller(home, {
+        ...env,
+        LORE_TEST_KILL_AFTER_PROFILE_CLAIM: "",
+      });
+
+      expect(recovered.status, recovered.stderr).toBe(0);
+      const contents = readFileSync(profile, "utf8");
+      expect(contents).toContain("export KEEP_ME=1");
+      expect(contents.match(/# Added by lore installer/g)).toHaveLength(1);
+      expect(
+        readdirSync(home).filter((name) =>
+          name.startsWith(".bashrc.lore-original."),
+        ),
+      ).toHaveLength(0);
+    },
+  );
+
+  it("fails closed without publishing a profile when recovery claims are ambiguous", () => {
+    const { home, env } = fixture();
+    const profile = join(home, ".bashrc");
+    for (const [index, contents] of ["first\n", "second\n"].entries()) {
+      const staged = join(home, `.claim-${index}`);
+      writeFileSync(staged, contents);
+      const info = lstatSync(staged, { bigint: true });
+      const sha256 = createHash("sha256").update(contents).digest("hex");
+      renameSync(
+        staged,
+        `${profile}.lore-original.${String(index).repeat(43)}.${info.dev}.${info.ino}.${sha256}`,
+      );
+    }
+
+    const install = runInstaller(home, env);
+
+    expect(install.status, install.stderr).toBe(0);
+    expect(install.stderr).toContain(
+      "Refusing ambiguous shell profile recovery claims",
+    );
+    expect(existsSync(profile)).toBe(false);
+    expect(
+      readdirSync(home).filter((name) =>
+        name.startsWith(".bashrc.lore-original."),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("quotes command substitution in the install path", () => {
+    const { home, env } = fixture();
+    env.LORE_INSTALL_DIR = join(home, "bin'$(touch PWNED)");
+
+    const install = runInstaller(home, env);
+    expect(install.status, install.stderr).toBe(0);
+
+    const profile = join(home, ".bashrc");
+    const source = spawnSync(
+      "bash",
+      ["--noprofile", "--norc", "-c", 'source "$1"', "bash", profile],
+      { cwd: home, env, encoding: "utf8" },
+    );
+    expect(source.status, source.stderr).toBe(0);
+    expect(existsSync(join(home, "PWNED"))).toBe(false);
+  });
+
+  it("adds PATH when a profile merely mentions the install directory", () => {
+    const { home, env } = fixture();
+    const installDir = join(home, ".local", "bin");
+    const profile = join(home, ".bashrc");
+    writeFileSync(profile, `# tools are installed under ${installDir}\n`);
+
+    const install = runInstaller(home, env);
+
+    expect(install.status, install.stderr).toBe(0);
+    expect(readFileSync(profile, "utf8")).toContain(
+      `export PATH='${installDir}':"$PATH"`,
+    );
+  });
+
+  it("restores the previous binary and receipt when channel commit fails", () => {
+    const { home, env } = fixture();
+    const installDir = join(home, ".local", "bin");
+    const stateDir = join(home, ".lore");
+    mkdirSync(installDir, { recursive: true });
+    mkdirSync(stateDir);
+    writeFileSync(join(installDir, "lore"), "OLD BINARY\n");
+    writeFileSync(join(stateDir, "install-path"), "OLD RECEIPT");
+    mkdirSync(join(stateDir, "channel"));
+
+    const install = runInstaller(home, env);
+
+    expect(install.status).not.toBe(0);
+    expect(readFileSync(join(installDir, "lore"), "utf8")).toBe("OLD BINARY\n");
+    expect(readFileSync(join(stateDir, "install-path"), "utf8")).toBe(
+      "OLD RECEIPT",
+    );
+  });
+
+  it.each([
+    ["a previous nightly channel", "nightly"],
+    ["an absent previous channel", null],
+  ])(
+    "rolls back %s after late channel publication failure",
+    (_label, before) => {
+      const { home, env } = fixture();
+      const stateDir = join(home, ".lore");
+      const fakeBin = env.PATH?.split(":")[0];
+      if (!fakeBin) throw new Error("fixture PATH is missing");
+      mkdirSync(stateDir);
+      const channel = join(stateDir, "channel");
+      if (before !== null) writeFileSync(channel, before);
+      writeExecutable(
+        join(fakeBin, "sync"),
+        [
+          "#!/bin/sh",
+          "set -eu",
+          '"$LORE_TEST_REAL_SYNC" "$@"',
+          'if [ "${1:-}" = "$LORE_TEST_CHANNEL" ] && [ ! -e "$LORE_TEST_SYNC_MARKER" ]; then',
+          '  : > "$LORE_TEST_SYNC_MARKER"',
+          "  exit 1",
+          "fi",
+          "",
+        ].join("\n"),
+      );
+      env.LORE_TEST_REAL_SYNC = realCommand("sync");
+      env.LORE_TEST_CHANNEL = channel;
+      env.LORE_TEST_SYNC_MARKER = join(dirname(home), "channel-sync-failed");
+
+      const install = runInstaller(home, env, "--no-modify-path");
+
+      expect(install.status).not.toBe(0);
+      if (before === null) {
+        expect(existsSync(channel)).toBe(false);
+      } else {
+        expect(readFileSync(channel, "utf8")).toBe(before);
+      }
+    },
+  );
+
+  it("preserves a successor channel published during late-failure rollback", () => {
+    const { home, env } = fixture();
+    const stateDir = join(home, ".lore");
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    mkdirSync(stateDir);
+    const channel = join(stateDir, "channel");
+    writeFileSync(channel, "nightly");
+    writeExecutable(
+      join(fakeBin, "sync"),
+      [
+        "#!/bin/sh",
+        "set -eu",
+        '"$LORE_TEST_REAL_SYNC" "$@"',
+        'if [ "${1:-}" = "$LORE_TEST_CHANNEL" ] && [ ! -e "$LORE_TEST_SYNC_MARKER" ]; then',
+        '  : > "$LORE_TEST_SYNC_MARKER"',
+        '  rm -f -- "$LORE_TEST_CHANNEL"',
+        "  printf '%s' 'successor' > \"$LORE_TEST_CHANNEL\"",
+        "  exit 1",
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    env.LORE_TEST_REAL_SYNC = realCommand("sync");
+    env.LORE_TEST_CHANNEL = channel;
+    env.LORE_TEST_SYNC_MARKER = join(dirname(home), "channel-successor-wrote");
+
+    const install = runInstaller(home, env, "--no-modify-path");
+
+    expect(install.status).not.toBe(0);
+    expect(readFileSync(channel, "utf8")).toBe("successor");
+  });
+
+  it("does not roll back over a successor executable and receipt generation", () => {
+    const { home, env } = fixture();
+    const installDir = join(home, ".local", "bin");
+    const stateDir = join(home, ".lore");
+    const fakeBin = env.PATH?.split(":")[0];
+    if (!fakeBin) throw new Error("fixture PATH is missing");
+    mkdirSync(installDir, { recursive: true });
+    mkdirSync(stateDir);
+    writeFileSync(join(installDir, "lore"), "OLD BINARY\n");
+    writeFileSync(join(stateDir, "install-path"), "OLD RECEIPT");
+    writeExecutable(
+      join(fakeBin, "sync"),
+      [
+        "#!/bin/sh",
+        "set -eu",
+        '"$LORE_TEST_REAL_SYNC" "$@"',
+        'if [ "${1:-}" = "$LORE_TEST_RECEIPT" ] && [ ! -e "$LORE_TEST_SYNC_MARKER" ]; then',
+        '  : > "$LORE_TEST_SYNC_MARKER"',
+        '  rm -f -- "$LORE_TEST_DEST"',
+        "  printf '%s' 'REPLACEMENT BINARY' > \"$LORE_TEST_DEST\"",
+        "  printf '%s' 'REPLACEMENT RECEIPT' > \"$LORE_TEST_RECEIPT\"",
+        "fi",
+        "",
+      ].join("\n"),
+    );
+    env.LORE_TEST_REAL_SYNC = realCommand("sync");
+    env.LORE_TEST_DEST = join(installDir, "lore");
+    env.LORE_TEST_RECEIPT = join(stateDir, "install-path");
+    env.LORE_TEST_SYNC_MARKER = join(dirname(home), "sync-hook-ran");
+
+    const install = runInstaller(home, env);
+
+    expect(install.status).not.toBe(0);
+    expect(readFileSync(join(installDir, "lore"), "utf8")).toBe(
+      "REPLACEMENT BINARY",
+    );
+    expect(readFileSync(join(stateDir, "install-path"), "utf8")).toBe(
+      "REPLACEMENT RECEIPT",
+    );
+    expect(existsSync(join(home, ".bashrc"))).toBe(false);
+  });
+
+  it("round-trips the native Windows executable and exact MSYS PATH directory", () => {
+    const { home, env } = fixture();
+    const nativeExecutable = String.raw`C:\Users\tester\.local\bin\lore.exe`;
+    env.LORE_TEST_UNAME_S = "MSYS_NT-10.0";
+    env.LORE_TEST_WINDOWS_PATH = nativeExecutable;
+
+    const install = runInstaller(home, env);
+    expect(install.status, install.stderr).toBe(0);
+
+    const executable = join(home, ".local", "bin", "lore.exe");
+    const pathInstallDir = join(home, ".local", "bin");
+    expect(readFileSync(join(home, ".lore", "install-path"), "utf8")).toBe(
+      expectedReceipt(executable, pathInstallDir).replace(
+        `executable=${executable}`,
+        `executable=${nativeExecutable}`,
+      ),
+    );
+    expect(readFileSync(join(home, ".bashrc"), "utf8")).toContain(
+      `export PATH='${pathInstallDir}':"$PATH"`,
+    );
+  });
+});

--- a/packages/gateway/test/jsonc-parser-plugin.test.ts
+++ b/packages/gateway/test/jsonc-parser-plugin.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import * as esbuild from "esbuild";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { jsoncParserEsmPlugin } from "../script/jsonc-parser-plugin";
+
+const packageDir = join(fileURLToPath(import.meta.url), "..", "..");
+const require = createRequire(import.meta.url);
+
+describe("jsonc-parser bundle resolver", () => {
+  test("produces a self-contained Node bundle with working JSONC parsing", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "lore-jsonc-bundle-"));
+    const outputFile = join(outputDir, "json-config.cjs");
+
+    try {
+      await esbuild.build({
+        entryPoints: [join(packageDir, "src/cli/json-config.ts")],
+        bundle: true,
+        format: "cjs",
+        target: "node22",
+        platform: "node",
+        outfile: outputFile,
+        plugins: [jsoncParserEsmPlugin(packageDir)],
+      });
+
+      const bundledSource = readFileSync(outputFile, "utf8");
+      expect(bundledSource).not.toMatch(/["']\.\/impl\//);
+
+      const bundled = require(outputFile) as {
+        parseJsonConfigText(
+          text: string,
+          file: string,
+        ): Record<string, unknown>;
+      };
+      expect(
+        bundled.parseJsonConfigText(
+          '{\n  // accepted JSONC\n  "enabled": true,\n}',
+          "config.jsonc",
+        ),
+      ).toEqual({ enabled: true });
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/gateway/test/lastseen-provider-tag.e2e.test.ts
+++ b/packages/gateway/test/lastseen-provider-tag.e2e.test.ts
@@ -1,21 +1,13 @@
 /**
- * End-to-end wiring guard for #942 (follow-up to #829/#940).
+ * End-to-end wiring guard for process-global auth capture.
  *
- * These drive the FULL pipeline (handleRequest → handleConversationTurn →
- * setLastSeenAuth) over HTTP, then observe the global fallback credential via
- * getLastSeenAuth(). They pin the BEHAVIOR — not just the pure helper — so a
- * revert of the two `setLastSeenAuth(..., resolveLastSeenProvider(...))` call
- * sites back to `extractProviderHeader(...) || undefined` fails here (the
- * unit tests in upstream-routes.test.ts would still pass on such a revert).
- *
- * The credential and the upstream destination are built together by the SDK on
- * the same outbound request, so deriving the tag from `x-lore-upstream-url`
- * always names the credential's true owner — closing the null-tag cross-borrow
- * window without reintroducing the #829 cross-contamination.
+ * The global fallback is legacy single-user state. It may be populated only by
+ * an unambiguous local request to a configured direct provider. Client-selected
+ * routes and remote/hosted gateways must keep credentials session-scoped.
  */
 import { describe, it, expect, afterEach } from "vitest";
 import type { Harness } from "./helpers/harness";
-import { createHarness } from "./helpers/harness";
+import { createHarness, TEST_GATEWAY_AUTH_TOKEN } from "./helpers/harness";
 import {
   makeConversationFixtures,
   STANDARD_TOOLS,
@@ -35,7 +27,7 @@ function body(userMessage: string): Record<string, unknown> {
   };
 }
 
-describe("global fallback provider tag derived from upstream URL (#942)", () => {
+describe("legacy process-global auth capture", () => {
   let harness: Harness | undefined;
 
   afterEach(async () => {
@@ -43,16 +35,13 @@ describe("global fallback provider tag derived from upstream URL (#942)", () => 
     harness = undefined;
   });
 
-  it("tags the global from x-lore-upstream-url when no x-lore-provider header is sent", async () => {
+  it("does not capture auth from a client-selected upstream URL", async () => {
     harness = await createHarness({
       fixtures: makeConversationFixtures([
         { userMessage: "header-less credentialed turn", assistantText: "ok" },
       ]),
     });
 
-    // A credentialed request that carries NO x-lore-provider (the shape
-    // produced by title/summary-gen calls bypassing chat.headers), but whose
-    // upstream destination is recognizable.
     const r = await harness.chat(
       body("header-less credentialed turn"),
       "anthropic-key-942",
@@ -61,32 +50,46 @@ describe("global fallback provider tag derived from upstream URL (#942)", () => 
     expect(r.status).toBe(200);
     await r.text();
 
-    // The global is now tagged "anthropic" (derived from the URL) — a worker
-    // for a DIFFERENT provider must NOT be able to borrow it (#829 guard).
     expect(getLastSeenAuth("openai")).toBeNull();
-    // The credential's OWN provider still resolves it.
-    expect(getLastSeenAuth("anthropic")).toEqual({
-      scheme: "api-key",
-      value: "anthropic-key-942",
-    });
+    expect(getLastSeenAuth("anthropic")).toBeNull();
   });
 
-  it("leaves the global agnostic (legacy) when neither provider nor upstream-url header is present", async () => {
+  it("does not capture auth on a remote gateway", async () => {
     harness = await createHarness({
       fixtures: makeConversationFixtures([
-        { userMessage: "plain legacy turn", assistantText: "ok" },
+        { userMessage: "remote credentialed turn", assistantText: "ok" },
       ]),
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
     });
 
-    // No x-lore-provider AND no x-lore-upstream-url → null/agnostic tag, which
-    // every provider lookup may borrow. This is the load-bearing single-
-    // provider legacy path the fix must NOT break.
-    const r = await harness.chat(body("plain legacy turn"), "legacy-key-942");
+    const r = await harness.chat(
+      body("remote credentialed turn"),
+      "remote-key-942",
+      { "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN },
+    );
     expect(r.status).toBe(200);
     await r.text();
 
-    const cred = { scheme: "api-key", value: "legacy-key-942" };
-    expect(getLastSeenAuth("openai")).toEqual(cred);
-    expect(getLastSeenAuth("anthropic")).toEqual(cred);
+    expect(getLastSeenAuth("openai")).toBeNull();
+    expect(getLastSeenAuth("anthropic")).toBeNull();
+  });
+
+  it("captures auth for a local header-less configured direct-provider route", async () => {
+    harness = await createHarness({ fixtures: [] });
+
+    // An intercepted slash command avoids background worker activity while
+    // still exercising handleRequest's early auth-capture path end-to-end.
+    const r = await harness.chat(body("/lore:unknown"), "local-key-942");
+    expect(r.status).toBe(200);
+    await r.text();
+
+    expect(getLastSeenAuth("openai")).toBeNull();
+    expect(getLastSeenAuth("anthropic")).toEqual({
+      scheme: "api-key",
+      value: "local-key-942",
+    });
   });
 });

--- a/packages/gateway/test/lifecycle-lock-sigkill-child.ts
+++ b/packages/gateway/test/lifecycle-lock-sigkill-child.ts
@@ -1,0 +1,29 @@
+import { acquireLifecycleLock } from "../src/lifecycle-lock";
+
+const [phase, lockPath] = process.argv.slice(2);
+if (
+  !lockPath ||
+  ![
+    "crash-initialize",
+    "crash-recovery",
+    "crash-release",
+    "acquire-release",
+  ].includes(phase)
+) {
+  throw new Error("Expected a lifecycle crash phase and lock path");
+}
+
+const kill = () => process.kill(process.pid, "SIGKILL");
+const lock = await acquireLifecycleLock("upgrade", {
+  lockPath,
+  timeoutMs: 5_000,
+  _afterLockDirectoryCreated: phase === "crash-initialize" ? kill : undefined,
+  _afterLockRecoveryValidated: phase === "crash-recovery" ? kill : undefined,
+  _afterLockOwnerRemoved: phase === "crash-release" ? kill : undefined,
+});
+
+lock.release();
+
+if (phase !== "acquire-release") {
+  throw new Error(`Crash injection did not fire for ${phase}`);
+}

--- a/packages/gateway/test/lifecycle-lock.test.ts
+++ b/packages/gateway/test/lifecycle-lock.test.ts
@@ -1,0 +1,596 @@
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  acquireLifecycleLock,
+  clearUninstallTombstoneForVerifiedInstall,
+  createUninstallTombstone,
+  currentUninstallTombstoneToken,
+  isVerifiedPackageInvocation,
+  LifecycleLockBusyError,
+  LifecycleLockLostError,
+  stableUnixProcessIdentity,
+  withLifecycleLock,
+  type LifecycleLockOptions,
+  type LifecycleLockOwner,
+} from "../src/lifecycle-lock";
+
+const roots: string[] = [];
+
+function lockPath(): string {
+  const root = mkdtempSync(join(tmpdir(), "lore-lifecycle-lock-"));
+  roots.push(root);
+  return join(root, ".lore", "lifecycle.lock");
+}
+
+function owner(
+  overrides: Partial<LifecycleLockOwner> = {},
+): LifecycleLockOwner {
+  return {
+    version: 1,
+    token: "o".repeat(43),
+    pid: 101,
+    operation: "gateway-start",
+    createdAt: "2020-01-01T00:00:00.000Z",
+    processStartedAt: "2020-01-01T00:00:00.000Z",
+    processIdentity: "boot:old-process",
+    ...overrides,
+  };
+}
+
+function writeOwner(path: string, value: LifecycleLockOwner | string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  writeFileSync(
+    join(path, "owner.json"),
+    typeof value === "string" ? value : `${JSON.stringify(value)}\n`,
+    { mode: 0o600 },
+  );
+}
+
+function options(
+  path: string,
+  overrides: LifecycleLockOptions = {},
+): LifecycleLockOptions {
+  return {
+    lockPath: path,
+    pid: 202,
+    processIdentity: "boot:new-process",
+    processStartedAt: "2024-01-01T00:00:00.000Z",
+    createToken: () => "n".repeat(43),
+    ...overrides,
+  };
+}
+
+function boundedClock(): Pick<
+  LifecycleLockOptions,
+  "now" | "sleep" | "timeoutMs" | "retryDelayMs"
+> {
+  let now = 1000;
+  return {
+    now: () => now,
+    sleep: async (ms) => {
+      now += ms;
+    },
+    timeoutMs: 10,
+    retryDelayMs: 5,
+  };
+}
+
+function runLifecycleChild(
+  phase:
+    | "crash-initialize"
+    | "crash-recovery"
+    | "crash-release"
+    | "acquire-release",
+  path: string,
+) {
+  return spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      join(import.meta.dirname, "lifecycle-lock-sigkill-child.ts"),
+      phase,
+      path,
+    ],
+    { encoding: "utf8", timeout: 90_000 },
+  );
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("lifecycle lock generations", () => {
+  test("distinguishes same-second Unix PID generations using stable start ticks", () => {
+    const secondResolutionStartedAt = "Fri Aug 14 11:22:33 2026";
+    const predecessor = stableUnixProcessIdentity({
+      bootId: "boot-generation",
+      startTicks: "10001",
+      secondResolutionStartedAt,
+    });
+    const successor = stableUnixProcessIdentity({
+      bootId: "boot-generation",
+      startTicks: "10002",
+      secondResolutionStartedAt,
+    });
+
+    expect(predecessor).toBe("unix-procfs:boot-generation:10001");
+    expect(successor).toBe("unix-procfs:boot-generation:10002");
+    expect(successor).not.toBe(predecessor);
+  });
+
+  test("rejects lstart-only Unix identity metadata", () => {
+    expect(
+      stableUnixProcessIdentity({
+        secondResolutionStartedAt: "Fri Aug 14 11:22:33 2026",
+      }),
+    ).toBeNull();
+    expect(
+      stableUnixProcessIdentity({
+        bootId: "boot-generation",
+        secondResolutionStartedAt: "Fri Aug 14 11:22:33 2026",
+      }),
+    ).toBeNull();
+  });
+
+  test("publishes an owner-only generation record and releases only itself", async () => {
+    const path = lockPath();
+    const lock = await acquireLifecycleLock(
+      "upgrade",
+      options(path, { now: () => Date.parse("2024-02-03T04:05:06.000Z") }),
+    );
+    expect(JSON.parse(readFileSync(join(path, "owner.json"), "utf8"))).toEqual({
+      version: 1,
+      token: "n".repeat(43),
+      pid: 202,
+      operation: "upgrade",
+      createdAt: "2024-02-03T04:05:06.000Z",
+      processStartedAt: "2024-01-01T00:00:00.000Z",
+      processIdentity: "boot:new-process",
+    });
+    if (process.platform !== "win32") {
+      expect(lstatSync(dirname(path)).mode & 0o777).toBe(0o700);
+      expect(lstatSync(path).mode & 0o777).toBe(0o700);
+      expect(lstatSync(join(path, "owner.json")).mode & 0o777).toBe(0o600);
+    }
+    lock.release();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "recovers in a fresh process after SIGKILL between directory creation and owner publication",
+    () => {
+      const path = lockPath();
+      const killed = runLifecycleChild("crash-initialize", path);
+      expect(killed.error).toBeUndefined();
+      expect(killed.status, killed.stderr).toBeNull();
+      expect(killed.signal).toBe("SIGKILL");
+      expect(existsSync(path)).toBe(true);
+      expect(existsSync(join(path, "owner.json"))).toBe(false);
+      expect(
+        readdirSync(dirname(path)).filter((entry) =>
+          entry.startsWith(".lifecycle.lock.init."),
+        ),
+      ).toHaveLength(1);
+
+      const recovered = runLifecycleChild("acquire-release", path);
+      expect(recovered.error).toBeUndefined();
+      expect(recovered.status, recovered.stderr).toBe(0);
+      expect(existsSync(path)).toBe(false);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "recovers in a fresh process after SIGKILL between owner removal and directory removal",
+    () => {
+      const path = lockPath();
+      const killed = runLifecycleChild("crash-release", path);
+      expect(killed.error).toBeUndefined();
+      expect(killed.status, killed.stderr).toBeNull();
+      expect(killed.signal).toBe("SIGKILL");
+      expect(existsSync(path)).toBe(true);
+      expect(existsSync(join(path, "owner.json"))).toBe(false);
+      expect(
+        readdirSync(dirname(path)).some((entry) =>
+          entry.startsWith(".lifecycle.lock.release."),
+        ),
+      ).toBe(true);
+
+      const recovered = runLifecycleChild("acquire-release", path);
+      expect(recovered.error).toBeUndefined();
+      expect(recovered.status, recovered.stderr).toBe(0);
+      expect(existsSync(path)).toBe(false);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "a second SIGKILL during incomplete-generation recovery remains recoverable",
+    () => {
+      const path = lockPath();
+      expect(runLifecycleChild("crash-initialize", path).signal).toBe(
+        "SIGKILL",
+      );
+      const killedRecovery = runLifecycleChild("crash-recovery", path);
+      expect(killedRecovery.error).toBeUndefined();
+      expect(killedRecovery.status, killedRecovery.stderr).toBeNull();
+      expect(killedRecovery.signal).toBe("SIGKILL");
+      expect(existsSync(join(path, "owner.json"))).toBe(false);
+
+      const recovered = runLifecycleChild("acquire-release", path);
+      expect(recovered.error).toBeUndefined();
+      expect(recovered.status, recovered.stderr).toBe(0);
+      expect(existsSync(path)).toBe(false);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "does not apply a delayed release claim to a replacement directory",
+    async () => {
+      const path = lockPath();
+      expect(runLifecycleChild("crash-release", path).signal).toBe("SIGKILL");
+      renameSync(path, `${path}.predecessor`);
+      mkdirSync(path, { mode: 0o700 });
+
+      await expect(
+        acquireLifecycleLock("upgrade", options(path, boundedClock())),
+      ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+      expect(readdirSync(path)).toEqual([]);
+    },
+  );
+
+  test("recovers only an empty directory backed by a dead initialization generation", async () => {
+    const ambiguous = lockPath();
+    mkdirSync(ambiguous, { recursive: true, mode: 0o700 });
+    await expect(
+      acquireLifecycleLock("upgrade", options(ambiguous, boundedClock())),
+    ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+
+    const recoverable = lockPath();
+    mkdirSync(recoverable, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(dirname(recoverable), `.lifecycle.lock.init.${owner().token}`),
+      `${JSON.stringify(owner())}\n`,
+      { mode: 0o600 },
+    );
+    const lock = await acquireLifecycleLock(
+      "upgrade",
+      options(recoverable, { inspectProcess: () => ({ state: "dead" }) }),
+    );
+    expect(lock.owner.token).toBe("n".repeat(43));
+    lock.release();
+  });
+
+  test("does not steal the empty directory of a live initializer", async () => {
+    const path = lockPath();
+    let contender!: Promise<unknown>;
+    const initializer = acquireLifecycleLock(
+      "upgrade",
+      options(path, {
+        pid: 101,
+        processIdentity: "boot:initializer",
+        createToken: () => "i".repeat(43),
+        _afterLockDirectoryCreated: () => {
+          contender = acquireLifecycleLock(
+            "setup",
+            options(path, {
+              ...boundedClock(),
+              pid: 303,
+              processIdentity: "boot:contender",
+              createToken: () => "c".repeat(43),
+              inspectProcess: (pid) =>
+                pid === 101
+                  ? { state: "alive", identity: "boot:initializer" }
+                  : { state: "alive", identity: "boot:contender" },
+            }),
+          );
+        },
+      }),
+    );
+
+    const lock = await initializer;
+    await expect(contender).rejects.toBeInstanceOf(LifecycleLockBusyError);
+    expect(lock.owner.token).toBe("i".repeat(43));
+    lock.release();
+  });
+
+  test("a releaser cannot remove a successor published in its cleanup window", async () => {
+    const path = lockPath();
+    let successor!: Promise<Awaited<ReturnType<typeof acquireLifecycleLock>>>;
+    const predecessor = await acquireLifecycleLock(
+      "upgrade",
+      options(path, {
+        createToken: () => "p".repeat(43),
+        _afterLockOwnerRemoved: () => {
+          successor = acquireLifecycleLock(
+            "setup",
+            options(path, {
+              pid: 303,
+              processIdentity: "boot:successor",
+              createToken: () => "s".repeat(43),
+            }),
+          );
+        },
+      }),
+    );
+
+    predecessor.release();
+    const successorLock = await successor;
+    expect(
+      JSON.parse(readFileSync(join(path, "owner.json"), "utf8")).token,
+    ).toBe(successorLock.owner.token);
+    successorLock.release();
+  });
+
+  test("bounds contention without stealing an old live owner", async () => {
+    const path = lockPath();
+    writeOwner(path, owner());
+    await expect(
+      acquireLifecycleLock(
+        "upgrade",
+        options(path, {
+          ...boundedClock(),
+          inspectProcess: () => ({
+            state: "alive",
+            identity: "boot:old-process",
+          }),
+        }),
+      ),
+    ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+    expect(
+      JSON.parse(readFileSync(join(path, "owner.json"), "utf8")).token,
+    ).toBe("o".repeat(43));
+  });
+
+  test("reclaims dead and PID-reused owners without predecessor deletion", async () => {
+    const path = lockPath();
+    const predecessor = await acquireLifecycleLock(
+      "gateway-start",
+      options(path, {
+        pid: 101,
+        processIdentity: "boot:old-process",
+        createToken: () => "o".repeat(43),
+      }),
+    );
+    const successor = await acquireLifecycleLock(
+      "gateway-shutdown",
+      options(path, {
+        pid: 101,
+        inspectProcess: () => ({
+          state: "alive",
+          identity: "boot:reused-process",
+        }),
+      }),
+    );
+    expect(() => predecessor.release()).toThrow(LifecycleLockLostError);
+    expect(
+      JSON.parse(readFileSync(join(path, "owner.json"), "utf8")).token,
+    ).toBe(successor.owner.token);
+    successor.release();
+  });
+
+  test("a delayed stale reclaimer cannot move a published successor", async () => {
+    const path = lockPath();
+    const stale = owner();
+    writeOwner(path, stale);
+    const claim = join(dirname(path), `.lifecycle.lock.claim.${stale.token}`);
+    renameSync(path, claim);
+    const successor = await acquireLifecycleLock("upgrade", options(path));
+    expect(() => renameSync(path, claim)).toThrow();
+    expect(
+      JSON.parse(readFileSync(join(path, "owner.json"), "utf8")).token,
+    ).toBe(successor.owner.token);
+    successor.release();
+  });
+
+  test("does not replace an attacker-created empty stale-claim path", async () => {
+    const path = lockPath();
+    const stale = owner();
+    writeOwner(path, stale);
+    const claim = join(dirname(path), `.lifecycle.lock.claim.${stale.token}`);
+    mkdirSync(claim, { mode: 0o700 });
+
+    await expect(
+      acquireLifecycleLock(
+        "upgrade",
+        options(path, {
+          ...boundedClock(),
+          inspectProcess: () => ({ state: "dead" }),
+        }),
+      ),
+    ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+    expect(
+      JSON.parse(readFileSync(join(path, "owner.json"), "utf8")).token,
+    ).toBe(stale.token);
+    expect(readdirSync(claim)).toEqual([]);
+  });
+
+  test("keeps malformed, loose-mode, and symlink locks conservatively busy", async () => {
+    const malformed = lockPath();
+    writeOwner(malformed, "not json");
+    await expect(
+      acquireLifecycleLock("uninstall", options(malformed, boundedClock())),
+    ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+
+    const malformedClaim = lockPath();
+    mkdirSync(malformedClaim, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(dirname(malformedClaim), `.lifecycle.lock.init.${"x".repeat(43)}`),
+      "not json",
+      { mode: 0o600 },
+    );
+    await expect(
+      acquireLifecycleLock(
+        "uninstall",
+        options(malformedClaim, boundedClock()),
+      ),
+    ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+
+    if (process.platform !== "win32") {
+      const looseEmpty = lockPath();
+      mkdirSync(looseEmpty, { recursive: true, mode: 0o755 });
+      await expect(
+        acquireLifecycleLock("setup", options(looseEmpty, boundedClock())),
+      ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+
+      const loose = lockPath();
+      writeOwner(loose, owner());
+      chmodSync(join(loose, "owner.json"), 0o644);
+      await expect(
+        acquireLifecycleLock("setup", options(loose, boundedClock())),
+      ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+
+      const link = lockPath();
+      const target = join(dirname(link), "target");
+      mkdirSync(dirname(link), { recursive: true, mode: 0o700 });
+      mkdirSync(target, { mode: 0o700 });
+      writeFileSync(join(target, "sentinel"), "preserve", { mode: 0o600 });
+      symlinkSync(target, link);
+      await expect(
+        acquireLifecycleLock("upgrade", options(link, boundedClock())),
+      ).rejects.toBeInstanceOf(LifecycleLockBusyError);
+      expect(readFileSync(join(target, "sentinel"), "utf8")).toBe("preserve");
+    }
+  });
+
+  test("is reentrant within one async lifecycle transition", async () => {
+    const path = lockPath();
+    const tokens: string[] = [];
+    await withLifecycleLock(
+      "setup",
+      async (outer) => {
+        tokens.push(outer.owner.token);
+        await withLifecycleLock("hosted-install", (inner) => {
+          tokens.push(inner.owner.token);
+        });
+      },
+      options(path),
+    );
+    expect(tokens).toEqual(["n".repeat(43), "n".repeat(43)]);
+  });
+});
+
+describe("uninstall tombstone generations", () => {
+  test("rejects a start queued before uninstall publishes its tombstone", async () => {
+    const path = lockPath();
+    let release!: () => void;
+    let held!: () => void;
+    const heldPromise = new Promise<void>((resolve) => (held = resolve));
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const uninstall = withLifecycleLock(
+      "uninstall",
+      async (lock) => {
+        held();
+        await gate;
+        createUninstallTombstone(lock);
+      },
+      options(path, {
+        timeoutMs: 1000,
+        inspectProcess: () => ({
+          state: "alive",
+          identity: "boot:new-process",
+        }),
+      }),
+    );
+    await heldPromise;
+    const queued = withLifecycleLock(
+      "gateway-start",
+      () => "resurrected",
+      options(path, {
+        timeoutMs: 1000,
+        retryDelayMs: 1,
+        inspectProcess: () => ({
+          state: "alive",
+          identity: "boot:new-process",
+        }),
+      }),
+    );
+    const rejection = expect(queued).rejects.toThrow(/stale gateway-start/);
+    release();
+    await uninstall;
+    await rejection;
+  });
+
+  test("requires verified generation evidence before clearing a tombstone", async () => {
+    const path = lockPath();
+    await withLifecycleLock(
+      "uninstall",
+      (lock) => createUninstallTombstone(lock),
+      options(path),
+    );
+    await expect(
+      withLifecycleLock(
+        "gateway-start",
+        () => "started",
+        options(path, { seaBinary: true }),
+      ),
+    ).rejects.toThrow(/Lore is uninstalled/);
+
+    await expect(
+      withLifecycleLock(
+        "hosted-install",
+        (lock) => {
+          const token = currentUninstallTombstoneToken(lock);
+          if (!token) throw new Error("missing tombstone");
+          clearUninstallTombstoneForVerifiedInstall(lock, token, () => false);
+        },
+        options(path),
+      ),
+    ).rejects.toThrow(/binary\/receipt verification/);
+
+    await withLifecycleLock(
+      "hosted-install",
+      (lock) => {
+        const token = currentUninstallTombstoneToken(lock);
+        if (!token) throw new Error("missing tombstone");
+        clearUninstallTombstoneForVerifiedInstall(lock, token, () => true);
+      },
+      options(path),
+    );
+    await expect(
+      withLifecycleLock("gateway-start", () => "started", options(path)),
+    ).resolves.toBe("started");
+  });
+
+  test("recognizes only the declared installed package CLI", () => {
+    const path = lockPath();
+    const packageRoot = join(
+      dirname(dirname(path)),
+      "node_modules",
+      "@loreai",
+      "gateway",
+    );
+    const entry = join(packageRoot, "dist", "bin.cjs");
+    mkdirSync(dirname(entry), { recursive: true });
+    writeFileSync(entry, "#!/usr/bin/env node\n");
+    writeFileSync(
+      join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "@loreai/gateway",
+        bin: { lore: "./dist/bin.cjs" },
+      }),
+    );
+    expect(
+      isVerifiedPackageInvocation({ entryPath: entry, seaBinary: false }),
+    ).toBe(true);
+    expect(
+      isVerifiedPackageInvocation({ entryPath: entry, seaBinary: true }),
+    ).toBe(false);
+  });
+});

--- a/packages/gateway/test/lifecycle-wiring.test.ts
+++ b/packages/gateway/test/lifecycle-wiring.test.ts
@@ -1,0 +1,45 @@
+import { dirname, join } from "node:path";
+import { rmSync } from "node:fs";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { startGateway } from "../src/cli/start";
+import {
+  acquireLifecycleLock,
+  createUninstallTombstone,
+  LifecycleLockBusyError,
+} from "../src/lifecycle-lock";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("gateway lifecycle production wiring", () => {
+  test("active uninstall blocks gateway start before listener creation", async () => {
+    const lock = await acquireLifecycleLock("uninstall");
+    vi.useFakeTimers();
+    try {
+      const pending = startGateway({ port: 0, local: true, quiet: true });
+      const rejection = expect(pending).rejects.toBeInstanceOf(
+        LifecycleLockBusyError,
+      );
+      await vi.advanceTimersByTimeAsync(5000);
+      await rejection;
+    } finally {
+      lock.release();
+    }
+  });
+
+  test("a persisted uninstall generation blocks a fresh gateway start", async () => {
+    const lock = await acquireLifecycleLock("uninstall");
+    const marker = join(dirname(lock.path), "uninstalled.json");
+    createUninstallTombstone(lock);
+    lock.release();
+    try {
+      await expect(
+        startGateway({ port: 0, local: true, quiet: true }),
+      ).rejects.toThrow(/Lore is uninstalled/);
+    } finally {
+      rmSync(marker, { force: true });
+    }
+  });
+});

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -2681,6 +2681,69 @@ describe("createGatewayLLMClient.prompt", () => {
     expect(text).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
+
+  test("invokes onAuthRejected without retaining the upstream body or URL secrets", async () => {
+    const privateBodyMarker = "PRIVATE_AUTH_RESPONSE_BODY_MARKER";
+    const userinfoMarker = "PRIVATE_AUTH_INFO_USERINFO";
+    const queryMarker = "PRIVATE_AUTH_INFO_QUERY";
+    const fragmentMarker = "PRIVATE_AUTH_INFO_FRAGMENT";
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: privateBodyMarker } }), {
+        status: 401,
+        statusText: "private reason",
+      }),
+    );
+    const onAuthRejected = vi.fn();
+    const client = createGatewayLLMClient(
+      {
+        anthropic:
+          `https://user:${userinfoMarker}@example.com/custom` +
+          `?token=${queryMarker}#${fragmentMarker}`,
+        openai: UPSTREAMS.openai,
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test-stale" }),
+      { providerID: "anthropic", modelID: "claude-sonnet-5" },
+      { onAuthRejected },
+    );
+
+    await expect(
+      client.prompt("system", "user", { workerID: "lore-import" }),
+    ).resolves.toBeNull();
+
+    expect(onAuthRejected).toHaveBeenCalledTimes(1);
+    const info = onAuthRejected.mock.calls[0]?.[0];
+    expect(info).toMatchObject({
+      status: 401,
+      providerID: "anthropic",
+      modelID: "claude-sonnet-5",
+      url: "https://example.com/custom",
+      scheme: "api-key",
+      workerID: "lore-import",
+    });
+    const serialized = JSON.stringify(info);
+    expect(serialized).not.toContain(privateBodyMarker);
+    expect(serialized).not.toContain(userinfoMarker);
+    expect(serialized).not.toContain(queryMarker);
+    expect(serialized).not.toContain(fragmentMarker);
+  });
+
+  test("onAuthRejected hook exceptions preserve the null-return contract", async () => {
+    mockFetch.mockResolvedValue(new Response("", { status: 403 }));
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+      {
+        onAuthRejected: () => {
+          throw new Error("diagnostic handler bug");
+        },
+      },
+    );
+
+    await expect(
+      client.prompt("system", "user", { workerID: "lore-import" }),
+    ).resolves.toBeNull();
+  });
 });
 
 describe("worker provider body validation", () => {
@@ -6489,13 +6552,13 @@ describe("worker diagnostic redaction", () => {
   });
 
   test.each([400, 401, 429, 500])(
-    "HTTP %i exposes neither provider body nor URL credentials/path/query in diagnostics",
+    "HTTP %i exposes neither provider body, statusText, nor URL credentials/query in diagnostics",
     async (status) => {
       const bodySentinel = `BODY_SECRET_${status}\nFORGED_LOG_LINE_${status}`;
+      const reasonSentinel = `STATUS_TEXT_SECRET_${status}`;
       const urlSentinels = [
         "URL_USER_SECRET",
         "URL_PASSWORD_SECRET",
-        "private-worker-path",
         "QUERY_SECRET",
       ];
       const upstreamUrl =
@@ -6505,7 +6568,11 @@ describe("worker diagnostic redaction", () => {
         async () =>
           new Response(
             JSON.stringify({ error: { code: status, message: bodySentinel } }),
-            { status, headers: { "retry-after": "0" } },
+            {
+              status,
+              statusText: reasonSentinel,
+              headers: { "retry-after": "0" },
+            },
           ),
       );
       const client = createGatewayLLMClient(
@@ -6543,11 +6610,93 @@ describe("worker diagnostic redaction", () => {
       for (const dump of [logDump, sentryDump, lastError]) {
         expect(dump).not.toContain(bodySentinel);
         expect(dump).not.toContain("FORGED_LOG_LINE");
+        expect(dump).not.toContain(reasonSentinel);
         for (const sentinel of urlSentinels) {
           expect(dump).not.toContain(sentinel);
         }
       }
-      expect(logDump).toContain("https://example.com");
+      expect(logDump).toContain("https://example.com/private-worker-path");
     },
   );
+
+  test("malformed successful responses never expose their prefix or statusText", async () => {
+    const bodyMarker = "PRIVATE_MALFORMED_WORKER_BODY_MARKER";
+    const reasonMarker = "PRIVATE_WORKER_REASON_MARKER";
+    mockFetch.mockResolvedValueOnce(
+      new Response(`${bodyMarker} not-json`, {
+        status: 200,
+        statusText: reasonMarker,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    await expect(
+      client.prompt("system", "user", { workerID: "lore-distill" }),
+    ).resolves.toBeNull();
+
+    const output = capturedLogs.join("\n");
+    expect(output).toContain("invalid");
+    expect(output).not.toContain(bodyMarker);
+    expect(output).not.toContain(reasonMarker);
+  });
+
+  test("response diagnostics exclude body-controlled fields and content-type values", async () => {
+    const bodyMarker = "PRIVATE_WORKER_EMPTY_FIELD_MARKER";
+    const headerMarker = "PRIVATE_WORKER_CONTENT_TYPE_MARKER";
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [{ type: bodyMarker }],
+          stop_reason: bodyMarker,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": `application/json; note=${headerMarker}` },
+        },
+      ),
+    );
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    await expect(
+      client.prompt("system", "user", { workerID: "lore-distill" }),
+    ).resolves.toBeNull();
+
+    const output = capturedLogs.join("\n");
+    expect(output).toContain("invalid anthropic response");
+    expect(output).not.toContain(bodyMarker);
+    expect(output).not.toContain(headerMarker);
+  });
+
+  test("thrown transport details never reach retry or terminal logs", async () => {
+    const thrownMarker = "PRIVATE_WORKER_THROWN_ERROR_MARKER";
+    mockFetch.mockRejectedValue(new Error(thrownMarker));
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "https://api.anthropic.com",
+        openai: "https://api.openai.com",
+      },
+      () => ({ scheme: "api-key", value: "sk-ant-test" }),
+      { providerID: "anthropic", modelID: "claude-test" },
+    );
+
+    await expect(
+      client.prompt("system", "user", { workerID: "lore-distill" }),
+    ).resolves.toBeNull();
+    expect(capturedLogs.join("\n")).not.toContain(thrownMarker);
+  });
 });

--- a/packages/gateway/test/management-access.test.ts
+++ b/packages/gateway/test/management-access.test.ts
@@ -1,0 +1,308 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { data, ensureProject, ltm } from "@loreai/core";
+import { connect } from "node:net";
+import { loadConfig, type GatewayConfig } from "../src/config";
+import { isLoopbackAddress, startServer } from "../src/server";
+
+type ServerHandle = Awaited<ReturnType<typeof startServer>>;
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    ...loadConfig(),
+    port: 0,
+    hosts: ["127.0.0.1"],
+    debug: false,
+    remoteGateway: false,
+    hostedMode: false,
+    ...overrides,
+  };
+}
+
+describe("management route access control", () => {
+  let wideListener: ServerHandle;
+  let remotePeer: ServerHandle;
+  let mappedLoopbackPeer: ServerHandle;
+
+  beforeAll(async () => {
+    // A wildcard listener is intentionally public for the data plane. Access to
+    // management routes must depend on the socket peer, not the bind address.
+    wideListener = await startServer(makeConfig({ hosts: ["0.0.0.0"] }));
+    remotePeer = await startServer(makeConfig(), {
+      // A real non-loopback source address is not available hermetically on all
+      // CI hosts. This seam changes only the address delivered by the
+      // node:http bridge; requests still traverse a real TCP socket and server.
+      peerAddressForRequest: () => "192.0.2.10",
+    });
+    mappedLoopbackPeer = await startServer(makeConfig(), {
+      peerAddressForRequest: () => "::ffff:127.0.0.1",
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      wideListener.stop(),
+      remotePeer.stop(),
+      mappedLoopbackPeer.stop(),
+    ]);
+  });
+
+  const urlFor = (server: ServerHandle, path: string): string =>
+    `http://127.0.0.1:${server.port}${path}`;
+
+  test("allows loopback clients through a 0.0.0.0 listener", async () => {
+    const response = await fetch(urlFor(wideListener, "/api/v1/projects"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(expect.any(Array));
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test.each([
+    ["management API", "/api/v1/projects"],
+    ["dashboard", "/ui"],
+    ["dashboard root", "/"],
+  ])("allows same-origin browser access to the %s", async (_label, path) => {
+    const origin = `http://127.0.0.1:${wideListener.port}`;
+    const response = await fetch(urlFor(wideListener, path), {
+      headers: { origin },
+      redirect: "manual",
+    });
+
+    expect(response.status).not.toBe(404);
+    expect(response.status).not.toBe(500);
+    expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    expect(response.headers.get("access-control-allow-origin")).not.toBe("*");
+  });
+
+  test("prevents remote sites from framing the loopback dashboard", async () => {
+    const response = await fetch(urlFor(wideListener, "/ui"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(response.headers.get("content-security-policy")).toContain(
+      "frame-ancestors 'none'",
+    );
+  });
+
+  test("allows IPv4-mapped IPv6 loopback peers", async () => {
+    const response = await fetch(
+      urlFor(mappedLoopbackPeer, "/api/v1/projects"),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  test("ignores forged forwarding headers from a non-loopback peer", async () => {
+    const response = await fetch(urlFor(remotePeer, "/api/v1/projects"), {
+      headers: {
+        forwarded: "for=127.0.0.1;host=localhost",
+        "x-forwarded-for": "127.0.0.1, ::1",
+        "x-real-ip": "127.0.0.1",
+      },
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("denies destructive API calls without touching data", async () => {
+    const projectPath = `/test/remote-management-${Date.now()}`;
+    const projectId = ensureProject(projectPath, "remote-management-guard");
+
+    const response = await fetch(
+      urlFor(remotePeer, `/api/v1/projects/${projectId}`),
+      { method: "DELETE" },
+    );
+
+    expect(response.status).toBe(404);
+    expect(
+      data.listProjects().some((project) => project.id === projectId),
+    ).toBe(true);
+  });
+
+  test("denies before parsing a management request body", async () => {
+    const response = await fetch(urlFor(remotePeer, "/api/v1/import/record"), {
+      method: "POST",
+      headers: {
+        "content-encoding": "not-a-real-encoding",
+        "content-type": "application/json",
+      },
+      body: "not json",
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+  });
+
+  test("responds without waiting for an unauthorized body to arrive", async () => {
+    const rawResponse = await new Promise<string>((resolve, reject) => {
+      const socket = connect(remotePeer.port, "127.0.0.1");
+      let received = "";
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error("management denial waited for the request body"));
+      }, 2_000);
+      const finish = (): void => {
+        clearTimeout(timer);
+        socket.destroy();
+        resolve(received);
+      };
+      socket.once("connect", () => {
+        socket.write(
+          "POST /api/v1/import/record HTTP/1.1\r\n" +
+            `Host: 127.0.0.1:${remotePeer.port}\r\n` +
+            "Content-Type: application/json\r\n" +
+            "Content-Length: 100000\r\n" +
+            "\r\n" +
+            "{",
+        );
+      });
+      socket.on("data", (chunk) => {
+        received += chunk.toString();
+        if (received.includes("\r\n\r\n")) finish();
+      });
+      socket.once("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      socket.once("close", () => {
+        if (received) finish();
+      });
+    });
+
+    expect(rawResponse).toContain("404 Not Found");
+    expect(rawResponse.toLowerCase()).toContain("connection: close");
+  });
+
+  test.each(["/ui", "/ui/projects", "/"])(
+    "denies remote dashboard route %s without enumeration",
+    async (path) => {
+      const response = await fetch(urlFor(remotePeer, path), {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(404);
+      expect(await response.text()).toBe("");
+    },
+  );
+
+  test("denies management preflights from non-loopback peers", async () => {
+    const response = await fetch(urlFor(remotePeer, "/api/v1/projects"), {
+      method: "OPTIONS",
+      headers: {
+        origin: "http://localhost:4173",
+        "access-control-request-method": "DELETE",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-methods")).toBeNull();
+  });
+
+  test("denies management preflights from non-loopback origins", async () => {
+    const response = await fetch(urlFor(wideListener, "/api/v1/projects"), {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://attacker.example",
+        "access-control-request-method": "DELETE",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-methods")).toBeNull();
+  });
+
+  test("denies a simple management POST from a remote web origin", async () => {
+    const projectPath = `/test/browser-management-${Date.now()}`;
+    const projectId = ensureProject(projectPath, "browser-management-guard");
+    const knowledgeId = ltm.create({
+      projectPath,
+      category: "gotcha",
+      title: "Browser management guard",
+      content: "This entry must survive a cross-origin management request.",
+      session: "management-access-test",
+      scope: "project",
+    });
+    const response = await fetch(
+      urlFor(wideListener, `/api/v1/projects/${projectId}/clear`),
+      {
+        method: "POST",
+        // text/plain makes this a CORS-safelisted request that a browser can
+        // send without preflight. The Origin check must still stop it.
+        headers: {
+          origin: "https://attacker.example",
+          "content-type": "text/plain",
+        },
+        body: "{}",
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(ltm.get(knowledgeId)).not.toBeNull();
+  });
+
+  test("reflects only an allowed loopback origin on management preflight", async () => {
+    const origin = "http://localhost:4173";
+    const response = await fetch(urlFor(wideListener, "/api/v1/projects"), {
+      method: "OPTIONS",
+      headers: {
+        origin,
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    expect(response.headers.get("access-control-allow-origin")).not.toBe("*");
+    expect(response.headers.get("vary")).toContain("Origin");
+  });
+
+  test("keeps no-Origin health and data-plane routes reachable remotely", async () => {
+    const health = await fetch(urlFor(remotePeer, "/health"));
+    expect(health.status).toBe(200);
+    expect(health.headers.get("access-control-allow-origin")).toBeNull();
+
+    const dataPlane = await fetch(urlFor(remotePeer, "/v1/messages"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json",
+    });
+    expect(dataPlane.status).toBe(400);
+    expect(dataPlane.headers.get("access-control-allow-origin")).toBeNull();
+  });
+});
+
+describe("isLoopbackAddress", () => {
+  test.each([
+    "127.0.0.1",
+    "127.255.255.254",
+    "::1",
+    "0:0:0:0:0:0:0:1",
+    "::ffff:127.0.0.1",
+    "::ffff:7f00:1",
+  ])("accepts loopback address %s", (address) => {
+    expect(isLoopbackAddress(address)).toBe(true);
+  });
+
+  test.each([
+    undefined,
+    "",
+    "localhost",
+    "0.0.0.0",
+    "::",
+    "192.168.1.20",
+    "100.64.0.10",
+    "203.0.113.10",
+    "2001:db8::1",
+    "::ffff:192.168.1.20",
+  ])("rejects non-loopback address %s", (address) => {
+    expect(isLoopbackAddress(address)).toBe(false);
+  });
+});

--- a/packages/gateway/test/openrouter-provider-routing.test.ts
+++ b/packages/gateway/test/openrouter-provider-routing.test.ts
@@ -4,6 +4,7 @@
  */
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { existsSync, unlinkSync } from "node:fs";
+import { request as httpRequest } from "node:http";
 import {
   close as closeDB,
   loadSessionTracking,
@@ -26,11 +27,46 @@ type Started = {
   baseURL: string;
   config: GatewayConfig;
   dbPath: string;
-  server: { stop(): void };
+  server: { stop(): Promise<void> };
   previousEnv: Map<string, string | undefined>;
 };
 
 let started: Started | undefined;
+
+function postLoopback(
+  baseURL: string,
+  path: string,
+  headers: Record<string, string>,
+  body: string,
+): Promise<Response> {
+  const url = new URL(path, baseURL);
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(
+      url,
+      {
+        method: "POST",
+        headers: {
+          ...headers,
+          "content-length": String(Buffer.byteLength(body)),
+        },
+      },
+      (incoming) => {
+        const chunks: Buffer[] = [];
+        incoming.on("data", (chunk: Buffer) => chunks.push(chunk));
+        incoming.once("error", reject);
+        incoming.once("end", () => {
+          resolve(
+            new Response(Buffer.concat(chunks), {
+              status: incoming.statusCode ?? 500,
+            }),
+          );
+        });
+      },
+    );
+    request.once("error", reject);
+    request.end(body);
+  });
+}
 
 function openAIResponse(content = "hello"): Response {
   return new Response(
@@ -162,6 +198,10 @@ async function start(
     LORE_DB_PATH: `/tmp/lore-openrouter-routing-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
     LORE_LISTEN_PORT: "0",
     LORE_DEBUG: "false",
+    // This suite exercises local caller-selected provider routing. Keep it
+    // hermetic when the developer shell binds Lore on a non-loopback host.
+    LORE_REMOTE_GATEWAY: "0",
+    LORE_HOSTED_MODE: "0",
     LORE_BATCH_DISABLED: options.batchDisabled === false ? undefined : "1",
     LORE_WORKER_MODEL: options.workerModel,
     LORE_WORKER_API_KEY: options.dedicatedKey ? DEDICATED_KEY : undefined,
@@ -203,7 +243,7 @@ async function stop(): Promise<void> {
   if (!started) return;
   const current = started;
   started = undefined;
-  current.server.stop();
+  await current.server.stop();
   const { resetPipelineState, setUpstreamInterceptor } =
     await import("../src/pipeline");
   const { _setTestVertexTokenProvider } = await import("../src/vertex-auth");
@@ -761,7 +801,10 @@ describe("OpenRouter provider routing", () => {
         protocol: "openai",
         providerID: "openrouter",
         model: "anthropic/claude-sonnet-4-6",
-        headers: {},
+        headers: {
+          authorization: "Bearer persisted-secret",
+          "anthropic-beta": "safe-beta",
+        },
         providerOptions: legacyPolicy,
       }),
     });
@@ -780,6 +823,9 @@ describe("OpenRouter provider routing", () => {
       })
     ).text();
     expect(workerBodies(legacyStart)[0].provider).toEqual(legacyPolicy);
+    expect(
+      (await activeSession()).upstreamByProvider.get("openrouter")?.headers,
+    ).toEqual({ "anthropic-beta": "safe-beta" });
 
     saveSessionTracking(sid, {
       lastUpstream: JSON.stringify({
@@ -935,13 +981,11 @@ describe("OpenRouter provider routing", () => {
       return responsesResponse();
     });
 
-    const response = await fetch(`${run.baseURL}/v1/codex/responses`, {
-      method: "POST",
-      headers: requestHeaders(
-        "openai-codex",
-        "https://chatgpt.com/backend-api",
-      ),
-      body: JSON.stringify({
+    const response = await postLoopback(
+      run.baseURL,
+      "/v1/codex/responses",
+      requestHeaders("openai-codex", "https://chatgpt.com/backend-api"),
+      JSON.stringify({
         model: "gpt-5.1-codex-mini",
         input: "Hello",
         stream: false,
@@ -955,7 +999,7 @@ describe("OpenRouter provider routing", () => {
           },
         ],
       }),
-    });
+    );
     expect(response.ok).toBe(true);
     await response.text();
     if (!forwarded) throw new Error("Codex request was not forwarded");

--- a/packages/gateway/test/parse-curl-headers.test.ts
+++ b/packages/gateway/test/parse-curl-headers.test.ts
@@ -14,6 +14,7 @@
  */
 import { describe, test, expect } from "vitest";
 import { parseCurlHeaders } from "../src/config";
+import { applyUpstreamExtraHeaders } from "../src/translate/types";
 
 describe("parseCurlHeaders", () => {
   test("returns empty object for undefined / empty input", () => {
@@ -76,6 +77,26 @@ describe("parseCurlHeaders", () => {
       );
       expect(result).toEqual({ "x-good": "1", "x-also-good": "2" });
       expect(errors.length).toBe(1);
+      expect(JSON.stringify(errors)).toContain("line 2");
+      expect(JSON.stringify(errors)).not.toContain("no-colon-here");
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("never includes malformed header contents in diagnostics", () => {
+    const secret = "arbitrary-secret-value";
+    const origError = console.error;
+    const errors: unknown[] = [];
+    console.error = (...args: unknown[]) => errors.push(args);
+    try {
+      expect(
+        parseCurlHeaders(`X-Api-Key ${secret}\nBad ${secret}: value`),
+      ).toEqual({});
+      const output = JSON.stringify(errors);
+      expect(output).toContain("line 1");
+      expect(output).toContain("line 2");
+      expect(output).not.toContain(secret);
     } finally {
       console.error = origError;
     }
@@ -127,5 +148,51 @@ describe("parseCurlHeaders", () => {
   test("Cloudflare AI Gateway style: cf-aig-authorization", () => {
     const result = parseCurlHeaders("cf-aig-authorization: Bearer my-token");
     expect(result).toEqual({ "cf-aig-authorization": "Bearer my-token" });
+  });
+
+  test("configured provider auth atomically replaces every client variant", () => {
+    const headers = {
+      authorization: "Bearer client",
+      "x-api-key": "client-api-key",
+      "x-goog-api-key": "client-google-key",
+      "x-safe": "preserved",
+    };
+    applyUpstreamExtraHeaders(headers, {
+      authorization: "Bearer administrator",
+    });
+    expect(headers).toEqual({
+      authorization: "Bearer administrator",
+      "x-safe": "preserved",
+    });
+  });
+
+  test("configured mixed provider auth fails instead of forwarding competitors", () => {
+    expect(() =>
+      applyUpstreamExtraHeaders(
+        { "x-api-key": "client" },
+        {
+          authorization: "Bearer administrator",
+          "x-api-key": "administrator-key",
+        },
+      ),
+    ).toThrow("conflicting authentication mechanisms");
+  });
+
+  test("gateway access can never be configured for upstream forwarding", () => {
+    expect(() =>
+      applyUpstreamExtraHeaders(
+        { "x-safe": "preserved" },
+        { "x-lore-gateway-token": "must-not-forward" },
+      ),
+    ).toThrow("gateway access header");
+  });
+
+  test("case-variant gateway access extras cannot bypass the forwarding guard", () => {
+    expect(() =>
+      applyUpstreamExtraHeaders(
+        { "x-safe": "preserved" },
+        { "X-Lore-Gateway-Token": "must-not-forward" },
+      ),
+    ).toThrow("gateway access header");
   });
 });

--- a/packages/gateway/test/pidfile.test.ts
+++ b/packages/gateway/test/pidfile.test.ts
@@ -1,69 +1,139 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { chmodSync, lstatSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dataDir } from "@loreai/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  writePidFile,
-  readPidFile,
-  removePidFile,
+  inspectGatewayProcessFile,
+  inspectPidFile,
   isProcessAlive,
+  readGatewayProcessFile,
+  readLegacyPidFile,
+  readPidFile,
+  removeGatewayProcessFile,
+  removeLegacyPidFile,
+  removePidFile,
+  writeGatewayProcessFile,
+  writePidFile,
 } from "../src/pidfile";
 
-// Clean up any pid file we wrote during tests.
+let base: string;
+let previousXdg: string | undefined;
+
+beforeEach(() => {
+  previousXdg = process.env.XDG_DATA_HOME;
+  base = mkdtempSync(join(tmpdir(), "lore-pidfile-test-"));
+  process.env.XDG_DATA_HOME = base;
+});
+
 afterEach(() => {
-  try {
-    writePidFile(999999);
-    removePidFile(999999);
-  } catch {
-    /* best effort */
-  }
+  if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = previousXdg;
+  rmSync(base, { recursive: true, force: true });
 });
 
 describe("pidfile", () => {
-  it("readPidFile returns null when no file exists", () => {
-    writePidFile(999999);
-    removePidFile(999999);
-    expect(readPidFile()).toBeNull();
-  });
+  it("distinguishes absent, legacy, authenticated, and invalid evidence", () => {
+    expect(inspectPidFile()).toEqual({ state: "absent" });
+    expect(inspectGatewayProcessFile()).toEqual({ state: "absent" });
 
-  it("writePidFile + readPidFile round-trips a pid", () => {
     writePidFile(4242);
     expect(readPidFile()).toBe(4242);
-  });
+    expect(readGatewayProcessFile()).toBeNull();
+    expect(inspectPidFile()).toMatchObject({
+      state: "legacy",
+      record: { pid: 4242 },
+    });
+    expect(inspectGatewayProcessFile()).toMatchObject({ state: "invalid" });
 
-  it("writePidFile overwrites an existing pid file", () => {
-    writePidFile(4242);
-    writePidFile(5353);
-    expect(readPidFile()).toBe(5353);
-  });
+    const record = {
+      version: 2 as const,
+      pid: 5353,
+      port: 3207,
+      hosts: ["127.0.0.1", "::1"],
+      token: "secret".repeat(8),
+      processIdentity: "generation-one",
+    };
+    writeGatewayProcessFile(record);
+    expect(readPidFile()).toBe(record.pid);
+    expect(readGatewayProcessFile()).toEqual(record);
+    expect(inspectPidFile()).toEqual({ state: "process", record });
+    expect(inspectGatewayProcessFile()).toEqual({ state: "valid", record });
 
-  it("removePidFile deletes the file when pid matches", () => {
-    writePidFile(4242);
-    removePidFile(4242);
-    expect(readPidFile()).toBeNull();
-  });
-
-  it("removePidFile does NOT delete the file when pid differs", () => {
-    writePidFile(5353);
-    removePidFile(4242); // wrong pid — should not remove
-    expect(readPidFile()).toBe(5353);
-  });
-
-  it("removePidFile is a no-op when no file exists", () => {
-    removePidFile(4242);
-    expect(readPidFile()).toBeNull();
-  });
-
-  it("readPidFile rejects invalid content", () => {
     writePidFile(0);
     expect(readPidFile()).toBeNull();
-    writePidFile(-5);
+    expect(inspectPidFile()).toMatchObject({ state: "invalid" });
+  });
+
+  it("writes owner-only files and atomically overwrites legacy values", () => {
+    writePidFile(4242);
+    writePidFile(5353);
+    expect(readPidFile()).toBe(5353);
+    if (process.platform !== "win32") {
+      chmodSync(join(dataDir(), "gateway.pid"), 0o666);
+      writePidFile(6464);
+      expect(lstatSync(join(dataDir(), "gateway.pid")).mode & 0o777).toBe(
+        0o600,
+      );
+    }
+  });
+
+  it("removePidFile removes only a matching PID", () => {
+    writePidFile(5353);
+    removePidFile(4242);
+    expect(readPidFile()).toBe(5353);
+    removePidFile(5353);
     expect(readPidFile()).toBeNull();
+    expect(() => removePidFile(5353)).not.toThrow();
   });
 
-  it("isProcessAlive returns true for the current process", () => {
+  it("token/identity cleanup preserves a same-PID successor", () => {
+    const predecessor = {
+      version: 2 as const,
+      pid: 4242,
+      port: 3207,
+      hosts: ["127.0.0.1"],
+      token: "predecessor".repeat(4),
+      processIdentity: "generation-one",
+    };
+    const successor = {
+      ...predecessor,
+      token: "successor".repeat(4),
+      processIdentity: "generation-two",
+    };
+    writeGatewayProcessFile(successor);
+    removeGatewayProcessFile(predecessor);
+    expect(readGatewayProcessFile()).toEqual(successor);
+  });
+
+  it("legacy identity cleanup preserves a same-PID replacement", () => {
+    writePidFile(4242);
+    const predecessor = readLegacyPidFile();
+    if (!predecessor) throw new Error("missing legacy PID fixture");
+    writePidFile(4242);
+    expect(removeLegacyPidFile(predecessor)).toBe("changed");
+    expect(readPidFile()).toBe(4242);
+    expect(readLegacyPidFile()?.identity).not.toEqual(predecessor.identity);
+  });
+
+  it("requires loopback hosts when destructive discovery requests it", () => {
+    const record = {
+      version: 2 as const,
+      pid: 4242,
+      port: 3207,
+      hosts: ["192.0.2.1"],
+      token: "a".repeat(32),
+      processIdentity: "generation-one",
+    };
+    writeGatewayProcessFile(record);
+    expect(inspectGatewayProcessFile()).toEqual({ state: "valid", record });
+    expect(
+      inspectGatewayProcessFile({ requireLoopbackHosts: true }),
+    ).toMatchObject({ state: "invalid" });
+  });
+
+  it("reports current and non-existent process liveness", () => {
     expect(isProcessAlive(process.pid)).toBe(true);
-  });
-
-  it("isProcessAlive returns false for a non-existent pid", () => {
-    // PID 2^31-1 is effectively never a live process.
     expect(isProcessAlive(2147483646)).toBe(false);
   });
 });

--- a/packages/gateway/test/pipeline-streaming.test.ts
+++ b/packages/gateway/test/pipeline-streaming.test.ts
@@ -32,6 +32,13 @@ import {
   DEFAULT_SYSTEM,
 } from "./helpers/fixtures";
 
+function loadLocalConfig() {
+  const config = loadConfig();
+  config.remoteGateway = false;
+  config.hostedMode = false;
+  return config;
+}
+
 function makeStreamBody(userMessage: string): Record<string, unknown> {
   return {
     model: DEFAULT_MODEL,
@@ -589,7 +596,7 @@ describe("Pipeline — streaming responses", () => {
           rawHeaders: { "x-lore-agent": "title" },
           signal: controller.signal,
         },
-        loadConfig(),
+        loadLocalConfig(),
       );
       await Promise.resolve();
       controller.abort(new DOMException("client disconnected", "AbortError"));
@@ -619,7 +626,7 @@ describe("Pipeline — streaming responses", () => {
           metadata: {},
           rawHeaders: { "x-lore-agent": "title" },
         },
-        loadConfig(),
+        loadLocalConfig(),
       );
       await vi.advanceTimersByTimeAsync(300_000);
       const response = await pending;
@@ -654,14 +661,13 @@ describe("Pipeline — streaming responses", () => {
               metadata: {},
               rawHeaders: {
                 "x-api-key": "test-key",
-                authorization: "Bearer test-key",
                 "x-lore-agent": "title",
                 "x-lore-provider": provider,
                 "x-lore-upstream-url": upstream,
               },
               signal: caller.signal,
             },
-            loadConfig(),
+            loadLocalConfig(),
           ),
           new Promise<never>((_resolve, reject) => {
             responseTimer = setTimeout(
@@ -717,13 +723,12 @@ describe("Pipeline — streaming responses", () => {
             metadata: {},
             rawHeaders: {
               "x-api-key": "test-key",
-              authorization: "Bearer test-key",
               "x-lore-agent": "title",
               "x-lore-provider": provider,
               "x-lore-upstream-url": upstream,
             },
           },
-          loadConfig(),
+          loadLocalConfig(),
         );
         await Promise.resolve();
         await vi.advanceTimersByTimeAsync(300_000);
@@ -864,7 +869,7 @@ describe("Pipeline — streaming responses", () => {
               "x-lore-upstream-url": "https://api.anthropic.com",
             },
           },
-          loadConfig(),
+          loadLocalConfig(),
         );
         await new Promise((resolve) => setImmediate(resolve));
         expect(pulls).toBeLessThan(chunks.length);
@@ -950,7 +955,7 @@ describe("Pipeline — streaming responses", () => {
               "x-lore-upstream-url": "https://api.anthropic.com",
             },
           },
-          loadConfig(),
+          loadLocalConfig(),
         );
         await expect(
           response.text(),

--- a/packages/gateway/test/portfile.test.ts
+++ b/packages/gateway/test/portfile.test.ts
@@ -1,66 +1,86 @@
-import { describe, test, expect, afterEach } from "vitest";
-import { writePortFile, readPortFile, removePortFile } from "../src/portfile";
+import { chmodSync, lstatSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { dataDir } from "@loreai/core";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  inspectPortFile,
+  readPortFile,
+  removePortFile,
+  writePortFile,
+} from "../src/portfile";
 
-// Clean up any port file we wrote during tests.
+let base: string;
+let previousXdg: string | undefined;
+
+beforeEach(() => {
+  previousXdg = process.env.XDG_DATA_HOME;
+  base = mkdtempSync(join(tmpdir(), "lore-portfile-test-"));
+  process.env.XDG_DATA_HOME = base;
+});
+
 afterEach(() => {
-  try {
-    // Force-remove by writing a known value then removing with that value.
-    writePortFile(99999);
-    removePortFile(99999);
-  } catch {
-    /* best effort */
-  }
+  if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = previousXdg;
+  rmSync(base, { recursive: true, force: true });
 });
 
 describe("portfile", () => {
-  test("readPortFile returns null when no file exists", () => {
-    // Ensure no port file exists (afterEach from previous test handles this,
-    // but also clean before first run).
-    writePortFile(99999);
-    removePortFile(99999);
-
+  test("round-trips and overwrites legacy port values", () => {
     expect(readPortFile()).toBeNull();
-  });
-
-  test("writePortFile + readPortFile round-trips a port number", () => {
     writePortFile(3207);
     expect(readPortFile()).toBe(3207);
-  });
-
-  test("writePortFile overwrites an existing port file", () => {
-    writePortFile(3207);
     writePortFile(5673);
     expect(readPortFile()).toBe(5673);
   });
 
-  test("removePortFile deletes the file when port matches", () => {
+  test("restores owner-only permissions when replacing a file", () => {
+    if (process.platform === "win32") return;
     writePortFile(3207);
-    removePortFile(3207);
-    expect(readPortFile()).toBeNull();
-  });
-
-  test("removePortFile does NOT delete the file when port differs", () => {
+    chmodSync(join(dataDir(), "gateway.port"), 0o666);
     writePortFile(5673);
-    removePortFile(3207); // wrong port — should not remove
-    expect(readPortFile()).toBe(5673);
+    expect(lstatSync(join(dataDir(), "gateway.port")).mode & 0o777).toBe(0o600);
   });
 
-  test("removePortFile is a no-op when no file exists", () => {
-    // Should not throw.
+  test("legacy cleanup removes only a matching port", () => {
+    writePortFile(5673);
     removePortFile(3207);
+    expect(readPortFile()).toBe(5673);
+    removePortFile(5673);
     expect(readPortFile()).toBeNull();
+    expect(() => removePortFile(5673)).not.toThrow();
   });
 
-  test("readPortFile rejects invalid content", () => {
-    // Simulate corrupted file by writing a valid port, then we can't
-    // easily write arbitrary content via the API — but we can verify
-    // the validation logic by writing port 0 (invalid) and checking.
-    // Actually writePortFile accepts any number, but readPortFile
-    // validates port > 0 && port <= 65535.
+  test("rejects invalid legacy content", () => {
     writePortFile(0);
     expect(readPortFile()).toBeNull();
-
     writePortFile(70000);
     expect(readPortFile()).toBeNull();
+  });
+
+  test("strict inspection distinguishes absent from legacy invalid evidence", () => {
+    expect(inspectPortFile()).toEqual({ state: "absent" });
+    writePortFile(3207);
+    expect(inspectPortFile()).toMatchObject({ state: "invalid" });
+  });
+
+  test("round-trips an authenticated generation record", () => {
+    const token = "owner".repeat(8);
+    writePortFile(3207, token);
+    expect(readPortFile()).toBe(3207);
+    expect(inspectPortFile()).toEqual({
+      state: "valid",
+      record: { version: 1, port: 3207, token },
+    });
+  });
+
+  test("token cleanup preserves a same-port successor", () => {
+    const successorToken = "successor".repeat(4);
+    writePortFile(3207, successorToken);
+    removePortFile(3207, "predecessor".repeat(4));
+    expect(inspectPortFile()).toEqual({
+      state: "valid",
+      record: { version: 1, port: 3207, token: successorToken },
+    });
   });
 });

--- a/packages/gateway/test/quota.test.ts
+++ b/packages/gateway/test/quota.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { log } from "@loreai/core";
 
 // Bridge: upstreamFetch now uses undici's own fetch (not globalThis.fetch),
 // so tests that mock globalThis.fetch need this shim to intercept calls.
@@ -61,6 +62,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
 });
 
 // ---------------------------------------------------------------------------
@@ -298,6 +300,50 @@ describe("fetchOAuthQuotaSnapshot", () => {
 
     const snap = await fetchOAuthQuotaSnapshot(BEARER);
     expect(snap).toBeNull();
+  });
+
+  test("malformed JSON diagnostics never include the response prefix or statusText", async () => {
+    const bodyMarker = "PRIVATE_QUOTA_MALFORMED_PREFIX";
+    const reasonMarker = "PRIVATE_QUOTA_REASON_MARKER";
+    const messages: string[] = [];
+    vi.spyOn(log, "warn").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(`${bodyMarker} not-json`, {
+          status: 200,
+          statusText: reasonMarker,
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    expect(await fetchOAuthQuotaSnapshot(BEARER)).toBeNull();
+    const output = messages.join("\n");
+    expect(output).toContain("200");
+    expect(output).not.toContain(bodyMarker);
+    expect(output).not.toContain(reasonMarker);
+  });
+
+  test("network diagnostics do not log thrown URL or error details", async () => {
+    const userinfoMarker = "PRIVATE_QUOTA_THROWN_USERINFO";
+    const queryMarker = "PRIVATE_QUOTA_THROWN_QUERY";
+    const messages: string[] = [];
+    vi.spyOn(log, "warn").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.reject(
+        new Error(
+          `request failed at https://user:${userinfoMarker}@example.com/quota?token=${queryMarker}`,
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    expect(await fetchOAuthQuotaSnapshot(BEARER)).toBeNull();
+    const output = messages.join("\n");
+    expect(output).not.toContain(userinfoMarker);
+    expect(output).not.toContain(queryMarker);
   });
 });
 

--- a/packages/gateway/test/recall-codex-stream.test.ts
+++ b/packages/gateway/test/recall-codex-stream.test.ts
@@ -141,10 +141,10 @@ function codexStreamRequiredError(): Response {
   );
 }
 
-let teardownFn: (() => void) | undefined;
+let teardownFn: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  teardownFn?.();
+afterEach(async () => {
+  await teardownFn?.();
   teardownFn = undefined;
 });
 
@@ -200,11 +200,13 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     });
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       setUpstreamInterceptor(undefined);
       for (const suffix of ["", "-shm", "-wal"]) {
@@ -421,11 +423,13 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     });
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       setUpstreamInterceptor(undefined);
       for (const suffix of ["", "-shm", "-wal"]) {

--- a/packages/gateway/test/recall-marker-split.e2e.test.ts
+++ b/packages/gateway/test/recall-marker-split.e2e.test.ts
@@ -151,10 +151,10 @@ function anthropicFinalStream(text: string): Response {
 // Test lifecycle
 // ---------------------------------------------------------------------------
 
-let teardownFn: (() => void) | undefined;
+let teardownFn: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  teardownFn?.();
+afterEach(async () => {
+  await teardownFn?.();
   teardownFn = undefined;
 });
 
@@ -171,6 +171,8 @@ async function spinUpGateway(projectDir: string) {
   await loadLoreConfig(projectDir);
 
   const config = loadConfig();
+  config.remoteGateway = false;
+  config.hostedMode = false;
   const server = await startServer(config);
   return {
     baseURL: `http://127.0.0.1:${server.port}`,
@@ -180,14 +182,14 @@ async function spinUpGateway(projectDir: string) {
   };
 }
 
-function teardownAll(
+async function teardownAll(
   dbPath: string,
   projectDir: string,
-  server: { stop: () => void },
+  server: { stop: () => Promise<void> },
   closeDB: () => void,
   setUpstreamInterceptor: (i: undefined) => void,
-) {
-  server.stop();
+): Promise<void> {
+  await server.stop();
   closeDB();
   setUpstreamInterceptor(undefined);
   for (const suffix of ["", "-shm", "-wal"]) {

--- a/packages/gateway/test/recall-openai-stream.test.ts
+++ b/packages/gateway/test/recall-openai-stream.test.ts
@@ -88,10 +88,10 @@ function openAIFinalJSON(): Response {
   });
 }
 
-let teardownFn: (() => void) | undefined;
+let teardownFn: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  teardownFn?.();
+afterEach(async () => {
+  await teardownFn?.();
   teardownFn = undefined;
 });
 
@@ -132,11 +132,13 @@ describe("recall interception — OpenAI streaming path", () => {
     });
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       setUpstreamInterceptor(undefined);
       for (const suffix of ["", "-shm", "-wal"]) {

--- a/packages/gateway/test/remote-attribution.test.ts
+++ b/packages/gateway/test/remote-attribution.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { Harness } from "./helpers/harness";
-import { createHarness } from "./helpers/harness";
+import { createHarness, TEST_GATEWAY_AUTH_TOKEN } from "./helpers/harness";
 import {
   makeConversationFixtures,
   STANDARD_TOOLS,
@@ -35,22 +35,18 @@ function pathlessBody(userMessage: string): Record<string, unknown> {
 
 describe("remote gateway: path-less session attribution", () => {
   let harness: Harness;
-  let prevRemote: string | undefined;
-
-  beforeEach(() => {
-    prevRemote = process.env.LORE_REMOTE_GATEWAY;
-    process.env.LORE_REMOTE_GATEWAY = "1";
-  });
 
   afterEach(async () => {
     if (harness) await harness.teardown();
-    if (prevRemote === undefined) delete process.env.LORE_REMOTE_GATEWAY;
-    else process.env.LORE_REMOTE_GATEWAY = prevRemote;
   });
 
   it("routes two unrelated path-less sessions to DISTINCT buckets (never merged)", async () => {
     // Two unrelated conversations → two fingerprints → two sessions.
     harness = await createHarness({
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
       fixtures: [
         ...makeConversationFixtures([
           { userMessage: "alpha project question one", assistantText: "A1." },
@@ -66,7 +62,10 @@ describe("remote gateway: path-less session attribution", () => {
 
     // Suppress the harness default x-lore-project header — this test
     // intentionally sends path-less requests.
-    const noProject = { "x-lore-project": "" };
+    const noProject = {
+      "x-lore-project": "",
+      "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+    };
     const r1 = await harness.chat(
       pathlessBody("alpha project question one"),
       "test-key",

--- a/packages/gateway/test/remote-session-tenant-binding.e2e.test.ts
+++ b/packages/gateway/test/remote-session-tenant-binding.e2e.test.ts
@@ -1,0 +1,586 @@
+/**
+ * End-to-end regression coverage for authenticated session identity on a
+ * remote gateway. Client-provided session/project headers are not tenant IDs:
+ * two credentials may send identical values and must still receive isolated
+ * Lore sessions, prompts, persistence, and background-worker credentials.
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { resolveAuth } from "../src/auth";
+import type { Harness } from "./helpers/harness";
+import { createHarness, TEST_GATEWAY_AUTH_TOKEN } from "./helpers/harness";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  makeFixtureEntry,
+  STANDARD_TOOLS,
+} from "./helpers/fixtures";
+
+const SHARED_SESSION = "shared-client-session-1234";
+const SHARED_PROJECT = "/remote/shared-project";
+const PRIVATE_A = "tenant A private prompt: rotate the alpha signing key";
+const PRIVATE_B = "tenant B private prompt: investigate the beta payroll job";
+const FOLLOW_UP_A = "tenant A follow-up: add the alpha regression test";
+
+function body(messages: Array<{ role: string; content: string }>) {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages,
+    tools: STANDARD_TOOLS,
+  };
+}
+
+function fixtures(count = 3) {
+  return Array.from({ length: count }, (_, seq) =>
+    makeFixtureEntry({
+      seq,
+      requestMessages: [],
+      responseText:
+        seq === 0
+          ? "tenant A response"
+          : seq === 1
+            ? "tenant B response"
+            : `response-${seq}`,
+    }),
+  );
+}
+
+type AuthCase = {
+  name: string;
+  scheme: "api-key" | "bearer";
+  credentialA: string;
+  credentialB: string;
+};
+
+const AUTH_CASES: AuthCase[] = [
+  {
+    name: "API keys",
+    scheme: "api-key",
+    credentialA: "remote-api-key-tenant-A",
+    credentialB: "remote-api-key-tenant-B",
+  },
+  {
+    name: "bearer credentials",
+    scheme: "bearer",
+    credentialA: "remote-bearer-tenant-A",
+    credentialB: "remote-bearer-tenant-B",
+  },
+];
+
+async function chatAs(
+  harness: Harness,
+  requestBody: unknown,
+  authCase: AuthCase,
+  credential: string,
+  clientSessionId = SHARED_SESSION,
+): Promise<Response> {
+  const authHeaders: Record<string, string> =
+    authCase.scheme === "api-key"
+      ? {}
+      : { authorization: `Bearer ${credential}` };
+  return harness.chat(
+    requestBody,
+    authCase.scheme === "api-key" ? credential : null,
+    {
+      "x-lore-session-id": clientSessionId,
+      "x-lore-project": SHARED_PROJECT,
+      "x-lore-tenant": "attacker-controlled-storage-owner",
+      "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+      ...authHeaders,
+    },
+  );
+}
+
+describe("remote authenticated tenant session binding", () => {
+  let harness: Harness | undefined;
+
+  afterEach(async () => {
+    if (harness) await harness.teardown();
+    harness = undefined;
+  });
+
+  test.each(AUTH_CASES)(
+    "isolates identical client headers by $name across a restart",
+    async (authCase) => {
+      harness = await createHarness({
+        fixtures: fixtures(),
+        configOverrides: {
+          remoteGateway: true,
+          gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+        },
+      });
+
+      let response = await chatAs(
+        harness,
+        body([{ role: "user", content: PRIVATE_A }]),
+        authCase,
+        authCase.credentialA,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+
+      response = await chatAs(
+        harness,
+        body([{ role: "user", content: PRIVATE_B }]),
+        authCase,
+        authCase.credentialB,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+
+      const beforeRestart = harness.queryDB<{
+        session_id: string;
+        header_session_id: string;
+        credential_fingerprint: string;
+      }>(
+        `SELECT session_id, header_session_id, credential_fingerprint
+           FROM session_state
+          WHERE header_name = 'x-lore-session-id'
+          ORDER BY session_id`,
+      );
+      expect(beforeRestart).toHaveLength(2);
+      expect(new Set(beforeRestart.map((row) => row.session_id)).size).toBe(2);
+      expect(
+        new Set(beforeRestart.map((row) => row.credential_fingerprint)).size,
+      ).toBe(2);
+      for (const row of beforeRestart) {
+        expect(row.header_session_id).toBe(SHARED_SESSION);
+        expect(row.credential_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+        expect(row.credential_fingerprint).not.toContain(authCase.credentialA);
+        expect(row.credential_fingerprint).not.toContain(authCase.credentialB);
+      }
+
+      const tenantProjects = harness.queryDB<{
+        id: string;
+        tenant_id: string;
+      }>(
+        "SELECT id, tenant_id FROM projects WHERE path = ? ORDER BY tenant_id",
+        [SHARED_PROJECT],
+      );
+      expect(tenantProjects).toHaveLength(2);
+      expect(new Set(tenantProjects.map((row) => row.id)).size).toBe(2);
+      expect(new Set(tenantProjects.map((row) => row.tenant_id))).toEqual(
+        new Set(beforeRestart.map((row) => row.credential_fingerprint)),
+      );
+
+      const promptsBeforeRestart = harness.queryDB<{
+        session_id: string;
+        content: string;
+        project_id: string;
+        tenant_id: string;
+      }>(
+        `SELECT t.session_id, t.content, t.project_id, p.tenant_id
+           FROM temporal_messages t JOIN projects p ON p.id = t.project_id
+          WHERE t.content LIKE '%private prompt%'`,
+      );
+      const promptA = promptsBeforeRestart.find((row) =>
+        row.content.includes(PRIVATE_A),
+      );
+      const promptB = promptsBeforeRestart.find((row) =>
+        row.content.includes(PRIVATE_B),
+      );
+      const sidA = promptA?.session_id;
+      const sidB = promptB?.session_id;
+      expect(sidA).toBeTruthy();
+      expect(sidB).toBeTruthy();
+      expect(sidA).not.toBe(sidB);
+      expect(promptA?.project_id).not.toBe(promptB?.project_id);
+      expect(promptA?.tenant_id).not.toBe(promptB?.tenant_id);
+
+      expect(resolveAuth(sidA, "anthropic")).toEqual({
+        scheme: authCase.scheme,
+        value: authCase.credentialA,
+      });
+      expect(resolveAuth(sidB, "anthropic")).toEqual({
+        scheme: authCase.scheme,
+        value: authCase.credentialB,
+      });
+
+      await harness.restartPipeline();
+
+      response = await chatAs(
+        harness,
+        body([
+          { role: "user", content: PRIVATE_A },
+          { role: "assistant", content: "tenant A response" },
+          { role: "user", content: FOLLOW_UP_A },
+        ]),
+        authCase,
+        authCase.credentialA,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+
+      const afterRestart = harness.queryDB<{ session_id: string }>(
+        `SELECT session_id
+           FROM session_state
+          WHERE header_name = 'x-lore-session-id'
+          ORDER BY session_id`,
+      );
+      expect(afterRestart).toHaveLength(2);
+      expect(afterRestart.map((row) => row.session_id)).toContain(sidA);
+      expect(afterRestart.map((row) => row.session_id)).toContain(sidB);
+      expect(
+        harness.queryDB("SELECT id FROM projects WHERE path = ?", [
+          SHARED_PROJECT,
+        ]),
+      ).toHaveLength(2);
+
+      const allPrivatePrompts = harness.queryDB<{
+        session_id: string;
+        content: string;
+      }>("SELECT session_id, content FROM temporal_messages");
+      const aContent = allPrivatePrompts
+        .filter((row) => row.session_id === sidA)
+        .map((row) => row.content)
+        .join("\n");
+      const bContent = allPrivatePrompts
+        .filter((row) => row.session_id === sidB)
+        .map((row) => row.content)
+        .join("\n");
+      expect(aContent).toContain(PRIVATE_A);
+      expect(aContent).toContain(FOLLOW_UP_A);
+      expect(aContent).not.toContain(PRIVATE_B);
+      expect(bContent).toContain(PRIVATE_B);
+      expect(bContent).not.toContain(PRIVATE_A);
+
+      // The restart clears every worker key, then the resumed turn repopulates
+      // only tenant A's credential.
+      expect(resolveAuth(sidA, "anthropic")).toEqual({
+        scheme: authCase.scheme,
+        value: authCase.credentialA,
+      });
+      expect(resolveAuth(sidB, "anthropic")).toBeNull();
+    },
+  );
+
+  test("preserves provider-specific credentials inside one remote tenant session", async () => {
+    harness = await createHarness({
+      fixtures: fixtures(2),
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+
+    let response = await harness.chat(
+      body([{ role: "user", content: PRIVATE_A }]),
+      AUTH_CASES[0].credentialA,
+      {
+        "x-lore-session-id": SHARED_SESSION,
+        "x-lore-project": SHARED_PROJECT,
+        "x-lore-provider": "anthropic",
+        "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+      },
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    response = await harness.chat(
+      body([
+        { role: "user", content: PRIVATE_A },
+        { role: "assistant", content: "tenant A response" },
+        { role: "user", content: FOLLOW_UP_A },
+      ]),
+      AUTH_CASES[0].credentialA,
+      {
+        "x-lore-session-id": SHARED_SESSION,
+        "x-lore-project": SHARED_PROJECT,
+        "x-lore-provider": "openai",
+        "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+      },
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    const rows = harness.queryDB<{ session_id: string }>(
+      "SELECT session_id FROM session_state WHERE header_name = 'x-lore-session-id'",
+    );
+    expect(rows).toHaveLength(1);
+    expect(resolveAuth(rows[0].session_id, "anthropic")).toEqual({
+      scheme: "api-key",
+      value: AUTH_CASES[0].credentialA,
+    });
+    expect(resolveAuth(rows[0].session_id, "openai")).toEqual({
+      scheme: "api-key",
+      value: AUTH_CASES[0].credentialA,
+    });
+  });
+
+  test("retains tenant ownership through streamed completion callbacks", async () => {
+    harness = await createHarness({
+      fixtures: fixtures(2),
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+    const authCase = AUTH_CASES[0];
+
+    for (const [credential, content] of [
+      [authCase.credentialA, PRIVATE_A],
+      [authCase.credentialB, PRIVATE_B],
+    ]) {
+      const response = await chatAs(
+        harness,
+        { ...body([{ role: "user", content }]), stream: true },
+        authCase,
+        credential,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+
+    const rows = harness.queryDB<{
+      content: string;
+      project_id: string;
+      tenant_id: string;
+    }>(
+      `SELECT t.content, t.project_id, p.tenant_id
+         FROM temporal_messages t JOIN projects p ON p.id = t.project_id
+        WHERE t.content LIKE '%private prompt%'`,
+    );
+    const rowA = rows.find((row) => row.content.includes(PRIVATE_A));
+    const rowB = rows.find((row) => row.content.includes(PRIVATE_B));
+    expect(rowA?.project_id).toBeTruthy();
+    expect(rowB?.project_id).toBeTruthy();
+    expect(rowA?.project_id).not.toBe(rowB?.project_id);
+    expect(rowA?.tenant_id).not.toBe(rowB?.tenant_id);
+  });
+
+  test("fails closed instead of adopting an unbound historical mapping", async () => {
+    harness = await createHarness({
+      fixtures: fixtures(1),
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+    const historicalSid = "historical-unbound-remote-session";
+    const database = new DatabaseSync(harness.dbPath);
+    try {
+      database
+        .prepare(
+          `INSERT INTO session_state
+             (session_id, force_min_layer, updated_at, header_name, header_session_id)
+           VALUES (?, 0, ?, 'x-lore-session-id', ?)`,
+        )
+        .run(historicalSid, Date.now(), SHARED_SESSION);
+    } finally {
+      database.close();
+    }
+
+    await harness.restartPipeline();
+    const response = await chatAs(
+      harness,
+      body([{ role: "user", content: PRIVATE_A }]),
+      AUTH_CASES[0],
+      AUTH_CASES[0].credentialA,
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    const rows = harness.queryDB<{
+      session_id: string;
+      credential_fingerprint: string;
+    }>(
+      `SELECT session_id, credential_fingerprint
+         FROM session_state
+        WHERE header_name = 'x-lore-session-id'
+        ORDER BY session_id`,
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows).toContainEqual({
+      session_id: historicalSid,
+      credential_fingerprint: "",
+    });
+    const fresh = rows.find((row) => row.session_id !== historicalSid);
+    expect(fresh?.credential_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+    expect(resolveAuth(historicalSid, "anthropic")).toBeNull();
+  });
+
+  test("adopts a resumed conversation only within the same remote credential", async () => {
+    harness = await createHarness({
+      fixtures: fixtures(),
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+    const authCase = AUTH_CASES[0];
+
+    let response = await chatAs(
+      harness,
+      body([{ role: "user", content: PRIVATE_A }]),
+      authCase,
+      authCase.credentialA,
+      "remote-session-before-restart",
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+    response = await chatAs(
+      harness,
+      body([
+        { role: "user", content: PRIVATE_A },
+        { role: "assistant", content: "tenant A response" },
+        { role: "user", content: FOLLOW_UP_A },
+      ]),
+      authCase,
+      authCase.credentialA,
+      "remote-session-before-restart",
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    const original = harness.queryDB<{ session_id: string }>(
+      "SELECT session_id FROM session_state WHERE header_name = 'x-lore-session-id'",
+    );
+    expect(original).toHaveLength(1);
+    await harness.restartPipeline();
+
+    response = await chatAs(
+      harness,
+      body([
+        { role: "user", content: PRIVATE_A },
+        { role: "assistant", content: "tenant A response" },
+        { role: "user", content: FOLLOW_UP_A },
+        { role: "assistant", content: "tenant A follow-up response" },
+        { role: "user", content: "tenant A third turn after restart" },
+      ]),
+      authCase,
+      authCase.credentialA,
+      "remote-session-after-restart",
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    const resumed = harness.queryDB<{
+      session_id: string;
+      header_session_id: string;
+      credential_fingerprint: string;
+    }>(
+      `SELECT session_id, header_session_id, credential_fingerprint
+         FROM session_state
+        WHERE header_name = 'x-lore-session-id'`,
+    );
+    expect(resumed).toHaveLength(1);
+    expect(resumed[0].session_id).toBe(original[0].session_id);
+    expect(resumed[0].header_session_id).toBe("remote-session-after-restart");
+    expect(resumed[0].credential_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("never adopts another credential's persisted conversation after restart", async () => {
+    harness = await createHarness({
+      fixtures: fixtures(),
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+    const authCase = AUTH_CASES[0];
+
+    let response = await chatAs(
+      harness,
+      body([{ role: "user", content: PRIVATE_A }]),
+      authCase,
+      authCase.credentialA,
+      "tenant-a-before-restart",
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+    response = await chatAs(
+      harness,
+      body([
+        { role: "user", content: PRIVATE_A },
+        { role: "assistant", content: "tenant A response" },
+        { role: "user", content: FOLLOW_UP_A },
+      ]),
+      authCase,
+      authCase.credentialA,
+      "tenant-a-before-restart",
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    await harness.restartPipeline();
+    response = await chatAs(
+      harness,
+      body([
+        { role: "user", content: PRIVATE_A },
+        { role: "assistant", content: "tenant A response" },
+        { role: "user", content: FOLLOW_UP_A },
+        { role: "assistant", content: "tenant A follow-up response" },
+        { role: "user", content: "resumed history sent by tenant B" },
+      ]),
+      authCase,
+      authCase.credentialB,
+      "tenant-b-after-restart",
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    const rows = harness.queryDB<{ session_id: string }>(
+      "SELECT session_id FROM session_state WHERE header_name = 'x-lore-session-id'",
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((row) => row.session_id)).size).toBe(2);
+  });
+
+  test("does not correlate unauthenticated remote requests by client headers", async () => {
+    harness = await createHarness({
+      fixtures: fixtures(2),
+      configOverrides: {
+        remoteGateway: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+    const headers = {
+      "x-lore-session-id": SHARED_SESSION,
+      "x-lore-project": SHARED_PROJECT,
+      "x-lore-tenant": "attacker-controlled-storage-owner",
+      "x-lore-gateway-token": TEST_GATEWAY_AUTH_TOKEN,
+    };
+
+    let response = await harness.chat(
+      body([{ role: "user", content: PRIVATE_A }]),
+      null,
+      headers,
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+    response = await harness.chat(
+      body([{ role: "user", content: PRIVATE_B }]),
+      null,
+      headers,
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    const rows = harness.queryDB<{
+      session_id: string;
+      header_session_id: string | null;
+      credential_fingerprint: string;
+    }>(
+      "SELECT session_id, header_session_id, credential_fingerprint FROM session_state",
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((row) => row.session_id)).size).toBe(2);
+    expect(rows.every((row) => row.header_session_id === null)).toBe(true);
+    expect(rows.every((row) => row.credential_fingerprint === "")).toBe(true);
+    const projects = harness.queryDB<{ tenant_id: string }>(
+      "SELECT tenant_id FROM projects WHERE path = ?",
+      [SHARED_PROJECT],
+    );
+    expect(projects).toHaveLength(2);
+    expect(new Set(projects.map((row) => row.tenant_id)).size).toBe(2);
+    expect(projects.every((row) => row.tenant_id.length > 0)).toBe(true);
+    expect(
+      projects.every(
+        (row) => row.tenant_id !== "attacker-controlled-storage-owner",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/gateway/test/remote-warming-admin.e2e.test.ts
+++ b/packages/gateway/test/remote-warming-admin.e2e.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+import {
+  _resetForTest,
+  checkCircuitBreaker,
+  isCircuitBreakerTripped,
+  isWarmingEnabled,
+  resetCircuitBreaker,
+  setWarmingEnabled,
+} from "../src/cache-warmer";
+import {
+  createHarness,
+  TEST_GATEWAY_AUTH_TOKEN,
+  type Harness,
+} from "./helpers/harness";
+import { DEFAULT_MODEL } from "./helpers/fixtures";
+
+const ACCESS_HEADER = "x-lore-gateway-token";
+const TENANTS = ["tenant-a-provider-key", "tenant-b-provider-key"] as const;
+const BUCKETS = [
+  "tenant-a\x1fmodel\x1fupstream",
+  "tenant-b\x1fmodel\x1fupstream",
+];
+
+function slashBody(command: string): Record<string, unknown> {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 64,
+    messages: [{ role: "user", content: command }],
+  };
+}
+
+function tripBreakers(): void {
+  const miss = {
+    ok: true,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 1,
+  };
+  for (const bucket of BUCKETS) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      checkCircuitBreaker(miss, bucket, true);
+    }
+    expect(isCircuitBreakerTripped(bucket)).toBe(true);
+  }
+}
+
+describe("remote warming administration isolation", () => {
+  let harness: Harness;
+
+  beforeAll(async () => {
+    harness = await createHarness({
+      fixtures: [],
+      configOverrides: {
+        remoteGateway: true,
+        hostedMode: true,
+        gatewayAuthToken: TEST_GATEWAY_AUTH_TOKEN,
+      },
+    });
+  });
+
+  afterEach(() => {
+    setWarmingEnabled(true);
+    _resetForTest();
+  });
+
+  afterAll(async () => {
+    setWarmingEnabled(true);
+    resetCircuitBreaker();
+    await harness.teardown();
+  });
+
+  test.each([
+    [TENANTS[0], TENANTS[1]],
+    [TENANTS[1], TENANTS[0]],
+  ])(
+    "rejects two tenants in provider-key order %s then %s",
+    async (first, second) => {
+      setWarmingEnabled(false);
+      for (const tenant of [first, second]) {
+        const response = await harness.chat(
+          slashBody("/lore:warm:on"),
+          tenant,
+          { [ACCESS_HEADER]: TEST_GATEWAY_AUTH_TOKEN },
+        );
+        expect(response.status).toBe(403);
+        expect(await response.text()).toContain(
+          "Global cache-warming administration is unavailable",
+        );
+        expect(isWarmingEnabled()).toBe(false);
+      }
+
+      setWarmingEnabled(true);
+      for (const tenant of [first, second]) {
+        const response = await harness.chat(
+          slashBody("/lore:warm:off"),
+          tenant,
+          { [ACCESS_HEADER]: TEST_GATEWAY_AUTH_TOKEN },
+        );
+        expect(response.status).toBe(403);
+        await response.body?.cancel();
+        expect(isWarmingEnabled()).toBe(true);
+      }
+
+      tripBreakers();
+      for (const tenant of [first, second]) {
+        const response = await harness.chat(
+          slashBody("/lore:warm:reset"),
+          tenant,
+          { [ACCESS_HEADER]: TEST_GATEWAY_AUTH_TOKEN },
+        );
+        expect(response.status).toBe(403);
+        await response.body?.cancel();
+        for (const bucket of BUCKETS) {
+          expect(isCircuitBreakerTripped(bucket)).toBe(true);
+        }
+      }
+    },
+  );
+
+  test.each(["/lore:warm:on", "/lore:warm:off", "/lore:warm:reset"])(
+    "rejects gateway-token-only request for %s",
+    async (command) => {
+      setWarmingEnabled(false);
+      tripBreakers();
+
+      const response = await harness.chat(slashBody(command), null, {
+        [ACCESS_HEADER]: TEST_GATEWAY_AUTH_TOKEN,
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.text()).toContain(
+        "Global cache-warming administration is unavailable",
+      );
+      expect(isWarmingEnabled()).toBe(false);
+      for (const bucket of BUCKETS) {
+        expect(isCircuitBreakerTripped(bucket)).toBe(true);
+      }
+    },
+  );
+});

--- a/packages/gateway/test/responses-compact-routing.test.ts
+++ b/packages/gateway/test/responses-compact-routing.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MockAgent } from "undici";
+import { loadConfig } from "../src/config";
+import {
+  handleResponsesCompactEndpoint,
+  resetPipelineState,
+} from "../src/pipeline";
+import { setUpstreamDispatcherForTest } from "../src/fetch";
+
+describe("Responses compact fallback routing", () => {
+  let mock: MockAgent | undefined;
+
+  afterEach(async () => {
+    setUpstreamDispatcherForTest(null);
+    await mock?.close();
+    mock = undefined;
+    await resetPipelineState({ fast: true });
+  });
+
+  it("routes provider-selected compact fallback to the provider endpoint", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let receivedAuthorization = "";
+    mock
+      .get("https://chatgpt.com")
+      .intercept({
+        path: "/backend-api/codex/responses/compact",
+        method: "POST",
+      })
+      .reply((opts) => {
+        const headers = opts.headers as Record<string, string>;
+        receivedAuthorization = headers.authorization ?? "";
+        return {
+          statusCode: 200,
+          data: JSON.stringify({ output: [] }),
+          responseOptions: {
+            headers: { "content-type": "application/json" },
+          },
+        };
+      });
+    setUpstreamDispatcherForTest(mock);
+
+    const response = await handleResponsesCompactEndpoint(
+      new Request("http://gateway.test/v1/responses/compact", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer codex-session-token",
+          "content-type": "application/json",
+          "x-lore-provider": "openai-codex",
+          "x-lore-project": "/tmp/lore-compact-provider-routing",
+        },
+        body: JSON.stringify({
+          model: "gpt-5.4",
+          input: [{ type: "message", role: "user", content: "compact" }],
+        }),
+      }),
+      loadConfig(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(receivedAuthorization).toBe("Bearer codex-session-token");
+  });
+
+  it("honors a safe custom compact endpoint without leaking admin extras", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let capturedHeaders: Record<string, string> = {};
+    mock
+      .get("https://compact.corp.example")
+      .intercept({ path: "/custom/responses/compact", method: "POST" })
+      .reply((opts) => {
+        capturedHeaders = opts.headers as Record<string, string>;
+        return {
+          statusCode: 200,
+          data: JSON.stringify({ output: [] }),
+          responseOptions: {
+            headers: { "content-type": "application/json" },
+          },
+        };
+      });
+    setUpstreamDispatcherForTest(mock);
+
+    const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
+    config.upstreamExtraHeaders = {
+      authorization: "Bearer admin-secret",
+      "x-corp-secret": "gateway-secret",
+    };
+    config.upstreamExtraHeaderBases = ["https://api.openai.com"];
+
+    const response = await handleResponsesCompactEndpoint(
+      new Request("http://gateway.test/v1/responses/compact", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer client-token",
+          "content-type": "application/json",
+          "x-lore-provider": "openai",
+          "x-lore-upstream-url": "https://compact.corp.example/custom",
+          "x-lore-upstream-path": "/custom/responses/compact",
+          "x-lore-project": "/tmp/lore-compact-custom-routing",
+        },
+        body: JSON.stringify({
+          model: "gpt-5.4",
+          input: [{ type: "message", role: "user", content: "compact" }],
+        }),
+      }),
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedHeaders.authorization).toBe("Bearer client-token");
+    expect(capturedHeaders["x-corp-secret"]).toBeUndefined();
+  });
+
+  it("fails closed when a compact request has a provider with no endpoint", async () => {
+    const response = await handleResponsesCompactEndpoint(
+      new Request("http://gateway.test/v1/responses/compact", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer provider-token",
+          "content-type": "application/json",
+          "x-lore-provider": "vllm",
+        },
+        body: JSON.stringify({
+          model: "custom-model",
+          input: [{ type: "message", role: "user", content: "compact" }],
+        }),
+      }),
+      loadConfig(),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: "compaction_routing_failed",
+    });
+  });
+
+  it("rejects conflicting auth before reading or routing compact input", async () => {
+    const response = await handleResponsesCompactEndpoint(
+      new Request("http://gateway.test/v1/responses/compact", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer bearer-token",
+          "x-api-key": "api-key-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ model: "gpt-5.4", input: [] }),
+      }),
+      loadConfig(),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(
+      "Conflicting authentication headers",
+    );
+  });
+});

--- a/packages/gateway/test/routing-log-redaction.test.ts
+++ b/packages/gateway/test/routing-log-redaction.test.ts
@@ -1,0 +1,261 @@
+import { log } from "@loreai/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../src/config";
+import {
+  handleRequest,
+  resetPipelineState,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+import type { GatewayRequest } from "../src/translate/types";
+import { _setModelDataForTest } from "../src/worker-model";
+
+const silentSink = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  captureException: vi.fn(),
+};
+
+afterEach(async () => {
+  setUpstreamInterceptor(undefined);
+  log.registerSink(silentSink);
+  await resetPipelineState({ fast: true });
+});
+
+describe("routing log credential redaction", () => {
+  it("records only the auth scheme, never credential bytes", async () => {
+    const credential = "routing-secret-prefix-and-suffix";
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: vi.fn(),
+      error: vi.fn(),
+      captureException: vi.fn(),
+    });
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "resp_routing_log",
+            object: "response",
+            status: "completed",
+            model: "gpt-5.4",
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const request: GatewayRequest = {
+      protocol: "openai-responses",
+      model: "gpt-5.4",
+      system: "Generate a short title for this conversation.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "title me" }] },
+      ],
+      tools: [],
+      stream: false,
+      maxTokens: 64,
+      metadata: {},
+      rawHeaders: { authorization: `Bearer ${credential}` },
+    };
+
+    const response = await handleRequest(request, loadConfig());
+
+    expect(response.status).toBe(200);
+    const routingMessage = messages.find((message) =>
+      message.startsWith("upstream:"),
+    );
+    expect(routingMessage).toContain("scheme=bearer");
+    expect(routingMessage).not.toContain(credential);
+    expect(routingMessage).not.toContain(credential.slice(0, 8));
+  });
+
+  it("strips userinfo, query values, and fragments from routing URLs", async () => {
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: vi.fn(),
+      error: vi.fn(),
+      captureException: vi.fn(),
+    });
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "msg_route_url",
+            type: "message",
+            role: "assistant",
+            model: "claude-test",
+            content: [{ type: "text", text: "ok" }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const config = loadConfig();
+    config.upstreamAnthropic =
+      "https://user:LOCAL_LOG_SECRET@example.com/custom?code=QUERY_LOG_SECRET#FRAGMENT_SECRET";
+    const response = await handleRequest(
+      {
+        protocol: "anthropic",
+        model: "unrouted-model",
+        system: "You are a coding assistant.",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hello" }] },
+        ],
+        tools: [],
+        stream: false,
+        maxTokens: 64,
+        metadata: {},
+        rawHeaders: {
+          "x-lore-agent": "coder",
+          "x-lore-project": process.cwd(),
+        },
+      },
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    const output = messages.join("\n");
+    expect(output).toContain("https://example.com/custom");
+    expect(output).not.toContain("LOCAL_LOG_SECRET");
+    expect(output).not.toContain("QUERY_LOG_SECRET");
+    expect(output).not.toContain("FRAGMENT_SECRET");
+  });
+
+  it("never logs an upstream response body", async () => {
+    const privateBodyMarker = "PRIVATE_UPSTREAM_RESPONSE_BODY_MARKER";
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      captureException: vi.fn(),
+    });
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          JSON.stringify({ error: { message: privateBodyMarker } }),
+          { status: 500, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const request: GatewayRequest = {
+      protocol: "anthropic",
+      model: "claude-test",
+      system: "You are a coding assistant.",
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      tools: [],
+      stream: false,
+      maxTokens: 64,
+      metadata: {},
+      rawHeaders: { "x-lore-agent": "coder" },
+    };
+
+    const response = await handleRequest(request, loadConfig());
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).toContain(privateBodyMarker);
+    expect(messages.join("\n")).not.toContain(privateBodyMarker);
+  });
+
+  it("never logs malformed successful upstream text or statusText", async () => {
+    const privateBodyMarker = "PRIVATE_MALFORMED_FOREGROUND_BODY_MARKER";
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      captureException: vi.fn(),
+    });
+    setUpstreamInterceptor(
+      async () =>
+        new Response(`${privateBodyMarker} not-json`, {
+          status: 200,
+          statusText: "PRIVATE_FOREGROUND_REASON_MARKER",
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const request: GatewayRequest = {
+      protocol: "anthropic",
+      model: "claude-test",
+      system: "You are a coding assistant.",
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      tools: [],
+      stream: false,
+      maxTokens: 64,
+      metadata: {},
+      rawHeaders: { "x-lore-agent": "coder" },
+    };
+
+    const response = await handleRequest(request, loadConfig());
+
+    expect(response.status).toBe(502);
+    const output = messages.join("\n");
+    expect(output).toContain("pipeline request failed");
+    expect(output).not.toContain(privateBodyMarker);
+    expect(output).not.toContain("PRIVATE_FOREGROUND_REASON_MARKER");
+  });
+
+  it("sanitizes the configured worker initialization URL", async () => {
+    const userinfoMarker = "PRIVATE_WORKER_INIT_USERINFO";
+    const queryMarker = "PRIVATE_WORKER_INIT_QUERY";
+    const fragmentMarker = "PRIVATE_WORKER_INIT_FRAGMENT";
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      captureException: vi.fn(),
+    });
+    const config = loadConfig();
+    config.workerUpstream =
+      `https://user:${userinfoMarker}@worker.example/custom` +
+      `?token=${queryMarker}#${fragmentMarker}`;
+
+    await resetPipelineState({ fast: true });
+    _setModelDataForTest({});
+    let intercepted = false;
+    setUpstreamInterceptor(async () => {
+      intercepted = true;
+      return new Response(
+        JSON.stringify({
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const response = await handleRequest(
+      {
+        protocol: "anthropic",
+        model: "claude-test",
+        system: "You are a coding assistant.",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hello" }] },
+        ],
+        tools: [],
+        stream: false,
+        maxTokens: 64,
+        metadata: {},
+        rawHeaders: {
+          "x-lore-agent": "coder",
+          "x-lore-project": process.cwd(),
+        },
+      },
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    expect(intercepted).toBe(true);
+    const output = messages.join("\n");
+    expect(output).toContain("worker routing:");
+    expect(output).toContain("source=session");
+    expect(output).toContain("https://worker.example/custom");
+    expect(output).not.toContain(userinfoMarker);
+    expect(output).not.toContain(queryMarker);
+    expect(output).not.toContain(fragmentMarker);
+  });
+});

--- a/packages/gateway/test/run-shutdown-race.test.ts
+++ b/packages/gateway/test/run-shutdown-race.test.ts
@@ -1,0 +1,72 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  maybeAutoImport: vi.fn(),
+  startGateway: vi.fn(),
+  safeExit: vi.fn((code: number) => {
+    throw new Error(`__safeExit__:${code}`);
+  }),
+  forcedExit: vi.fn((code: number) => {
+    throw new Error(`__forcedExit__:${code}`);
+  }),
+}));
+
+vi.mock("node:child_process", () => ({ spawn: mocks.spawn }));
+vi.mock("../src/cli/import-auto", () => ({
+  maybeAutoImport: mocks.maybeAutoImport,
+}));
+vi.mock("../src/cli/exit", () => ({
+  safeExit: mocks.safeExit,
+  forcedExit: mocks.forcedExit,
+}));
+vi.mock("../src/cli/start", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/cli/start")>();
+  return { ...original, startGateway: mocks.startGateway };
+});
+
+import { commandRun } from "../src/cli/run";
+import { makeProcessShutdownController } from "../src/cli/shutdown";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("commandRun shutdown ordering", () => {
+  test("authenticated shutdown during auto-import prevents a later child spawn", async () => {
+    const shutdown = vi.fn(async () => {});
+    const controller = makeProcessShutdownController(shutdown, {
+      deadlineMs: 1000,
+      safeExit: mocks.safeExit,
+      forcedExit: mocks.forcedExit,
+    });
+    let shutdownRequest: Promise<never> | undefined;
+    mocks.startGateway.mockResolvedValue({
+      config: {
+        hosts: ["127.0.0.1"],
+        port: 3207,
+        debug: false,
+      },
+      port: 3207,
+      owned: true,
+      shutdown,
+      processShutdown: controller,
+    });
+    mocks.maybeAutoImport.mockImplementation(async () => {
+      // Adversarial order: publication already exposed authenticated control,
+      // which starts teardown while commandRun is suspended at this await.
+      shutdownRequest = controller(0);
+    });
+    mocks.spawn.mockReturnValue(Object.assign(new EventEmitter(), { pid: 42 }));
+
+    await expect(commandRun({}, ["test-agent"])).rejects.toThrow(
+      "__safeExit__:0",
+    );
+    await expect(shutdownRequest).rejects.toThrow("__safeExit__:0");
+    expect(controller.isShutdownStarted()).toBe(true);
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gateway/test/run-upstream-adoption.test.ts
+++ b/packages/gateway/test/run-upstream-adoption.test.ts
@@ -22,12 +22,15 @@ const GATEWAY = "http://127.0.0.1:3207";
 // Env keys the adoption logic reads/writes — save + restore around each test.
 const TOUCHED_ENV = [
   "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_CUSTOM_HEADERS",
   "OPENAI_BASE_URL",
   "GOOGLE_GEMINI_BASE_URL",
   "COPILOT_API_URL",
   "LORE_UPSTREAM_ANTHROPIC",
   "LORE_UPSTREAM_OPENAI",
   "LORE_UPSTREAM_OPENROUTER",
+  "LORE_GATEWAY_AUTH_TOKEN",
+  "LORE_REMOTE_URL",
 ];
 
 describe("lore run upstream adoption", () => {
@@ -213,6 +216,77 @@ describe("resolveLaunchTarget", () => {
     // Env merged from all agents includes Claude Code's base URL too (harmless).
     expect(target.env.ANTHROPIC_BASE_URL).toBe(GATEWAY);
   });
+
+  test("remote Claude launch uses an env/header, never a URL or CLI argument, for gateway access", () => {
+    const token = "remote-launch-gateway-access-token-at-least-32";
+    process.env.LORE_GATEWAY_AUTH_TOKEN = token;
+    const target = resolveLaunchTarget(
+      { command: "claude", def: claude },
+      "https://lore.example",
+      ["claude"],
+      [],
+      null,
+      true,
+    );
+
+    expect(target.env.LORE_REMOTE_URL).toBe("https://lore.example");
+    expect(target.env.ANTHROPIC_CUSTOM_HEADERS).toContain(
+      `x-lore-gateway-token: ${token}`,
+    );
+    expect(target.args.join(" ")).not.toContain(token);
+    expect(target.env.LORE_REMOTE_URL).not.toContain(token);
+  });
+
+  test("remote Claude launch replaces an inherited gateway token header", () => {
+    const token = "replacement-gateway-access-token-at-least-32";
+    process.env.LORE_GATEWAY_AUTH_TOKEN = token;
+    process.env.ANTHROPIC_CUSTOM_HEADERS =
+      "X-Lore-Gateway-Token: stale-token\nX-Custom: retain-me";
+
+    const target = resolveLaunchTarget(
+      { command: "claude", def: claude },
+      "https://lore.example",
+      ["claude"],
+      [],
+      null,
+      true,
+    );
+
+    const headers = target.env.ANTHROPIC_CUSTOM_HEADERS.split("\n");
+    expect(
+      headers.filter((line) => {
+        const colonIndex = line.indexOf(":");
+        return (
+          colonIndex >= 0 &&
+          line.slice(0, colonIndex).trim().toLowerCase() ===
+            "x-lore-gateway-token"
+        );
+      }),
+    ).toEqual([`x-lore-gateway-token: ${token}`]);
+    expect(headers).toContain("X-Custom: retain-me");
+    expect(target.args.join(" ")).not.toContain(token);
+  });
+
+  test.each(["pi", "opencode"])(
+    "remote %s launch exposes LORE_REMOTE_URL for its adapter without putting the token in args",
+    (binary) => {
+      const token = "remote-adapter-gateway-token-at-least-32";
+      process.env.LORE_GATEWAY_AUTH_TOKEN = token;
+      const def = AGENTS.find((agent) => agent.binary === binary);
+      if (!def) throw new Error(`missing ${binary} agent definition`);
+      const target = resolveLaunchTarget(
+        { command: binary, def },
+        "https://lore.example",
+        [binary],
+        [],
+        null,
+        true,
+      );
+
+      expect(target.env.LORE_REMOTE_URL).toBe("https://lore.example");
+      expect(target.args.join(" ")).not.toContain(token);
+    },
+  );
 
   test("explicit command: injects adoption headers only for the matching agent", () => {
     const selection = { command: "claude", def: claude };

--- a/packages/gateway/test/runtime-files.test.ts
+++ b/packages/gateway/test/runtime-files.test.ts
@@ -1,0 +1,302 @@
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  readGatewayProcessFile,
+  writeGatewayProcessFile,
+} from "../src/pidfile";
+import { readPortFile, writePortFile } from "../src/portfile";
+import { openDaemonLogFile } from "../src/cli/start";
+import {
+  _setRuntimeFileWindowsSecurityForTest,
+  readRuntimeFile,
+  type RuntimeFileWindowsSecurityRequest,
+  type RuntimeFileWindowsSecurityResult,
+} from "../src/runtime-files";
+
+const RECORD = {
+  version: 1 as const,
+  pid: 4242,
+  port: 3207,
+  hosts: ["127.0.0.1"],
+  token: "a".repeat(32),
+};
+
+describe.skipIf(process.platform === "win32")("gateway runtime files", () => {
+  let base: string;
+  let previousXdg: string | undefined;
+
+  beforeEach(() => {
+    previousXdg = process.env.XDG_DATA_HOME;
+    base = mkdtempSync(join(tmpdir(), "lore-runtime-test-"));
+    process.env.XDG_DATA_HOME = base;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = previousXdg;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const runtimeDir = () => join(base, "lore");
+
+  it("creates owner-only runtime records in an owner-only directory", () => {
+    writePortFile(3207);
+    writeGatewayProcessFile(RECORD);
+    expect(lstatSync(runtimeDir()).mode & 0o777).toBe(0o700);
+    expect(lstatSync(join(runtimeDir(), "gateway.port")).mode & 0o777).toBe(
+      0o600,
+    );
+    expect(lstatSync(join(runtimeDir(), "gateway.pid")).mode & 0o777).toBe(
+      0o600,
+    );
+  });
+
+  it("tightens an existing runtime directory before writing", () => {
+    mkdirSync(runtimeDir(), { recursive: true, mode: 0o777 });
+    chmodSync(runtimeDir(), 0o777);
+    writePortFile(3207);
+    expect(lstatSync(runtimeDir()).mode & 0o777).toBe(0o700);
+  });
+
+  it("rejects a symlink used as the runtime data directory", () => {
+    const target = join(base, "target");
+    mkdirSync(target);
+    symlinkSync(target, runtimeDir(), "dir");
+    expect(() => writePortFile(3207)).toThrow(/non-directory runtime data/);
+    expect(existsSync(join(target, "gateway.port"))).toBe(false);
+  });
+
+  it("atomically replaces runtime-record symlinks without touching targets", () => {
+    mkdirSync(runtimeDir(), { mode: 0o700 });
+    const portTarget = join(base, "victim-port");
+    const pidTarget = join(base, "victim-pid");
+    writeFileSync(portTarget, "preserve port target");
+    writeFileSync(pidTarget, "preserve pid target");
+    symlinkSync(portTarget, join(runtimeDir(), "gateway.port"));
+    symlinkSync(pidTarget, join(runtimeDir(), "gateway.pid"));
+
+    writePortFile(3207);
+    writeGatewayProcessFile(RECORD);
+
+    expect(readFileSync(portTarget, "utf8")).toBe("preserve port target");
+    expect(readFileSync(pidTarget, "utf8")).toBe("preserve pid target");
+    expect(lstatSync(join(runtimeDir(), "gateway.port")).isSymbolicLink()).toBe(
+      false,
+    );
+    expect(lstatSync(join(runtimeDir(), "gateway.pid")).isSymbolicLink()).toBe(
+      false,
+    );
+    expect(readPortFile()).toBe(3207);
+    expect(readGatewayProcessFile()).toEqual(RECORD);
+  });
+
+  it("appends to an existing log and tightens its permissions", () => {
+    mkdirSync(runtimeDir(), { mode: 0o700 });
+    const logPath = join(runtimeDir(), "gateway.log");
+    writeFileSync(logPath, "before");
+    chmodSync(logPath, 0o666);
+    const fd = openDaemonLogFile();
+    try {
+      writeSync(fd, " after");
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(logPath, "utf8")).toBe("before after");
+    expect(lstatSync(logPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects unsafe daemon log targets", () => {
+    mkdirSync(runtimeDir(), { mode: 0o700 });
+    const target = join(base, "victim.log");
+    writeFileSync(target, "preserve");
+    symlinkSync(target, join(runtimeDir(), "gateway.log"));
+    expect(() => openDaemonLogFile()).toThrow(/non-regular runtime file/);
+    expect(readFileSync(target, "utf8")).toBe("preserve");
+  });
+
+  it("rejects runtime paths owned by another user", () => {
+    if (typeof process.getuid !== "function") return;
+    mkdirSync(runtimeDir(), { mode: 0o700 });
+    const uid = process.getuid();
+    vi.spyOn(process, "getuid").mockReturnValue(uid + 1);
+    expect(() => writePortFile(3207)).toThrow(/not owned by the current user/);
+  });
+});
+
+const WINDOWS_PRIVATE_RESULT: RuntimeFileWindowsSecurityResult = {
+  status: 0,
+  signal: null,
+  stdout: "LORE_RUNTIME_ACL_PRIVATE\n",
+  stderr: "",
+};
+
+describe("Windows gateway runtime ACLs", () => {
+  let base: string;
+  let customDataHome: string;
+  let previousXdg: string | undefined;
+
+  beforeEach(() => {
+    previousXdg = process.env.XDG_DATA_HOME;
+    base = mkdtempSync(join(tmpdir(), "lore-windows-runtime-test-"));
+    customDataHome = join(base, "User & (private)! data");
+    mkdirSync(customDataHome);
+    process.env.XDG_DATA_HOME = customDataHome;
+  });
+
+  afterEach(() => {
+    _setRuntimeFileWindowsSecurityForTest(null);
+    vi.restoreAllMocks();
+    if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = previousXdg;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const installWindowsSecurity = (
+    run: (
+      request: RuntimeFileWindowsSecurityRequest,
+    ) => RuntimeFileWindowsSecurityResult,
+  ): void => {
+    _setRuntimeFileWindowsSecurityForTest({
+      platform: "win32",
+      powershellPath:
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      run,
+    });
+  };
+
+  it("publishes and reads records only after private ACL validation", () => {
+    const requests: RuntimeFileWindowsSecurityRequest[] = [];
+    installWindowsSecurity((request) => {
+      requests.push(request);
+      if (request.kind === "file" && request.action === "secure") {
+        // The replayable token must not be written before the DACL is private.
+        expect(readFileSync(request.path, "utf8")).toBe("");
+      }
+      return WINDOWS_PRIVATE_RESULT;
+    });
+
+    const token = "private-token".repeat(4);
+    const record = { ...RECORD, token };
+    writePortFile(record.port, token);
+    writeGatewayProcessFile(record);
+
+    expect(readPortFile()).toBe(record.port);
+    expect(readGatewayProcessFile()).toEqual(record);
+    expect(
+      requests.some(
+        ({ action, kind }) => action === "secure" && kind === "directory",
+      ),
+    ).toBe(true);
+    expect(
+      requests.filter(
+        ({ action, kind }) => action === "secure" && kind === "file",
+      ),
+    ).toHaveLength(2);
+    expect(
+      requests.some(
+        ({ action, kind }) => action === "verify" && kind === "file",
+      ),
+    ).toBe(true);
+    for (const request of requests) {
+      // Paths (and therefore usernames) travel through the child environment,
+      // never through a command line or shell-interpreted script fragment.
+      expect(request.args).not.toContain(request.path);
+      expect(request.env.LORE_RUNTIME_ACL_PATH).toBe(request.path);
+    }
+  });
+
+  it("refuses to read a token-bearing record with a broad DACL", () => {
+    installWindowsSecurity(() => WINDOWS_PRIVATE_RESULT);
+    writeGatewayProcessFile(RECORD);
+
+    installWindowsSecurity((request) =>
+      request.kind === "file" && request.action === "verify"
+        ? {
+            status: 1,
+            signal: null,
+            stdout: "",
+            stderr: "runtime ACL contains a broad access rule",
+          }
+        : WINDOWS_PRIVATE_RESULT,
+    );
+
+    expect(() => readRuntimeFile("gateway.pid", { ownerOnly: true })).toThrow(
+      /broad access rule/,
+    );
+    expect(readGatewayProcessFile()).toBeNull();
+  });
+
+  it("does not publish record content when a private file DACL cannot be established", () => {
+    installWindowsSecurity((request) =>
+      request.kind === "file" && request.action === "secure"
+        ? {
+            status: 1,
+            signal: null,
+            stdout: "",
+            stderr: "runtime ACL remains inherited",
+          }
+        : WINDOWS_PRIVATE_RESULT,
+    );
+
+    expect(() => writeGatewayProcessFile(RECORD)).toThrow(
+      /runtime ACL remains inherited/,
+    );
+    expect(readdirSync(join(customDataHome, "lore"))).toEqual([]);
+  });
+
+  it("fails closed and leaves no record when the Windows ACL command fails", () => {
+    const commandError = Object.assign(new Error("spawn failed"), {
+      code: "ENOENT",
+    });
+    installWindowsSecurity(() => ({
+      status: null,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      error: commandError,
+    }));
+
+    expect(() => writeGatewayProcessFile(RECORD)).toThrow(
+      /Windows runtime ACL command failed/,
+    );
+    expect(existsSync(join(customDataHome, "lore", "gateway.pid"))).toBe(false);
+  });
+
+  it("rejects a runtime directory replaced during ACL establishment", () => {
+    let replaced = false;
+    installWindowsSecurity((request) => {
+      if (
+        !replaced &&
+        request.kind === "directory" &&
+        request.action === "secure"
+      ) {
+        replaced = true;
+        renameSync(request.path, `${request.path}.replaced`);
+        mkdirSync(request.path);
+      }
+      return WINDOWS_PRIVATE_RESULT;
+    });
+
+    expect(() => writeGatewayProcessFile(RECORD)).toThrow(
+      /changed while opening/,
+    );
+    expect(existsSync(join(customDataHome, "lore", "gateway.pid"))).toBe(false);
+  });
+});

--- a/packages/gateway/test/sentry-bust-spiral.test.ts
+++ b/packages/gateway/test/sentry-bust-spiral.test.ts
@@ -94,7 +94,8 @@ describe("bust-spiral Sentry wiring (#797 / #952)", () => {
       // level:error→warning and fingerprint mutations): a past-grace spiral is
       // a high-severity, fingerprint-grouped issue. The BustSpiralInfo —
       // including the #952 `capFit` field — must reach the Sentry context so
-      // dashboards can distinguish structural busts from growth busts.
+      // dashboards can distinguish structural busts from growth busts without
+      // exporting the session identifier.
       const hook = installAndGetHook();
       hook.onSpiral?.(sampleInfo({ capFit: false }));
 
@@ -106,7 +107,7 @@ describe("bust-spiral Sentry wiring (#797 / #952)", () => {
       expect(opts.level).toBe("error");
       expect(opts.fingerprint).toEqual(["bust-spiral-past-grace"]);
       const contexts = opts.contexts as { bust_spiral: core.BustSpiralInfo };
-      expect(contexts.bust_spiral.sessionID).toBe("sess-abc");
+      expect(contexts.bust_spiral.sessionID).toBeUndefined();
       expect(contexts.bust_spiral.capFit).toBe(false);
     });
 

--- a/packages/gateway/test/sentry-empty-completion.test.ts
+++ b/packages/gateway/test/sentry-empty-completion.test.ts
@@ -34,11 +34,15 @@ describe("captureEmptyCompletion", () => {
       level: "warning",
       fingerprint: ["empty-completion", "openai-responses"],
     });
-    // Full diagnostic payload is attached for triage.
-    expect(
-      (opts as { contexts: { empty_completion: Record<string, unknown> } })
-        .contexts.empty_completion,
-    ).toMatchObject({ protocol: "openai-responses", model: "gpt-4o-mini" });
+    // Operational diagnostics are attached for triage without the session ID.
+    const context = (
+      opts as { contexts: { empty_completion: Record<string, unknown> } }
+    ).contexts.empty_completion;
+    expect(context).toMatchObject({
+      protocol: "openai-responses",
+      model: "gpt-4o-mini",
+    });
+    expect(context.sessionID).toBeUndefined();
   });
 
   it("is a no-op when Sentry is not initialized", () => {

--- a/packages/gateway/test/server.test.ts
+++ b/packages/gateway/test/server.test.ts
@@ -3,7 +3,7 @@
  *
  * Starts a real gateway server (via `startServer`) on a random port and
  * exercises the pre-pipeline routes + error paths that the replay
- * integration tests (replay.test.ts) don't reach: CORS preflight, health,
+ * integration tests (replay.test.ts) don't reach: OPTIONS, health,
  * 404, invalid-JSON 400 on each protocol endpoint, the /v1/models passthrough
  * 502 path (unreachable upstream), the `/` redirect, and the empty-hosts
  * defensive default.
@@ -13,7 +13,11 @@
  */
 import { describe, test, expect, beforeAll, afterAll } from "vitest";
 import { connect } from "node:net";
-import { createServer as createHttpServer } from "node:http";
+import {
+  createServer as createHttpServer,
+  request as httpRequest,
+} from "node:http";
+import { Readable } from "node:stream";
 import { brotliCompressSync, gzipSync, zstdCompressSync } from "node:zlib";
 import { startServer } from "../src/server";
 import { loadConfig } from "../src/config";
@@ -22,12 +26,87 @@ import { MAX_HTTP_REQUEST_DECOMPRESSED_BYTES } from "../src/http-body";
 
 type ServerHandle = Awaited<ReturnType<typeof startServer>>;
 
+function fetch(input: string | URL, init: RequestInit = {}): Promise<Response> {
+  const url = new URL(input);
+  const headers = new Headers(init.headers);
+  let body: Buffer | undefined;
+  if (typeof init.body === "string") {
+    body = Buffer.from(init.body);
+  } else if (init.body instanceof ArrayBuffer) {
+    body = Buffer.from(init.body);
+  } else if (ArrayBuffer.isView(init.body)) {
+    body = Buffer.from(
+      init.body.buffer,
+      init.body.byteOffset,
+      init.body.byteLength,
+    );
+  } else if (init.body !== undefined && init.body !== null) {
+    throw new TypeError("server test loopback fetch received unsupported body");
+  }
+  if (body && !headers.has("content-length")) {
+    headers.set("content-length", String(body.byteLength));
+  }
+
+  return new Promise<Response>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        hostname: url.hostname.replace(/^\[|\]$/g, ""),
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method: init.method ?? "GET",
+        headers: Object.fromEntries(headers),
+      },
+      (incoming) => {
+        const responseHeaders = new Headers();
+        for (let index = 0; index < incoming.rawHeaders.length; index += 2) {
+          responseHeaders.append(
+            incoming.rawHeaders[index],
+            incoming.rawHeaders[index + 1],
+          );
+        }
+        const status = incoming.statusCode ?? 500;
+        const noBody =
+          init.method === "HEAD" ||
+          status === 204 ||
+          status === 205 ||
+          status === 304;
+        if (noBody) incoming.resume();
+        resolve(
+          new Response(
+            noBody
+              ? null
+              : (Readable.toWeb(
+                  incoming,
+                ) as unknown as ReadableStream<Uint8Array>),
+            {
+              status,
+              statusText: incoming.statusMessage,
+              headers: responseHeaders,
+            },
+          ),
+        );
+      },
+    );
+    request.once("error", reject);
+    if (init.signal) {
+      const abort = () => request.destroy();
+      init.signal.addEventListener("abort", abort, { once: true });
+      request.once("close", () =>
+        init.signal?.removeEventListener("abort", abort),
+      );
+    }
+    request.end(body);
+  });
+}
+
 function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
   return {
     ...loadConfig(),
     port: 0,
     hosts: ["127.0.0.1"],
     debug: false,
+    remoteGateway: false,
+    hostedMode: false,
     // Refused port → upstreamFetch fails fast so /v1/models returns 502.
     upstreamAnthropic: "http://127.0.0.1:9",
     ...overrides,
@@ -42,11 +121,113 @@ beforeAll(async () => {
   baseURL = `http://127.0.0.1:${server.port}`;
 });
 
-afterAll(() => {
-  server.stop();
+afterAll(async () => {
+  await server.stop();
 });
 
 describe("server routing", () => {
+  test("owner control identity is unavailable without a configured token", async () => {
+    const res = await fetch(`${baseURL}/_lore/control`, {
+      headers: { authorization: "Bearer attacker" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test("owner control identity requires the exact configured token", async () => {
+    const token = "test-control-token".repeat(3);
+    const controlled = await startServer(makeConfig(), { controlToken: token });
+    try {
+      const url = `http://127.0.0.1:${controlled.port}/_lore/control`;
+      expect((await fetch(url)).status).toBe(404);
+      expect(
+        (
+          await fetch(url, {
+            headers: { authorization: "Bearer wrong-token" },
+          })
+        ).status,
+      ).toBe(404);
+      const res = await fetch(url, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        status: "ok",
+        service: "lore",
+        pid: process.pid,
+      });
+      expect(
+        (
+          await fetch(url, {
+            method: "POST",
+            headers: { authorization: `Bearer ${token}` },
+          })
+        ).status,
+      ).toBe(404);
+    } finally {
+      await controlled.stop();
+    }
+  });
+
+  test("authenticated POST flushes its response before shutdown closes the listener", async () => {
+    const token = "shutdown-control-token".repeat(3);
+    let controlled: ServerHandle;
+    let callbackCount = 0;
+    let markShutdownComplete!: () => void;
+    const shutdownComplete = new Promise<void>((resolve) => {
+      markShutdownComplete = resolve;
+    });
+    controlled = await startServer(makeConfig(), {
+      controlToken: token,
+      onShutdown: async () => {
+        callbackCount += 1;
+        await controlled.stop();
+        markShutdownComplete();
+      },
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${controlled.port}/_lore/control`,
+      {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+      },
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ok",
+      service: "lore",
+      pid: process.pid,
+      shutdown: "requested",
+    });
+    await shutdownComplete;
+    expect(callbackCount).toBe(1);
+  });
+
+  test("unauthorized POST is an indistinguishable 404 and does not invoke shutdown", async () => {
+    const token = "shutdown-control-token".repeat(3);
+    let callbackCount = 0;
+    const controlled = await startServer(makeConfig(), {
+      controlToken: token,
+      onShutdown: () => {
+        callbackCount += 1;
+      },
+    });
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${controlled.port}/_lore/control`,
+        {
+          method: "POST",
+          headers: { authorization: "Bearer wrong-token" },
+        },
+      );
+      expect(response.status).toBe(404);
+      await response.arrayBuffer();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(callbackCount).toBe(0);
+    } finally {
+      await controlled.stop();
+    }
+  });
+
   test("destroying a client socket aborts a pending upstream fetch", async () => {
     let markStarted!: () => void;
     const started = new Promise<void>((resolve) => (markStarted = resolve));
@@ -83,7 +264,7 @@ describe("server routing", () => {
       ]);
     } finally {
       socket.destroy();
-      gateway.stop();
+      await gateway.stop();
       upstream.closeAllConnections();
       await new Promise<void>((resolve) => upstream.close(() => resolve()));
     }
@@ -127,26 +308,27 @@ describe("server routing", () => {
       ]);
     } finally {
       socket.destroy();
-      gateway.stop();
+      await gateway.stop();
       upstream.closeAllConnections();
       await new Promise<void>((resolve) => upstream.close(() => resolve()));
     }
   });
 
-  test("OPTIONS preflight returns 204 with permissive CORS headers", async () => {
+  test("no-Origin OPTIONS remains a 204 without enabling browser CORS", async () => {
     const res = await fetch(`${baseURL}/v1/messages`, { method: "OPTIONS" });
     expect(res.status).toBe(204);
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
-    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(res.headers.get("access-control-allow-methods")).toBeNull();
+    expect(res.headers.get("access-control-allow-headers")).toBeNull();
   });
 
-  test("GET /health returns ok + version with CORS", async () => {
+  test("GET /health remains public without making it browser-readable cross-origin", async () => {
     const res = await fetch(`${baseURL}/health`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { status: string; version: string };
     expect(body.status).toBe("ok");
     expect(typeof body.version).toBe("string");
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
   });
 
   test("unknown route returns a 404 error envelope", async () => {
@@ -177,6 +359,7 @@ describe("server routing", () => {
     };
     expect(body.error.type).toBe("invalid_request_error");
     expect(body.error.message).toBe("Invalid JSON body");
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
   });
 
   // A zstd-compressed body (as Codex sends) is decoded first; if the *decoded*
@@ -294,7 +477,7 @@ describe("server routing", () => {
     const res = await fetch(`${baseURL}/`, { redirect: "manual" });
     // undici surfaces a manual redirect as an opaqueredirect (status 0); a
     // real 3xx is also acceptable. Regression guard: Response.redirect()'s
-    // headers are immutable, so withCors() used to throw "immutable" and the
+    // headers are immutable, so the old CORS wrapper used to throw and the
     // root path 500'd instead of redirecting.
     expect(res.status).not.toBe(500);
     expect([0, 301, 302, 307, 308]).toContain(res.status);
@@ -309,7 +492,7 @@ describe("startServer configuration", () => {
       const res = await fetch(`http://127.0.0.1:${s.port}/health`);
       expect(res.status).toBe(200);
     } finally {
-      s.stop();
+      await s.stop();
     }
   });
 
@@ -319,7 +502,7 @@ describe("startServer configuration", () => {
       const res = await fetch(`http://127.0.0.1:${s.port}/health`);
       expect(res.status).toBe(200);
     } finally {
-      s.stop();
+      await s.stop();
     }
   });
 
@@ -341,7 +524,7 @@ describe("startServer configuration", () => {
       const res = await fetch(`http://127.0.0.1:${s.port}/health`);
       expect(res.status).toBe(200);
     } finally {
-      s.stop();
+      await s.stop();
     }
   });
 
@@ -358,7 +541,7 @@ describe("startServer configuration", () => {
       const res = await fetch(`http://127.0.0.1:${s.port}/health`);
       expect(res.status).toBe(200);
     } finally {
-      s.stop();
+      await s.stop();
     }
   });
 
@@ -397,7 +580,7 @@ describe("startServer configuration", () => {
       const body = (await res.json()) as { status: string };
       expect(body.status).toBe("ok");
     } finally {
-      s.stop();
+      await s.stop();
     }
   });
 });

--- a/packages/gateway/test/session-adoption.e2e.test.ts
+++ b/packages/gateway/test/session-adoption.e2e.test.ts
@@ -422,12 +422,15 @@ describe("issue #796: restart-proof session adoption (Tier 3b)", () => {
         state.is_subagent,
       );
       for (const index of [2, 6]) {
-        const id = deterministicID("user", index, [
+        const sourceId = deterministicID(first.session_id, "user", index, [
+          { type: "text", text: users[index / 2] },
+        ]);
+        const nextSourceId = deterministicID(secondSession, "user", index, [
           { type: "text", text: users[index / 2] },
         ]);
         db.prepare(
-          "UPDATE temporal_messages SET session_id = ? WHERE id = ?",
-        ).run(secondSession, id);
+          "UPDATE temporal_messages SET session_id = ?, source_id = ? WHERE source_id = ?",
+        ).run(secondSession, nextSourceId, sourceId);
       }
     } finally {
       db.close();

--- a/packages/gateway/test/session-credential-learning.test.ts
+++ b/packages/gateway/test/session-credential-learning.test.ts
@@ -1,0 +1,307 @@
+/**
+ * End-to-end regression coverage for credential leakage through Tier 2
+ * session-header learning. Credential values must never become learning inputs
+ * or be promoted into session_state as raw credentials.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { _resetGlobalHeaderValues } from "../src/session";
+import {
+  buildUpstreamSnapshotHeaders,
+  forwardClientHeaders,
+} from "../src/translate/types";
+import type { Harness } from "./helpers/harness";
+import { createHarness } from "./helpers/harness";
+import {
+  DEFAULT_MODEL,
+  DEFAULT_SYSTEM,
+  makeFixtureEntry,
+  STANDARD_TOOLS,
+} from "./helpers/fixtures";
+
+const SAFE_HEADER_NAME = "x-client-session-id";
+
+function learningHeaders(
+  suffix: "aaaa" | "bbbb",
+  includeAlternativeAuth = false,
+): Record<string, string> {
+  const headers = {
+    // Non-x names cannot reach promotion, but belong in the persistence corpus
+    // so the end-to-end assertion covers the complete shared policy.
+    // Authorization is covered by the historical-cleanup corpus below. It is
+    // intentionally absent because ingress rejects ambiguous auth mechanisms.
+    "Proxy-Authorization": `proxy-authorization-credential-${suffix}`,
+    "api-key": `api-key-non-x-credential-${suffix}`,
+    "cf-aig-authorization": `cf-aig-authorization-credential-${suffix}`,
+
+    // First-pass credential shapes contain session/affinity and an auth marker.
+    "x-auth-session-id": `auth-session-credential-${suffix}`,
+    "x-bearer-session-id": `bearer-session-credential-${suffix}`,
+    "x-key-session-id": `key-session-credential-${suffix}`,
+    "x-oauth-session-id": `oauth-session-credential-${suffix}`,
+    "x-secret-session-id": `secret-session-credential-${suffix}`,
+    "x-session-key": `session-key-credential-${suffix}`,
+    "x-token-session-id": `token-session-credential-${suffix}`,
+
+    // Second-pass credential shapes are generic ID-like x-* headers.
+    "x-access-key-id": `access-key-credential-${suffix}`,
+    "x-api-key": `api-key-credential-${suffix}`,
+    "x-auth-token": `auth-token-credential-${suffix}`,
+    "x-client-secret": `client-secret-credential-${suffix}`,
+    "x-credential-id": `credential-id-value-${suffix}`,
+    "x-custom-auth": `custom-auth-credential-${suffix}`,
+    "x-password": `password-credential-${suffix}`,
+    "x-refresh-token": `refresh-token-credential-${suffix}`,
+    "x-session-auth": `session-auth-credential-${suffix}`,
+    "x-session-secret": `session-secret-credential-${suffix}`,
+    "x-session-token": `session-token-credential-${suffix}`,
+
+    // A non-credential session header must still learn and persist normally.
+    [SAFE_HEADER_NAME]: `safe-session-value-${suffix}`,
+  };
+  return includeAlternativeAuth
+    ? {
+        ...headers,
+        "x-goog-api-key": `goog-api-key-credential-${suffix}`,
+      }
+    : headers;
+}
+
+function body(messages: Array<{ role: string; content: string }>) {
+  return {
+    model: DEFAULT_MODEL,
+    max_tokens: 1024,
+    stream: false,
+    system: DEFAULT_SYSTEM,
+    messages,
+    tools: STANDARD_TOOLS,
+  };
+}
+
+describe("shared credential forwarding policy", () => {
+  test("removes credential-shaped headers from foreground and snapshot forwarding", () => {
+    // The pure filtering boundary can receive conflicting auth candidates even
+    // though ingress correctly rejects that combination before session learning.
+    const rawHeaders = learningHeaders("aaaa", true);
+    const safe = {
+      [SAFE_HEADER_NAME]: rawHeaders[SAFE_HEADER_NAME],
+    };
+
+    expect(forwardClientHeaders(rawHeaders)).toEqual(safe);
+    expect(buildUpstreamSnapshotHeaders(rawHeaders)).toEqual(safe);
+  });
+});
+
+describe("Tier 2 credential exclusion", () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    _resetGlobalHeaderValues();
+  });
+
+  afterEach(async () => {
+    _resetGlobalHeaderValues();
+    if (harness) await harness.teardown();
+  });
+
+  test("never persists credential candidates while a legitimate session header still learns", async () => {
+    harness = await createHarness({
+      fixtures: Array.from({ length: 4 }, (_, seq) =>
+        makeFixtureEntry({
+          seq,
+          requestMessages: [],
+          responseText: `response-${seq}`,
+        }),
+      ),
+    });
+
+    const headersA = learningHeaders("aaaa");
+    const headersB = learningHeaders("bbbb");
+    const chat = async (
+      messages: Array<{ role: string; content: string }>,
+      headers: Record<string, string>,
+    ) => {
+      const response = await harness.chat(
+        body(messages),
+        headers["x-api-key"],
+        headers,
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    };
+
+    // Session A supplies two stable observations.
+    await chat([{ role: "user", content: "session A opening" }], headersA);
+    await chat(
+      [
+        { role: "user", content: "session A opening" },
+        { role: "assistant", content: "response-0" },
+        { role: "user", content: "session A follow-up" },
+      ],
+      headersA,
+    );
+
+    // Session B gives every header a distinct global value, satisfying the
+    // vulnerable learner's cross-session uniqueness condition.
+    await chat([{ role: "user", content: "session B opening" }], headersB);
+
+    // Session A's third stable observation reaches the promotion threshold.
+    await chat(
+      [
+        { role: "user", content: "session A opening" },
+        { role: "assistant", content: "response-0" },
+        { role: "user", content: "session A follow-up" },
+        { role: "assistant", content: "response-1" },
+        { role: "user", content: "session A final turn" },
+      ],
+      headersA,
+    );
+
+    const learned = harness.queryDB<{
+      header_name: string;
+      header_session_id: string;
+    }>(
+      "SELECT header_name, header_session_id FROM session_state WHERE header_name IS NOT NULL",
+    );
+    expect(learned).toContainEqual({
+      header_name: SAFE_HEADER_NAME,
+      header_session_id: headersA[SAFE_HEADER_NAME],
+    });
+
+    const credentialNames = Object.keys(headersA).filter(
+      (name) => name !== SAFE_HEADER_NAME,
+    );
+    credentialNames.push("Authorization");
+    const rawCredentialValues = [
+      ...credentialNames.map((name) => headersA[name]),
+      ...credentialNames.map((name) => headersB[name]),
+      "authorization-credential-aaaa",
+      "authorization-credential-bbbb",
+    ].filter((value): value is string => value !== undefined);
+    const placeholders = (values: string[]) => values.map(() => "?").join(",");
+    const leaked = harness.queryDB<{
+      header_name: string;
+      header_session_id: string;
+    }>(
+      `SELECT header_name, header_session_id FROM session_state
+       WHERE header_name IN (${placeholders(credentialNames)})
+          OR header_session_id IN (${placeholders(rawCredentialValues)})`,
+      [...credentialNames, ...rawCredentialValues],
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  test("clears credential mappings persisted by older versions on restart", async () => {
+    harness = await createHarness({
+      fixtures: [
+        makeFixtureEntry({
+          seq: 0,
+          requestMessages: [],
+          responseText: "response-0",
+        }),
+      ],
+    });
+    const historicalCredentials = [
+      ["historical-auth-token", "x-auth-token", "historical-auth-token-secret"],
+      [
+        "historical-bearer-session",
+        "x-bearer-session-id",
+        "historical-bearer-session-secret",
+      ],
+      [
+        "historical-bearer-underscore",
+        "x_bearer_session_id",
+        "historical-bearer-underscore-secret",
+      ],
+      [
+        "historical-bearer-camel",
+        "xBearerSessionId",
+        "historical-bearer-camel-secret",
+      ],
+    ] as const;
+    const historicalSafeMappings = [
+      [
+        "historical-claude-session",
+        "x-claude-code-session-id",
+        "historical-claude-session-value",
+      ],
+      [
+        "historical-session-affinity",
+        "x-session-affinity",
+        "historical-session-affinity-value",
+      ],
+      [
+        "historical-generic-session",
+        "x-session-id",
+        "historical-generic-session-value",
+      ],
+    ] as const;
+    const database = new DatabaseSync(harness.dbPath);
+    try {
+      const insert = database.prepare(
+        `INSERT INTO session_state
+             (session_id, force_min_layer, updated_at, header_name, header_session_id)
+           VALUES (?, 0, ?, ?, ?)`,
+      );
+      for (const [sessionID, headerName, headerValue] of [
+        ...historicalCredentials,
+        ...historicalSafeMappings,
+      ]) {
+        insert.run(sessionID, Date.now(), headerName, headerValue);
+      }
+    } finally {
+      database.close();
+    }
+
+    await harness.restartPipeline();
+    const response = await harness.chat(
+      body([{ role: "user", content: "restart cleanup" }]),
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+
+    const credentialSessionIDs = historicalCredentials.map(
+      ([sessionID]) => sessionID,
+    );
+    const placeholders = credentialSessionIDs.map(() => "?").join(",");
+    expect(
+      harness.queryDB<{
+        session_id: string;
+        header_name: string | null;
+        header_session_id: string | null;
+      }>(
+        `SELECT session_id, header_name, header_session_id
+           FROM session_state WHERE session_id IN (${placeholders})
+           ORDER BY session_id`,
+        credentialSessionIDs,
+      ),
+    ).toEqual(
+      [...credentialSessionIDs].sort().map((sessionID) => ({
+        session_id: sessionID,
+        header_name: null,
+        header_session_id: null,
+      })),
+    );
+    expect(
+      harness.queryDB<{
+        session_id: string;
+        header_name: string;
+        header_session_id: string;
+      }>(
+        `SELECT session_id, header_name, header_session_id
+           FROM session_state
+          WHERE session_id IN (${historicalSafeMappings.map(() => "?").join(",")})
+          ORDER BY session_id`,
+        historicalSafeMappings.map(([sessionID]) => sessionID),
+      ),
+    ).toEqual(
+      [...historicalSafeMappings]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([sessionID, headerName, headerSessionId]) => ({
+          session_id: sessionID,
+          header_name: headerName,
+          header_session_id: headerSessionId,
+        })),
+    );
+  });
+});

--- a/packages/gateway/test/session.test.ts
+++ b/packages/gateway/test/session.test.ts
@@ -12,6 +12,7 @@ import {
   KNOWN_SESSION_HEADERS,
   ROTATION_MAX_AGE_MS,
   isSessionHeaderName,
+  isCredentialHeaderName,
   isIdLikeValue,
   collectCandidateHeaders,
   learnHeaders,
@@ -350,6 +351,39 @@ describe("fingerprintMessages", () => {
     });
     expect(hash1).not.toBe(hash2);
   });
+
+  test("remote tenant fingerprints use a versioned encoding distinct from historical rows", async () => {
+    const messages = [{ role: "user", content: "Hello" }];
+    const tenantFingerprint = "a".repeat(64);
+    const historical = await fingerprintMessages(messages, {
+      authSuffix: tenantFingerprint,
+    });
+    const remote = await fingerprintMessages(messages, { tenantFingerprint });
+    expect(remote).not.toBe(historical);
+    expect(remote).toMatch(
+      new RegExp(
+        `^lore-tenant-fingerprint-v1:${tenantFingerprint}:[a-f0-9]{16}$`,
+      ),
+    );
+    expect(remote).toBe(
+      await fingerprintMessages(messages, { tenantFingerprint }),
+    );
+  });
+
+  test("remote message fingerprints retain the full tenant boundary", async () => {
+    const messages = [{ role: "user", content: "identical opening" }];
+    const tenantA = "a".repeat(64);
+    const tenantB = "b".repeat(64);
+    const fingerprintA = await fingerprintMessages(messages, {
+      tenantFingerprint: tenantA,
+    });
+    const fingerprintB = await fingerprintMessages(messages, {
+      tenantFingerprint: tenantB,
+    });
+    expect(fingerprintA).not.toBe(fingerprintB);
+    expect(fingerprintA).toContain(tenantA);
+    expect(fingerprintB).toContain(tenantB);
+  });
 });
 
 // ===========================================================================
@@ -551,6 +585,80 @@ describe("collectCandidateHeaders", () => {
     });
     expect(candidates.size).toBe(0);
   });
+
+  const credentialHeaderCorpus = [
+    { name: "Authorization", promotionPass: "not-x" },
+    { name: "Proxy-Authorization", promotionPass: "not-x" },
+    { name: "api-key", promotionPass: "not-x" },
+    { name: "cf-aig-authorization", promotionPass: "not-x" },
+    { name: "x-api-key", promotionPass: "second" },
+    { name: "x-goog-api-key", promotionPass: "second" },
+    { name: "x-session-token", promotionPass: "second" },
+    { name: "x-session-auth", promotionPass: "second" },
+    { name: "x-session-secret", promotionPass: "second" },
+    { name: "x-auth-token", promotionPass: "second" },
+    { name: "x-authtoken", promotionPass: "second" },
+    { name: "x-refresh-token", promotionPass: "second" },
+    { name: "x-client-secret", promotionPass: "second" },
+    { name: "x-access-key-id", promotionPass: "second" },
+    { name: "x-custom-auth", promotionPass: "second" },
+    { name: "x-credential-id", promotionPass: "second" },
+    { name: "x-password", promotionPass: "second" },
+    { name: "x-session-key", promotionPass: "first" },
+    { name: "x-client-session-key", promotionPass: "first" },
+    { name: "x-auth-session-id", promotionPass: "first" },
+    { name: "x-oauth-session-id", promotionPass: "first" },
+    { name: "x-secret-session-id", promotionPass: "first" },
+    { name: "x-token-session-id", promotionPass: "first" },
+    { name: "x-key-session-id", promotionPass: "first" },
+  ] as const;
+
+  test.each(credentialHeaderCorpus)(
+    "rejects credential header $name before the $promotionPass promotion pass",
+    ({ name, promotionPass }) => {
+      _resetGlobalHeaderValues();
+      const value = "credential-value-aaaa1111";
+      const otherValue = "credential-value-bbbb2222";
+
+      expect(isCredentialHeaderName(name)).toBe(true);
+      expect(collectCandidateHeaders({ [name]: value }).has(name)).toBe(false);
+
+      // Confirm that this corpus drives both promotion loops on the vulnerable
+      // implementation, rather than only testing names that could never reach
+      // either loop.
+      if (promotionPass === "first") {
+        expect(isSessionHeaderName(name)).toBe(true);
+      } else if (promotionPass === "second") {
+        expect(isSessionHeaderName(name)).toBe(false);
+      }
+
+      // Model an already-tracked candidate at the promotion threshold and a
+      // second session carrying a distinct value. Collection must remove the
+      // credential before either promotion pass can inspect it.
+      learnHeaders(undefined, { [name]: otherValue });
+      const preexisting = new Map([[name, { value, seenCount: 2 }]]);
+      const result = learnHeaders(preexisting, { [name]: value });
+
+      expect(result.updatedCandidates.has(name)).toBe(false);
+      expect(result.promoted).toBeNull();
+    },
+  );
+
+  test.each(KNOWN_SESSION_HEADERS)(
+    "does not classify established session header %s as a credential",
+    (name) => {
+      const value = "legitimate-session-value-1234";
+      expect(isCredentialHeaderName(name)).toBe(false);
+      expect(collectCandidateHeaders({ [name]: value }).get(name)).toBe(value);
+    },
+  );
+
+  test.each(["x-keyboard-session-id", "x-monkey-session-id"])(
+    "does not reject non-credential key substring in %s",
+    (name) => {
+      expect(isCredentialHeaderName(name)).toBe(false);
+    },
+  );
 });
 
 // ===========================================================================
@@ -644,6 +752,23 @@ describe("learnHeaders", () => {
       value: "session-aaaa1111",
     });
   });
+
+  test.each([
+    ["x-client-session-id", "first"],
+    ["x-conversation-id", "second"],
+  ] as const)(
+    "still learns legitimate %s headers through the %s promotion pass",
+    (name, _promotionPass) => {
+      const headers = { [name]: "session-aaaa1111" };
+      learnHeaders(undefined, { [name]: "session-bbbb2222" });
+
+      const r1 = learnHeaders(undefined, headers);
+      const r2 = learnHeaders(r1.updatedCandidates, headers);
+      const r3 = learnHeaders(r2.updatedCandidates, headers);
+
+      expect(r3.promoted).toEqual({ name, value: "session-aaaa1111" });
+    },
+  );
 
   test("prefers session-named headers over generic ones for promotion", () => {
     // Both headers are stable for 3 turns and cross-session unique,

--- a/packages/gateway/test/setup-backup.test.ts
+++ b/packages/gateway/test/setup-backup.test.ts
@@ -4,7 +4,13 @@ import {
   setPath,
   deletePath,
   captureJsonBackup,
+  refreshJsonBackup,
+  parseJsonBackup,
+  parseJsonSetupJournal,
+  prepareJsonSetupJournal,
+  selectJsonSetupJournalState,
   applyJsonBackup,
+  retainSkippedJsonBackup,
   readLegacyJsonBackup,
   LORE_BACKUP_KEY,
   getTomlTopLevelValue,
@@ -16,6 +22,7 @@ import {
   setEnvValueRaw,
   deleteEnvKey,
   buildEnvBackupBlock,
+  refreshEnvBackupBlock,
   prependEnvBackupBlock,
   restoreEnvBackup,
 } from "../src/cli/setup-backup";
@@ -82,6 +89,105 @@ describe("captureJsonBackup", () => {
       hadPrior: false,
     });
   });
+
+  it("retains pre-setup provenance while advancing the managed value", () => {
+    const first = captureJsonBackup(
+      { env: { ANTHROPIC_BASE_URL: "https://api.anthropic.com" } },
+      CLAUDE_LORE_VALUES,
+    );
+    const second = refreshJsonBackup(
+      {
+        env: {
+          ANTHROPIC_BASE_URL: "http://127.0.0.1:3207",
+          DISABLE_AUTO_COMPACT: "1",
+        },
+      },
+      {
+        ...CLAUDE_LORE_VALUES,
+        "env.ANTHROPIC_BASE_URL": "http://127.0.0.1:3399",
+      },
+      first,
+    );
+    expect(
+      second.entries.find((entry) => entry.path === "env.ANTHROPIC_BASE_URL"),
+    ).toMatchObject({
+      priorValue: "https://api.anthropic.com",
+      loreValue: "http://127.0.0.1:3399",
+    });
+  });
+
+  it("strictly rejects arbitrary and prototype-polluting paths", () => {
+    const base = {
+      version: 1,
+      savedAt: "2026-06-21T00:00:00.000Z",
+      entries: [
+        {
+          path: "env.__proto__.polluted",
+          loreValue: "x",
+          hadPrior: false,
+        },
+      ],
+    };
+    expect(() => parseJsonBackup(base)).toThrow("Invalid JSON backup path");
+    expect(() =>
+      parseJsonBackup({
+        ...base,
+        entries: [
+          {
+            path: "arbitrary.user.value",
+            loreValue: "x",
+            hadPrior: false,
+          },
+        ],
+      }),
+    ).toThrow("Invalid JSON setup backup entry");
+  });
+});
+
+describe("JSON setup journal recovery", () => {
+  const beforeText =
+    '{"env":{"ANTHROPIC_BASE_URL":"https://api.anthropic.com"}}\n';
+  const afterText =
+    '{"env":{"ANTHROPIC_BASE_URL":"http://127.0.0.1:3207","DISABLE_AUTO_COMPACT":"1"}}\n';
+  const beforeConfig = JSON.parse(beforeText) as Record<string, unknown>;
+  const afterConfig = JSON.parse(afterText) as Record<string, unknown>;
+  const journal = prepareJsonSetupJournal({
+    oldBackup: null,
+    newBackup: captureJsonBackup(beforeConfig, CLAUDE_LORE_VALUES),
+    beforeText,
+    beforeConfig,
+    afterText,
+    afterConfig,
+  });
+
+  it("selects exact old and new states", () => {
+    expect(selectJsonSetupJournalState(journal, beforeText, beforeConfig)).toBe(
+      "old",
+    );
+    expect(selectJsonSetupJournalState(journal, afterText, afterConfig)).toBe(
+      "new",
+    );
+  });
+
+  it("fails closed for an unknown managed projection", () => {
+    const unknown = structuredClone(afterConfig) as {
+      env: Record<string, unknown>;
+    };
+    unknown.env.ANTHROPIC_BASE_URL = "https://user.example";
+    expect(() =>
+      selectJsonSetupJournalState(
+        journal,
+        `${JSON.stringify(unknown)}\n`,
+        unknown,
+      ),
+    ).toThrow("Unknown Lore setup journal config state");
+  });
+
+  it("rejects extra journal metadata", () => {
+    expect(() =>
+      parseJsonSetupJournal({ ...journal, unexpected: true }),
+    ).toThrow("Invalid JSON setup journal metadata");
+  });
 });
 
 describe("applyJsonBackup", () => {
@@ -146,6 +252,19 @@ describe("applyJsonBackup", () => {
     };
     applyJsonBackup(cfg, captureJsonBackup({}, {}, { pluginAdded: false }));
     expect(cfg.plugin).toEqual(["@loreai/opencode"]);
+  });
+
+  it("retains only skipped provenance after a partial restore", () => {
+    const backup = captureJsonBackup({}, CLAUDE_LORE_VALUES, {
+      pluginAdded: true,
+    });
+    const remaining = retainSkippedJsonBackup(backup, [
+      "env.ANTHROPIC_BASE_URL",
+    ]);
+    expect(remaining?.entries.map((entry) => entry.path)).toEqual([
+      "env.ANTHROPIC_BASE_URL",
+    ]);
+    expect(remaining?.pluginAdded).toBeUndefined();
   });
 });
 
@@ -268,7 +387,7 @@ describe("TOML backup block round-trip", () => {
     expect(restoreTomlBackup('model = "gpt"\n').summary.hadBackup).toBe(false);
   });
 
-  it("leaves the file untouched when the footer is missing (no data loss)", () => {
+  it("rejects a missing footer without mutating the input", () => {
     // A hand-edited/corrupted block with a header but no footer must NOT cause
     // the rest of the file to be truncated (Seer #876 HIGH).
     const block = buildTomlBackupBlock(
@@ -277,9 +396,10 @@ describe("TOML backup block round-trip", () => {
     ) as string;
     const headerOnly = block.split("\n").slice(0, -1).join("\n"); // drop footer
     const content = `${headerOnly}\nmodel = "gpt-5"\nopenai_base_url = "http://127.0.0.1:3299/v1"\n`;
-    const { content: result, summary } = restoreTomlBackup(content);
-    expect(summary.hadBackup).toBe(false);
-    expect(result).toBe(content); // byte-identical — nothing deleted
+    expect(() => restoreTomlBackup(content)).toThrow(
+      "Invalid Codex Lore backup block",
+    );
+    expect(content).toContain('model = "gpt-5"');
   });
 });
 
@@ -421,11 +541,47 @@ describe("dotenv backup block round-trip", () => {
     expect(buildEnvBackupBlock(withBlock, lore)).toBeNull();
   });
 
-  it("refuses to restore a corrupted block (missing footer)", () => {
+  it("rejects a corrupted block (missing footer)", () => {
     const content =
       "# lore setup backup — original values (run `lore setup undo hermes` to restore):\n#   FOO (was unset) # lore-set x\nOPENAI_BASE_URL=x\n";
-    const { content: result, summary } = restoreEnvBackup(content);
-    expect(summary.hadBackup).toBe(false);
-    expect(result).toBe(content); // byte-identical — nothing touched
+    expect(() => restoreEnvBackup(content)).toThrow(
+      "Invalid Lore env backup block",
+    );
+    expect(content).toContain("OPENAI_BASE_URL=x");
+  });
+
+  it("round-trips an explicitly empty prior value across refresh", () => {
+    const original = "OPENAI_BASE_URL=\n";
+    const block = buildEnvBackupBlock(original, lore) as string;
+    let content = setEnvValueRaw(
+      original,
+      "OPENAI_BASE_URL",
+      lore.OPENAI_BASE_URL,
+    );
+    content = setEnvValueRaw(
+      content,
+      "HERMES_INFERENCE_PROVIDER",
+      lore.HERMES_INFERENCE_PROVIDER,
+    );
+    content = prependEnvBackupBlock(content, block);
+    const refreshed = refreshEnvBackupBlock(content, {
+      ...lore,
+      OPENAI_BASE_URL: "http://127.0.0.1:3399/v1",
+    });
+    let configured = refreshed.content;
+    configured = setEnvValueRaw(
+      configured,
+      "OPENAI_BASE_URL",
+      "http://127.0.0.1:3399/v1",
+    );
+    configured = setEnvValueRaw(
+      configured,
+      "HERMES_INFERENCE_PROVIDER",
+      lore.HERMES_INFERENCE_PROVIDER,
+    );
+    configured = prependEnvBackupBlock(configured, refreshed.block);
+    expect(
+      getEnvValue(restoreEnvBackup(configured).content, "OPENAI_BASE_URL"),
+    ).toBe("");
   });
 });

--- a/packages/gateway/test/setup-external-sigkill-child.ts
+++ b/packages/gateway/test/setup-external-sigkill-child.ts
@@ -1,0 +1,20 @@
+import {
+  _setSetupExternalEffectHookForTest,
+  commandSetup,
+} from "../src/cli/setup";
+
+const [killPhase] = process.argv.slice(2);
+if (
+  killPhase !== "after-installed-journal" &&
+  killPhase !== "before-journal-cleanup"
+) {
+  throw new Error("Expected an external-effect crash phase.");
+}
+
+_setSetupExternalEffectHookForTest((phase) => {
+  if (phase === killPhase) {
+    process.kill(process.pid, "SIGKILL");
+  }
+});
+
+await commandSetup(["opencode"], { port: 3299 });

--- a/packages/gateway/test/setup-io.test.ts
+++ b/packages/gateway/test/setup-io.test.ts
@@ -14,11 +14,20 @@ import {
   writeFileSync,
   readFileSync,
   existsSync,
+  chmodSync,
+  lstatSync,
+  symlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
+import { createServer, type Server } from "node:http";
 import { join } from "node:path";
 import { commandSetup, loadJsonSetupBackup } from "../src/cli/setup";
 import { writePortFile } from "../src/portfile";
+import {
+  readGatewayProcessFile,
+  removePidFile,
+  writeGatewayProcessFile,
+} from "../src/pidfile";
 
 // Integration coverage for the setup.ts IO surface (backup capture on setup,
 // `lore setup undo`, liveness reporting, port detection). Everything is scoped
@@ -58,6 +67,32 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function authenticatedGateway(token: string): Promise<Server> {
+  return await new Promise((resolve) => {
+    const server = createServer((request, response) => {
+      if (
+        request.url === "/_lore/control" &&
+        request.headers.authorization === `Bearer ${token}`
+      ) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({ status: "ok", service: "lore", pid: process.pid }),
+        );
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+    server.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
 describe("commandSetup — Claude Code", () => {
   const claudePath = () => join(home, ".claude", "settings.json");
 
@@ -92,13 +127,98 @@ describe("commandSetup — Claude Code", () => {
     expect(existsSync(`${claudePath()}.lore-backup`)).toBe(false);
   });
 
-  it("detects the live gateway port from the port file (falls back when down)", async () => {
-    // Seed a port file; the probe will fail (nothing listening) so setup falls
-    // back to the default port. Exercises detectLiveGatewayPort's probe path.
+  it("ignores an unauthenticated stale port file", async () => {
     writePortFile(5673);
     await commandSetup(["claude-code"], {});
     const cfg = JSON.parse(readFileSync(claudePath(), "utf8"));
     expect(cfg.env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3207");
+  });
+
+  it("selects and reports an authenticated process-record port", async () => {
+    const token = "setup-authenticated-token".repeat(2);
+    const server = await authenticatedGateway(token);
+    const port = (server.address() as { port: number }).port;
+    writeGatewayProcessFile({
+      version: 2,
+      pid: process.pid,
+      port,
+      hosts: ["127.0.0.1"],
+      token,
+      processIdentity: "test:setup-authenticated",
+    });
+    try {
+      await commandSetup(["claude-code"], {});
+      const cfg = JSON.parse(readFileSync(claudePath(), "utf8"));
+      expect(cfg.env.ANTHROPIC_BASE_URL).toBe(`http://127.0.0.1:${port}`);
+      expect(logged()).toContain(
+        `Gateway is reachable at http://127.0.0.1:${port}`,
+      );
+    } finally {
+      removePidFile(process.pid);
+      await closeServer(server);
+    }
+  });
+
+  it("does not trust a listener that only spoofs public health", async () => {
+    const server = await new Promise<Server>((resolve) => {
+      const listener = createServer((_request, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end('{"status":"ok"}');
+      });
+      listener.listen(0, "127.0.0.1", () => resolve(listener));
+    });
+    const port = (server.address() as { port: number }).port;
+    try {
+      expect(readGatewayProcessFile()).toBeNull();
+      await commandSetup(["claude-code"], { port });
+      expect(logged()).toContain(
+        `Gateway is not reachable at http://127.0.0.1:${port}`,
+      );
+      expect(logged()).not.toContain("Gateway is reachable at");
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("restores absence after first setup created the JSON config", async () => {
+    await commandSetup(["claude-code"], { port: 3299 });
+    await commandSetup(["undo", "claude-code"], {});
+    expect(existsSync(claudePath())).toBe(false);
+    expect(existsSync(`${claudePath()}.lore-backup`)).toBe(false);
+  });
+
+  it("fails closed on a deleted and recreated matching config generation", async () => {
+    await commandSetup(["claude-code"], { port: 3299 });
+    const configured = readFileSync(claudePath(), "utf8");
+    rmSync(claudePath());
+    writeFileSync(claudePath(), configured);
+
+    await expect(commandSetup(["undo", "claude-code"], {})).rejects.toThrow(
+      "config generation",
+    );
+    expect(readFileSync(claudePath(), "utf8")).toBe(configured);
+    expect(existsSync(`${claudePath()}.lore-backup`)).toBe(true);
+  });
+
+  it("rejects a symlinked config without overwriting its target", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    const target = join(home, "claude-target.json");
+    writeFileSync(target, '{"secret":"untouched"}\n');
+    symlinkSync(target, claudePath());
+
+    await expect(commandSetup(["claude-code"], { port: 3299 })).rejects.toThrow(
+      "symbolic links are not allowed",
+    );
+    expect(readFileSync(target, "utf8")).toBe('{"secret":"untouched"}\n');
+  });
+
+  it("preserves config mode and creates a private sidecar", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudePath(), "{}\n");
+    chmodSync(claudePath(), 0o640);
+    await commandSetup(["claude-code"], { port: 3299 });
+    expect(lstatSync(claudePath()).mode & 0o777).toBe(0o640);
+    expect(lstatSync(`${claudePath()}.lore-backup`).mode & 0o777).toBe(0o600);
   });
 });
 
@@ -145,13 +265,50 @@ describe("commandSetup — OpenCode", () => {
 
     await commandSetup(["undo", "opencode"], {});
 
-    const restored = JSON.parse(readFileSync(ocPath(), "utf8"));
-    // Provider baseURLs + compaction were lore-set on an empty config → undo
-    // removes them entirely (prunes emptied objects).
-    expect(restored.provider).toBeUndefined();
-    expect(restored.compaction).toBeUndefined();
-    expect(restored._loreBackup).toBeUndefined();
+    // Setup created this file from absence, so undo restores absence.
+    expect(existsSync(ocPath())).toBe(false);
     expect(existsSync(`${ocPath()}.lore-backup`)).toBe(false);
+  });
+
+  it("restores absence after first setup created the OpenCode config", async () => {
+    await commandSetup(["opencode"], { port: 3299, noPlugin: true });
+    await commandSetup(["undo", "opencode"], {});
+    expect(existsSync(ocPath())).toBe(false);
+  });
+
+  it("restores overwritten provider and plugin containers exactly", async () => {
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(
+      ocPath(),
+      '{"provider":["custom"],"plugin":"manual","compaction":null}\n',
+    );
+    await commandSetup(["opencode"], { port: 3299, noPlugin: true });
+    await commandSetup(["undo", "opencode"], {});
+    expect(JSON.parse(readFileSync(ocPath(), "utf8"))).toEqual({
+      provider: ["custom"],
+      plugin: "manual",
+      compaction: null,
+    });
+  });
+
+  it("edits and undoes active JSONC without dropping comments", async () => {
+    const jsoncPath = join(home, ".config", "opencode", "opencode.jsonc");
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+    writeFileSync(
+      jsoncPath,
+      `{
+  // Keep this user comment.
+  "theme": "tokyonight",
+}\n`,
+    );
+
+    await commandSetup(["opencode"], { port: 3299, "no-plugin": true });
+    expect(readFileSync(jsoncPath, "utf8")).toContain("Keep this user comment");
+    await commandSetup(["undo", "opencode"], {});
+    const restored = readFileSync(jsoncPath, "utf8");
+    expect(restored).toContain("Keep this user comment");
+    expect(restored).not.toContain("baseURL");
+    expect(restored).not.toContain('"provider"');
   });
 
   it("does NOT remove a plugin lore never added (Seer #876)", async () => {
@@ -276,13 +433,16 @@ describe("commandSetup — OpenCode", () => {
     expect(existsSync(`${ocPath()}.lore-backup`)).toBe(false);
   });
 
-  it("tolerates a corrupt sidecar backup (nothing to undo, no throw)", async () => {
+  it("fails closed on a corrupt sidecar before setup overwrites config", async () => {
     mkdirSync(join(home, ".config", "opencode"), { recursive: true });
     writeFileSync(ocPath(), JSON.stringify({ provider: {} }, null, 2));
     writeFileSync(`${ocPath()}.lore-backup`, "{ not valid json");
 
-    await commandSetup(["undo", "opencode"], {});
-    expect(logged().toLowerCase()).toContain("no lore backup");
+    const original = readFileSync(ocPath(), "utf8");
+    await expect(
+      commandSetup(["opencode"], { port: 3399, noPlugin: true }),
+    ).rejects.toThrow("Invalid Lore setup backup");
+    expect(readFileSync(ocPath(), "utf8")).toBe(original);
   });
 
   it("loadJsonSetupBackup returns null for an unreadable sidecar (never throws)", () => {
@@ -295,15 +455,14 @@ describe("commandSetup — OpenCode", () => {
     expect(loadJsonSetupBackup(ocPath())).toBeNull();
   });
 
-  it("undo tolerates an unreadable sidecar instead of crashing", async () => {
+  it("undo fails closed on an unreadable sidecar", async () => {
     mkdirSync(join(home, ".config", "opencode"), { recursive: true });
     writeFileSync(ocPath(), JSON.stringify({ provider: {} }, null, 2));
     mkdirSync(`${ocPath()}.lore-backup`, { recursive: true });
 
-    await expect(
-      commandSetup(["undo", "opencode"], {}),
-    ).resolves.toBeUndefined();
-    expect(logged().toLowerCase()).toContain("no lore backup");
+    await expect(commandSetup(["undo", "opencode"], {})).rejects.toThrow(
+      "Could not read Lore setup backup",
+    );
   });
 
   it("re-running setup never overwrites the TRUE original backup", async () => {
@@ -489,6 +648,17 @@ describe("commandSetup — undo with nothing to restore", () => {
 });
 
 describe("commandSetup — argument handling", () => {
+  it("does not print a rejected remote URL secret", async () => {
+    await commandSetup(["codex"], {
+      remote: "https://user:super-secret@gateway.example/lore",
+    });
+    expect(process.exitCode).toBe(1);
+    expect(logged()).toContain("Invalid remote URL");
+    expect(logged()).not.toContain("super-secret");
+    expect(existsSync(join(home, ".codex"))).toBe(false);
+    process.exitCode = 0;
+  });
+
   it("rejects an unknown app for setup", async () => {
     await commandSetup(["bogus"], { port: 3299 });
     expect(logged()).toContain('Unknown app "bogus"');

--- a/packages/gateway/test/setup-liveness.test.ts
+++ b/packages/gateway/test/setup-liveness.test.ts
@@ -8,21 +8,26 @@ import {
 describe("chooseSetupPort", () => {
   it("returns undefined for the remote path (port is irrelevant)", () => {
     expect(
-      chooseSetupPort({ remoteUrl: "http://remote:3207", livePort: 5673 }),
+      chooseSetupPort({
+        remoteUrl: "http://remote:3207",
+        authenticatedPort: 5673,
+      }),
     ).toBeUndefined();
   });
 
   it("honors an explicit --port over a detected live port", () => {
-    expect(chooseSetupPort({ explicitPort: 8080, livePort: 5673 })).toBe(8080);
+    expect(
+      chooseSetupPort({ explicitPort: 8080, authenticatedPort: 5673 }),
+    ).toBe(8080);
   });
 
   it("uses a detected live gateway port when no explicit port is given", () => {
     // This is the fix for the 3207 → 5673 → random fallback mismatch.
-    expect(chooseSetupPort({ livePort: 5673 })).toBe(5673);
+    expect(chooseSetupPort({ authenticatedPort: 5673 })).toBe(5673);
   });
 
   it("returns undefined (→ default port) when nothing is detected", () => {
-    expect(chooseSetupPort({ livePort: null })).toBeUndefined();
+    expect(chooseSetupPort({ authenticatedPort: null })).toBeUndefined();
     expect(chooseSetupPort({})).toBeUndefined();
   });
 });

--- a/packages/gateway/test/setup-sigkill-child.ts
+++ b/packages/gateway/test/setup-sigkill-child.ts
@@ -1,0 +1,23 @@
+import { commandSetup } from "../src/cli/setup";
+import { _setTrustedFileCommitHookForTest } from "../src/cli/json-config";
+
+const [agent, operation, rawCommit] = process.argv.slice(2);
+const killAfterCommit = Number(rawCommit);
+if (
+  !["claude-code", "opencode", "pi"].includes(agent) ||
+  (operation !== "setup" && operation !== "undo") ||
+  !Number.isInteger(killAfterCommit)
+) {
+  throw new Error("Expected an agent, setup|undo, and a commit number.");
+}
+
+_setTrustedFileCommitHookForTest((_file, commit) => {
+  if (commit === killAfterCommit) process.kill(process.pid, "SIGKILL");
+});
+
+await commandSetup(
+  operation === "setup" ? [agent] : ["undo", agent],
+  operation === "setup"
+    ? { port: 3299, ...(agent === "opencode" ? { noPlugin: true } : {}) }
+    : {},
+);

--- a/packages/gateway/test/setup-transaction.test.ts
+++ b/packages/gateway/test/setup-transaction.test.ts
@@ -1,0 +1,1187 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  _setSetupExternalEffectHookForTest,
+  commandSetup,
+  setupExternalEffectJournalPath,
+} from "../src/cli/setup";
+import {
+  _setStagedTrustedFileCommitHookForTest,
+  _setTrustedDirectoryFsyncHookForTest,
+  _setTrustedFileCommitHookForTest,
+  _setTrustedFilePublishHookForTest,
+  atomicWriteTrustedFile,
+  readTrustedTextFile,
+  removeTrustedFile,
+} from "../src/cli/json-config";
+import {
+  lifecycleLockPath,
+  LifecycleLockLostError,
+  withLifecycleLock,
+} from "../src/lifecycle-lock";
+
+interface FileState {
+  bytes: Buffer | null;
+  mode: number | null;
+}
+
+let home: string;
+let originalHome: string | undefined;
+let originalPath: string | undefined;
+let logSpy: MockInstance;
+let errorSpy: MockInstance;
+
+function claudePath(): string {
+  return join(home, ".claude", "settings.json");
+}
+
+function readState(file: string): FileState {
+  if (!existsSync(file)) return { bytes: null, mode: null };
+  return {
+    bytes: readFileSync(file),
+    mode: lstatSync(file).mode & 0o7777,
+  };
+}
+
+function expectState(file: string, expected: FileState): void {
+  expect(readState(file)).toEqual(expected);
+}
+
+function installFakeNpm(
+  state: "installed" | "absent" | "unknown",
+  installStatus = 0,
+  logPath = join(home, "npm.log"),
+): void {
+  const bin = join(home, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    join(bin, "npm"),
+    `#!/bin/sh
+printf '%s\n' "$*" >> '${logPath}'
+if [ "$1" = "ls" ]; then
+  ${state === "installed" ? `printf '%s\n' '{"dependencies":{"@loreai/opencode":{}}}'; exit 0` : state === "absent" ? `printf '%s\n' '{"dependencies":{}}'; exit 0` : `printf '%s\n' 'not-json'; exit 2`}
+fi
+if [ "$1" = "install" ]; then
+  exit ${installStatus}
+fi
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  process.env.PATH = `${bin}:${originalPath ?? ""}`;
+}
+
+function installFakeAgent(binary: string): void {
+  const bin = join(home, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(bin, binary), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+}
+
+function useOnlyFakePath(): void {
+  process.env.PATH = join(home, "bin");
+}
+
+interface FakeNpmPackageState {
+  state: "absent" | "installed";
+  version?: string;
+  source?: string;
+}
+
+interface FakeNpmGeneration {
+  packageDevice: string;
+  packageInode: string;
+  packageMtimeNs: string;
+  packageCtimeNs: string;
+  manifestDevice: string;
+  manifestInode: string;
+  manifestMtimeNs: string;
+  manifestCtimeNs: string;
+}
+
+const FAKE_INSTALLED_PACKAGE: FakeNpmPackageState = {
+  state: "installed",
+  version: "9.9.9",
+  source: "https://registry.example/@loreai/opencode/-/opencode-9.9.9.tgz",
+};
+
+function installStatefulFakeNpm(options: {
+  initial: FakeNpmPackageState;
+  installStatus?: number;
+  uninstallStatus?: number;
+}): void {
+  const bin = join(home, "bin");
+  const statePath = join(home, "npm-state.json");
+  const logPath = join(home, "npm.log");
+  const npmRoot = join(home, "npm-global", "node_modules");
+  const packagePath = join(npmRoot, "@loreai", "opencode");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(npmRoot, { recursive: true });
+  if (options.initial.state === "installed") {
+    mkdirSync(packagePath, { recursive: true });
+    writeFileSync(
+      join(packagePath, "package.json"),
+      JSON.stringify({
+        name: "@loreai/opencode",
+        version: options.initial.version,
+      }),
+    );
+  }
+  writeFileSync(statePath, JSON.stringify(options.initial));
+  writeFileSync(
+    join(bin, "npm"),
+    `#!${process.execPath}
+const fs = require("node:fs");
+const path = require("node:path");
+const statePath = ${JSON.stringify(statePath)};
+const logPath = ${JSON.stringify(logPath)};
+const npmRoot = ${JSON.stringify(npmRoot)};
+const packagePath = ${JSON.stringify(packagePath)};
+const npmPackage = "@loreai/opencode";
+const installedPackage = ${JSON.stringify(FAKE_INSTALLED_PACKAGE)};
+const installStatus = ${options.installStatus ?? 0};
+const uninstallStatus = ${options.uninstallStatus ?? 0};
+const args = process.argv.slice(2);
+fs.appendFileSync(logPath, args.join(" ") + "\\n");
+let state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+if (args[0] === "ls") {
+  const dependencies = state.state === "installed"
+    ? { [npmPackage]: { version: state.version, resolved: state.source, path: packagePath } }
+    : {};
+  process.stdout.write(JSON.stringify({ dependencies }));
+  process.exit(0);
+}
+if (args[0] === "root") {
+  process.stdout.write(npmRoot + "\\n");
+  process.exit(0);
+}
+if (args[0] === "install") {
+  if (installStatus === 0) {
+    fs.rmSync(packagePath, { recursive: true, force: true });
+    fs.mkdirSync(packagePath, { recursive: true });
+    fs.writeFileSync(path.join(packagePath, "package.json"), JSON.stringify({ name: npmPackage, version: installedPackage.version }));
+    state = installedPackage;
+    fs.writeFileSync(statePath, JSON.stringify(state));
+  }
+  process.exit(installStatus);
+}
+if (args[0] === "uninstall") {
+  if (uninstallStatus === 0) {
+    fs.rmSync(packagePath, { recursive: true, force: true });
+    fs.writeFileSync(statePath, JSON.stringify({ state: "absent" }));
+  }
+  process.exit(uninstallStatus);
+}
+process.exit(2);
+`,
+    { mode: 0o755 },
+  );
+  process.env.PATH = `${bin}:${originalPath ?? ""}`;
+}
+
+function fakeNpmPackagePath(): string {
+  return join(home, "npm-global", "node_modules", "@loreai", "opencode");
+}
+
+function fakeNpmGeneration(): FakeNpmGeneration {
+  const packageStats = lstatSync(fakeNpmPackagePath(), { bigint: true });
+  const manifestStats = lstatSync(join(fakeNpmPackagePath(), "package.json"), {
+    bigint: true,
+  });
+  return {
+    packageDevice: packageStats.dev.toString(),
+    packageInode: packageStats.ino.toString(),
+    packageMtimeNs: packageStats.mtimeNs.toString(),
+    packageCtimeNs: packageStats.ctimeNs.toString(),
+    manifestDevice: manifestStats.dev.toString(),
+    manifestInode: manifestStats.ino.toString(),
+    manifestMtimeNs: manifestStats.mtimeNs.toString(),
+    manifestCtimeNs: manifestStats.ctimeNs.toString(),
+  };
+}
+
+function replaceFakeNpmGeneration(): void {
+  rmSync(fakeNpmPackagePath(), { recursive: true, force: true });
+  mkdirSync(fakeNpmPackagePath(), { recursive: true });
+  writeFileSync(
+    join(fakeNpmPackagePath(), "package.json"),
+    JSON.stringify({
+      name: "@loreai/opencode",
+      version: FAKE_INSTALLED_PACKAGE.version,
+    }),
+  );
+}
+
+function publishFakeNpmSuccessorGeneration(): void {
+  replaceFakeNpmGeneration();
+  writeFileSync(
+    join(home, "npm-state.json"),
+    JSON.stringify(FAKE_INSTALLED_PACKAGE),
+  );
+}
+
+function removeFakeNpmPackage(): void {
+  rmSync(fakeNpmPackagePath(), { recursive: true, force: true });
+  writeFileSync(
+    join(home, "npm-state.json"),
+    JSON.stringify({ state: "absent" }),
+  );
+}
+
+function fakeNpmState(): FakeNpmPackageState {
+  return JSON.parse(
+    readFileSync(join(home, "npm-state.json"), "utf8"),
+  ) as FakeNpmPackageState;
+}
+
+function fakeNpmCommands(): string[] {
+  return readFileSync(join(home, "npm.log"), "utf8").trim().split("\n");
+}
+
+function loggedOutput(): string {
+  return [...logSpy.mock.calls, ...errorSpy.mock.calls]
+    .map((call) => call.join(" "))
+    .join("\n");
+}
+
+function externalJournalPath(): string {
+  return setupExternalEffectJournalPath(lifecycleLockPath());
+}
+
+function opencodePath(): string {
+  return join(home, ".config", "opencode", "opencode.json");
+}
+
+function hermesPath(): string {
+  return join(home, ".hermes", ".env");
+}
+
+function installAutoFailureAgents(): void {
+  installFakeAgent("opencode");
+  installFakeAgent("claude");
+  installFakeAgent("hermes");
+  useOnlyFakePath();
+}
+
+function seedAutoFailureConfigs(): {
+  opencode: FileState;
+  claude: FileState;
+} {
+  mkdirSync(dirname(opencodePath()), { recursive: true });
+  writeFileSync(opencodePath(), '{"theme":"dark"}\n', { mode: 0o640 });
+  mkdirSync(dirname(claudePath()), { recursive: true });
+  writeFileSync(claudePath(), '{"theme":"light"}\n', { mode: 0o600 });
+  return {
+    opencode: readState(opencodePath()),
+    claude: readState(claudePath()),
+  };
+}
+
+function failClaudeSetup(message: string): void {
+  _setTrustedFileCommitHookForTest((file) => {
+    if (file === claudePath()) throw new Error(message);
+  });
+}
+
+function runSigkillChild(operation: "setup" | "undo", commit: number): void {
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      join(import.meta.dirname, "setup-sigkill-child.ts"),
+      "claude-code",
+      operation,
+      String(commit),
+    ],
+    {
+      env: {
+        ...process.env,
+        HOME: home,
+        LORE_CONFIG_DIR: join(home, ".lore"),
+      },
+      encoding: "utf8",
+      // A source-loaded child can take over 30 seconds to boot when the full
+      // suite saturates CI workers. Keep a finite hang guard without turning
+      // ordinary scheduler contention into a recovery failure.
+      timeout: 90_000,
+    },
+  );
+  expect(child.error).toBeUndefined();
+  expect(child.status, child.stderr).toBeNull();
+  expect(child.signal).toBe("SIGKILL");
+}
+
+function runExternalEffectSigkillChild(
+  phase:
+    | "after-installed-journal"
+    | "before-journal-cleanup" = "after-installed-journal",
+): void {
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      join(import.meta.dirname, "setup-external-sigkill-child.ts"),
+      phase,
+    ],
+    {
+      env: {
+        ...process.env,
+        HOME: home,
+        LORE_CONFIG_DIR: join(home, ".lore"),
+      },
+      encoding: "utf8",
+      timeout: 90_000,
+    },
+  );
+  expect(child.error).toBeUndefined();
+  expect(child.status, child.stderr).toBeNull();
+  expect(child.signal).toBe("SIGKILL");
+}
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  originalPath = process.env.PATH;
+  home = mkdtempSync(join(tmpdir(), "lore-setup-transaction-"));
+  process.env.HOME = home;
+  rmSync(externalJournalPath(), { force: true });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+});
+
+afterEach(() => {
+  _setSetupExternalEffectHookForTest(null);
+  _setStagedTrustedFileCommitHookForTest(null);
+  _setTrustedDirectoryFsyncHookForTest(null);
+  _setTrustedFileCommitHookForTest(null);
+  _setTrustedFilePublishHookForTest(null);
+  vi.unstubAllGlobals();
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+  process.exitCode = undefined;
+  rmSync(externalJournalPath(), { force: true });
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("setup transaction publication", () => {
+  it("preserves a replacement created immediately before publication", () => {
+    const file = join(home, "publish.json");
+    writeFileSync(file, '{"before":true}\n');
+    const expected = readTrustedTextFile(file)?.identity;
+    if (!expected) throw new Error("missing fixture identity");
+    _setTrustedFilePublishHookForTest((operation, path) => {
+      if (operation !== "write" || path !== file) return;
+      rmSync(file);
+      writeFileSync(file, '{"replacement":true}\n');
+    });
+
+    expect(() =>
+      atomicWriteTrustedFile(file, '{"lore":true}\n', {
+        expectedIdentity: expected,
+      }),
+    ).toThrow("immediately before publication");
+    expect(readFileSync(file, "utf8")).toBe('{"replacement":true}\n');
+  });
+
+  it("preserves a replacement created immediately before removal", () => {
+    const file = join(home, "remove.json");
+    writeFileSync(file, '{"before":true}\n');
+    const expected = readTrustedTextFile(file)?.identity;
+    if (!expected) throw new Error("missing fixture identity");
+    _setTrustedFilePublishHookForTest((operation, path) => {
+      if (operation !== "remove" || path !== file) return;
+      rmSync(file);
+      writeFileSync(file, '{"replacement":true}\n');
+    });
+
+    expect(() => removeTrustedFile(file, expected)).toThrow(
+      "immediately before removal",
+    );
+    expect(readFileSync(file, "utf8")).toBe('{"replacement":true}\n');
+  });
+
+  it.each([1, 2, 3])(
+    "restores config and sidecar exactly after commit %i fails",
+    async (commit) => {
+      mkdirSync(dirname(claudePath()), { recursive: true });
+      writeFileSync(claudePath(), '{"theme":"dark"}\n', { mode: 0o640 });
+      const sidecar = `${claudePath()}.lore-backup`;
+      const beforeConfig = readState(claudePath());
+      const beforeSidecar = readState(sidecar);
+      _setTrustedFileCommitHookForTest((_file, current) => {
+        if (current === commit) throw new Error(`failure after ${commit}`);
+      });
+
+      await expect(
+        commandSetup(["claude-code"], { port: 3299 }),
+      ).rejects.toThrow(`failure after ${commit}`);
+      expectState(claudePath(), beforeConfig);
+      expectState(sidecar, beforeSidecar);
+    },
+  );
+
+  it("publishes journal, config, then strict v3 sidecar", async () => {
+    const sidecar = `${claudePath()}.lore-backup`;
+    const commits: string[] = [];
+    _setTrustedFileCommitHookForTest((file) => commits.push(file));
+
+    await commandSetup(["claude-code"], { port: 3299 });
+
+    expect(commits).toEqual([sidecar, claudePath(), sidecar]);
+    expect(JSON.parse(readFileSync(sidecar, "utf8")).version).toBe(3);
+  });
+
+  it("fails closed on unknown npm state without files or success reporting", async () => {
+    installFakeNpm("unknown");
+    const config = join(home, ".config", "opencode", "opencode.json");
+
+    await commandSetup(["opencode"], { port: 3299 });
+
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(dirname(config))).toBe(false);
+    expect(existsSync(config)).toBe(false);
+    expect(existsSync(`${config}.lore-backup`)).toBe(false);
+    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls]
+      .map((call) => call.join(" "))
+      .join("\n");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+    expect(output).not.toContain("Tip: for terminal use");
+  });
+
+  it("reports explicit OpenCode setup failure without success or liveness output when npm install fails", async () => {
+    installFakeNpm("absent", 42);
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    const config = join(home, ".config", "opencode", "opencode.json");
+
+    await commandSetup(["opencode"], { port: 3299 });
+
+    expect(process.exitCode).toBe(1);
+    expect(readFileSync(join(home, "npm.log"), "utf8")).toContain(
+      "install -g @loreai/opencode",
+    );
+    expect(existsSync(config)).toBe(false);
+    expect(existsSync(`${config}.lore-backup`)).toBe(false);
+    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls]
+      .map((call) => call.join(" "))
+      .join("\n");
+    expect(output).toContain("npm install failed");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+    expect(output).not.toContain("Tip: for terminal use");
+  });
+
+  it("rolls back earlier apps and stops auto setup when OpenCode npm install fails", async () => {
+    installFakeNpm("absent", 42);
+    installFakeAgent("codex");
+    installFakeAgent("opencode");
+    installFakeAgent("claude");
+    useOnlyFakePath();
+
+    const codexConfig = join(home, ".codex", "config.toml");
+    mkdirSync(dirname(codexConfig), { recursive: true });
+    writeFileSync(codexConfig, 'model = "gpt-5.5"\n', { mode: 0o640 });
+    const beforeCodex = readState(codexConfig);
+    const opencodeConfig = join(home, ".config", "opencode", "opencode.json");
+    const claudeConfig = join(home, ".claude", "settings.json");
+
+    await commandSetup([], { port: 3299 });
+
+    expect(process.exitCode).toBe(1);
+    expectState(codexConfig, beforeCodex);
+    expect(existsSync(opencodeConfig)).toBe(false);
+    expect(existsSync(`${opencodeConfig}.lore-backup`)).toBe(false);
+    expect(existsSync(claudeConfig)).toBe(false);
+    expect(existsSync(`${claudeConfig}.lore-backup`)).toBe(false);
+    const output = [...logSpy.mock.calls, ...errorSpy.mock.calls]
+      .map((call) => call.join(" "))
+      .join("\n");
+    expect(output).toContain("npm install failed");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Claude Code configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+    expect(output).not.toContain("Tip: for terminal use");
+  });
+
+  it("uninstalls a package first installed by this auto setup when a later app fails", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installAutoFailureAgents();
+    const before = seedAutoFailureConfigs();
+    failClaudeSetup("later Claude setup failure");
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "later Claude setup failure",
+    );
+
+    expect(fakeNpmCommands()).toEqual([
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "install -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "uninstall -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+    ]);
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(existsSync(externalJournalPath())).toBe(false);
+    expectState(opencodePath(), before.opencode);
+    expectState(`${opencodePath()}.lore-backup`, {
+      bytes: null,
+      mode: null,
+    });
+    expectState(claudePath(), before.claude);
+    expectState(`${claudePath()}.lore-backup`, { bytes: null, mode: null });
+    expect(existsSync(hermesPath())).toBe(false);
+    const output = loggedOutput();
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Claude Code configured");
+    expect(output).not.toContain("Hermes Agent configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+    expect(output).not.toContain("Tip: for terminal use");
+  });
+
+  it("never removes a pre-existing package when a later auto app fails", async () => {
+    const initial: FakeNpmPackageState = {
+      state: "installed",
+      version: "1.2.3",
+      source: "file:/user/opencode-plugin-1.2.3.tgz",
+    };
+    installStatefulFakeNpm({ initial });
+    installAutoFailureAgents();
+    const before = seedAutoFailureConfigs();
+    failClaudeSetup("later setup failed with existing package");
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "later setup failed with existing package",
+    );
+
+    expect(fakeNpmCommands()).toEqual([
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+    ]);
+    expect(fakeNpmState()).toEqual(initial);
+    expectState(opencodePath(), before.opencode);
+    expectState(claudePath(), before.claude);
+    expect(existsSync(hermesPath())).toBe(false);
+    const output = loggedOutput();
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+    expect(output).not.toContain("Tip: for terminal use");
+  });
+
+  it("compensates npm when the aggregate staged-file commit fails", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    mkdirSync(dirname(opencodePath()), { recursive: true });
+    writeFileSync(opencodePath(), '{"theme":"dark"}\n', { mode: 0o640 });
+    const before = readState(opencodePath());
+    _setStagedTrustedFileCommitHookForTest(() => {
+      throw new Error("aggregate setup commit failure");
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "aggregate setup commit failure",
+    );
+
+    expect(fakeNpmCommands()).toEqual([
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "install -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "uninstall -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+    ]);
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(existsSync(externalJournalPath())).toBe(false);
+    expectState(opencodePath(), before);
+    expectState(`${opencodePath()}.lore-backup`, {
+      bytes: null,
+      mode: null,
+    });
+    const output = loggedOutput();
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+    expect(output).not.toContain("Tip: for terminal use");
+  });
+
+  it("commits a newly installed package and all files after successful auto setup", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    installFakeAgent("claude");
+    useOnlyFakePath();
+
+    await commandSetup([], { port: 3299 });
+
+    expect(fakeNpmCommands()).toEqual([
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "install -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+    ]);
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(externalJournalPath())).toBe(false);
+    const opencode = JSON.parse(readFileSync(opencodePath(), "utf8"));
+    expect(opencode.plugin).toContain("@loreai/opencode");
+    expect(opencode.compaction.auto).toBe(false);
+    const claude = JSON.parse(readFileSync(claudePath(), "utf8"));
+    expect(claude.env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:3299");
+    const output = loggedOutput();
+    expect(output).toContain("OpenCode configured");
+    expect(output).toContain("Claude Code configured");
+    expect(output).toContain("Gateway is not reachable");
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("reports compensation failure while still restoring all setup files", async () => {
+    installStatefulFakeNpm({
+      initial: { state: "absent" },
+      uninstallStatus: 73,
+    });
+    installAutoFailureAgents();
+    const before = seedAutoFailureConfigs();
+    failClaudeSetup("later failure before failed compensation");
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "Setup failed and could not be fully rolled back",
+    );
+
+    expect(fakeNpmCommands()).toEqual([
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "install -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "uninstall -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+    ]);
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    expectState(opencodePath(), before.opencode);
+    expectState(claudePath(), before.claude);
+    expect(existsSync(hermesPath())).toBe(false);
+    expect(process.exitCode).toBe(1);
+    const output = loggedOutput();
+    expect(output).toContain("npm uninstall failed while rolling back");
+    expect(output).toContain("Could not restore the prior global state");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+    expect(output).not.toContain("Tip: for terminal use");
+  });
+
+  it("refuses file commit after concurrent package removal and preserves recovery evidence", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    mkdirSync(dirname(opencodePath()), { recursive: true });
+    writeFileSync(opencodePath(), '{"theme":"dark"}\n', { mode: 0o640 });
+    const before = readState(opencodePath());
+    _setSetupExternalEffectHookForTest((phase) => {
+      if (phase === "before-prepare") removeFakeNpmPackage();
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "could not be fully rolled back",
+    );
+
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expectState(opencodePath(), before);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    const output = loggedOutput();
+    expect(output).toContain("changed before setup commit");
+    expect(output).toContain("successor state was preserved");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+  });
+
+  it("restores committed evidence when the package changes during journal removal", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setTrustedFilePublishHookForTest((operation, path) => {
+      if (operation === "remove" && path === externalJournalPath()) {
+        replaceFakeNpmGeneration();
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "changed during setup journal cleanup",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(fakeNpmPackagePath())).toBe(true);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(JSON.parse(readFileSync(externalJournalPath(), "utf8")).phase).toBe(
+      "committed",
+    );
+    const config = JSON.parse(readFileSync(opencodePath(), "utf8"));
+    expect(config.plugin).toContain("@loreai/opencode");
+    const output = loggedOutput();
+    expect(output).toContain("recovery evidence was restored");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+
+    await expect(commandSetup(["status"], {})).rejects.toThrow(
+      "committed setup generation",
+    );
+    expect(existsSync(externalJournalPath())).toBe(true);
+  });
+
+  it("preserves package and config when committed-journal publication reports a later failure", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setTrustedDirectoryFsyncHookForTest((directory) => {
+      if (directory !== dirname(externalJournalPath())) return;
+      if (!existsSync(externalJournalPath())) return;
+      const journal = JSON.parse(readFileSync(externalJournalPath(), "utf8"));
+      if (journal.phase === "committed") {
+        throw new Error("committed journal post-publication failure");
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "committed journal post-publication failure",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(fakeNpmPackagePath())).toBe(true);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(JSON.parse(readFileSync(externalJournalPath(), "utf8")).phase).toBe(
+      "committed",
+    );
+    const config = JSON.parse(readFileSync(opencodePath(), "utf8"));
+    expect(config.plugin).toContain("@loreai/opencode");
+    const output = loggedOutput();
+    expect(output).toContain("crossed its durable commit point");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+
+    _setTrustedDirectoryFsyncHookForTest(null);
+    await commandSetup(["status"], {});
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(externalJournalPath())).toBe(false);
+    expect(JSON.parse(readFileSync(opencodePath(), "utf8"))).toEqual(config);
+  });
+
+  it("rolls back package and config when committed-journal publication never starts", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    let journalWrites = 0;
+    _setTrustedFilePublishHookForTest((operation, path) => {
+      if (operation !== "write" || path !== externalJournalPath()) return;
+      journalWrites += 1;
+      if (journalWrites === 4) {
+        throw new Error("committed journal pre-publication failure");
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "committed journal pre-publication failure",
+    );
+
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(fakeNpmCommands()).toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(existsSync(externalJournalPath())).toBe(false);
+  });
+
+  it("rolls back package and config when committed evidence disappears after publication", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setTrustedDirectoryFsyncHookForTest((directory) => {
+      if (directory !== dirname(externalJournalPath())) return;
+      if (!existsSync(externalJournalPath())) return;
+      const journal = JSON.parse(readFileSync(externalJournalPath(), "utf8"));
+      if (journal.phase === "committed") {
+        rmSync(externalJournalPath());
+        throw new Error("committed journal disappeared");
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "committed journal disappeared",
+    );
+
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(fakeNpmCommands()).toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(existsSync(externalJournalPath())).toBe(false);
+  });
+
+  it("rolls back package and config while preserving malformed replacement evidence", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setTrustedDirectoryFsyncHookForTest((directory) => {
+      if (directory !== dirname(externalJournalPath())) return;
+      if (!existsSync(externalJournalPath())) return;
+      const journal = JSON.parse(readFileSync(externalJournalPath(), "utf8"));
+      if (journal.phase === "committed") {
+        writeFileSync(externalJournalPath(), "not-json\n");
+        throw new Error("committed journal replaced with malformed evidence");
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "could not be fully rolled back",
+    );
+
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(fakeNpmCommands()).toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(readFileSync(externalJournalPath(), "utf8")).toBe("not-json\n");
+  });
+
+  it("rolls back package and config while preserving a valid replacement journal generation", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setTrustedDirectoryFsyncHookForTest((directory) => {
+      if (directory !== dirname(externalJournalPath())) return;
+      if (!existsSync(externalJournalPath())) return;
+      const bytes = readFileSync(externalJournalPath());
+      const journal = JSON.parse(bytes.toString("utf8"));
+      if (journal.phase === "committed") {
+        rmSync(externalJournalPath());
+        writeFileSync(externalJournalPath(), bytes);
+        throw new Error("committed journal generation replaced");
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "could not be fully rolled back",
+    );
+
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(fakeNpmCommands()).toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(JSON.parse(readFileSync(externalJournalPath(), "utf8")).phase).toBe(
+      "committed",
+    );
+  });
+
+  it("distinguishes and preserves a same-version/source successor generation before commit", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setSetupExternalEffectHookForTest((phase) => {
+      if (phase === "before-prepare") replaceFakeNpmGeneration();
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "could not be fully rolled back",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(fakeNpmPackagePath())).toBe(true);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    const output = loggedOutput();
+    expect(output).toContain("changed before setup commit");
+    expect(output).toContain("successor state was preserved");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+  });
+
+  it("revalidates absence immediately before initial npm installation", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setSetupExternalEffectHookForTest((phase) => {
+      if (phase === "before-install-mutation") {
+        publishFakeNpmSuccessorGeneration();
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "could not be fully rolled back",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(fakeNpmPackagePath())).toBe(true);
+    expect(fakeNpmCommands()).not.toContain("install -g @loreai/opencode");
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    const output = loggedOutput();
+    expect(output).toContain("changed immediately before installation");
+    expect(output).toContain("successor state was preserved");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+  });
+
+  it("revalidates the installed generation immediately before destructive rollback", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setSetupExternalEffectHookForTest((phase) => {
+      if (phase === "before-prepare") {
+        throw new Error("force rollback before the logical commit");
+      }
+      if (phase === "before-rollback-mutation") {
+        replaceFakeNpmGeneration();
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "could not be fully rolled back",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(fakeNpmPackagePath())).toBe(true);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    const output = loggedOutput();
+    expect(output).toContain("no longer matches Lore's installed generation");
+    expect(output).toContain("successor state was preserved");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+  });
+
+  it("revalidates the installed generation immediately before committed-journal cleanup", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setSetupExternalEffectHookForTest((phase) => {
+      if (phase === "before-journal-cleanup") replaceFakeNpmGeneration();
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "changed before setup journal cleanup",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(fakeNpmPackagePath())).toBe(true);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(JSON.parse(readFileSync(externalJournalPath(), "utf8")).phase).toBe(
+      "committed",
+    );
+    const config = JSON.parse(readFileSync(opencodePath(), "utf8"));
+    expect(config.plugin).toContain("@loreai/opencode");
+    const output = loggedOutput();
+    expect(output).toContain("successor state");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+  });
+
+  it("does not roll back npm after lifecycle ownership is lost before external prepare", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setSetupExternalEffectHookForTest((phase) => {
+      if (phase === "before-prepare") {
+        throw new LifecycleLockLostError("simulated lock theft before prepare");
+      }
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "simulated lock theft before prepare",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    const output = loggedOutput();
+    expect(output).toContain("Lifecycle-lock ownership was lost");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+  });
+
+  it("does not roll back npm when lifecycle ownership is lost immediately before rollback", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+    _setStagedTrustedFileCommitHookForTest(() => {
+      throw new LifecycleLockLostError("simulated lock loss before rollback");
+    });
+
+    await expect(commandSetup([], { port: 3299 })).rejects.toThrow(
+      "simulated lock loss before rollback",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(existsSync(opencodePath())).toBe(false);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    const output = loggedOutput();
+    expect(output).toContain("Lifecycle-lock ownership was lost");
+    expect(output).not.toContain("OpenCode configured");
+    expect(output).not.toContain("Gateway is reachable");
+    expect(output).not.toContain("Gateway is not reachable");
+  });
+
+  it("recovers the exact package generation on the next setup after SIGKILL", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+
+    runExternalEffectSigkillChild();
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    if (process.platform !== "win32") {
+      expect(lstatSync(externalJournalPath()).mode & 0o777).toBe(0o600);
+    }
+
+    await commandSetup(["status"], {});
+
+    expect(fakeNpmState()).toEqual({ state: "absent" });
+    expect(existsSync(externalJournalPath())).toBe(false);
+    expect(fakeNpmCommands()).toEqual([
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "install -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+      "uninstall -g @loreai/opencode",
+      "ls -g @loreai/opencode --json --depth=0 --long",
+    ]);
+    expect(loggedOutput()).toContain(
+      "Recovering interrupted global installation",
+    );
+  });
+
+  it("preserves an exact committed package and registered config after SIGKILL at the final boundary", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+
+    runExternalEffectSigkillChild("before-journal-cleanup");
+    const installedGeneration = fakeNpmGeneration();
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(JSON.parse(readFileSync(externalJournalPath(), "utf8")).phase).toBe(
+      "committed",
+    );
+    const committedConfig = JSON.parse(readFileSync(opencodePath(), "utf8"));
+    expect(committedConfig.plugin).toContain("@loreai/opencode");
+    expect(committedConfig.compaction.auto).toBe(false);
+
+    await commandSetup(["status"], {});
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(fakeNpmGeneration()).toEqual(installedGeneration);
+    expect(existsSync(externalJournalPath())).toBe(false);
+    const reconciledConfig = JSON.parse(readFileSync(opencodePath(), "utf8"));
+    expect(reconciledConfig).toEqual(committedConfig);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(loggedOutput()).not.toContain(
+      "Recovering interrupted global installation",
+    );
+  });
+
+  it("preserves a changed package generation on the next setup after SIGKILL", async () => {
+    installStatefulFakeNpm({ initial: { state: "absent" } });
+    installFakeAgent("opencode");
+    useOnlyFakePath();
+
+    runExternalEffectSigkillChild();
+    replaceFakeNpmGeneration();
+
+    await expect(commandSetup(["status"], {})).rejects.toThrow(
+      "successor state",
+    );
+
+    expect(fakeNpmState()).toEqual(FAKE_INSTALLED_PACKAGE);
+    expect(existsSync(fakeNpmPackagePath())).toBe(true);
+    expect(existsSync(externalJournalPath())).toBe(true);
+    expect(fakeNpmCommands()).not.toContain("uninstall -g @loreai/opencode");
+    expect(loggedOutput()).not.toContain("OpenCode configured");
+  });
+
+  it("supports setup undo reentrantly under an uninstall lifecycle lock", async () => {
+    await commandSetup(["claude-code"], { port: 3299 });
+    await withLifecycleLock("uninstall", async (outerLock) => {
+      await commandSetup(["undo", "claude-code"], {});
+      outerLock.assertOwned();
+    });
+    expect(existsSync(`${claudePath()}.lore-backup`)).toBe(false);
+    expect(existsSync(claudePath())).toBe(false);
+  });
+});
+
+describe.skipIf(process.platform === "win32")(
+  "SIGKILL journal recovery",
+  () => {
+    it.each([1, 2, 3])(
+      "recovers setup and undo after hard kill at commit %i",
+      async (commit) => {
+        mkdirSync(dirname(claudePath()), { recursive: true });
+        const original =
+          '{"env":{"ANTHROPIC_BASE_URL":"https://api.anthropic.com"}}\n';
+        writeFileSync(claudePath(), original);
+
+        runSigkillChild("setup", commit);
+        expect(
+          JSON.parse(readFileSync(`${claudePath()}.lore-backup`, "utf8"))
+            .version,
+        ).toBe(commit < 3 ? 2 : 3);
+        await commandSetup(["claude-code"], { port: 3299 });
+
+        runSigkillChild("undo", commit);
+        await commandSetup(["undo", "claude-code"], {});
+
+        expect(JSON.parse(readFileSync(claudePath(), "utf8"))).toEqual(
+          JSON.parse(original),
+        );
+        expect(existsSync(`${claudePath()}.lore-backup`)).toBe(false);
+      },
+    );
+  },
+);

--- a/packages/gateway/test/setup.test.ts
+++ b/packages/gateway/test/setup.test.ts
@@ -32,34 +32,22 @@ describe("normalizeBaseUrl", () => {
     expect(normalizeBaseUrl(undefined, 8080)).toBe("http://127.0.0.1:8080/v1");
   });
 
-  test("remote URL without trailing slash", () => {
-    expect(normalizeBaseUrl("http://remote:3207", undefined)).toBe(
-      "http://remote:3207/v1",
-    );
-  });
-
-  test("remote URL with trailing slash", () => {
-    expect(normalizeBaseUrl("http://remote:3207/", undefined)).toBe(
-      "http://remote:3207/v1",
-    );
-  });
-
-  test("remote URL with multiple trailing slashes", () => {
-    expect(normalizeBaseUrl("http://remote:3207///", undefined)).toBe(
-      "http://remote:3207/v1",
-    );
-  });
-
-  test("remote URL already ending in /v1", () => {
-    expect(normalizeBaseUrl("http://remote:3207/v1", undefined)).toBe(
-      "http://remote:3207/v1",
-    );
-  });
-
-  test("remote URL ending in /v1/", () => {
-    expect(normalizeBaseUrl("http://remote:3207/v1/", undefined)).toBe(
-      "http://remote:3207/v1",
-    );
+  test.each([
+    ["http://remote:3207", "http://remote:3207/v1"],
+    ["http://remote:3207/", "http://remote:3207/v1"],
+    ["http://remote:3207///", "http://remote:3207/v1"],
+    ["http://remote:3207/v1", "http://remote:3207/v1"],
+    ["http://remote:3207/v1/", "http://remote:3207/v1"],
+    ["https://gateway.example/lore", "https://gateway.example/lore/v1"],
+    [
+      "https://gateway.example/team/lore/",
+      "https://gateway.example/team/lore/v1",
+    ],
+    ["http://localhost:8080/lore", "http://localhost:8080/lore/v1"],
+    ["http://[::1]:8080/v1", "http://[::1]:8080/v1"],
+    [" HTTPS://GATEWAY.EXAMPLE:443/lore/ ", "https://gateway.example/lore/v1"],
+  ])("normalizes supported remote URL %s", (input, expected) => {
+    expect(normalizeBaseUrl(input, undefined)).toBe(expected);
   });
 
   test("remote URL takes precedence over port", () => {
@@ -68,22 +56,33 @@ describe("normalizeBaseUrl", () => {
     );
   });
 
-  test("rejects URL with double-quotes", () => {
-    expect(() =>
-      normalizeBaseUrl('http://evil.com/v1"inject', undefined),
-    ).toThrow("Invalid characters");
-  });
-
-  test("rejects URL with control characters", () => {
-    expect(() =>
-      normalizeBaseUrl("http://evil.com/v1\nmalicious", undefined),
-    ).toThrow("Invalid characters");
-  });
-
-  test("rejects URL with backslash", () => {
-    expect(() => normalizeBaseUrl("http://evil.com\\v1", undefined)).toThrow(
-      "Invalid characters",
-    );
+  test.each([
+    ["malformed", "not a URL"],
+    ["missing host", "https://"],
+    ["empty authority", "https:///gateway.example"],
+    ["file protocol", "file:///tmp/lore.sock"],
+    ["javascript protocol", "javascript:super-secret"],
+    ["username", "https://alice@gateway.example"],
+    ["password", "https://alice:super-secret@gateway.example"],
+    ["empty userinfo", "https://@gateway.example"],
+    ["query", "https://gateway.example/lore?token=super-secret"],
+    ["empty query", "https://gateway.example/lore?"],
+    ["fragment", "https://gateway.example/lore#super-secret"],
+    ["empty fragment", "https://gateway.example/lore#"],
+    ["double quote", 'http://evil.com/v1"inject'],
+    ["control character", "http://evil.com/v1\nmalicious"],
+    ["backslash", "http://evil.com\\v1"],
+  ])("rejects a remote URL with %s without echoing it", (_case, input) => {
+    let error: unknown;
+    try {
+      normalizeBaseUrl(input, undefined);
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("Invalid remote URL");
+    expect((error as Error).message).not.toContain(input);
+    expect((error as Error).message).not.toContain("super-secret");
   });
 
   test("rejects whitespace-only remote URL", () => {
@@ -745,6 +744,17 @@ describe("updateHermesEnv", () => {
     expect(second).toBe(first);
     // Exactly one backup block (the footer appears once per block).
     expect(second.match(/# end lore setup backup/g)?.length).toBe(1);
+  });
+
+  test("canonicalizes duplicate live assignments so the final value routes through Lore", () => {
+    const result = updateHermesEnv(
+      "OPENAI_BASE_URL=https://first/v1\nOPENAI_BASE_URL=https://shadowing/v1\n",
+      BASE,
+    );
+    const live = result
+      .split("\n")
+      .filter((line) => line.startsWith("OPENAI_BASE_URL="));
+    expect(live).toEqual([`OPENAI_BASE_URL=${BASE}`]);
   });
 });
 

--- a/packages/gateway/test/shutdown-active-stream.test.ts
+++ b/packages/gateway/test/shutdown-active-stream.test.ts
@@ -1,0 +1,387 @@
+import { createServer, type Server } from "node:http";
+import { once } from "node:events";
+import { createConnection, type AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { embedding, log } from "@loreai/core";
+import type { GatewayProcessRecord } from "../src/pidfile";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("startGateway active-stream shutdown", () => {
+  it("bounds authenticated shutdown when a socket sends incomplete headers", async () => {
+    const core = await import("@loreai/core");
+    vi.spyOn(embedding, "settleDocumentEmbeds").mockResolvedValue(undefined);
+    vi.spyOn(embedding, "resetProvider").mockResolvedValue(undefined);
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockResolvedValue(undefined);
+    vi.spyOn(core, "close").mockImplementation(() => {});
+
+    const { startServer } = await import("../src/server");
+    const { requestGatewayShutdown, startGateway } =
+      await import("../src/cli/start");
+    let processRecord: GatewayProcessRecord | null = null;
+    let markRemoved!: () => void;
+    const removed = new Promise<void>((resolve) => {
+      markRemoved = resolve;
+    });
+    const handle = await startGateway(
+      { port: 0, local: true, quiet: true },
+      {
+        readProcess: () => processRecord,
+        authenticate: async () => null,
+        writePort: () => {},
+        removePort: () => {},
+        writeProcess: (record) => {
+          processRecord = record;
+        },
+        removeProcess: () => {
+          processRecord = null;
+          markRemoved();
+        },
+        startServer: (config, options) =>
+          startServer(config, { ...options, shutdownDeadlineMs: 75 }),
+      },
+    );
+    const partialSocket = createConnection(handle.port, "127.0.0.1");
+
+    try {
+      await once(partialSocket, "connect");
+      partialSocket.write("GET /health HTTP/1.1\r\nHost: localhost\r\n");
+
+      const record = processRecord;
+      expect(record).not.toBeNull();
+      if (!record) throw new Error("gateway process record was not published");
+      const requestResult = await requestGatewayShutdown(record, 500);
+      expect(requestResult).toBe("accepted");
+
+      await expect(
+        Promise.race([
+          removed,
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("gateway shutdown did not settle")),
+              500,
+            ),
+          ),
+        ]),
+      ).resolves.toBeUndefined();
+      if (!partialSocket.destroyed) await once(partialSocket, "close");
+      expect(partialSocket.destroyed).toBe(true);
+      expect(processRecord).toBeNull();
+      await expect(handle.shutdown()).resolves.toBeUndefined();
+    } finally {
+      partialSocket.destroy();
+      await handle.shutdown().catch(() => {});
+    }
+  });
+
+  it("force-exits nonzero when authenticated control teardown never settles", async () => {
+    const { startServer } = await import("../src/server");
+    const { requestGatewayShutdown, startGateway } =
+      await import("../src/cli/start");
+    const { makeProcessShutdownController } =
+      await import("../src/cli/shutdown");
+    let processRecord: GatewayProcessRecord | null = null;
+    let markForced!: (code: number) => void;
+    const forced = new Promise<number>((resolve) => {
+      markForced = resolve;
+    });
+    let releaseReset!: () => void;
+    const resetGate = new Promise<void>((resolve) => {
+      releaseReset = resolve;
+    });
+    const reset = vi.fn(() => resetGate);
+    let allowTestCleanup!: () => void;
+    const testCleanupAllowed = new Promise<void>((resolve) => {
+      allowTestCleanup = resolve;
+    });
+    let markRemoved!: () => void;
+    const removed = new Promise<void>((resolve) => {
+      markRemoved = resolve;
+    });
+    const safeExit = vi.fn((_code: number): never => {
+      throw new Error("safe exit must not run");
+    });
+    const forcedExit = vi.fn((code: number): never => {
+      markForced(code);
+      throw new Error(`__forcedExit__:${code}`);
+    });
+
+    const handle = await startGateway(
+      { port: 0, local: true, quiet: true, processBoundary: true },
+      {
+        readProcess: () => processRecord,
+        authenticate: async () => null,
+        writePort: () => {},
+        removePort: () => {},
+        writeProcess: (record) => {
+          processRecord = record;
+        },
+        removeProcess: () => {
+          processRecord = null;
+          markRemoved();
+        },
+        resetPipelineState: reset,
+        startServer: (config, options) =>
+          startServer(config, { ...options, shutdownDeadlineMs: 20 }),
+        createProcessShutdownController: (shutdown) => {
+          const controller = makeProcessShutdownController(shutdown, {
+            deadlineMs: 20,
+            safeExit,
+            forcedExit,
+          });
+          return Object.assign(
+            async (code: number, signal?: NodeJS.Signals): Promise<never> => {
+              try {
+                return await controller(code, signal);
+              } catch {
+                await testCleanupAllowed;
+                releaseReset();
+                return await new Promise<never>(() => {});
+              }
+            },
+            {
+              attachChild: controller.attachChild,
+              childExited: controller.childExited,
+              isShutdownStarted: controller.isShutdownStarted,
+              killChildAndWait: controller.killChildAndWait,
+            },
+          );
+        },
+      },
+    );
+
+    const record = processRecord;
+    expect(record).not.toBeNull();
+    if (!record) throw new Error("gateway process record was not published");
+
+    // The accepted response must arrive before process teardown starts.
+    await expect(requestGatewayShutdown(record, 500)).resolves.toBe("accepted");
+    await expect(forced).resolves.toBe(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(forcedExit).toHaveBeenCalledWith(1);
+    expect(safeExit).not.toHaveBeenCalled();
+    // Teardown never reached safe closure, so live-generation evidence remains.
+    expect(processRecord).toEqual(record);
+
+    // A concurrent signal/control request shares the same teardown attempt.
+    void handle.processShutdown?.(143);
+    expect(reset).toHaveBeenCalledTimes(1);
+    allowTestCleanup();
+    await removed;
+  });
+
+  it("starts listener close, cancels the stream, then awaits listener completion", async () => {
+    const order: string[] = [];
+    const core = await import("@loreai/core");
+    vi.spyOn(embedding, "settleDocumentEmbeds").mockImplementation(async () => {
+      order.push("embed-drain");
+    });
+    vi.spyOn(embedding, "resetProvider").mockResolvedValue(undefined);
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockResolvedValue(undefined);
+    vi.spyOn(core, "close").mockImplementation(() => {});
+
+    const { createForegroundAbortScope } = await import("../src/pipeline");
+    const { startGateway } = await import("../src/cli/start");
+    const caller = new AbortController();
+    const stream = createForegroundAbortScope(caller.signal);
+    let markCloseStarted!: () => void;
+    const closeStarted = new Promise<void>((resolve) => {
+      markCloseStarted = resolve;
+    });
+    let processRecord: GatewayProcessRecord | null = null;
+    let activeServer: Server | undefined;
+    const handle = await startGateway(
+      { port: 0, local: true, quiet: true },
+      {
+        readProcess: () => processRecord,
+        authenticate: async () => null,
+        writePort: () => {},
+        removePort: () => {},
+        writeProcess: (record) => {
+          processRecord = record;
+        },
+        removeProcess: () => {
+          processRecord = null;
+        },
+        startServer: async () => {
+          activeServer = createServer((_request, response) => {
+            response.writeHead(200, {
+              "content-type": "text/event-stream",
+            });
+            response.write("data: active\n\n");
+            stream.signal.addEventListener(
+              "abort",
+              () => {
+                order.push("stream-cancelled");
+                response.end();
+              },
+              { once: true },
+            );
+          });
+          await new Promise<void>((resolve, reject) => {
+            activeServer?.once("error", reject);
+            activeServer?.listen(0, "127.0.0.1", resolve);
+          });
+          const port = (activeServer.address() as AddressInfo).port;
+          return {
+            ready: Promise.resolve(),
+            port,
+            hosts: ["127.0.0.1"],
+            stop: () => {
+              order.push("listener-close-started");
+              markCloseStarted();
+              return new Promise<void>((resolve, reject) => {
+                activeServer?.close((error) => {
+                  if (error) reject(error);
+                  else {
+                    order.push("listener-closed");
+                    resolve();
+                  }
+                });
+              });
+            },
+          };
+        },
+      },
+    );
+
+    let shutdown: Promise<void> | undefined;
+    let cancelledByShutdown = false;
+    try {
+      const response = await fetch(`http://127.0.0.1:${handle.port}/stream`);
+      const reader = response.body?.getReader();
+      expect((await reader?.read())?.done).toBe(false);
+      shutdown = handle.shutdown();
+      await closeStarted;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      cancelledByShutdown = stream.signal.aborted;
+    } finally {
+      if (!stream.signal.aborted) caller.abort();
+      await shutdown;
+      stream.dispose();
+      if (activeServer?.listening) {
+        await new Promise<void>((resolve) =>
+          activeServer?.close(() => resolve()),
+        );
+      }
+    }
+
+    expect(cancelledByShutdown).toBe(true);
+    expect(order).toEqual([
+      "listener-close-started",
+      "stream-cancelled",
+      "listener-closed",
+      "embed-drain",
+    ]);
+  });
+
+  it("runs the published remote callback through the same shutdown cleanup", async () => {
+    const core = await import("@loreai/core");
+    vi.spyOn(embedding, "settleDocumentEmbeds").mockResolvedValue(undefined);
+    vi.spyOn(embedding, "resetProvider").mockResolvedValue(undefined);
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockResolvedValue(undefined);
+    vi.spyOn(core, "close").mockImplementation(() => {});
+    const { startGateway } = await import("../src/cli/start");
+    let processRecord: GatewayProcessRecord | null = null;
+    let requestRemoteShutdown: (() => void | Promise<void>) | undefined;
+    let stopCalls = 0;
+    let markRemoved!: () => void;
+    const removed = new Promise<void>((resolve) => {
+      markRemoved = resolve;
+    });
+    await startGateway(
+      { port: 0, local: true, quiet: true },
+      {
+        readProcess: () => processRecord,
+        authenticate: async () => null,
+        writePort: () => {},
+        removePort: () => {},
+        writeProcess: (record) => {
+          processRecord = record;
+        },
+        removeProcess: () => {
+          processRecord = null;
+          markRemoved();
+        },
+        startServer: async (_config, options) => {
+          requestRemoteShutdown = options?.onShutdown;
+          return {
+            ready: Promise.resolve(),
+            port: 49322,
+            hosts: ["127.0.0.1"],
+            stop: async () => {
+              stopCalls += 1;
+            },
+          };
+        },
+      },
+    );
+
+    expect(requestRemoteShutdown).toBeTypeOf("function");
+    void requestRemoteShutdown?.();
+    await removed;
+    expect(stopCalls).toBe(1);
+    expect(processRecord).toBeNull();
+  });
+
+  it("reports remote shutdown rejection and sets a nonzero exit code", async () => {
+    const core = await import("@loreai/core");
+    vi.spyOn(embedding, "settleDocumentEmbeds").mockResolvedValue(undefined);
+    vi.spyOn(embedding, "resetProvider").mockResolvedValue(undefined);
+    vi.spyOn(core, "shutdownVectorPoolAsync").mockResolvedValue(undefined);
+    vi.spyOn(core, "close").mockImplementation(() => {});
+    const { startGateway } = await import("../src/cli/start");
+    let processRecord: GatewayProcessRecord | null = null;
+    let requestRemoteShutdown: (() => void | Promise<void>) | undefined;
+    let markReported!: () => void;
+    const reported = new Promise<void>((resolve) => {
+      markReported = resolve;
+    });
+    const warnings: string[] = [];
+    vi.spyOn(log, "warn").mockImplementation((message) => {
+      warnings.push(String(message));
+      if (String(message).includes("Remote shutdown failed")) markReported();
+    });
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await startGateway(
+        { port: 0, local: true, quiet: true },
+        {
+          readProcess: () => processRecord,
+          authenticate: async () => null,
+          writePort: () => {},
+          removePort: () => {},
+          writeProcess: (record) => {
+            processRecord = record;
+          },
+          removeProcess: () => {
+            processRecord = null;
+          },
+          startServer: async (_config, options) => {
+            requestRemoteShutdown = options?.onShutdown;
+            return {
+              ready: Promise.resolve(),
+              port: 49323,
+              hosts: ["127.0.0.1"],
+              stop: async () => {
+                throw new Error("injected listener close failure");
+              },
+            };
+          },
+        },
+      );
+
+      void requestRemoteShutdown?.();
+      await reported;
+      expect(process.exitCode).toBe(1);
+      expect(warnings.join("\n")).toContain(
+        "Remote shutdown failed: injected listener close failure",
+      );
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+});

--- a/packages/gateway/test/shutdown.test.ts
+++ b/packages/gateway/test/shutdown.test.ts
@@ -36,12 +36,14 @@ import {
   SHUTDOWN_DEADLINE_MS,
   parseShutdownDeadline,
   makeSignalShutdownHandler,
+  makeProcessShutdownController,
   makeChildForwardHandler,
   installSignalShutdown,
   installChildSignalForwarding,
 } from "../src/cli/shutdown";
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   safeExitMock.mockClear();
   forcedExitMock.mockClear();
@@ -53,6 +55,7 @@ describe("signalExitCode", () => {
     expect(signalExitCode("SIGTERM")).toBe(143);
     expect(signalExitCode("SIGHUP")).toBe(129);
     expect(signalExitCode("SIGQUIT")).toBe(131);
+    expect(signalExitCode("SIGKILL")).toBe(137);
   });
 
   test("falls back to 129 (128 + 1) for unknown signals", () => {
@@ -79,8 +82,17 @@ describe("parseShutdownDeadline", () => {
     ["zero", "0"],
     ["negative", "-5"],
     ["Infinity", "Infinity"],
+    ["NaN", "NaN"],
+    ["fractional", "10.5"],
+    ["timer overflow", "2147483648"],
+    ["unsafe integer", "9007199254740992"],
   ])("falls back to default for %s input — never disables", (_label, raw) => {
     expect(parseShutdownDeadline(raw, 4000)).toBe(4000);
+  });
+
+  test("clamps tiny integers and accepts the largest Node timer", () => {
+    expect(parseShutdownDeadline("1", 4000)).toBe(10);
+    expect(parseShutdownDeadline("2147483647", 4000)).toBe(2147483647);
   });
 });
 
@@ -129,16 +141,24 @@ describe("runShutdownWithDeadline", () => {
       ),
     ).toBe(true);
   });
+
+  test("swallows a synchronous shutdown throw and still resolves", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = await runShutdownWithDeadline(() => {
+      throw new Error("synchronous boom");
+    }, 1000);
+    expect(result).toEqual({ timedOut: false, failed: true });
+  });
 });
 
 describe("makeSignalShutdownHandler", () => {
-  test("first signal runs shutdown then force-exits with the signal code", async () => {
+  test("first signal runs shutdown then safely exits with the signal code", async () => {
     const shutdown = vi.fn(async () => {});
     const handle = makeSignalShutdownHandler(shutdown);
-    await expect(handle("SIGINT")).rejects.toThrow("__forcedExit__:130");
+    await expect(handle("SIGINT")).rejects.toThrow("__safeExit__:130");
     expect(shutdown).toHaveBeenCalledTimes(1);
-    expect(forcedExitMock).toHaveBeenCalledWith(130);
-    expect(safeExitMock).not.toHaveBeenCalled();
+    expect(safeExitMock).toHaveBeenCalledWith(130);
+    expect(forcedExitMock).not.toHaveBeenCalled();
   });
 
   test("first signal STILL uses forcedExit when shutdown hangs past the deadline", async () => {
@@ -146,7 +166,10 @@ describe("makeSignalShutdownHandler", () => {
     const shutdown = vi.fn(
       () => new Promise<void>(() => {}), // never resolves
     );
-    const handle = makeSignalShutdownHandler(shutdown);
+    const processShutdown = makeProcessShutdownController(shutdown, {
+      deadlineMs: 20,
+    });
+    const handle = makeSignalShutdownHandler(shutdown, processShutdown);
     await expect(handle("SIGINT")).rejects.toThrow("__forcedExit__:130");
     expect(forcedExitMock).toHaveBeenCalledWith(130);
     expect(safeExitMock).not.toHaveBeenCalled();
@@ -157,7 +180,7 @@ describe("makeSignalShutdownHandler", () => {
     const shutdown = vi.fn(async () => {});
     const handle = makeSignalShutdownHandler(shutdown);
 
-    await expect(handle("SIGTERM")).rejects.toThrow("__forcedExit__:143");
+    await expect(handle("SIGTERM")).rejects.toThrow("__safeExit__:143");
     expect(shutdown).toHaveBeenCalledTimes(1);
 
     // Second interrupt: exits at once, shutdown not invoked a second time.
@@ -166,29 +189,242 @@ describe("makeSignalShutdownHandler", () => {
   });
 });
 
-describe("makeChildForwardHandler", () => {
-  test("first signal forwards to the child and does not exit", () => {
-    const child = { kill: vi.fn() };
-    const handle = makeChildForwardHandler(child);
-    handle("SIGINT");
-    expect(child.kill).toHaveBeenCalledWith("SIGINT");
+describe("makeProcessShutdownController", () => {
+  test("deduplicates signal and control requests onto one whole-teardown deadline", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const shutdown = vi.fn(() => new Promise<void>(() => {}));
+    const controller = makeProcessShutdownController(shutdown, {
+      deadlineMs: 20,
+    });
+
+    const control = controller(0);
+    const signal = controller(143);
+    expect(signal).toBe(control);
+    await expect(control).rejects.toThrow("__forcedExit__:143");
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(forcedExitMock).toHaveBeenCalledWith(143);
     expect(safeExitMock).not.toHaveBeenCalled();
+  });
+
+  test("force-exits nonzero when teardown rejects", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const controller = makeProcessShutdownController(
+      async () => {
+        throw new Error("teardown failed");
+      },
+      { deadlineMs: 1000 },
+    );
+
+    await expect(controller(0)).rejects.toThrow("__forcedExit__:1");
+    expect(forcedExitMock).toHaveBeenCalledWith(1);
+    expect(safeExitMock).not.toHaveBeenCalled();
+  });
+
+  test("exposes shutdown start and rejects a late child attachment", async () => {
+    const controller = makeProcessShutdownController(async () => {}, {
+      deadlineMs: 1000,
+    });
+    expect(controller.isShutdownStarted()).toBe(false);
+    const request = controller(0);
+    expect(controller.isShutdownStarted()).toBe(true);
+    expect(() => controller.attachChild({ kill: vi.fn(() => true) })).toThrow(
+      "Cannot attach a child after shutdown has started",
+    );
+    await expect(request).rejects.toThrow("__safeExit__:0");
+  });
+});
+
+describe("makeChildForwardHandler", () => {
+  test("first signal forwards to the child and starts the shared deadline", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const child = { kill: vi.fn((_signal: NodeJS.Signals) => true) };
+    const shutdown = vi.fn(async () => {});
+    const controller = makeProcessShutdownController(shutdown, {
+      deadlineMs: 20,
+    });
+    const handle = makeChildForwardHandler(child, controller);
+    handle("SIGINT");
+    const pending = controller(130);
+    const exit = expect(pending).rejects.toThrow("__forcedExit__:130");
+    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith("SIGINT"));
+    await exit;
+    expect(child.kill).toHaveBeenCalledWith("SIGINT");
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(safeExitMock).not.toHaveBeenCalled();
+  });
+
+  test("second signal SIGKILLs once and waits for the child to be reaped", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const child = { kill: vi.fn((_signal: NodeJS.Signals) => true) };
+    const controller = makeProcessShutdownController(async () => {}, {
+      deadlineMs: 1000,
+    });
+    const handle = makeChildForwardHandler(child, controller);
+
+    handle("SIGINT");
+    const pending = controller(130);
+
+    handle("SIGINT");
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual([
+      "SIGINT",
+      "SIGKILL",
+    ]);
+    expect(safeExitMock).not.toHaveBeenCalled();
+    expect(forcedExitMock).not.toHaveBeenCalled();
+    handle("SIGTERM");
+    expect(child.kill).toHaveBeenCalledTimes(2);
+    expect(controller.childExited(0)).toBe(pending);
+    await expect(pending).rejects.toThrow("__safeExit__:130");
+    expect(child.kill).toHaveBeenCalledTimes(2);
+    expect(forcedExitMock).not.toHaveBeenCalled();
+    expect(safeExitMock).toHaveBeenCalledWith(130);
+  });
+
+  test("registers child escalation before the absolute outer deadline", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const child = { kill: vi.fn((_signal: NodeJS.Signals) => true) };
+    const controller = makeProcessShutdownController(async () => {}, {
+      deadlineMs: parseShutdownDeadline("1"),
+    });
+    controller.attachChild(child);
+
+    const request = controller(0);
+    const exit = expect(request).rejects.toThrow("__forcedExit__:1");
+    await vi.advanceTimersByTimeAsync(5);
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual([
+      "SIGTERM",
+      "SIGKILL",
+    ]);
+    expect(forcedExitMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(5);
+    await exit;
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual([
+      "SIGTERM",
+      "SIGKILL",
+    ]);
+    expect(forcedExitMock).toHaveBeenCalledWith(1);
+  });
+
+  test("authenticated shutdown signals a live child and waits for it", async () => {
+    const child = { kill: vi.fn(() => true) };
+    const shutdown = vi.fn(async () => {});
+    const controller = makeProcessShutdownController(shutdown, {
+      deadlineMs: 1000,
+    });
+    controller.attachChild(child);
+
+    const request = controller(0);
+    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith("SIGTERM"));
+    await Promise.resolve();
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(safeExitMock).not.toHaveBeenCalled();
+
+    const reaped = controller.childExited(0);
+    expect(reaped).toBe(request);
+    await expect(request).rejects.toThrow("__safeExit__:0");
+    expect(safeExitMock).toHaveBeenCalledWith(0);
+  });
+
+  test("does not escalate an obedient child after it is reaped", async () => {
+    vi.useFakeTimers();
+    const child = { kill: vi.fn(() => true) };
+    const controller = makeProcessShutdownController(async () => {}, {
+      deadlineMs: 100,
+    });
+    controller.attachChild(child);
+
+    const request = controller(0);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+    expect(controller.childExited(0)).toBe(request);
+    await expect(request).rejects.toThrow("__safeExit__:0");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  test("escalates an ignoring child once and waits for it to be reaped", async () => {
+    vi.useFakeTimers();
+    const child = { kill: vi.fn((_signal: NodeJS.Signals) => true) };
+    const controller = makeProcessShutdownController(async () => {}, {
+      deadlineMs: 100,
+    });
+    controller.attachChild(child);
+
+    const request = controller(0);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual([
+      "SIGTERM",
+      "SIGKILL",
+    ]);
+    expect(safeExitMock).not.toHaveBeenCalled();
+
+    expect(controller.childExited(137)).toBe(request);
+    await expect(request).rejects.toThrow("__safeExit__:137");
     expect(forcedExitMock).not.toHaveBeenCalled();
   });
 
-  test("second signal force-exits and stops forwarding", () => {
+  test("force-exits nonzero when escalation fails and the child stays live", async () => {
+    vi.useFakeTimers();
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const child = { kill: vi.fn() };
-    const handle = makeChildForwardHandler(child);
+    const child = {
+      kill: vi.fn((signal: NodeJS.Signals) => signal !== "SIGKILL"),
+    };
+    const controller = makeProcessShutdownController(async () => {}, {
+      deadlineMs: 100,
+    });
+    controller.attachChild(child);
 
-    handle("SIGINT");
-    expect(child.kill).toHaveBeenCalledTimes(1);
-
-    // forcedExit throws (never returns in prod), so child.kill is not reached.
-    expect(() => handle("SIGINT")).toThrow("__forcedExit__:130");
-    expect(child.kill).toHaveBeenCalledTimes(1);
-    expect(forcedExitMock).toHaveBeenCalledWith(130);
+    const request = controller(0);
+    const exit = expect(request).rejects.toThrow("__forcedExit__:1");
+    await vi.advanceTimersByTimeAsync(100);
+    await exit;
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual([
+      "SIGTERM",
+      "SIGKILL",
+    ]);
+    expect(forcedExitMock).toHaveBeenCalledWith(1);
     expect(safeExitMock).not.toHaveBeenCalled();
+  });
+
+  test("child nonzero racing authenticated zero upgrades the outcome", async () => {
+    const child = { kill: vi.fn((_signal: NodeJS.Signals) => true) };
+    const controller = makeProcessShutdownController(async () => {}, {
+      deadlineMs: 1000,
+    });
+    controller.attachChild(child);
+
+    const request = controller(0);
+    expect(controller.childExited(7)).toBe(request);
+    await expect(request).rejects.toThrow("__safeExit__:7");
+    expect(safeExitMock).toHaveBeenCalledWith(7);
+  });
+
+  test("duplicate triggers signal the child and tear down the gateway once", async () => {
+    vi.useFakeTimers();
+    const child = { kill: vi.fn((_signal: NodeJS.Signals) => true) };
+    const shutdown = vi.fn(async () => {});
+    const controller = makeProcessShutdownController(shutdown, {
+      deadlineMs: 100,
+    });
+    controller.attachChild(child);
+
+    const control = controller(0);
+    const signal = controller(143, "SIGTERM");
+    expect(signal).toBe(control);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(child.kill.mock.calls.map(([childSignal]) => childSignal)).toEqual([
+      "SIGTERM",
+      "SIGKILL",
+    ]);
+    expect(controller(0)).toBe(control);
+    expect(controller.childExited(0)).toBe(control);
+    await expect(control).rejects.toThrow("__safeExit__:143");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(child.kill).toHaveBeenCalledTimes(2);
+    expect(shutdown).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -203,7 +439,10 @@ describe("install*", () => {
 
   test("installChildSignalForwarding registers SIGINT and SIGTERM handlers", () => {
     const onSpy = vi.spyOn(process, "on").mockReturnValue(process);
-    installChildSignalForwarding({ kill: vi.fn() });
+    installChildSignalForwarding(
+      { kill: vi.fn(() => true) },
+      makeProcessShutdownController(async () => {}),
+    );
     const signals = onSpy.mock.calls.map((c) => c[0]);
     expect(signals).toContain("SIGINT");
     expect(signals).toContain("SIGTERM");

--- a/packages/gateway/test/start-gateway-reuse.test.ts
+++ b/packages/gateway/test/start-gateway-reuse.test.ts
@@ -1,169 +1,363 @@
-/**
- * Regression test for the `lore run <agent>` EADDRINUSE reuse path.
- *
- * Bug: when a lore gateway was already listening on the target port,
- * `startGateway()` crashed with EADDRINUSE instead of detecting the running
- * gateway via its `/health` endpoint and reusing it. The probe-and-reuse logic
- * lived in a `catch` block, but the bind (`await startServer(config)`) was
- * placed *outside* the `try`, so the rejection escaped uncaught.
- *
- * These tests bind a real port first, then assert `startGateway()`:
- *   1. reuses a live lore gateway (returns `owned: false`) without throwing, and
- *   2. throws a friendly error when the port is held by a non-lore process.
- */
-import { describe, it, expect, afterEach } from "vitest";
+import { createServer as createHttpServer } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
 import {
   createServer as createNetServer,
+  type AddressInfo,
   type Server as NetServer,
 } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readPortFile, removePortFile } from "../src/portfile";
+import {
+  readGatewayProcessFile,
+  removePidFile,
+  writeGatewayProcessFile,
+} from "../src/pidfile";
 
-describe("startGateway EADDRINUSE reuse", () => {
+describe("startGateway authenticated reuse", () => {
   const teardowns: Array<() => void | Promise<void>> = [];
+  let base: string;
+  let previousXdg: string | undefined;
+
+  beforeEach(() => {
+    previousXdg = process.env.XDG_DATA_HOME;
+    base = mkdtempSync(join(tmpdir(), "lore-start-reuse-test-"));
+    process.env.XDG_DATA_HOME = base;
+  });
 
   afterEach(async () => {
     while (teardowns.length) {
-      const fn = teardowns.pop();
       try {
-        await fn?.();
+        await teardowns.pop()?.();
       } catch {
-        /* best-effort cleanup */
+        // Best-effort listener cleanup after an assertion failure.
       }
     }
+    const port = readPortFile();
+    if (port) removePortFile(port);
+    const record = readGatewayProcessFile();
+    if (record) removePidFile(record.pid);
+    if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = previousXdg;
+    rmSync(base, { recursive: true, force: true });
   });
 
-  it("reuses an existing lore gateway instead of throwing EADDRINUSE", async () => {
-    const { startServer } = await import("../src/server");
+  it("reuses an existing authenticated gateway instead of EADDRINUSE", async () => {
     const { startGateway } = await import("../src/cli/start");
-    const { loadConfig } = await import("../src/config");
-
-    // Start a real lore gateway on an OS-assigned port. It serves `/health`,
-    // which is exactly what the reuse probe looks for.
-    const config = loadConfig();
-    config.port = 0;
-    config.hosts = ["127.0.0.1"];
-    const existing = await startServer(config);
-    teardowns.push(() => existing.stop());
-
-    const port = existing.port;
-    expect(port).toBeGreaterThan(0);
-
-    // The occupied port now hosts a live gateway. startGateway() must detect it
-    // via the /health probe and adopt it (owned:false) rather than crash.
-    const handle = await startGateway({ port, local: true, quiet: true });
-    teardowns.push(() => handle.shutdown());
-
-    expect(handle.owned).toBe(false);
-    expect(handle.port).toBe(port);
-  });
-
-  it("reuses a gateway bound to a different interface (probes 127.0.0.1)", async () => {
-    const { startServer } = await import("../src/server");
-    const { startGateway } = await import("../src/cli/start");
-    const { loadConfig } = await import("../src/config");
-
-    // Existing gateway is bound to 127.0.0.1 only.
-    const config = loadConfig();
-    config.port = 0;
-    config.hosts = ["127.0.0.1"];
-    const existing = await startServer(config);
-    teardowns.push(() => existing.stop());
-
-    const port = existing.port;
-    expect(port).toBeGreaterThan(0);
-
-    // New startGateway() is configured with hosts = ["127.0.0.2", "0.0.0.0"]:
-    //   - config.hosts[0] is 127.0.0.2 — binds fine (nothing there), and a
-    //     /health probe of http://127.0.0.2:<port> REFUSES (no gateway there),
-    //     so the OLD single-host probe (config.hosts[0] only) would conclude
-    //     "not a lore gateway" and throw. This is the precondition that fails
-    //     on the base branch.
-    //   - the second host 0.0.0.0 then conflicts with the 127.0.0.1 occupant →
-    //     EADDRINUSE, entering the reuse path.
-    // The fix probes 127.0.0.1 (always) in addition to the configured hosts,
-    // finds the live gateway there, and adopts it (owned:false). 127.0.0.0/8 is
-    // entirely loopback on Linux, so this stays hermetic with no host setup.
-    //
-    // Regression guard: reverting the probe to config.hosts[0] only makes this
-    // test fail (127.0.0.2 has no gateway), per quality/REVIEW.md §1.
+    const existing = await startGateway({ port: 0, local: true, quiet: true });
+    teardowns.push(() => existing.shutdown());
     const handle = await startGateway({
-      port,
-      hosts: ["127.0.0.2", "0.0.0.0"],
+      port: existing.port,
       local: true,
       quiet: true,
     });
-    teardowns.push(() => handle.shutdown());
-
     expect(handle.owned).toBe(false);
-    expect(handle.port).toBe(port);
+    expect(handle.port).toBe(existing.port);
+    expect(handle.managementToken).toBe(existing.managementToken);
   });
 
-  it("reuses a gateway on a non-overlapping interface instead of starting a second one (issue #908)", async () => {
-    const { startServer } = await import("../src/server");
-    const { startGateway } = await import("../src/cli/start");
+  it("authenticates and reuses an owned gateway on forbidden port 6669", async () => {
     const { loadConfig } = await import("../src/config");
-
-    // Existing gateway is bound to 127.0.0.1 only.
+    const { currentProcessIdentity } = await import("../src/lifecycle-lock");
+    const { startServer } = await import("../src/server");
+    const { probeGatewayIdentityDetailed, probeGatewayStatus, startGateway } =
+      await import("../src/cli/start");
+    const { fetchMemoryHealth } = await import("../src/cli/inventory");
+    const token = "forbidden-port-control-token".padEnd(32, "x");
     const config = loadConfig();
-    config.port = 0;
+    config.port = 6669;
+    config.portExplicit = true;
     config.hosts = ["127.0.0.1"];
-    const existing = await startServer(config);
+    config.remoteGateway = false;
+    config.hostedMode = false;
+    const existing = await startServer(config, { controlToken: token });
     teardowns.push(() => existing.stop());
+    const record = {
+      version: 2 as const,
+      pid: process.pid,
+      port: 6669,
+      hosts: ["127.0.0.1"],
+      token,
+      processIdentity:
+        currentProcessIdentity() ?? `unverified:${"x".repeat(32)}`,
+    };
+    const baseURL = "http://127.0.0.1:6669";
 
-    const port = existing.port;
-    expect(port).toBeGreaterThan(0);
+    await expect(probeGatewayStatus(baseURL)).resolves.toBe("healthy");
+    await expect(
+      probeGatewayIdentityDetailed(baseURL, "wrong-token"),
+    ).resolves.toEqual({ kind: "rejected" });
+    await expect(probeGatewayIdentityDetailed(baseURL, token)).resolves.toEqual(
+      {
+        kind: "authenticated",
+        identity: { pid: process.pid },
+      },
+    );
+    await expect(fetchMemoryHealth(baseURL)).resolves.not.toBeNull();
 
-    // New instance is configured for 127.0.0.2 ONLY — a NON-overlapping loopback
-    // interface. Binding 127.0.0.2:<port> SUCCEEDS (it's a distinct socket
-    // address from the occupied 127.0.0.1:<port>), so the bind never throws
-    // EADDRINUSE and the post-bind reuse path is never entered. Without the
-    // PRE-bind probe, startGateway() would happily start a SECOND gateway here
-    // (owned:true) sharing the same port file / pid file / SQLite DB. The fix
-    // probes 127.0.0.1 before binding, finds the live gateway, and adopts it
-    // (owned:false). 127.0.0.0/8 is entirely loopback on Linux, so this stays
-    // hermetic with no host setup.
-    //
-    // Regression guard: removing the pre-bind probe makes 127.0.0.2:<port> bind
-    // cleanly → owned:true → this assertion fails, per quality/REVIEW.md §1.
+    const handle = await startGateway(
+      { port: 6669, local: true, quiet: true },
+      { readProcess: () => record },
+    );
+    expect(handle.owned).toBe(false);
+    expect(handle.port).toBe(6669);
+  });
+
+  it("preserves Fetch transport for non-loopback probes", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+    try {
+      const { probeGatewayStatus } = await import("../src/cli/start");
+      await expect(
+        probeGatewayStatus("https://gateway.example.test"),
+      ).resolves.toBe("healthy");
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://gateway.example.test/health",
+        expect.anything(),
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("preserves the deadline classification for loopback probes", async () => {
+    const hanging = createHttpServer(() => {});
+    await new Promise<void>((resolve, reject) => {
+      hanging.once("error", reject);
+      hanging.listen(0, "127.0.0.1", resolve);
+    });
+    teardowns.push(
+      () => new Promise<void>((resolve) => hanging.close(() => resolve())),
+    );
+    const port = (hanging.address() as AddressInfo).port;
+    const { probeGatewayStatus } = await import("../src/cli/start");
+
+    await expect(
+      probeGatewayStatus(`http://127.0.0.1:${port}`, 10),
+    ).resolves.toBe("timeout");
+  });
+
+  it("reuses the authenticated record's random port when no port is explicit", async () => {
+    const { startGateway } = await import("../src/cli/start");
+    const record = {
+      version: 1 as const,
+      pid: 4242,
+      port: 49152,
+      hosts: ["0.0.0.0", "127.0.0.1"],
+      token: "a".repeat(32),
+    };
+    const handle = await startGateway(
+      { local: true, quiet: true },
+      {
+        readProcess: () => record,
+        authenticate: async () => "0.0.0.0",
+      },
+    );
+    expect(handle).toMatchObject({
+      owned: false,
+      port: 49152,
+      managementToken: record.token,
+    });
+    expect(handle.config.hosts).toEqual(["0.0.0.0"]);
+  });
+
+  it("reuses a gateway on a non-overlapping interface", async () => {
+    const { startGateway } = await import("../src/cli/start");
+    const existing = await startGateway({ port: 0, local: true, quiet: true });
+    teardowns.push(() => existing.shutdown());
     const handle = await startGateway({
-      port,
+      port: existing.port,
       hosts: ["127.0.0.2"],
       local: true,
       quiet: true,
     });
-    teardowns.push(() => handle.shutdown());
-
     expect(handle.owned).toBe(false);
-    expect(handle.port).toBe(port);
-    // The handle MUST report the interface the gateway actually answered on
-    // (127.0.0.1), NOT the requested-but-dead 127.0.0.2 — callers build the
-    // agent's gateway URL from config.hosts[0] (run.ts), so a non-reachable
-    // host here would point the agent at a refused address.
     expect(handle.config.hosts).toEqual(["127.0.0.1"]);
   });
 
-  it("throws a friendly error when the port is held by a non-lore process", async () => {
-    const { startGateway } = await import("../src/cli/start");
+  it("treats a public /health spoof as foreign", async () => {
+    const { probeGateway, startGateway } = await import("../src/cli/start");
+    const fake = createHttpServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", service: "lore" }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      fake.once("error", reject);
+      fake.listen(0, "127.0.0.1", resolve);
+    });
+    teardowns.push(
+      () => new Promise<void>((resolve) => fake.close(() => resolve())),
+    );
+    const port = (fake.address() as AddressInfo).port;
+    expect(await probeGateway(`http://127.0.0.1:${port}`)).toBe(true);
+    await expect(
+      startGateway({ port, local: true, quiet: true }),
+    ).rejects.toThrow(/not an authenticated lore gateway/i);
+  });
 
-    // Occupy a port with a plain TCP server that does NOT speak HTTP. It
-    // destroys incoming connections so the /health probe fails fast (rather
-    // than hanging until the probe timeout).
+  it("reports a friendly error for a non-HTTP foreign process", async () => {
+    const { startGateway } = await import("../src/cli/start");
     const net: NetServer = createNetServer((socket) => socket.destroy());
-    const port: number = await new Promise((resolve, reject) => {
+    const port = await new Promise<number>((resolve, reject) => {
       net.once("error", reject);
       net.listen(0, "127.0.0.1", () => {
-        const addr = net.address();
-        if (addr && typeof addr === "object") resolve(addr.port);
+        const address = net.address();
+        if (address && typeof address === "object") resolve(address.port);
         else reject(new Error("no OS-assigned port"));
       });
     });
     teardowns.push(
       () => new Promise<void>((resolve) => net.close(() => resolve())),
     );
-
-    // Explicit port held by a non-lore process: probe returns false, so
-    // startGateway() surfaces the actionable error instead of a raw EADDRINUSE.
     await expect(
       startGateway({ port, local: true, quiet: true }),
-    ).rejects.toThrow(/not a lore gateway/i);
+    ).rejects.toThrow(/not an authenticated lore gateway/i);
+  });
+
+  it("removes port and PID state when process-record publication fails", async () => {
+    const { startGateway } = await import("../src/cli/start");
+    await expect(
+      startGateway(
+        { port: 0, local: true, quiet: true },
+        {
+          writeProcess: (record) => {
+            writeGatewayProcessFile(record);
+            throw new Error("injected process-record write failure");
+          },
+        },
+      ),
+    ).rejects.toThrow("injected process-record write failure");
+    expect(readPortFile()).toBeNull();
+    expect(readGatewayProcessFile()).toBeNull();
+  });
+
+  it("retains discovery evidence if publication cleanup cannot close listener", async () => {
+    const { startGateway } = await import("../src/cli/start");
+    let processRecord: ReturnType<typeof readGatewayProcessFile> = null;
+    let portPublished = false;
+    let removed = false;
+    const fakeServer = {
+      ready: Promise.resolve(),
+      port: 49321,
+      hosts: ["127.0.0.1"],
+      stop: async () => {
+        throw new Error("injected listener close failure");
+      },
+    };
+    await expect(
+      startGateway(
+        { port: 0, local: true, quiet: true },
+        {
+          readProcess: () => processRecord,
+          authenticate: async () => null,
+          startServer: async () => fakeServer,
+          writePort: () => {
+            portPublished = true;
+          },
+          removePort: () => {
+            removed = true;
+          },
+          writeProcess: (record) => {
+            processRecord = record;
+            throw new Error("injected publication failure");
+          },
+          removeProcess: () => {
+            removed = true;
+          },
+        },
+      ),
+    ).rejects.toThrow(/discovery evidence was retained/);
+    expect(portPublished).toBe(true);
+    expect((processRecord as unknown as { port: number }).port).toBe(49321);
+    expect(removed).toBe(false);
+  });
+
+  it("serializes concurrent starts through process-record publication", async () => {
+    const { startGateway } = await import("../src/cli/start");
+    let processRecord: ReturnType<typeof readGatewayProcessFile> = {
+      version: 1,
+      pid: 9191,
+      port: 49191,
+      hosts: ["127.0.0.1"],
+      token: "stale-owner-token".repeat(3),
+    };
+    let releaseProbe!: () => void;
+    let markProbe!: () => void;
+    const probeStarted = new Promise<void>((resolve) => (markProbe = resolve));
+    const probeGate = new Promise<void>((resolve) => (releaseProbe = resolve));
+    const io = {
+      readProcess: () => processRecord,
+      authenticate: async (record: NonNullable<typeof processRecord>) => {
+        if (record.pid === 9191) {
+          markProbe();
+          await probeGate;
+          return null;
+        }
+        return record.hosts[0];
+      },
+      writePort: () => {},
+      removePort: () => {},
+      writeProcess: (record: NonNullable<typeof processRecord>) => {
+        processRecord = record;
+      },
+      removeProcess: (pid: number) => {
+        if (processRecord?.pid === pid) processRecord = null;
+      },
+    };
+    const firstPromise = startGateway({ local: true, quiet: true }, io);
+    await probeStarted;
+    const secondPromise = startGateway({ local: true, quiet: true }, io);
+    releaseProbe();
+    const first = await firstPromise;
+    teardowns.push(() => first.shutdown());
+    const second = await secondPromise;
+    expect(first.owned).toBe(true);
+    expect(second.owned).toBe(false);
+    expect(second.port).toBe(first.port);
+    expect(second.managementToken).toBe(first.managementToken);
+  });
+
+  it("makes a successor wait until shutdown removes predecessor records", async () => {
+    const { startGateway } = await import("../src/cli/start");
+    let processRecord: ReturnType<typeof readGatewayProcessFile> = null;
+    let recordsRemoved = false;
+    const sharedIO = {
+      readProcess: () => processRecord,
+      authenticate: async (record: NonNullable<typeof processRecord>) =>
+        record.hosts[0],
+      writePort: () => {},
+      removePort: () => {},
+      writeProcess: (record: NonNullable<typeof processRecord>) => {
+        processRecord = record;
+      },
+      removeProcess: (pid: number) => {
+        if (processRecord?.pid === pid) processRecord = null;
+        recordsRemoved = true;
+      },
+    };
+    const first = await startGateway(
+      { port: 0, local: true, quiet: true },
+      sharedIO,
+    );
+    const readsAfterRemoval: boolean[] = [];
+    const shutdownPromise = first.shutdown();
+    const secondPromise = startGateway(
+      { port: first.port, local: true, quiet: true },
+      {
+        ...sharedIO,
+        readProcess: () => {
+          readsAfterRemoval.push(recordsRemoved);
+          return processRecord;
+        },
+      },
+    );
+    await shutdownPromise;
+    const second = await secondPromise;
+    teardowns.push(() => second.shutdown());
+    expect(readsAfterRemoval.length).toBeGreaterThan(0);
+    expect(readsAfterRemoval.every(Boolean)).toBe(true);
+    expect(second.owned).toBe(true);
   });
 });

--- a/packages/gateway/test/stop-plan.test.ts
+++ b/packages/gateway/test/stop-plan.test.ts
@@ -1,154 +1,340 @@
-import { describe, it, expect, vi } from "vitest";
-import { planStop, runStop, realStopIO, type StopIO } from "../src/cli/stop";
-import { readPidFile } from "../src/pidfile";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { planStop, realStopIO, runStop, type StopIO } from "../src/cli/stop";
+import {
+  inspectPidFile,
+  readLegacyPidFile,
+  readPidFile,
+  removePidFile,
+  writePidFile,
+  type GatewayProcessRecord,
+  type LegacyPidFileRecord,
+} from "../src/pidfile";
 
-function makeStopIO(overrides: Partial<StopIO> = {}): {
-  io: StopIO;
-  info: string[];
-  errors: string[];
-  killed: () => number[];
-  removed: () => number[];
-} {
+const PROCESS_IDENTITY = "test-process-generation";
+const PROCESS_RECORD: GatewayProcessRecord = {
+  version: 2,
+  pid: 4242,
+  port: 3207,
+  hosts: ["127.0.0.1"],
+  token: "a".repeat(32),
+  processIdentity: PROCESS_IDENTITY,
+};
+
+let base: string;
+let previousXdg: string | undefined;
+
+beforeEach(() => {
+  previousXdg = process.env.XDG_DATA_HOME;
+  base = mkdtempSync(join(tmpdir(), "lore-stop-test-"));
+  process.env.XDG_DATA_HOME = base;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (previousXdg === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = previousXdg;
+  rmSync(base, { recursive: true, force: true });
+});
+
+function legacyPid(pid: number): LegacyPidFileRecord {
+  return {
+    pid,
+    identity: {
+      device: 1n,
+      inode: 2n,
+      size: 4n,
+      mtimeNs: 5n,
+      ctimeNs: 6n,
+      birthtimeNs: 7n,
+    },
+  };
+}
+
+function makeStopIO(overrides: Partial<StopIO> = {}) {
   const info: string[] = [];
   const errors: string[] = [];
   const killed: number[] = [];
   const removed: number[] = [];
   const io: StopIO = {
-    readPid: () => null,
+    inspectPidFile: () => ({ state: "absent" }),
+    readRecord: () => null,
     readPort: () => null,
-    probe: async () => false,
+    authenticate: async () => false,
+    requestShutdown: async () => "failed",
+    probeHealth: async () => false,
     isAlive: () => false,
     kill: (pid) => killed.push(pid),
-    removePid: (pid) => removed.push(pid),
+    removeRecord: (record) => removed.push(record.pid),
+    removeLegacyPid: (record) => {
+      removed.push(record.pid);
+      return "removed";
+    },
     sleep: async () => {},
     now: () => 0,
-    logInfo: (m) => info.push(m),
-    logError: (m) => errors.push(m),
+    logInfo: (message) => info.push(message),
+    logError: (message) => errors.push(message),
     ...overrides,
   };
-  return { io, info, errors, killed: () => killed, removed: () => removed };
+  return { io, info, errors, killed, removed };
 }
 
 describe("planStop", () => {
-  it("signals a live PID", () => {
+  it("signals only an authenticated live PID", () => {
     expect(
-      planStop({ pid: 4242, pidAlive: true, port: 3207, portAlive: true }),
+      planStop({
+        pid: 4242,
+        pidState: "alive",
+        port: 3207,
+        portAlive: true,
+        pidMatchesGateway: true,
+      }),
     ).toEqual({ action: "signal", pid: 4242 });
+    expect(
+      planStop({
+        pid: 4242,
+        pidState: "alive",
+        port: null,
+        portAlive: false,
+        pidMatchesGateway: false,
+      }),
+    ).toEqual({ action: "uncertain", pid: 4242 });
   });
 
-  it("prefers signalling the PID even when the port is also alive", () => {
+  it("distinguishes foreground, stale, uncertain, and absent states", () => {
     expect(
-      planStop({ pid: 4242, pidAlive: true, port: 3207, portAlive: true })
-        .action,
-    ).toBe("signal");
-  });
-
-  it("reports a foreground gateway when the PID is dead but the port answers", () => {
-    expect(
-      planStop({ pid: 4242, pidAlive: false, port: 3207, portAlive: true }),
+      planStop({
+        pid: null,
+        pidState: "dead",
+        port: 3207,
+        portAlive: true,
+        pidMatchesGateway: false,
+      }),
     ).toEqual({ action: "foreground", port: 3207 });
-  });
-
-  it("reports a foreground gateway when there is no PID file but the port answers", () => {
     expect(
-      planStop({ pid: null, pidAlive: false, port: 3207, portAlive: true }),
-    ).toEqual({ action: "foreground", port: 3207 });
-  });
-
-  it("treats a dead PID with no live port as stale", () => {
-    expect(
-      planStop({ pid: 4242, pidAlive: false, port: null, portAlive: false }),
+      planStop({
+        pid: 4242,
+        pidState: "dead",
+        port: null,
+        portAlive: false,
+        pidMatchesGateway: false,
+      }),
     ).toEqual({ action: "stale", pid: 4242 });
-  });
-
-  it("treats a dead PID with a dead port as stale", () => {
     expect(
-      planStop({ pid: 4242, pidAlive: false, port: 3207, portAlive: false }),
-    ).toEqual({ action: "stale", pid: 4242 });
-  });
-
-  it("reports nothing running when there is no PID and no live port", () => {
+      planStop({
+        pid: 4242,
+        pidState: "unknown",
+        port: null,
+        portAlive: false,
+        pidMatchesGateway: false,
+      }),
+    ).toEqual({ action: "uncertain", pid: 4242 });
     expect(
-      planStop({ pid: null, pidAlive: false, port: null, portAlive: false }),
+      planStop({
+        pid: null,
+        pidState: "dead",
+        port: null,
+        portAlive: false,
+        pidMatchesGateway: false,
+      }),
     ).toEqual({ action: "none" });
   });
 });
 
 describe("runStop", () => {
-  it("signals a live PID and reports success once it exits", async () => {
-    let aliveChecks = 0;
+  it("reauthenticates and rechecks process identity immediately before signal", async () => {
+    let inspections = 0;
     const { io, info, killed, removed } = makeStopIO({
-      readPid: () => 4242,
-      // planStop sees it alive; the wait loop then sees it die.
-      isAlive: () => aliveChecks++ < 1,
+      inspectPidFile: () => ({ state: "process", record: PROCESS_RECORD }),
+      readRecord: () => PROCESS_RECORD,
+      authenticate: async () => true,
+      requestShutdown: async () => "unsupported",
+      inspectProcess: () =>
+        inspections++ < 2
+          ? { state: "alive", identity: PROCESS_IDENTITY }
+          : { state: "dead" },
     });
-    const code = await runStop(io);
-    expect(code).toBe(0);
-    expect(killed()).toEqual([4242]);
-    expect(removed()).toEqual([4242]);
+    expect(await runStop(io)).toBe(0);
+    expect(killed).toEqual([4242]);
+    expect(removed).toEqual([4242]);
     expect(info.join("\n")).toContain("Gateway stopped (pid 4242)");
   });
 
-  it("returns 1 when the signalled process never exits", async () => {
-    let t = 0;
-    const { io, errors } = makeStopIO({
-      readPid: () => 4242,
-      isAlive: () => true, // never dies
-      now: () => (t += 4000),
-      timeoutMs: 5000,
+  it("does not signal when PID generation changes after authentication", async () => {
+    const { io, errors, killed } = makeStopIO({
+      inspectPidFile: () => ({ state: "process", record: PROCESS_RECORD }),
+      readRecord: () => PROCESS_RECORD,
+      authenticate: async () => true,
+      requestShutdown: async () => "unsupported",
+      inspectProcess: () => ({
+        state: "alive",
+        identity: "reused-pid-generation",
+      }),
     });
-    const code = await runStop(io);
-    expect(code).toBe(1);
-    expect(errors.join("\n")).toContain("did not stop");
+    expect(await runStop(io)).toBe(1);
+    expect(killed).toEqual([]);
+    expect(errors.join("\n")).toContain("changed before signalling");
   });
 
-  it("reports a foreground gateway (live port, no PID) and returns 1", async () => {
-    const { io, errors } = makeStopIO({
-      readPid: () => null,
+  it("succeeds without signalling when authenticated shutdown removes an unverifiable generation", async () => {
+    const unverifiedRecord: GatewayProcessRecord = {
+      ...PROCESS_RECORD,
+      processIdentity: `unverified:${PROCESS_RECORD.token}`,
+    };
+    let record: GatewayProcessRecord | null = unverifiedRecord;
+    let now = 0;
+    const { io, info, killed } = makeStopIO({
+      inspectPidFile: () => ({ state: "process", record: unverifiedRecord }),
+      readRecord: () => record,
+      authenticate: async () => true,
+      requestShutdown: async () => "accepted",
+      inspectProcess: () => ({ state: "alive", identity: null }),
+      sleep: async (ms) => {
+        now += ms;
+        record = null;
+      },
+      now: () => now,
+    });
+    expect(await runStop(io)).toBe(0);
+    expect(killed).toEqual([]);
+    expect(info.join("\n")).toContain("Gateway stopped (pid 4242)");
+  });
+
+  it("does not remove or signal a token replacement raced into the request", async () => {
+    const replacement = {
+      ...PROCESS_RECORD,
+      token: "b".repeat(32),
+    };
+    let record: GatewayProcessRecord | null = PROCESS_RECORD;
+    const { io, errors, killed, removed } = makeStopIO({
+      inspectPidFile: () => ({ state: "process", record: PROCESS_RECORD }),
+      readRecord: () => record,
+      authenticate: async () => true,
+      requestShutdown: async () => {
+        record = replacement;
+        return "accepted";
+      },
+      inspectProcess: () => ({ state: "alive", identity: PROCESS_IDENTITY }),
+    });
+    expect(await runStop(io)).toBe(1);
+    expect(killed).toEqual([]);
+    expect(removed).toEqual([]);
+    expect(record).toBe(replacement);
+    expect(errors.join("\n")).toContain("changed during the shutdown request");
+  });
+
+  it("preserves the exact record without signalling when graceful shutdown fails", async () => {
+    const { io, errors, killed, removed } = makeStopIO({
+      inspectPidFile: () => ({ state: "process", record: PROCESS_RECORD }),
+      readRecord: () => PROCESS_RECORD,
+      authenticate: async () => true,
+      requestShutdown: async () => {
+        throw new Error("injected request failure");
+      },
+      inspectProcess: () => ({ state: "alive", identity: PROCESS_IDENTITY }),
+    });
+    expect(await runStop(io)).toBe(1);
+    expect(killed).toEqual([]);
+    expect(removed).toEqual([]);
+    expect(errors.join("\n")).toContain("preserving the process record");
+  });
+
+  it("preserves a live generation when control authentication is unavailable", async () => {
+    const { io, errors, killed, removed } = makeStopIO({
+      inspectPidFile: () => ({ state: "process", record: PROCESS_RECORD }),
+      readRecord: () => PROCESS_RECORD,
+      authenticate: async () => false,
+      inspectProcess: () => ({ state: "alive", identity: PROCESS_IDENTITY }),
+    });
+    expect(await runStop(io)).toBe(1);
+    expect(killed).toEqual([]);
+    expect(removed).toEqual([]);
+    expect(errors.join("\n")).toContain("preserving its process record");
+  });
+
+  it("preserves a legacy PID that becomes live before stale cleanup", async () => {
+    let inspections = 0;
+    const { io, errors, killed, removed } = makeStopIO({
+      inspectPidFile: () => ({ state: "legacy", record: legacyPid(4242) }),
+      inspectProcess: () =>
+        inspections++ === 0
+          ? { state: "dead" }
+          : { state: "alive", identity: "reused-pid-generation" },
+    });
+    expect(await runStop(io)).toBe(1);
+    expect(killed).toEqual([]);
+    expect(removed).toEqual([]);
+    expect(errors.join("\n")).toContain("preserving its process record");
+  });
+
+  it("cleans an exact dead legacy generation and reports foreground/absent", async () => {
+    const stale = makeStopIO({
+      inspectPidFile: () => ({ state: "legacy", record: legacyPid(4242) }),
+    });
+    expect(await runStop(stale.io)).toBe(0);
+    expect(stale.removed).toEqual([4242]);
+
+    const foreground = makeStopIO({
       readPort: () => 3207,
-      probe: async () => true,
+      probeHealth: async () => true,
     });
-    const code = await runStop(io);
-    expect(code).toBe(1);
-    expect(errors.join("\n")).toContain("no PID file");
+    expect(await runStop(foreground.io)).toBe(1);
+    expect(foreground.errors.join("\n")).toContain("no matching PID");
+
+    const absent = makeStopIO();
+    expect(await runStop(absent.io)).toBe(0);
+    expect(absent.info.join("\n")).toContain("No running gateway found");
   });
 
-  it("cleans up a stale PID file and returns 0", async () => {
-    const { io, info, removed } = makeStopIO({
-      readPid: () => 4242,
-      isAlive: () => false, // dead
+  it("fails closed on invalid PID evidence", async () => {
+    const { io, errors, killed, removed } = makeStopIO({
+      inspectPidFile: () => ({
+        state: "invalid",
+        reason: "PID file changed while reading",
+      }),
     });
-    const code = await runStop(io);
-    expect(code).toBe(0);
-    expect(removed()).toEqual([4242]);
-    expect(info.join("\n")).toContain("stale PID file");
-  });
-
-  it("reports nothing running and returns 0", async () => {
-    const { io, info } = makeStopIO();
-    const code = await runStop(io);
-    expect(code).toBe(0);
-    expect(info.join("\n")).toContain("No running gateway found");
+    expect(await runStop(io)).toBe(1);
+    expect(killed).toEqual([]);
+    expect(removed).toEqual([]);
+    expect(errors.join("\n")).toContain("preserving it");
   });
 });
 
 describe("realStopIO", () => {
-  it("wires real dependencies (without killing anything)", async () => {
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    try {
-      const io = realStopIO();
-      expect(io.readPid).toBe(readPidFile);
-      expect(typeof io.kill).toBe("function"); // not invoked here
-      expect(io.now()).toBeGreaterThan(0);
-      await io.sleep(0);
-      io.logInfo("hi");
-      io.logError("no");
-      expect(log).toHaveBeenCalledWith("[lore] hi");
-      expect(err).toHaveBeenCalledWith("[lore] no");
-    } finally {
-      log.mockRestore();
-      err.mockRestore();
-    }
+  it("wires production inspection and removes an exact stale legacy record", async () => {
+    const pid = 2147483646;
+    writePidFile(pid);
+    const io = realStopIO();
+    expect(io.inspectPidFile).toBe(inspectPidFile);
+    io.readPort = () => null;
+    io.inspectProcess = () => ({ state: "dead" });
+    io.logInfo = () => {};
+    io.logError = () => {};
+    expect(await runStop(io)).toBe(0);
+    expect(readPidFile()).toBeNull();
+  });
+
+  it("preserves a same-PID replacement raced into stale cleanup", async () => {
+    const pid = 2147483646;
+    writePidFile(pid);
+    const observed = readLegacyPidFile();
+    let inspections = 0;
+    const errors: string[] = [];
+    const io = realStopIO();
+    io.readPort = () => null;
+    io.inspectProcess = () => {
+      inspections += 1;
+      if (inspections === 2) writePidFile(pid);
+      return { state: "dead" };
+    };
+    io.logInfo = () => {};
+    io.logError = (message) => errors.push(message);
+    expect(await runStop(io)).toBe(1);
+    expect(readPidFile()).toBe(pid);
+    expect(readLegacyPidFile()?.identity).not.toEqual(observed?.identity);
+    expect(errors.join("\n")).toContain("changed before stale cleanup");
+    removePidFile(pid);
   });
 });

--- a/packages/gateway/test/store-turn-temporal.test.ts
+++ b/packages/gateway/test/store-turn-temporal.test.ts
@@ -1,8 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { db, ensureProject } from "@loreai/core";
+import {
+  close,
+  db,
+  ensureProject,
+  recallById,
+  temporal,
+  withTenant,
+  LOCAL_TENANT_ID,
+} from "@loreai/core";
 import { storeTurnTemporal } from "../src/pipeline";
-import { gatewayMessagesToLore } from "../src/temporal-adapter";
-import type { GatewayContentBlock, GatewayUsage } from "../src/translate/types";
+import {
+  deterministicID,
+  gatewayMessagesToLore,
+  legacyDeterministicID,
+} from "../src/temporal-adapter";
+import type {
+  GatewayContentBlock,
+  GatewayMessage,
+  GatewayUsage,
+} from "../src/translate/types";
 
 // #1084: storeTurnTemporal batches a turn's four temporal writes (user store +
 // tool-calls, assistant store + tool-calls) into ONE savepoint. The rows written
@@ -34,6 +50,32 @@ function rowsFor(sessionID: string) {
       "SELECT role, content FROM temporal_messages WHERE session_id = ? ORDER BY created_at ASC, id ASC",
     )
     .all(sessionID) as Array<{ role: string; content: string }>;
+}
+
+function identityRows(projectID: string, sessionID: string) {
+  return db()
+    .query(
+      `SELECT id, source_id, role, content
+         FROM temporal_messages
+        WHERE project_id = ? AND session_id = ?
+        ORDER BY created_at, rowid`,
+    )
+    .all(projectID, sessionID) as Array<{
+    id: string;
+    source_id: string | null;
+    role: string;
+    content: string;
+  }>;
+}
+
+function markerRecallID(messages: ReturnType<typeof gatewayMessagesToLore>) {
+  const marker = messages[2]?.parts[0];
+  if (marker?.type !== "text" || typeof marker.text !== "string") {
+    throw new Error("expected historical tool-result marker");
+  }
+  const id = marker.text.match(/\(t:([^)]*)\)$/)?.[1];
+  if (!id) throw new Error("expected temporal recall ID");
+  return id;
 }
 
 beforeEach(() => {
@@ -147,7 +189,281 @@ describe("storeTurnTemporal (#1084)", () => {
     const userRow = rowsFor(SESSION).find((r) => r.role === "user");
     expect(userRow?.content).toContain("DISTINCTIVE_TOOL_OUTPUT_XYZ");
     expect(userRow?.content).not.toContain("tool results provided");
+
+    const placeholder = loreMessages[0]?.parts[0];
+    if (placeholder?.type !== "text" || typeof placeholder.text !== "string") {
+      throw new Error("expected tool-result recall placeholder");
+    }
+    const recallID = placeholder.text.match(/\(t:([^)]*)\)$/)?.[1];
+    expect(recallID).toMatch(/^lore_tm_v1_/);
+    expect(recallById(`t:${recallID}`)).toContain(
+      "DISTINCTIVE_TOOL_OUTPUT_XYZ",
+    );
   });
+
+  it.each(["fresh-first", "legacy-first"] as const)(
+    "bridges pre-v82 gateway rows through the production path (%s)",
+    (order) => {
+      const projectPath = `/test/store-turn-temporal/v82-bridge-${order}`;
+      const sessionID = `v82-bridge-session-${order}`;
+      const otherSessionID = `${sessionID}-other`;
+      const tenantID = (order === "fresh-first" ? "c" : "d").repeat(64);
+      const callID = `legacy-call-${order}`;
+      const toolOutput = `LEGACY_TOOL_OUTPUT_${order}`;
+      const responseText = `same assistant acknowledgement ${order}`;
+      const toolUse: GatewayContentBlock[] = [
+        {
+          type: "tool_use",
+          id: callID,
+          name: "read",
+          input: { path: "legacy.ts" },
+        },
+      ];
+      const toolResult: GatewayContentBlock[] = [
+        {
+          type: "tool_result",
+          toolUseId: callID,
+          content: [{ type: "text", text: toolOutput }],
+        },
+      ];
+      const response: GatewayContentBlock[] = [
+        { type: "text", text: responseText },
+      ];
+      const conversation: GatewayMessage[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "read the legacy file" }],
+        },
+        { role: "assistant", content: toolUse },
+        { role: "user", content: toolResult },
+      ];
+      const convertedBeforeMigration = gatewayMessagesToLore(
+        conversation,
+        sessionID,
+      );
+      const legacyUserID = convertedBeforeMigration[2].legacySourceID;
+      if (!legacyUserID) throw new Error("expected legacy user identity");
+      const legacyResponseID = legacyDeterministicID("assistant", 0, response);
+      const legacyToolMessageID = legacyDeterministicID(
+        "assistant",
+        0,
+        toolUse,
+      );
+      const projectID = ensureProject(projectPath);
+      const responseParts = gatewayMessagesToLore(
+        [{ role: "assistant", content: response }],
+        sessionID,
+        conversation.length,
+      )[0].parts;
+
+      db()
+        .query(
+          `INSERT INTO temporal_messages
+             (id, source_id, project_id, session_id, role, content, tokens,
+              distilled, created_at, metadata)
+           VALUES (?, ?, ?, ?, 'user', ?, 1, 0, 1000, '{}'),
+                  (?, ?, ?, ?, 'assistant', ?, 1, 0, 2000, '{}')`,
+        )
+        .run(
+          legacyUserID,
+          legacyUserID,
+          projectID,
+          sessionID,
+          temporal.partsToText(convertedBeforeMigration[2].parts),
+          legacyResponseID,
+          legacyResponseID,
+          projectID,
+          sessionID,
+          temporal.partsToText(responseParts),
+        );
+      db()
+        .query(
+          `INSERT INTO tool_calls
+             (call_id, message_id, project_id, session_id, tool, status,
+              created_at, verifier, input_paths_json)
+           VALUES (?, ?, ?, ?, 'read', 'pending', 900, 0, '["legacy.ts"]')`,
+        )
+        .run(callID, legacyToolMessageID, projectID, sessionID);
+
+      // Reproduce the real v81 layouts, then restart through migrate(). This
+      // keeps IDs/FTS rows/tool data intact while v82 backfills source_id=id and
+      // rebuilds the owned tool-call primary key.
+      db().exec(`
+        DROP INDEX idx_temporal_source_identity;
+        ALTER TABLE temporal_messages DROP COLUMN source_id;
+        DROP TABLE IF EXISTS tool_calls_v81_bridge;
+        CREATE TABLE tool_calls_v81_bridge (
+          call_id TEXT PRIMARY KEY,
+          message_id TEXT NOT NULL,
+          project_id TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          tool TEXT NOT NULL,
+          status TEXT NOT NULL,
+          error_type TEXT,
+          error_message TEXT,
+          duration_ms INTEGER,
+          created_at INTEGER NOT NULL,
+          verifier INTEGER,
+          input_paths_json TEXT
+        );
+        INSERT INTO tool_calls_v81_bridge
+          (call_id, message_id, project_id, session_id, tool, status,
+           error_type, error_message, duration_ms, created_at, verifier,
+           input_paths_json)
+        SELECT call_id, message_id, project_id, session_id, tool, status,
+               error_type, error_message, duration_ms, created_at, verifier,
+               input_paths_json
+          FROM tool_calls;
+        DROP TABLE tool_calls;
+        ALTER TABLE tool_calls_v81_bridge RENAME TO tool_calls;
+        CREATE INDEX idx_tool_calls_project_tool_status
+          ON tool_calls (project_id, tool, status);
+        CREATE INDEX idx_tool_calls_project_session
+          ON tool_calls (project_id, session_id);
+        UPDATE schema_version SET version = 81;
+      `);
+      close();
+      expect(db().query("SELECT version FROM schema_version").get()).toEqual({
+        version: 82,
+      });
+
+      const noStoreLore = gatewayMessagesToLore(conversation, sessionID);
+      storeTurnTemporal({
+        loreMessages: noStoreLore,
+        assistantContentBlocks: response,
+        usage: USAGE,
+        model: "claude-sonnet-4-20250514",
+        projectPath,
+        sessionID,
+        noStore: true,
+      });
+      expect(markerRecallID(noStoreLore)).toBe(legacyUserID);
+      expect(identityRows(projectID, sessionID)).toEqual([
+        expect.objectContaining({ id: legacyUserID, source_id: legacyUserID }),
+        expect.objectContaining({
+          id: legacyResponseID,
+          source_id: legacyResponseID,
+        }),
+      ]);
+
+      const runTurn = (
+        tenant: string,
+        activeSessionID: string,
+        messages: GatewayMessage[] = conversation,
+      ) => {
+        const loreMessages = gatewayMessagesToLore(messages, activeSessionID);
+        withTenant(tenant, () =>
+          storeTurnTemporal({
+            loreMessages,
+            assistantContentBlocks: response,
+            usage: USAGE,
+            model: "claude-sonnet-4-20250514",
+            projectPath,
+            sessionID: activeSessionID,
+            noStore: false,
+          }),
+        );
+        return loreMessages;
+      };
+      const runFreshRows = () => {
+        runTurn(LOCAL_TENANT_ID, otherSessionID);
+        runTurn(tenantID, sessionID);
+      };
+
+      let migratedLore: ReturnType<typeof gatewayMessagesToLore>;
+      if (order === "fresh-first") {
+        runFreshRows();
+        migratedLore = runTurn(LOCAL_TENANT_ID, sessionID);
+      } else {
+        migratedLore = runTurn(LOCAL_TENANT_ID, sessionID);
+        runFreshRows();
+      }
+
+      const modernUserID = deterministicID(sessionID, "user", 2, toolResult);
+      const modernResponseID = deterministicID(
+        sessionID,
+        "assistant",
+        conversation.length,
+        response,
+      );
+      expect(identityRows(projectID, sessionID)).toEqual([
+        expect.objectContaining({
+          id: legacyUserID,
+          source_id: modernUserID,
+          role: "user",
+        }),
+        expect.objectContaining({
+          id: legacyResponseID,
+          source_id: modernResponseID,
+          role: "assistant",
+        }),
+      ]);
+      expect(markerRecallID(migratedLore)).toBe(legacyUserID);
+      expect(recallById(`t:${legacyUserID}`)).toContain(toolOutput);
+      expect(
+        db()
+          .query(
+            `SELECT message_id, status, input_paths_json FROM tool_calls
+              WHERE project_id = ? AND session_id = ? AND call_id = ?`,
+          )
+          .get(projectID, sessionID, callID),
+      ).toEqual({
+        message_id: legacyToolMessageID,
+        status: "completed",
+        input_paths_json: '["legacy.ts"]',
+      });
+
+      const otherSessionRows = identityRows(projectID, otherSessionID);
+      expect(otherSessionRows).toHaveLength(2);
+      expect(otherSessionRows.map((row) => row.id)).not.toContain(legacyUserID);
+      expect(otherSessionRows.map((row) => row.id)).not.toContain(
+        legacyResponseID,
+      );
+      const tenantProjectID = withTenant(tenantID, () =>
+        ensureProject(projectPath),
+      );
+      expect(tenantProjectID).not.toBe(projectID);
+      const tenantRows = identityRows(tenantProjectID, sessionID);
+      expect(tenantRows).toHaveLength(2);
+      expect(tenantRows.map((row) => row.id)).not.toContain(legacyUserID);
+      expect(tenantRows.map((row) => row.id)).not.toContain(legacyResponseID);
+
+      // Once claimed, the bridge stores the modern source ID. A later
+      // same-content assistant response in this mixed history must get a fresh
+      // v82 row rather than repeatedly falling back to legacy content identity.
+      const mixedConversation: GatewayMessage[] = [
+        ...conversation,
+        { role: "assistant", content: response },
+        {
+          role: "user",
+          content: [{ type: "text", text: "repeat the acknowledgement" }],
+        },
+      ];
+      const mixedLore = runTurn(LOCAL_TENANT_ID, sessionID, mixedConversation);
+      expect(markerRecallID(mixedLore)).toBe(legacyUserID);
+      const mixedRows = identityRows(projectID, sessionID);
+      expect(mixedRows).toHaveLength(4);
+      const repeatedResponses = mixedRows.filter(
+        (row) => row.role === "assistant" && row.content === responseText,
+      );
+      expect(repeatedResponses).toHaveLength(2);
+      expect(repeatedResponses.map((row) => row.id)).toContain(
+        legacyResponseID,
+      );
+      expect(new Set(repeatedResponses.map((row) => row.id)).size).toBe(2);
+
+      close();
+      expect(identityRows(projectID, sessionID)).toHaveLength(4);
+      expect(
+        db()
+          .query(
+            `SELECT status FROM tool_calls
+              WHERE project_id = ? AND session_id = ? AND call_id = ?`,
+          )
+          .get(projectID, sessionID, callID),
+      ).toEqual({ status: "completed" });
+    },
+  );
 
   it("batches the writes into a single savepoint (one SAVEPOINT + one RELEASE)", () => {
     const SESSION = freshSession();

--- a/packages/gateway/test/sync.test.ts
+++ b/packages/gateway/test/sync.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   db,
+  close as closeDb,
   ensureProject as ensureProjectCore,
   getKV,
   setKV,
   deleteTeamConfig,
   reinstallSyncCapture,
+  withTenant,
 } from "@loreai/core";
 import {
   ltm,
@@ -518,21 +520,13 @@ beforeEach(() => {
   db().exec("DELETE FROM sync_outbox");
   db().exec("DELETE FROM sync_state");
   db().exec("DELETE FROM sync_conflicts");
-  for (const t of [
-    "knowledge",
-    "entities",
-    "entity_aliases",
-    "entity_relations",
-    "knowledge_entity_refs",
-    "profiles",
-    "account_escrow",
-    "scope_keys",
-    "distillations",
-    "temporal_messages",
-    "projects",
+  for (const meta of [
+    ...syncData.SYNCED_TABLES.basic,
+    ...syncData.SYNCED_TABLES.pro,
+    ...syncData.SYNCED_TABLES.max,
   ]) {
-    setKV(`sync.push.${t}`, "0");
-    setKV(`sync.pull.${t}`, "0|");
+    setKV(`sync.push.${meta.table}`, "0");
+    setKV(`sync.pull.${meta.table}`, "0|");
   }
   // Reset change-capture to the free-tier baseline (drops any Pro fanout trigger a
   // prior test installed) so tier-gated capture doesn't leak across tests (#826/D).
@@ -1952,7 +1946,609 @@ describe("profiles (pull-only mirror)", () => {
   });
 });
 
+describe("cloud sync tenant boundary", () => {
+  const TENANT_A = "a".repeat(64);
+  const TENANT_B = "b".repeat(64);
+  const LOCAL = "";
+
+  function insertTenantKnowledge(
+    tenantId: string,
+    id: string,
+    content: string,
+  ): void {
+    withTenant(tenantId, () => {
+      const projectId = ensureProject("/tmp/lore-sync-tenant-boundary");
+      db()
+        .query(
+          `INSERT INTO knowledge
+             (id, logical_id, tenant_id, project_id, category, title, content, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'pattern', ?, ?, ?, ?)`,
+        )
+        .run(
+          id,
+          id,
+          tenantId,
+          projectId,
+          `tenant-${tenantId || "local"}`,
+          content,
+          now(),
+          now(),
+        );
+    });
+  }
+
+  test.each([
+    [TENANT_A, LOCAL, TENANT_B],
+    [TENANT_B, LOCAL, TENANT_A],
+  ])(
+    "real capture and push expose only local rows in adversarial order %#",
+    async (...tenantOrder) => {
+      syncData.enableSync("basic");
+      const ids: Record<string, string> = {
+        [LOCAL]: "tenant-boundary-local",
+        [TENANT_A]: "tenant-boundary-a",
+        [TENANT_B]: "tenant-boundary-b",
+      };
+
+      for (const tenantId of tenantOrder) {
+        insertTenantKnowledge(
+          tenantId,
+          ids[tenantId],
+          `private-${tenantId || "local"}`,
+        );
+      }
+
+      // The real TEMP trigger must not capture request-owned rows at all.
+      // Removing its lore_current_tenant() gate makes this assertion fail even
+      // though the read boundary below would still prevent an upload.
+      expect(
+        db()
+          .query(
+            "SELECT row_id, tenant_id FROM sync_outbox WHERE table_name = 'knowledge' ORDER BY seq",
+          )
+          .all(),
+      ).toEqual([{ row_id: ids[LOCAL], tenant_id: LOCAL }]);
+
+      // Pre-remediation rows have no trustworthy owner. Reproduce them with the
+      // migration's NULL quarantine marker, then put a newer LOCAL capture after
+      // them so the local cursor advances numerically beyond their seq values.
+      const insertLegacy = db().query(
+        `INSERT INTO sync_outbox
+           (table_name, row_id, op, changed_at, tenant_id)
+         VALUES ('knowledge', ?, 'upsert', ?, NULL)`,
+      );
+      insertLegacy.run(ids[TENANT_A], now());
+      insertLegacy.run(ids[TENANT_B], now());
+      withTenant(LOCAL, () => {
+        db()
+          .query(
+            "UPDATE knowledge SET content = ?, updated_at = ? WHERE tenant_id = ? AND id = ?",
+          )
+          .run("local-after-legacy", now(), LOCAL, ids[LOCAL]);
+      });
+
+      const visible = syncData.readOutbox(0, 500, "knowledge");
+      expect(new Set(visible.map((entry) => entry.row_id))).toEqual(
+        new Set([ids[LOCAL]]),
+      );
+      expect(visible.every((entry) => entry.tenant_id === LOCAL)).toBe(true);
+
+      // Manual/internal entry points also fail closed when invoked from a
+      // request tenant, independently of scheduler policy.
+      const tenantAttempt = await withTenant(TENANT_A, () =>
+        pushOnce(makeClient() as never),
+      );
+      expect(tenantAttempt).toEqual({
+        pushed: 0,
+        pulled: 0,
+        conflicts: 0,
+        skipped: 0,
+      });
+      expect(tableRows("knowledge")).toEqual([]);
+
+      const localProjectId = (
+        db()
+          .query("SELECT id FROM projects WHERE tenant_id = ? AND path = ?")
+          .get(LOCAL, "/tmp/lore-sync-tenant-boundary") as { id: string }
+      ).id;
+      tableRows("knowledge").push({
+        id: "tenant-pull-probe",
+        project_id: localProjectId,
+        category: "pattern",
+        title: "must not pull",
+        content: "request tenant must not observe account cloud data",
+        content_hash: "tenant-pull-probe-hash",
+        revision: 1,
+        is_deleted: false,
+        created_at: new Date(2_000_000).toISOString(),
+        updated_at: new Date(2_000_000).toISOString(),
+      });
+      const tenantPull = await withTenant(TENANT_A, () =>
+        pullOnce(makeClient() as never),
+      );
+      expect(tenantPull).toEqual({
+        pushed: 0,
+        pulled: 0,
+        conflicts: 0,
+        skipped: 0,
+      });
+      expect(
+        db()
+          .query("SELECT COUNT(*) AS n FROM knowledge WHERE id = ?")
+          .get("tenant-pull-probe"),
+      ).toEqual({ n: 0 });
+      remote.delete("knowledge");
+
+      await pushOnce(makeClient() as never);
+      expect(tableRows("knowledge").map((row) => row.id)).toEqual([ids[LOCAL]]);
+      expect(tableRows("knowledge")[0].content).toBe("local-after-legacy");
+
+      // Only the local row is acknowledged. Removing the outbox tenant filter
+      // causes the quarantined rows to be processed and recorded in sync_state;
+      // removing the prune filter deletes them as if acknowledged.
+      expect(
+        db()
+          .query(
+            `SELECT row_id, tenant_id FROM sync_state
+              WHERE row_id IN (?, ?, ?) ORDER BY row_id`,
+          )
+          .all(ids[LOCAL], ids[TENANT_A], ids[TENANT_B]),
+      ).toEqual([{ row_id: ids[LOCAL], tenant_id: LOCAL }]);
+      expect(
+        db()
+          .query(
+            "SELECT row_id FROM sync_outbox WHERE tenant_id IS NULL ORDER BY row_id",
+          )
+          .all(),
+      ).toEqual([{ row_id: ids[TENANT_A] }, { row_id: ids[TENANT_B] }]);
+    },
+  );
+
+  test.each([
+    { remoteGateway: true, hostedMode: false },
+    { remoteGateway: false, hostedMode: true },
+  ])("scheduler allocates no cycles or shutdown flush in %o", async (mode) => {
+    syncData.enableSync("basic");
+    insertTenantKnowledge(LOCAL, "scheduler-local", "must-stay-local");
+    vi.useFakeTimers();
+    try {
+      const stop = startSyncScheduler(mode, 60_000);
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await stop();
+      expect(tableRows("knowledge")).toEqual([]);
+      expect(syncData.getSyncState("knowledge", "scheduler-local")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("an in-process local-to-remote transition stops ticks and the final flush", async () => {
+    syncData.enableSync("basic");
+    insertTenantKnowledge(LOCAL, "scheduler-transition", "must-stay-local");
+    const mode = { remoteGateway: false, hostedMode: false };
+    vi.useFakeTimers();
+    try {
+      const stop = startSyncScheduler(mode, 60_000);
+      mode.remoteGateway = true;
+      await vi.advanceTimersByTimeAsync(60_000);
+      await stop();
+      expect(tableRows("knowledge")).toEqual([]);
+      expect(
+        syncData.getSyncState("knowledge", "scheduler-transition"),
+      ).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("pull parent-ownership registry", () => {
+  const REQUEST_TENANT = "c".repeat(64);
+  const PRO_TABLES = new Set(["distillations", "temporal_messages"]);
+  const PARENT_CASES = Object.entries(syncData.SYNC_TENANT_PARENT_REFS).flatMap(
+    ([table, refs]) =>
+      refs.map((ref) => ({
+        table,
+        ref,
+        label: `${table}.${ref.column}`,
+      })),
+  );
+
+  type ParentCase = (typeof PARENT_CASES)[number];
+
+  function parentId(c: ParentCase, column = c.ref.column): string {
+    return `pull-parent-${c.table}-${column}`;
+  }
+
+  function insertOwnedParent(
+    ref: syncData.SyncTenantParentRef,
+    id: string,
+    tenantId: string,
+  ): void {
+    withTenant(tenantId, () =>
+      syncData.withApplying(() => {
+        if (ref.parentTable === "projects") {
+          db()
+            .query(
+              `INSERT INTO projects
+                 (id, path, name, git_remote, created_at, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?)`,
+            )
+            .run(
+              id,
+              `/tmp/${id}-${tenantId || "local"}`,
+              id,
+              `test:${id}`,
+              now(),
+              tenantId,
+            );
+          return;
+        }
+
+        const projectId = `${id}-project`;
+        db()
+          .query(
+            `INSERT INTO projects
+               (id, path, name, git_remote, created_at, tenant_id)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            projectId,
+            `/tmp/${projectId}-${tenantId || "local"}`,
+            projectId,
+            `test:${projectId}`,
+            now(),
+            tenantId,
+          );
+        if (ref.parentTable === "entities") {
+          db()
+            .query(
+              `INSERT INTO entities
+                 (id, tenant_id, project_id, entity_type, canonical_name, created_at, updated_at)
+               VALUES (?, ?, ?, 'service', ?, ?, ?)`,
+            )
+            .run(id, tenantId, projectId, id, now(), now());
+          return;
+        }
+        db()
+          .query(
+            `INSERT INTO knowledge
+               (id, logical_id, tenant_id, project_id, category, title, content, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'pattern', ?, ?, ?, ?)`,
+          )
+          .run(id, id, tenantId, projectId, id, id, now(), now());
+      }),
+    );
+  }
+
+  function prepareParents(
+    c: ParentCase,
+    targetTenant: string | null,
+  ): Record<string, string> {
+    const values: Record<string, string> = {};
+    for (const ref of syncData.SYNC_TENANT_PARENT_REFS[c.table]) {
+      const id = parentId(c, ref.column);
+      values[ref.column] = id;
+      if (ref.column === c.ref.column) {
+        if (targetTenant !== null) insertOwnedParent(ref, id, targetTenant);
+      } else {
+        insertOwnedParent(ref, id, "");
+      }
+    }
+    return values;
+  }
+
+  function remoteChild(
+    c: ParentCase,
+    parents: Record<string, string>,
+    updatedAt = 2_000_000,
+  ): RemoteRow {
+    const id = `pull-child-${c.table}-${c.ref.column}`;
+    const updated_at = new Date(updatedAt).toISOString();
+    const common = {
+      content_hash: `hash-${id}`,
+      revision: 1,
+      is_deleted: false,
+      updated_at,
+    };
+    switch (c.table) {
+      case "knowledge":
+        return {
+          ...common,
+          id,
+          project_id: parents.project_id,
+          category: "pattern",
+          title: id,
+          content: id,
+          created_at: new Date(1_000_000).toISOString(),
+        };
+      case "entities":
+        return {
+          ...common,
+          id,
+          project_id: parents.project_id,
+          entity_type: "service",
+          canonical_name: id,
+          metadata: null,
+          cross_project: 0,
+          sync_rank: 0,
+          created_at: new Date(1_000_000).toISOString(),
+        };
+      case "entity_aliases":
+        return {
+          ...common,
+          id,
+          entity_id: parents.entity_id,
+          alias_type: "name",
+          alias_value: id,
+          source: "sync-test",
+          created_at: new Date(1_000_000).toISOString(),
+        };
+      case "entity_relations":
+        return {
+          ...common,
+          id,
+          entity_a: parents.entity_a,
+          entity_b: parents.entity_b,
+          relation: `relation-${c.ref.column}`,
+          source: "sync-test",
+          metadata: null,
+          created_at: new Date(1_000_000).toISOString(),
+        };
+      case "knowledge_entity_refs":
+        return {
+          ...common,
+          knowledge_id: parents.knowledge_id,
+          entity_id: parents.entity_id,
+        };
+      case "knowledge_meta":
+        return {
+          ...common,
+          logical_id: parents.logical_id,
+          base_confidence: 0.8,
+        };
+      case "knowledge_meta_crdt":
+        return {
+          ...common,
+          logical_id: parents.logical_id,
+          replica_id: `replica-${c.ref.column}`,
+          pos: 1,
+          neg: 0,
+        };
+      case "distillations":
+        return {
+          ...common,
+          id,
+          project_id: parents.project_id,
+          session_id: `session-${id}`,
+          narrative: id,
+          facts: "[]",
+          observations: "[]",
+          source_ids: "[]",
+          generation: 0,
+          token_count: 1,
+          r_compression: 1,
+          c_norm: 1,
+          call_type: "observer",
+          archived: 0,
+          created_at: new Date(1_000_000).toISOString(),
+        };
+      case "temporal_messages":
+        return {
+          id,
+          project_id: parents.project_id,
+          session_id: `session-${id}`,
+          role: "user",
+          content: id,
+          tokens: 1,
+          metadata: null,
+          created_at: new Date(1_000_000).toISOString(),
+          updated_at,
+        };
+      default:
+        throw new Error(`missing remote child fixture: ${c.table}`);
+    }
+  }
+
+  function enableTierFor(table: string): void {
+    if (PRO_TABLES.has(table)) {
+      syncData.withApplying(() =>
+        db()
+          .query(
+            "INSERT INTO profiles (id, tier, created_at, updated_at) VALUES ('parent-contract-pro', 'pro', ?, ?)",
+          )
+          .run(now(), now()),
+      );
+      reinstallSyncCapture();
+    }
+    syncData.enableSync(PRO_TABLES.has(table) ? "pro" : "basic");
+  }
+
+  function rawChildRows(
+    table: string,
+    row: RemoteRow,
+  ): Array<Record<string, unknown>> {
+    const meta = syncData.metaFor(table);
+    return db()
+      .query(
+        `SELECT * FROM ${table}
+          WHERE ${meta.idColumns.map((column) => `${column} = ?`).join(" AND ")}`,
+      )
+      .all(...meta.idColumns.map((column) => row[column]));
+  }
+
+  function tenantVisibleChildRows(
+    c: ParentCase,
+    row: RemoteRow,
+  ): Array<Record<string, unknown>> {
+    const meta = syncData.metaFor(c.table);
+    const parentJoin =
+      c.ref.parentKey === "logical_id"
+        ? `COALESCE(parent.logical_id, parent.id) = child.${c.ref.column}`
+        : `parent.id = child.${c.ref.column}`;
+    return withTenant(REQUEST_TENANT, () =>
+      db()
+        .query(
+          `SELECT child.* FROM ${c.table} child
+             JOIN ${c.ref.parentTable} parent ON ${parentJoin}
+            WHERE parent.tenant_id = ?
+              AND ${meta.idColumns.map((column) => `child.${column} = ?`).join(" AND ")}`,
+        )
+        .all(REQUEST_TENANT, ...meta.idColumns.map((column) => row[column])),
+    );
+  }
+
+  function expectQuarantined(
+    c: ParentCase,
+    row: RemoteRow,
+    before: Array<Record<string, unknown>>,
+    tenantVisibleBefore: Array<Record<string, unknown>>,
+  ): void {
+    const table = c.table;
+    const rowId = syncData.rowIdOf(table, row);
+    expect(rawChildRows(table, row)).toEqual(before);
+    expect(tenantVisibleChildRows(c, row)).toEqual(tenantVisibleBefore);
+    expect(syncData.getSyncState(table, rowId)).toBeNull();
+    expect(
+      db()
+        .query(
+          `SELECT 1 FROM sync_conflicts
+            WHERE table_name = ? AND row_id = ? AND resolution = 'pull_constraint_skip'`,
+        )
+        .get(table, rowId),
+    ).not.toBeNull();
+  }
+
+  test("battery is non-empty and covers every registered parent field", () => {
+    expect(PARENT_CASES.map((c) => c.label).sort()).toEqual([
+      "distillations.project_id",
+      "entities.project_id",
+      "entity_aliases.entity_id",
+      "entity_relations.entity_a",
+      "entity_relations.entity_b",
+      "knowledge.project_id",
+      "knowledge_entity_refs.entity_id",
+      "knowledge_entity_refs.knowledge_id",
+      "knowledge_meta.logical_id",
+      "knowledge_meta_crdt.logical_id",
+      "temporal_messages.project_id",
+    ]);
+  });
+
+  test.each(PARENT_CASES)(
+    "$label rejects a parent-first request tenant after restart",
+    async (c) => {
+      const parents = prepareParents(c, REQUEST_TENANT);
+      const row = remoteChild(c, parents);
+      tableRows(c.table).push(row);
+      enableTierFor(c.table);
+
+      closeDb();
+      const before = rawChildRows(c.table, row);
+      const tenantVisibleBefore = tenantVisibleChildRows(c, row);
+      const result = await pullOnce(makeClient() as never);
+
+      expect(result.skipped).toBe(1);
+      expectQuarantined(c, row, before, tenantVisibleBefore);
+
+      row.is_deleted = true;
+      row.updated_at = new Date(3_000_000).toISOString();
+      const tombstone = await pullOnce(makeClient() as never);
+      expect(tombstone.skipped).toBe(1);
+      expectQuarantined(c, row, before, tenantVisibleBefore);
+    },
+  );
+
+  test.each(PARENT_CASES)(
+    "$label quarantines missing-first, then rejects child-first non-local parent",
+    async (c) => {
+      const parents = prepareParents(c, null);
+      const row = remoteChild(c, parents);
+      const missingBefore = rawChildRows(c.table, row);
+      const missingTenantVisibleBefore = tenantVisibleChildRows(c, row);
+      tableRows(c.table).push(row);
+      enableTierFor(c.table);
+
+      const missing = await pullOnce(makeClient() as never);
+      expect(missing.skipped).toBe(1);
+      expectQuarantined(c, row, missingBefore, missingTenantVisibleBefore);
+
+      // Tombstones may legitimately outlive a missing parent. They remain a
+      // no-op locally and receive no per-row sync_state acknowledgement.
+      row.is_deleted = true;
+      row.updated_at = new Date(2_500_000).toISOString();
+      const missingTombstone = await pullOnce(makeClient() as never);
+      expect(missingTombstone.pulled).toBe(1);
+      expect(missingTombstone.skipped).toBe(0);
+      expect(rawChildRows(c.table, row)).toEqual(missingBefore);
+      expect(tenantVisibleChildRows(c, row)).toEqual(
+        missingTenantVisibleBefore,
+      );
+      expect(
+        syncData.getSyncState(c.table, syncData.rowIdOf(c.table, row)),
+      ).toBeNull();
+
+      insertOwnedParent(c.ref, parents[c.ref.column], REQUEST_TENANT);
+      row.is_deleted = false;
+      row.updated_at = new Date(3_000_000).toISOString();
+      closeDb();
+      const nonLocalBefore = rawChildRows(c.table, row);
+      const nonLocalTenantVisibleBefore = tenantVisibleChildRows(c, row);
+      const nonLocal = await pullOnce(makeClient() as never);
+
+      expect(nonLocal.skipped).toBe(1);
+      expectQuarantined(c, row, nonLocalBefore, nonLocalTenantVisibleBefore);
+    },
+  );
+
+  test.each(PARENT_CASES)(
+    "$label accepts a legitimate local parent and records sync_state",
+    async (c) => {
+      const parents = prepareParents(c, "");
+      const row = remoteChild(c, parents);
+      tableRows(c.table).push(row);
+      enableTierFor(c.table);
+
+      const result = await pullOnce(makeClient() as never);
+
+      expect(result.pulled).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(rawChildRows(c.table, row)).toHaveLength(1);
+      expect(
+        syncData.getSyncState(c.table, syncData.rowIdOf(c.table, row)),
+      ).not.toBeNull();
+
+      row.is_deleted = true;
+      row.updated_at = new Date(3_000_000).toISOString();
+      const tombstone = await pullOnce(makeClient() as never);
+      expect(tombstone.pulled).toBe(1);
+      expect(tombstone.skipped).toBe(0);
+      expect(
+        syncData.getSyncState(c.table, syncData.rowIdOf(c.table, row)),
+      ).toBeNull();
+      if (c.table === "knowledge") {
+        expect(currentContent(String(row.id))).toBeNull();
+      }
+    },
+  );
+});
+
 describe("syncOnce", () => {
+  test("the v81 marker re-seeds trustworthy live local rows after legacy quarantine", async () => {
+    syncData.enableSync("basic");
+    syncData.withApplying(() => insertKnowledge("v81-local", "live local"));
+    db().exec("DELETE FROM sync_outbox; DELETE FROM sync_state;");
+    setKV("sync.tenantIsolationReconcile", "1");
+
+    await syncOnce();
+
+    expect(tableRows("knowledge").some((row) => row.id === "v81-local")).toBe(
+      true,
+    );
+    expect(getKV("sync.tenantIsolationReconcile")).toBe("0");
+  });
+
   test("no-op when disabled; notAuthed when logged out", async () => {
     expect(await syncOnce()).toEqual({
       pushed: 0,
@@ -2029,7 +2625,10 @@ describe("syncOnce", () => {
     const errSpy = vi.spyOn(log, "error").mockImplementation(() => {});
     vi.useFakeTimers();
     try {
-      const stop = startSyncScheduler(60_000);
+      const stop = startSyncScheduler(
+        { remoteGateway: false, hostedMode: false },
+        60_000,
+      );
       // The scheduler runs its first cycle ~5s after start; drive it deterministically.
       await vi.advanceTimersByTimeAsync(5_000);
       await stop();

--- a/packages/gateway/test/telemetry-privacy.test.ts
+++ b/packages/gateway/test/telemetry-privacy.test.ts
@@ -1,0 +1,500 @@
+import { describe, expect, it } from "vitest";
+import { buildSentryOptions } from "../instrument";
+import {
+  SENTRY_DATA_COLLECTION,
+  scrubTelemetryEvent,
+  scrubTelemetryEnvelope,
+  scrubTelemetryText,
+  wrapTelemetryTransport,
+} from "../src/telemetry-privacy";
+
+const SECRETS = [
+  "bearer-production-secret",
+  "anthropic-production-key",
+  "query-production-secret",
+  "cookie-production-secret",
+  "password-production-secret",
+  "client-secret-camel-case",
+  "access-token-pascal-case",
+  "refresh-token-json",
+  "signature-colon-value",
+  "azure-subscription-secret",
+  "cloudflare-client-secret",
+  "/home/private/project-marker",
+  "prompt-title-marker",
+  "entity-alias-marker",
+  "/lore:private-command-marker",
+];
+
+function expectNoSecrets(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  for (const secret of SECRETS) expect(serialized).not.toContain(secret);
+}
+
+describe("telemetry privacy boundary", () => {
+  it("explicitly disables automatic sensitive-data collection", () => {
+    expect(SENTRY_DATA_COLLECTION).toEqual({
+      userInfo: false,
+      cookies: false,
+      httpHeaders: { request: false, response: false },
+      httpBodies: [],
+      queryParams: false,
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: false,
+      frameContextLines: 0,
+    });
+  });
+
+  it("wires privacy hooks and the final scrubber into production options", async () => {
+    let sent: unknown;
+    const options = buildSentryOptions(() => ({
+      send(envelope) {
+        sent = envelope;
+        return Promise.resolve({ statusCode: 200 });
+      },
+      flush: () => Promise.resolve(true),
+    }));
+    expect(options.sendDefaultPii).toBe(false);
+    expect(options.dataCollection).toEqual(SENTRY_DATA_COLLECTION);
+    expect(options.enableLogs).toBe(false);
+    expect(options.beforeSend).toBeTypeOf("function");
+    expect(options.beforeSendLog).toBeTypeOf("function");
+    expect(options.beforeSendSpan).toBeTypeOf("function");
+    expect(options.beforeSendTransaction).toBeTypeOf("function");
+    expect(options.beforeBreadcrumb).toBeTypeOf("function");
+
+    const transport = options.transport?.({
+      url: "https://sentry.invalid",
+      recordDroppedEvent: () => {},
+    });
+    await transport?.send([
+      {
+        event_id: "1234567890abcdef1234567890abcdef",
+        sent_at: new Date(0).toISOString(),
+      },
+      [
+        [
+          { type: "event" },
+          { request: { headers: { authorization: SECRETS[0] } } },
+        ],
+      ],
+    ]);
+
+    expectNoSecrets(sent);
+  });
+
+  it("drops application logs instead of trying to redact arbitrary content", async () => {
+    const privateMarkers = [
+      "PRIVATE_PROMPT_TITLE_MARKER",
+      "PRIVATE_ENTITY_ALIAS_MARKER",
+      "/home/private/PRIVATE_PROJECT_PATH_MARKER",
+      "/lore:PRIVATE_SLASH_COMMAND_MARKER",
+    ];
+    let sent: unknown;
+    const options = buildSentryOptions(() => ({
+      send(envelope) {
+        sent = envelope;
+        return Promise.resolve({ statusCode: 200 });
+      },
+      flush: () => Promise.resolve(true),
+    }));
+
+    expect(
+      options.beforeSendLog?.({
+        level: "info",
+        message: privateMarkers.join(" "),
+        attributes: { entityAlias: privateMarkers[1] },
+      }),
+    ).toBeNull();
+
+    const transport = options.transport?.({
+      url: "https://sentry.invalid",
+      recordDroppedEvent: () => {},
+    });
+    const adversarialEnvelope: unknown = [
+      { event_id: "event-id" },
+      [
+        [
+          {
+            type: "log",
+            item_count: 1,
+            content_type: "application/vnd.sentry.items.log+json",
+          },
+          {
+            items: [
+              {
+                body: privateMarkers.join(" "),
+                attributes: { promptTitle: privateMarkers[0] },
+              },
+            ],
+          },
+        ],
+        [{ type: "event" }, { message: "designed error telemetry" }],
+      ],
+    ];
+    await transport?.send(
+      adversarialEnvelope as Parameters<
+        NonNullable<typeof transport>["send"]
+      >[0],
+    );
+
+    const serialized = JSON.stringify(sent);
+    for (const marker of privateMarkers)
+      expect(serialized).not.toContain(marker);
+    expect(serialized).not.toContain('"type":"log"');
+    expect(serialized).toContain("Application error");
+  });
+
+  it("scrubs request data, breadcrumbs, contexts, and span attributes", () => {
+    const event = scrubTelemetryEvent({
+      request: {
+        url: `https://user:password-production-secret@example.com/v1/messages?api_key=query-production-secret#fragment`,
+        method: "POST",
+        headers: {
+          authorization: "Bearer bearer-production-secret",
+          "x-api-key": "anthropic-production-key",
+        },
+        query_string: "api_key=query-production-secret",
+        cookies: { session: "cookie-production-secret" },
+        data: { prompt: "private request body" },
+      },
+      user: {
+        id: "installation-id",
+        ip_address: "203.0.113.10",
+        email: "private@example.com",
+      },
+      breadcrumbs: [
+        {
+          message: "Authorization: Bearer bearer-production-secret",
+          data: {
+            url: "https://example.com/models?token=query-production-secret",
+            cookie: "cookie-production-secret",
+          },
+        },
+      ],
+      contexts: {
+        trace: {
+          span_id: "1234567890abcdef",
+          trace_id: "1234567890abcdef1234567890abcdef",
+          "http.request.header.x_api_key": "anthropic-production-key",
+          "http.query": "password=password-production-secret",
+          clientSecret: "client-secret-camel-case",
+          AccessToken: "access-token-pascal-case",
+          refresh_token: "refresh-token-json",
+          "request-signature": "signature-colon-value",
+          "ocp-apim-subscription-key": "azure-subscription-secret",
+          "cf-access-client-id": "cloudflare-client-secret",
+          promptTitle: "prompt-title-marker",
+          entityAlias: "entity-alias-marker",
+          projectPath: "/home/private/project-marker",
+          slashCommand: "/lore:private-command-marker",
+        },
+      },
+      tags: {
+        superSecret: "camel-suffix-secret",
+        cookieJar: "cookie-jar-secret",
+      },
+      spans: [
+        {
+          data: {
+            authorization: "Bearer bearer-production-secret",
+            "url.full":
+              "https://example.com/v1/messages?key=query-production-secret",
+          },
+          span_id: "1234567890abcdef",
+          trace_id: "1234567890abcdef1234567890abcdef",
+          start_timestamp: 1,
+        },
+      ],
+    });
+
+    expectNoSecrets(event);
+    expect(event.request).toEqual({
+      method: "POST",
+      url: "https://example.com/v1/messages",
+    });
+    expect(event.user).toEqual({ id: "installation-id" });
+    expect(event.breadcrumbs).toBeUndefined();
+    expect(event.tags?.superSecret).toBe("[Filtered]");
+    expect(event.tags?.cookieJar).toBe("[Filtered]");
+  });
+
+  it("uses the credential-header policy for structured and free-form values", () => {
+    const azure = "azure-subscription-secret";
+    const cloudflare = "cloudflare-client-secret";
+    const scrubbed = scrubTelemetryEnvelope({
+      attributes: {
+        "ocp-apim-subscription-key": azure,
+        "cf-access-client-id": cloudflare,
+      },
+      message:
+        `ocp-apim-subscription-key=${azure}\n` +
+        `cf-access-client-id: ${cloudflare}`,
+    });
+
+    expect(JSON.stringify(scrubbed)).not.toContain(azure);
+    expect(JSON.stringify(scrubbed)).not.toContain(cloudflare);
+  });
+
+  it("scrubs every item sent through the final transport boundary", async () => {
+    let sent: unknown;
+    const transport = wrapTelemetryTransport({
+      send(envelope: unknown) {
+        sent = envelope;
+        return Promise.resolve({ statusCode: 200 });
+      },
+      flush: () => Promise.resolve(true),
+    });
+    const envelope = [
+      { event_id: "event-id" },
+      [
+        [
+          { type: "event" },
+          {
+            request: {
+              url: "https://example.com/path?key=query-production-secret",
+              headers: { Authorization: "Bearer bearer-production-secret" },
+            },
+          },
+        ],
+        [
+          { type: "log" },
+          {
+            items: [
+              {
+                body: "x-api-key=anthropic-production-key",
+                attributes: {
+                  password: "password-production-secret",
+                },
+              },
+            ],
+          },
+        ],
+        [
+          { type: "span" },
+          {
+            items: [
+              {
+                data: {
+                  "http.request.header.authorization":
+                    "Bearer bearer-production-secret",
+                  "http.request.query": "key=query-production-secret",
+                },
+              },
+            ],
+          },
+        ],
+      ],
+    ];
+
+    await transport.send(envelope);
+
+    expectNoSecrets(sent);
+    expect(JSON.stringify(sent)).toContain("[Filtered]");
+  });
+
+  it("replaces arbitrary exception text and removes breadcrumbs", () => {
+    const marker = "PRIVATE_ARBITRARY_ERROR_MARKER";
+    const event = scrubTelemetryEvent({
+      message: `failure at /home/private/project: ${marker}`,
+      exception: { values: [{ type: "Error", value: marker }] },
+      breadcrumbs: [{ message: marker }],
+      extra: { detail: marker, errorMessage: marker },
+    });
+
+    expect(JSON.stringify(event)).not.toContain(marker);
+    expect(event.message).toBe("Application error");
+    expect(event.exception?.values?.[0]?.value).toBe("Application error");
+    expect(event.breadcrumbs).toBeUndefined();
+    expect(event.extra?.detail).toBe("[Filtered]");
+    expect(event.extra?.errorMessage).toBe("[Filtered]");
+  });
+
+  it("scrubs event message text at the final envelope boundary", () => {
+    const marker = "PRIVATE_FINAL_ENVELOPE_ERROR_MARKER";
+    const scrubbed = scrubTelemetryEnvelope([
+      { event_id: "event-id" },
+      [
+        [
+          { type: "event" },
+          {
+            message: marker,
+            exception: { values: [{ type: "Error", value: marker }] },
+          },
+        ],
+      ],
+    ]);
+
+    expect(JSON.stringify(scrubbed)).not.toContain(marker);
+    expect(JSON.stringify(scrubbed)).toContain("Application error");
+  });
+
+  it("scrubs cache-divergence snippet attributes at the final envelope boundary", () => {
+    const userMarker = "PRIVATE_DIVERGENCE_USER_MARKER";
+    const systemMarker = "PRIVATE_DIVERGENCE_SYSTEM_MARKER";
+    const scrubbed = scrubTelemetryEnvelope([
+      { event_id: "event-id" },
+      [
+        [
+          { type: "transaction" },
+          {
+            spans: [
+              {
+                data: {
+                  "lore.cache.divergence_prev_snippet": userMarker,
+                  "lore.cache.divergence_curr_snippet": systemMarker,
+                  "lore.cache.divergence_snippet_after": systemMarker,
+                  lorecachedivergencefallbacksnippet: userMarker,
+                  "lore.cache.divergence_point": "system[0].text",
+                  "lore.cache.divergence_reason": "system prompt changed",
+                  "lore.cache.prefix_match": 0.012,
+                },
+              },
+            ],
+          },
+        ],
+      ],
+    ]);
+
+    const serialized = JSON.stringify(scrubbed);
+    expect(serialized).not.toContain(userMarker);
+    expect(serialized).not.toContain(systemMarker);
+    expect(serialized.split("[Filtered]")).toHaveLength(5);
+    expect(serialized).toContain(
+      '"lore.cache.divergence_point":"system[0].text"',
+    );
+    expect(serialized).toContain(
+      '"lore.cache.divergence_reason":"system prompt changed"',
+    );
+    expect(serialized).toContain('"lore.cache.prefix_match":0.012');
+  });
+
+  it("redacts credentials and URL query values in free-form log text", () => {
+    const scrubbed = scrubTelemetryText(
+      "url=https://example.com/v1/messages?key=query-production-secret\n" +
+        "Authorization: Bearer bearer-production-secret\n" +
+        "x-api-key=anthropic-production-key\n" +
+        "clientSecret=client-secret-camel-case\n" +
+        'credentials={"refreshToken":"refresh-token-json"}\n' +
+        "AccessToken: access-token-pascal-case\n" +
+        "request_signature: signature-colon-value",
+    );
+
+    expectNoSecrets(scrubbed);
+    expect(scrubbed).toContain("https://example.com/v1/messages");
+  });
+
+  it.each([
+    {
+      name: "a quoted scalar containing whitespace",
+      input: 'request failed: token = "quoted secret value" status=401',
+      secrets: ["quoted secret value"],
+      expected: 'request failed: token = "[Filtered]" status=401',
+    },
+    {
+      name: "an unquoted scalar containing whitespace",
+      input: "request failed: token = unquoted secret value status=401",
+      secrets: ["unquoted secret value"],
+      expected: "request failed: token = [Filtered] status=401",
+    },
+    {
+      name: "an unquoted JSON scalar",
+      input: 'request failed: {"token":12345,"status":401}',
+      secrets: ["12345"],
+      expected: 'request failed: {"token":[Filtered],"status":401}',
+    },
+    {
+      name: "a boolean JSON scalar",
+      input: 'request failed: {"token":true,"status":401}',
+      secrets: ["true"],
+      expected: 'request failed: {"token":[Filtered],"status":401}',
+    },
+    {
+      name: "a null JSON scalar",
+      input: 'request failed: {"token":null,"status":401}',
+      secrets: ["null"],
+      expected: 'request failed: {"token":[Filtered],"status":401}',
+    },
+    {
+      name: "a JSON array",
+      input:
+        'request failed: credentials=["array-secret",{"nested":"object-secret"}] status=401',
+      secrets: ["array-secret", "object-secret"],
+      expected: "request failed: credentials=[Filtered] status=401",
+    },
+    {
+      name: "a JSON object",
+      input:
+        'request failed: credentials={"refreshToken":"refresh-secret","nested":["nested-secret"]} status=401',
+      secrets: ["refresh-secret", "nested-secret"],
+      expected: "request failed: credentials=[Filtered] status=401",
+    },
+    {
+      name: "a Cookie compound value",
+      input:
+        "request failed: Cookie: session=cookie-secret; refresh=refresh-secret, oauth=oauth-secret status=401",
+      secrets: ["cookie-secret", "refresh-secret", "oauth-secret"],
+      expected: "request failed: Cookie: [Filtered] status=401",
+    },
+    {
+      name: "a Cookie2 compound value",
+      input:
+        "request failed: Cookie2: session=cookie-secret; refresh=refresh-secret, oauth=oauth-secret status=401",
+      secrets: ["cookie-secret", "refresh-secret", "oauth-secret"],
+      expected: "request failed: Cookie2: [Filtered] status=401",
+    },
+    {
+      name: "a non-cookie compound header value",
+      input:
+        "request failed: x-auth-token: foo=first-secret; bar=second-secret status=401",
+      secrets: ["first-secret", "second-secret"],
+      expected: "request failed: x-auth-token: [Filtered] status=401",
+    },
+  ])("redacts the complete value of $name after arbitrary text", (testCase) => {
+    const scrubbed = scrubTelemetryText(testCase.input);
+
+    for (const secret of testCase.secrets) {
+      expect(scrubbed).not.toContain(secret);
+    }
+    expect(scrubbed).toBe(testCase.expected);
+  });
+
+  it.each([
+    "xapikey",
+    "x-authsessionid",
+    "x-oauthsessionid",
+    "x-secretsessionid",
+    "x-tokensessionid",
+    "x-keysessionid",
+  ])("redacts collapsed credential alias %s in free text", (name) => {
+    const secret = "collapsed-alias-secret";
+
+    expect(scrubTelemetryText(`request failed: ${name}=${secret}`)).toBe(
+      `request failed: ${name}=[Filtered]`,
+    );
+  });
+
+  it("redacts compound credential headers at the final envelope boundary", () => {
+    const scrubbed = scrubTelemetryEnvelope({
+      contexts: {
+        trace: {
+          diagnostic:
+            "x-auth-token: foo=first-secret; bar=second-secret status=401",
+        },
+      },
+    });
+
+    expect(JSON.stringify(scrubbed)).not.toContain("first-secret");
+    expect(JSON.stringify(scrubbed)).not.toContain("second-secret");
+    expect(JSON.stringify(scrubbed)).toContain("status=401");
+  });
+
+  it("preserves a bearer scheme diagnostic", () => {
+    for (const diagnostic of [
+      "routing decision scheme=bearer provider=anthropic",
+      "routing decision scheme=bearer selected upstream",
+    ]) {
+      expect(scrubTelemetryText(diagnostic)).toBe(diagnostic);
+    }
+  });
+});

--- a/packages/gateway/test/temporal-adapter.test.ts
+++ b/packages/gateway/test/temporal-adapter.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from "vitest";
 import {
+  deterministicID,
   gatewayMessagesToLore,
+  legacyDeterministicID,
   resolveToolResults,
 } from "../src/temporal-adapter";
 import type { GatewayMessage } from "../src/translate/types";
@@ -75,6 +77,63 @@ function makeToolConversation(): GatewayMessage[] {
     },
   ];
 }
+
+describe("deterministic message identity", () => {
+  test("is stable within a session and distinct across sessions", () => {
+    const content = [{ type: "text" as const, text: "identical response" }];
+    const first = deterministicID("session-a", "assistant", 0, content);
+
+    expect(deterministicID("session-a", "assistant", 0, content)).toBe(first);
+    expect(deterministicID("session-b", "assistant", 0, content)).not.toBe(
+      first,
+    );
+  });
+
+  test("uses the supplied absolute start index for single-message responses", () => {
+    const content = [{ type: "text" as const, text: "repeated answer" }];
+    const first = gatewayMessagesToLore(
+      [{ role: "assistant", content }],
+      "session-a",
+      1,
+    )[0].info.id;
+    const later = gatewayMessagesToLore(
+      [{ role: "assistant", content }],
+      "session-a",
+      3,
+    )[0].info.id;
+
+    expect(later).not.toBe(first);
+  });
+
+  test("carries exact invocation-relative pre-v82 IDs beside absolute modern IDs", () => {
+    const history: GatewayMessage[] = [
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "assistant", content: [{ type: "text", text: "second" }] },
+      { role: "user", content: [{ type: "text", text: "third" }] },
+    ];
+    const converted = gatewayMessagesToLore(history, "bridge-session");
+    expect(converted[2].legacySourceID).toBe(
+      legacyDeterministicID("user", 2, history[2].content),
+    );
+
+    const response = gatewayMessagesToLore(
+      [history[1]],
+      "bridge-session",
+      history.length,
+    )[0];
+    expect(response.info.id).toBe(
+      deterministicID(
+        "bridge-session",
+        "assistant",
+        history.length,
+        history[1].content,
+      ),
+    );
+    expect(response.legacySourceID).toBe(
+      legacyDeterministicID("assistant", 0, history[1].content),
+    );
+  });
+});
 
 // ---------------------------------------------------------------------------
 // resolveToolResults: pairing + stripping

--- a/packages/gateway/test/uninstall-sigkill-child.ts
+++ b/packages/gateway/test/uninstall-sigkill-child.ts
@@ -1,0 +1,27 @@
+import {
+  preflightRemoval,
+  removePath,
+  removePathBlocks,
+} from "../src/cli/uninstall";
+
+const [operation, home, target, installDir] = process.argv.slice(2);
+if ((operation !== "profile" && operation !== "purge") || !home || !target) {
+  throw new Error(
+    "Expected profile|purge, home, target, and optional install directory.",
+  );
+}
+
+if (operation === "profile") {
+  if (!installDir)
+    throw new Error("Profile crash requires an install directory.");
+  removePathBlocks(installDir, () => {}, home, {
+    beforeProfilePublish: (path) => {
+      if (path === target) process.kill(process.pid, "SIGKILL");
+    },
+  });
+} else {
+  const identity = preflightRemoval(target, true, home);
+  removePath(target, true, identity, home, {
+    afterQuarantine: () => process.kill(process.pid, "SIGKILL"),
+  });
+}

--- a/packages/gateway/test/uninstall.test.ts
+++ b/packages/gateway/test/uninstall.test.ts
@@ -1,0 +1,901 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  assertSafeRemovalPath,
+  formatStandaloneInstallReceipt,
+  gatewayRunning,
+  parseInstallReceipt,
+  planUninstall,
+  preflightRemoval,
+  removeBinary,
+  removeInstallerPathBlock,
+  removePath,
+  removePathBlocks,
+  runUninstall,
+  standaloneInstallProvenance,
+  type ExecutableIdentity,
+  type StagedFileRemoval,
+} from "../src/cli/uninstall";
+import {
+  commandSetup,
+  prevalidateSetupUndo,
+  stageSetupUndo,
+} from "../src/cli/setup";
+import { withLifecycleLock } from "../src/lifecycle-lock";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const path of temporaryDirectories.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+  vi.restoreAllMocks();
+});
+
+function temporaryDirectory(): string {
+  const path = mkdtempSync(join(tmpdir(), "lore-uninstall-"));
+  temporaryDirectories.push(path);
+  return path;
+}
+
+function fileIdentity(path: string): ExecutableIdentity {
+  const info = statSync(path, { bigint: true });
+  return {
+    device: info.dev,
+    inode: info.ino,
+    size: info.size,
+    mtimeNs: info.mtimeNs,
+    sha256: createHash("sha256").update(readFileSync(path)).digest("hex"),
+  };
+}
+
+function runSigkillChild(args: string[]): void {
+  const child = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      join(import.meta.dirname, "uninstall-sigkill-child.ts"),
+      ...args,
+    ],
+    { encoding: "utf8", timeout: 90_000 },
+  );
+  expect(child.error).toBeUndefined();
+  expect(child.status, child.stderr).toBeNull();
+  expect(child.signal).toBe("SIGKILL");
+}
+
+function uninstallClaims(parent: string): string[] {
+  return readdirSync(parent).filter((name) => name.includes("lore-uninstall"));
+}
+
+function stagedRemoval(
+  overrides: Partial<StagedFileRemoval> = {},
+): StagedFileRemoval {
+  return {
+    stageDeletion: vi.fn(),
+    assertDeleted: vi.fn(),
+    state: vi.fn(() => "missing" as const),
+    prepareCommit: vi.fn(),
+    commit: vi.fn(),
+    finalize: vi.fn(),
+    rollback: vi.fn(() => "restored" as const),
+    ...overrides,
+  };
+}
+
+describe("uninstall planning", () => {
+  it("preserves data by default and purges only the default data directory", () => {
+    const base = {
+      currentExecutable: "/home/me/.local/bin/lore",
+      hostedInstall: true,
+      receiptPath: "/home/me/.lore/install-path",
+      executableIdentity: {
+        device: 1n,
+        inode: 2n,
+        size: 3n,
+        mtimeNs: 4n,
+        sha256: "a".repeat(64),
+      },
+      receiptIdentity: {
+        device: 5n,
+        inode: 6n,
+        size: 7n,
+        mtimeNs: 8n,
+        sha256: "b".repeat(64),
+      },
+      packageManaged: false,
+      platform: "linux" as const,
+      home: "/home/me",
+      dataDir: "/home/me/.local/share/lore",
+      configDir: "/home/me/.lore",
+    };
+    const preserved = planUninstall({ ...base, purge: false });
+    expect(preserved.preservedDataPaths).toEqual([
+      "/home/me/.local/share/lore",
+    ]);
+    expect(preserved.removals).not.toContainEqual({
+      path: "/home/me/.local/share/lore",
+      recursive: true,
+    });
+
+    const purged = planUninstall({ ...base, purge: true });
+    expect(purged.preservedDataPaths).toEqual([]);
+    expect(purged.removals).toContainEqual({
+      path: "/home/me/.local/share/lore",
+      recursive: true,
+    });
+  });
+
+  it("never deletes package-managed executables or custom data", () => {
+    const plan = planUninstall({
+      currentExecutable: "/home/me/.cache/lore/node",
+      hostedInstall: false,
+      packageManaged: true,
+      packageEntryPath: "/home/me/.cache/lore/package/bin.ts",
+      platform: "linux",
+      purge: true,
+      home: "/home/me",
+      dataDir: "/home/me/.cache/lore",
+      configDir: "/tmp/custom-lore-config",
+    });
+    expect(plan.binaryPath).toBeNull();
+    expect(plan.receiptPath).toBeNull();
+    expect(
+      plan.removals.some(({ path }) => path === "/home/me/.cache/lore"),
+    ).toBe(false);
+    expect(plan.preservedDataPaths).toEqual([
+      "/home/me/.cache/lore",
+      "/tmp/custom-lore-config",
+    ]);
+  });
+
+  it("protects relative external databases from overlapping cleanup", () => {
+    const plan = planUninstall({
+      currentExecutable: "/home/me/.local/bin/lore",
+      hostedInstall: false,
+      packageManaged: false,
+      platform: "linux",
+      purge: true,
+      home: "/home/me",
+      cwd: "/home/me/.cache/lore",
+      dataDir: "/home/me/.local/share/lore",
+      configDir: "/home/me/.lore",
+      dbPath: "lore.db",
+    });
+    expect(
+      plan.removals.some(({ path }) => path === "/home/me/.cache/lore"),
+    ).toBe(false);
+    expect(plan.preservedDataPaths).toContain("lore.db");
+  });
+
+  it("keeps a verified Windows PATH install directory while retaining the running install", () => {
+    const executableIdentity = {
+      device: 1n,
+      inode: 2n,
+      size: 3n,
+      mtimeNs: 4n,
+      sha256: "a".repeat(64),
+    };
+    const receiptIdentity = {
+      device: 5n,
+      inode: 6n,
+      size: 7n,
+      mtimeNs: 8n,
+      sha256: "b".repeat(64),
+    };
+    const plan = planUninstall({
+      currentExecutable: "/home/me/.local/bin/lore.exe",
+      hostedInstall: true,
+      receiptPath: "/home/me/.lore/install-path",
+      pathInstallDir: "/home/me/.local/bin",
+      executableIdentity,
+      receiptIdentity,
+      packageManaged: false,
+      platform: "win32",
+      purge: false,
+      home: "/home/me",
+      dataDir: "/home/me/.local/share/lore",
+      configDir: "/home/me/.lore",
+    });
+
+    expect(plan).toMatchObject({
+      binaryPath: null,
+      binaryIdentity: null,
+      manualBinaryPath: "/home/me/.local/bin/lore.exe",
+      receiptPath: null,
+      receiptIdentity: null,
+      manualReceiptPath: "/home/me/.lore/install-path",
+      installDir: "/home/me/.local/bin",
+    });
+  });
+
+  it("does not trust a receipt PATH directory without full hosted-install verification", () => {
+    const plan = planUninstall({
+      currentExecutable: "/home/me/.local/bin/lore.exe",
+      hostedInstall: true,
+      receiptPath: "/home/me/.lore/install-path",
+      pathInstallDir: "/tmp/attacker-bin",
+      packageManaged: false,
+      platform: "win32",
+      purge: false,
+      home: "/home/me",
+      dataDir: "/home/me/.local/share/lore",
+      configDir: "/home/me/.lore",
+    });
+
+    expect(plan.installDir).toBeNull();
+  });
+});
+
+describe("strict hosted receipt identity", () => {
+  it("accepts a v3 identity-bound receipt and rejects the same bytes on a new inode", () => {
+    const home = temporaryDirectory();
+    const installDir = join(home, "bin");
+    const stateDir = join(home, ".lore");
+    const executable = join(installDir, "lore");
+    const receipt = join(stateDir, "install-path");
+    mkdirSync(installDir);
+    mkdirSync(stateDir);
+    writeFileSync(executable, "binary");
+    writeFileSync(
+      receipt,
+      formatStandaloneInstallReceipt({
+        executable,
+        pathInstallDir: installDir,
+        executableIdentity: fileIdentity(executable),
+      }),
+      { mode: 0o600 },
+    );
+    expect(parseInstallReceipt(readFileSync(receipt, "utf8"))).toMatchObject({
+      version: 3,
+      pathInstallDir: installDir,
+      executableIdentity: fileIdentity(executable),
+    });
+    expect(
+      standaloneInstallProvenance(executable, { seaBinary: true, home }),
+    ).toMatchObject({ hostedInstall: true });
+
+    renameSync(executable, `${executable}.old`);
+    writeFileSync(executable, "binary");
+    expect(
+      standaloneInstallProvenance(executable, { seaBinary: true, home }),
+    ).toEqual({ hostedInstall: false });
+  });
+
+  it("rejects path-only legacy receipts and symlinked state directories", () => {
+    const home = temporaryDirectory();
+    const executable = join(home, "bin", "lore");
+    const state = join(home, "state");
+    mkdirSync(dirname(executable));
+    mkdirSync(state);
+    writeFileSync(executable, "binary");
+    writeFileSync(join(state, "install-path"), executable);
+    symlinkSync(state, join(home, ".lore"));
+    expect(
+      standaloneInstallProvenance(executable, { seaBinary: true, home }),
+    ).toEqual({ hostedInstall: false });
+  });
+});
+
+describe("generation-bound deletion", () => {
+  it("removes only the recursively preflighted generation", () => {
+    const home = temporaryDirectory();
+    const target = join(home, ".cache", "lore");
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, "old"), "old");
+    const identity = preflightRemoval(target, true, home);
+
+    const removal = removePath(target, true, identity, home, {
+      afterQuarantine: () => {
+        mkdirSync(target);
+        writeFileSync(join(target, "successor"), "keep");
+      },
+    });
+    removal.prepareCommit();
+    removal.commit();
+    expect(readFileSync(join(target, "successor"), "utf8")).toBe("keep");
+  });
+
+  it("refuses intermediate symlinks and preserves post-preflight successors", () => {
+    const home = temporaryDirectory();
+    const target = join(home, "target");
+    mkdirSync(target);
+    symlinkSync(target, join(home, ".cache"));
+    expect(() =>
+      assertSafeRemovalPath(join(home, ".cache", "lore"), home),
+    ).toThrow(/intermediate symbolic link/);
+
+    const missing = join(home, "safe", "lore");
+    const identity = preflightRemoval(missing, true, home);
+    mkdirSync(missing, { recursive: true });
+    expect(() => removePath(missing, true, identity, home)).toThrow(
+      /appeared after uninstall preflight/,
+    );
+  });
+
+  it("stages executable deletion reversibly and preserves a successor", () => {
+    const home = temporaryDirectory();
+    const executable = join(home, "bin", "lore");
+    mkdirSync(dirname(executable));
+    writeFileSync(executable, "old");
+    const removal = removeBinary(executable, fileIdentity(executable), home);
+    removal.stageDeletion();
+    writeFileSync(executable, "successor");
+    expect(() => removal.assertDeleted()).toThrow(/replaced during uninstall/);
+    expect(removal.rollback()).toBe("preserved");
+    expect(readFileSync(executable, "utf8")).toBe("successor");
+  });
+});
+
+describe.skipIf(process.platform === "win32")(
+  "uninstall SIGKILL claim recovery",
+  () => {
+    it("recovers a shell profile stranded before replacement publication", () => {
+      const home = temporaryDirectory();
+      const installDir = join(home, "bin");
+      const profile = join(home, ".zshrc");
+      writeFileSync(
+        profile,
+        [
+          "export KEEP=1",
+          "# Added by lore installer",
+          `export PATH='${installDir}':"$PATH"`,
+          "",
+        ].join("\n"),
+      );
+
+      runSigkillChild(["profile", home, profile, installDir]);
+      expect(existsSync(profile)).toBe(false);
+      expect(uninstallClaims(home).length).toBeGreaterThan(0);
+
+      const recovery = removePathBlocks(installDir, () => {}, home);
+      recovery.prepareCommit();
+      recovery.commit();
+
+      expect(readFileSync(profile, "utf8")).toBe("export KEEP=1\n");
+      expect(uninstallClaims(home)).toEqual([]);
+    });
+
+    it("preserves a shell profile successor while committing its stranded claim", () => {
+      const home = temporaryDirectory();
+      const installDir = join(home, "bin");
+      const profile = join(home, ".zshrc");
+      writeFileSync(
+        profile,
+        `# Added by lore installer\nexport PATH='${installDir}':"$PATH"\n`,
+      );
+
+      runSigkillChild(["profile", home, profile, installDir]);
+      writeFileSync(profile, "export SUCCESSOR=1\n");
+
+      const recovery = removePathBlocks(installDir, () => {}, home);
+      recovery.prepareCommit();
+      recovery.commit();
+
+      expect(readFileSync(profile, "utf8")).toBe("export SUCCESSOR=1\n");
+      expect(uninstallClaims(home)).toEqual([]);
+    });
+
+    it("continues a purge claim stranded after canonical quarantine", () => {
+      const home = temporaryDirectory();
+      const target = join(home, ".local", "share", "lore");
+      mkdirSync(target, { recursive: true });
+      writeFileSync(join(target, "lore.db"), "memory");
+
+      runSigkillChild(["purge", home, target]);
+      expect(existsSync(target)).toBe(false);
+      expect(uninstallClaims(dirname(target)).length).toBe(1);
+
+      const recovery = removePath(
+        target,
+        true,
+        preflightRemoval(target, true, home),
+        home,
+      );
+      recovery.prepareCommit();
+      recovery.commit();
+
+      expect(existsSync(target)).toBe(false);
+      expect(uninstallClaims(dirname(target))).toEqual([]);
+    });
+
+    it("preserves a purge successor while committing the stranded generation", () => {
+      const home = temporaryDirectory();
+      const target = join(home, ".cache", "lore");
+      mkdirSync(target, { recursive: true });
+      writeFileSync(join(target, "old"), "old");
+
+      runSigkillChild(["purge", home, target]);
+      mkdirSync(target);
+      writeFileSync(join(target, "successor"), "keep");
+
+      const recovery = removePath(
+        target,
+        true,
+        preflightRemoval(target, true, home),
+        home,
+      );
+      recovery.prepareCommit();
+      recovery.commit();
+
+      expect(readFileSync(join(target, "successor"), "utf8")).toBe("keep");
+      expect(uninstallClaims(dirname(target))).toEqual([]);
+    });
+  },
+);
+
+describe("profile and uninstall transactions", () => {
+  it("removes only the exact installer PATH block", () => {
+    const installDir = "/home/me/.local/bin";
+    const content = [
+      "export KEEP=1",
+      "# Added by lore installer",
+      `export PATH='${installDir}':"$PATH"`,
+      "",
+    ].join("\n");
+    expect(removeInstallerPathBlock(content, installDir)).toBe(
+      "export KEEP=1\n",
+    );
+    expect(
+      removeInstallerPathBlock(
+        '# Added by lore installer\nexport PATH="/edited:$PATH"\n',
+        installDir,
+      ),
+    ).toContain("/edited");
+  });
+
+  it("rolls back staged executable state when later cleanup fails", async () => {
+    const rollback = vi.fn(() => "restored" as const);
+    await expect(
+      runUninstall(
+        {
+          binaryPath: "/home/me/bin/lore",
+          binaryIdentity: {
+            device: 1n,
+            inode: 2n,
+            size: 3n,
+            mtimeNs: 4n,
+            sha256: "a".repeat(64),
+          },
+          manualBinaryPath: null,
+          manualReceiptPath: null,
+          receiptPath: null,
+          installDir: "/home/me/bin",
+          removals: [],
+          preservedDataPaths: [],
+          packageManaged: false,
+        },
+        {
+          gatewayRunning: async () => false,
+          prevalidateSetupUndo: () => {},
+          stageSetupUndo: () => ({
+            prepareCommit: vi.fn(),
+            commit: vi.fn(),
+            rollback: vi.fn(),
+          }),
+          removeBinary: () => stagedRemoval({ rollback }),
+          removePathBlocks: () => {
+            throw new Error("profile changed");
+          },
+          removePath: vi.fn(),
+          log: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("profile changed");
+    expect(rollback).toHaveBeenCalledOnce();
+  });
+
+  it("removes Windows hosted PATH blocks while retaining the executable and receipt", async () => {
+    const home = temporaryDirectory();
+    const installDir = join(home, ".local", "bin");
+    const executable = join(installDir, "lore.exe");
+    const receipt = join(home, ".lore", "install-path");
+    const profile = join(home, ".bashrc");
+    mkdirSync(installDir, { recursive: true });
+    mkdirSync(dirname(receipt), { recursive: true });
+    writeFileSync(executable, "windows-binary");
+    writeFileSync(receipt, "verified-receipt");
+    writeFileSync(
+      profile,
+      [
+        "export KEEP=1",
+        "# Added by lore installer",
+        `export PATH='${installDir}':"$PATH"`,
+        "export ALSO_KEEP=2",
+        "",
+      ].join("\n"),
+    );
+    const plan = planUninstall({
+      currentExecutable: executable,
+      hostedInstall: true,
+      receiptPath: receipt,
+      pathInstallDir: installDir,
+      executableIdentity: fileIdentity(executable),
+      receiptIdentity: fileIdentity(receipt),
+      packageManaged: false,
+      platform: "win32",
+      purge: false,
+      home,
+      dataDir: join(home, ".local", "share", "lore"),
+      configDir: join(home, ".lore"),
+    });
+
+    const removeBinarySpy = vi.fn();
+    const removeReceiptSpy = vi.fn();
+    await expect(
+      runUninstall(plan, {
+        gatewayRunning: async () => false,
+        prevalidateSetupUndo: () => {},
+        stageSetupUndo: () => ({
+          prepareCommit: () => {},
+          commit: () => {},
+          rollback: () => {},
+        }),
+        removeBinary: removeBinarySpy,
+        removeReceipt: removeReceiptSpy,
+        removePathBlocks: (path, assertInstallRemoved) =>
+          removePathBlocks(path, assertInstallRemoved, home),
+        removePath: vi.fn(() => ({
+          prepareCommit: () => {},
+          commit: () => {},
+          rollback: () => {},
+        })),
+        log: vi.fn(),
+      }),
+    ).resolves.toBe(0);
+
+    expect(readFileSync(profile, "utf8")).toBe(
+      "export KEEP=1\nexport ALSO_KEEP=2\n",
+    );
+    expect(readFileSync(executable, "utf8")).toBe("windows-binary");
+    expect(readFileSync(receipt, "utf8")).toBe("verified-receipt");
+    expect(removeBinarySpy).not.toHaveBeenCalled();
+    expect(removeReceiptSpy).not.toHaveBeenCalled();
+  });
+
+  it("restores a Windows hosted PATH block when a later reversible step fails", async () => {
+    const home = temporaryDirectory();
+    const installDir = join(home, ".local", "bin");
+    const executable = join(installDir, "lore.exe");
+    const receipt = join(home, ".lore", "install-path");
+    const profile = join(home, ".bashrc");
+    mkdirSync(installDir, { recursive: true });
+    mkdirSync(dirname(receipt), { recursive: true });
+    writeFileSync(executable, "windows-binary");
+    writeFileSync(receipt, "verified-receipt");
+    const originalProfile = [
+      "export KEEP=1",
+      "# Added by lore installer",
+      `export PATH='${installDir}':"$PATH"`,
+      "export ALSO_KEEP=2",
+      "",
+    ].join("\n");
+    writeFileSync(profile, originalProfile);
+    const setupRollback = vi.fn();
+    let pathCleanupStaged = false;
+    const plan = planUninstall({
+      currentExecutable: executable,
+      hostedInstall: true,
+      receiptPath: receipt,
+      pathInstallDir: installDir,
+      executableIdentity: fileIdentity(executable),
+      receiptIdentity: fileIdentity(receipt),
+      packageManaged: false,
+      platform: "win32",
+      purge: false,
+      home,
+      dataDir: join(home, ".local", "share", "lore"),
+      configDir: join(home, ".lore"),
+    });
+
+    await expect(
+      runUninstall(plan, {
+        gatewayRunning: async () => false,
+        prevalidateSetupUndo: () => {},
+        stageSetupUndo: () => ({
+          prepareCommit: () => {
+            throw new Error("later setup validation failed");
+          },
+          commit: () => {},
+          rollback: setupRollback,
+        }),
+        removeBinary: vi.fn(),
+        removeReceipt: vi.fn(),
+        removePathBlocks: (path, assertInstallRemoved) => {
+          pathCleanupStaged = true;
+          return removePathBlocks(path, assertInstallRemoved, home);
+        },
+        removePath: vi.fn(() => ({
+          prepareCommit: () => {},
+          commit: () => {},
+          rollback: () => {},
+        })),
+        log: vi.fn(),
+      }),
+    ).rejects.toThrow("later setup validation failed");
+
+    expect(readFileSync(profile, "utf8")).toBe(originalProfile);
+    expect(readFileSync(executable, "utf8")).toBe("windows-binary");
+    expect(readFileSync(receipt, "utf8")).toBe("verified-receipt");
+    expect(setupRollback).toHaveBeenCalledOnce();
+    expect(pathCleanupStaged).toBe(true);
+  });
+
+  it.each(["receipt", "binary"] as const)(
+    "keeps setup and purge data intact when late %s validation fails",
+    async (failureAt) => {
+      let setupState: "configured" | "undone" = "configured";
+      let dataState: "present" | "quarantined" = "present";
+      const installationState: Record<
+        "binary" | "receipt",
+        "expected" | "missing"
+      > = { binary: "expected", receipt: "expected" };
+      const setupCommit = vi.fn();
+      const dataCommit = vi.fn();
+
+      const identifiedRemoval = (
+        name: "binary" | "receipt",
+      ): StagedFileRemoval => {
+        return {
+          stageDeletion: () => {
+            installationState[name] = "missing";
+          },
+          assertDeleted: () => {
+            if (installationState[name] !== "missing") {
+              throw new Error(`${name} still present`);
+            }
+          },
+          state: () => installationState[name],
+          prepareCommit: vi.fn(),
+          finalize: () => {
+            if (name === failureAt) {
+              throw new Error(`late ${name} validation failed`);
+            }
+          },
+          commit: vi.fn(),
+          rollback: () => {
+            installationState[name] = "expected";
+            return "restored";
+          },
+        };
+      };
+
+      await expect(
+        runUninstall(
+          {
+            binaryPath: "/home/me/bin/lore",
+            binaryIdentity: {
+              device: 1n,
+              inode: 2n,
+              size: 3n,
+              mtimeNs: 4n,
+              sha256: "a".repeat(64),
+            },
+            manualBinaryPath: null,
+            manualReceiptPath: null,
+            receiptPath: "/home/me/.lore/install-path",
+            receiptIdentity: {
+              device: 5n,
+              inode: 6n,
+              size: 7n,
+              mtimeNs: 8n,
+              sha256: "b".repeat(64),
+            },
+            installDir: "/home/me/bin",
+            removals: [{ path: "/home/me/.local/share/lore", recursive: true }],
+            preservedDataPaths: [],
+            packageManaged: false,
+          },
+          {
+            gatewayRunning: async () => false,
+            prevalidateSetupUndo: () => {},
+            stageSetupUndo: () => {
+              setupState = "undone";
+              return {
+                prepareCommit: vi.fn(),
+                commit: setupCommit,
+                rollback: () => {
+                  setupState = "configured";
+                },
+              };
+            },
+            removeBinary: () => identifiedRemoval("binary"),
+            removeReceipt: () => identifiedRemoval("receipt"),
+            removePath: () => {
+              dataState = "quarantined";
+              return {
+                prepareCommit: vi.fn(),
+                commit: dataCommit,
+                rollback: () => {
+                  dataState = "present";
+                },
+              };
+            },
+            removePathBlocks: () => ({
+              prepareCommit: vi.fn(),
+              commit: vi.fn(),
+              rollback: vi.fn(),
+            }),
+            log: vi.fn(),
+          },
+        ),
+      ).rejects.toThrow(`late ${failureAt} validation failed`);
+
+      expect(setupState).toBe("configured");
+      expect(dataState).toBe("present");
+      expect(installationState).toEqual({
+        binary: "expected",
+        receipt: "expected",
+      });
+      expect(setupCommit).not.toHaveBeenCalled();
+      expect(dataCommit).not.toHaveBeenCalled();
+    },
+  );
+
+  it("never attempts rollback after recursive deletion crosses the commit boundary", async () => {
+    const setupCommit = vi.fn();
+    const setupRollback = vi.fn();
+    const dataRollback = vi.fn();
+
+    await expect(
+      runUninstall(
+        {
+          binaryPath: null,
+          binaryIdentity: null,
+          manualBinaryPath: null,
+          manualReceiptPath: null,
+          receiptPath: null,
+          installDir: null,
+          removals: [{ path: "/home/me/.local/share/lore", recursive: true }],
+          preservedDataPaths: [],
+          packageManaged: true,
+        },
+        {
+          gatewayRunning: async () => false,
+          prevalidateSetupUndo: () => {},
+          stageSetupUndo: () => ({
+            prepareCommit: vi.fn(),
+            commit: setupCommit,
+            rollback: setupRollback,
+          }),
+          removePath: () => ({
+            prepareCommit: vi.fn(),
+            commit: () => {
+              throw new Error("partial recursive delete");
+            },
+            rollback: dataRollback,
+          }),
+          removePathBlocks: vi.fn(),
+          removeBinary: vi.fn(),
+          log: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow(/irreversible cleanup began/i);
+
+    expect(setupCommit).toHaveBeenCalledOnce();
+    expect(setupRollback).not.toHaveBeenCalled();
+    expect(dataRollback).not.toHaveBeenCalled();
+  });
+
+  it("restores setup config and quarantined purge data on a late profile failure", async () => {
+    const home = temporaryDirectory();
+    const originalHome = process.env.HOME;
+    const originalConfigDir = process.env.LORE_CONFIG_DIR;
+    process.env.HOME = home;
+    process.env.LORE_CONFIG_DIR = join(home, ".lore");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const config = join(home, ".claude", "settings.json");
+      mkdirSync(dirname(config), { recursive: true });
+      writeFileSync(config, '{"theme":"dark"}\n', { mode: 0o640 });
+      await commandSetup(["claude-code"], { port: 3299 });
+      const configured = readFileSync(config);
+      const sidecar = `${config}.lore-backup`;
+      const configuredSidecar = readFileSync(sidecar);
+
+      const binary = join(home, "bin", "lore");
+      mkdirSync(dirname(binary), { recursive: true });
+      writeFileSync(binary, "standalone-binary");
+      const purgeData = join(home, ".local", "share", "lore");
+      mkdirSync(purgeData, { recursive: true });
+      writeFileSync(join(purgeData, "lore.db"), "important-memory");
+      const purgeIdentity = preflightRemoval(purgeData, true, home);
+
+      await expect(
+        withLifecycleLock("uninstall", (lock) =>
+          runUninstall(
+            {
+              binaryPath: binary,
+              binaryIdentity: fileIdentity(binary),
+              manualBinaryPath: null,
+              manualReceiptPath: null,
+              receiptPath: null,
+              installDir: dirname(binary),
+              removals: [{ path: purgeData, recursive: true }],
+              preservedDataPaths: [],
+              packageManaged: false,
+            },
+            {
+              gatewayRunning: async () => false,
+              prevalidateSetupUndo,
+              stageSetupUndo: () => stageSetupUndo(lock),
+              removeBinary: (path, identity) =>
+                removeBinary(path, identity, home),
+              removePath: (path, recursive) =>
+                removePath(path, recursive, purgeIdentity, home),
+              removePathBlocks: () => ({
+                prepareCommit: () => {
+                  throw new Error("deterministic late profile failure");
+                },
+                commit: vi.fn(),
+                rollback: vi.fn(),
+              }),
+              log: vi.fn(),
+            },
+          ),
+        ),
+      ).rejects.toThrow("deterministic late profile failure");
+
+      expect(readFileSync(binary, "utf8")).toBe("standalone-binary");
+      expect(readFileSync(join(purgeData, "lore.db"), "utf8")).toBe(
+        "important-memory",
+      );
+      expect(readFileSync(config)).toEqual(configured);
+      expect(readFileSync(sidecar)).toEqual(configuredSidecar);
+
+      // Exact-generation restoration keeps the v3 sidecar usable, not merely
+      // byte-equal. A real setup undo must still accept and consume it.
+      await commandSetup(["undo", "claude-code"], {});
+      expect(JSON.parse(readFileSync(config, "utf8"))).toEqual({
+        theme: "dark",
+      });
+      expect(existsSync(sidecar)).toBe(false);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalConfigDir === undefined) delete process.env.LORE_CONFIG_DIR;
+      else process.env.LORE_CONFIG_DIR = originalConfigDir;
+    }
+  });
+});
+
+describe("gateway discovery", () => {
+  it("fails closed on rejected process identity without probing a legacy port", async () => {
+    const readPort = vi.fn(() => 4321);
+    const probePort = vi.fn(async () => "healthy" as const);
+    await expect(
+      gatewayRunning({
+        readProcessRecord: () => ({
+          version: 1,
+          pid: process.pid,
+          port: 4321,
+          hosts: ["127.0.0.1"],
+          token: "a".repeat(32),
+        }),
+        authenticateProcess: async () => "rejected",
+        readPort,
+        probePort,
+      }),
+    ).rejects.toThrow(/identity check was rejected/);
+    expect(readPort).not.toHaveBeenCalled();
+    expect(probePort).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/test/upgrade-artifact-auth.test.ts
+++ b/packages/gateway/test/upgrade-artifact-auth.test.ts
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/cli/lib/delta-upgrade", () => ({
+  attemptDeltaUpgrade: vi.fn(async () => null),
+}));
+
+import type { LifecycleLock } from "../src/lifecycle-lock";
+import { getPlatformBinaryName } from "../src/cli/lib/binary";
+import { downloadBinaryToTemp } from "../src/cli/lib/upgrade";
+
+const originalFetch = globalThis.fetch;
+const originalConfigDir = process.env.LORE_CONFIG_DIR;
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalConfigDir === undefined) delete process.env.LORE_CONFIG_DIR;
+  else process.env.LORE_CONFIG_DIR = originalConfigDir;
+  vi.restoreAllMocks();
+  for (const path of temporaryDirectories.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requestUrl(input: string | URL | Request): string {
+  if (typeof input === "string") return input;
+  return input instanceof URL ? input.href : input.url;
+}
+
+function fixture(
+  options: {
+    version?: string;
+    expectedBinarySha256?: string;
+    includeChecksums?: boolean;
+    tamperChecksums?: boolean;
+  } = {},
+) {
+  const root = mkdtempSync(join(tmpdir(), "lore-upgrade-auth-"));
+  temporaryDirectories.push(root);
+  process.env.LORE_CONFIG_DIR = join(root, "config");
+  mkdirSync(process.env.LORE_CONFIG_DIR);
+  const executable = join(
+    root,
+    process.platform === "win32" ? "lore.exe" : "lore",
+  );
+  writeFileSync(executable, "old binary");
+  const version = options.version ?? "0.40.1";
+  const filename = getPlatformBinaryName();
+  const binary = Buffer.from("authenticated replacement binary");
+  const compressed = gzipSync(binary);
+  const checksums = [
+    `${options.expectedBinarySha256 ?? sha256(binary)}  ${filename}`,
+    `${sha256(compressed)}  ${filename}.gz`,
+    "",
+  ].join("\n");
+  const checksumsDigest = options.tamperChecksums
+    ? sha256("different checksum metadata")
+    : sha256(checksums);
+  const checksumsUrl = `https://github.com/BYK/loreai/releases/download/${version}/lore-checksums.txt`;
+  const release = {
+    tag_name: version,
+    assets:
+      options.includeChecksums === false
+        ? []
+        : [
+            {
+              name: "lore-checksums.txt",
+              browser_download_url: checksumsUrl,
+              digest: `sha256:${checksumsDigest}`,
+            },
+          ],
+  };
+  const fetchMock = vi.fn(async (input: string | URL | Request) => {
+    const url = requestUrl(input);
+    if (url.includes(`/releases/tags/${version}`)) {
+      return Response.json(release);
+    }
+    if (url === checksumsUrl) return new Response(checksums);
+    if (url.endsWith(`${filename}.gz`)) return new Response(compressed);
+    if (url.endsWith(filename)) return new Response(binary);
+    throw new Error(`Unexpected URL: ${url}`);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  const lifecycleLock = {
+    assertOwned: vi.fn(),
+  } as unknown as LifecycleLock;
+  return { binary, executable, fetchMock, lifecycleLock, version };
+}
+
+describe("stable upgrade artifact authentication", () => {
+  it("installs a download matching publisher checksum metadata", async () => {
+    const { binary, executable, lifecycleLock, version } = fixture();
+
+    const result = await downloadBinaryToTemp(
+      version,
+      lifecycleLock,
+      undefined,
+      false,
+      executable,
+    );
+
+    expect(readFileSync(result.tempBinaryPath)).toEqual(binary);
+  });
+
+  it("fails closed before binary download when checksum metadata is missing", async () => {
+    const { executable, fetchMock, lifecycleLock, version } = fixture({
+      includeChecksums: false,
+    });
+
+    await expect(
+      downloadBinaryToTemp(
+        version,
+        lifecycleLock,
+        undefined,
+        false,
+        executable,
+      ),
+    ).rejects.toThrow(/checksum metadata/i);
+    expect(
+      fetchMock.mock.calls.some(([input]) => requestUrl(input).endsWith(".gz")),
+    ).toBe(false);
+  });
+
+  it("rejects and removes a stable binary whose checksum mismatches", async () => {
+    const { executable, lifecycleLock, version } = fixture({
+      expectedBinarySha256: "0".repeat(64),
+    });
+
+    await expect(
+      downloadBinaryToTemp(
+        version,
+        lifecycleLock,
+        undefined,
+        false,
+        executable,
+      ),
+    ).rejects.toThrow(/binary checksum mismatch/i);
+    expect(() => readFileSync(`${executable}.download`)).toThrow();
+  });
+
+  it("rejects checksum metadata that differs from its GitHub asset digest", async () => {
+    const { executable, fetchMock, lifecycleLock, version } = fixture({
+      tamperChecksums: true,
+    });
+
+    await expect(
+      downloadBinaryToTemp(
+        version,
+        lifecycleLock,
+        undefined,
+        false,
+        executable,
+      ),
+    ).rejects.toThrow(/checksum metadata digest mismatch/i);
+    expect(
+      fetchMock.mock.calls.some(([input]) => requestUrl(input).endsWith(".gz")),
+    ).toBe(false);
+  });
+
+  it("keeps pre-checksum releases installable when metadata is absent", async () => {
+    const { binary, executable, lifecycleLock, version } = fixture({
+      version: "0.40.0",
+      includeChecksums: false,
+    });
+
+    const result = await downloadBinaryToTemp(
+      version,
+      lifecycleLock,
+      undefined,
+      false,
+      executable,
+    );
+
+    expect(readFileSync(result.tempBinaryPath)).toEqual(binary);
+  });
+
+  it("fails closed on a new stable release in offline mode", async () => {
+    const { executable, fetchMock, lifecycleLock, version } = fixture();
+
+    await expect(
+      downloadBinaryToTemp(
+        version,
+        lifecycleLock,
+        undefined,
+        "explicit",
+        executable,
+      ),
+    ).rejects.toThrow(/publisher checksum metadata is unavailable/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/test/upgrade-lifecycle.test.ts
+++ b/packages/gateway/test/upgrade-lifecycle.test.ts
@@ -1,0 +1,348 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { commandUpgrade, standaloneUpgradeTargetDir } from "../src/cli/upgrade";
+import {
+  persistStandaloneUpgradeRecoveryJournal,
+  recoverStandaloneUpgradePublication,
+  standaloneUpgradeBackupTokens,
+} from "../src/cli/upgrade-recovery";
+import {
+  formatStandaloneInstallReceipt,
+  stageStandaloneUpgradeReceipt,
+  standaloneInstallProvenance,
+  type ExecutableIdentity,
+} from "../src/cli/uninstall";
+import {
+  lifecycleLockPath,
+  LifecycleLockBusyError,
+} from "../src/lifecycle-lock";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  rmSync(lifecycleLockPath(), { recursive: true, force: true });
+  for (const path of temporaryDirectories.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+interface UpgradeFixture {
+  home: string;
+  executable: string;
+  receipt: string;
+  installDir: string;
+  oldExecutable: ExecutableIdentity;
+  oldReceipt: ExecutableIdentity;
+}
+
+function fileIdentity(path: string): ExecutableIdentity {
+  const info = lstatSync(path, { bigint: true });
+  return {
+    device: info.dev,
+    inode: info.ino,
+    size: info.size,
+    mtimeNs: info.mtimeNs,
+    sha256: createHash("sha256").update(readFileSync(path)).digest("hex"),
+  };
+}
+
+function upgradeFixture(): UpgradeFixture {
+  const home = mkdtempSync(join(tmpdir(), "lore-upgrade-recovery-"));
+  temporaryDirectories.push(home);
+  const installDir = join(home, "bin");
+  const stateDir = join(home, ".lore");
+  const executable = join(installDir, "lore");
+  const receipt = join(stateDir, "install-path");
+  mkdirSync(installDir, { mode: 0o700 });
+  mkdirSync(stateDir, { mode: 0o700 });
+  writeFileSync(executable, "old binary", { mode: 0o700 });
+  const oldExecutable = fileIdentity(executable);
+  writeFileSync(
+    receipt,
+    formatStandaloneInstallReceipt({
+      executable,
+      pathInstallDir: installDir,
+      executableIdentity: oldExecutable,
+    }),
+    { mode: 0o600 },
+  );
+  return {
+    home,
+    executable,
+    receipt,
+    installDir,
+    oldExecutable,
+    oldReceipt: fileIdentity(receipt),
+  };
+}
+
+function stageRecovery(
+  fixture: UpgradeFixture,
+  replacementContent = "new binary",
+) {
+  const previous = standaloneUpgradeBackupTokens(fixture.executable);
+  const transaction = stageStandaloneUpgradeReceipt({
+    executable: fixture.executable,
+    executableIdentity: fixture.oldExecutable,
+    receiptPath: fixture.receipt,
+    receiptIdentity: fixture.oldReceipt,
+    pathInstallDir: fixture.installDir,
+    home: fixture.home,
+  });
+  const tokens = [...standaloneUpgradeBackupTokens(fixture.executable)].filter(
+    (token) => !previous.has(token),
+  );
+  expect(tokens).toHaveLength(1);
+  const token = tokens[0];
+  const executableBackup = join(
+    fixture.installDir,
+    `.${basename(fixture.executable)}.upgrade-backup-${token}`,
+  );
+  const receiptBackup = join(
+    dirname(fixture.receipt),
+    `.${basename(fixture.receipt)}.upgrade-backup-${token}`,
+  );
+  const replacement = join(fixture.installDir, "replacement");
+  writeFileSync(replacement, replacementContent, { mode: 0o700 });
+  const replacementSha256 = fileIdentity(replacement).sha256;
+  const journal = persistStandaloneUpgradeRecoveryJournal({
+    executable: fixture.executable,
+    receiptPath: fixture.receipt,
+    pathInstallDir: fixture.installDir,
+    oldExecutable: fixture.oldExecutable,
+    oldReceipt: fixture.oldReceipt,
+    replacementPath: replacement,
+    expectedReplacementSha256: replacementSha256,
+    previousBackupTokens: previous,
+    home: fixture.home,
+  });
+  return {
+    transaction,
+    replacement,
+    replacementSha256,
+    token,
+    executableBackup,
+    receiptBackup,
+    journal,
+  };
+}
+
+function expectNoRecoveryArtifacts(fixture: UpgradeFixture): void {
+  expect(
+    readdirSync(fixture.installDir).filter((name) =>
+      name.includes("upgrade-recovery"),
+    ),
+  ).toEqual([]);
+  expect(
+    readdirSync(dirname(fixture.receipt)).filter(
+      (name) =>
+        name.includes("upgrade-recovery") || name.includes("upgrade-backup"),
+    ),
+  ).toEqual([]);
+  expect(standaloneUpgradeBackupTokens(fixture.executable).size).toBe(0);
+}
+
+describe("upgrade lifecycle lock", () => {
+  test("package-managed upgrade cannot create an unmanaged standalone binary", () => {
+    expect(() =>
+      standaloneUpgradeTargetDir("/usr/bin/node", { hostedInstall: false }),
+    ).toThrow(/package manager.*no standalone binary/i);
+  });
+
+  test("verified hosted custom paths remain the upgrade target", () => {
+    expect(
+      standaloneUpgradeTargetDir("/opt/custom/lore", { hostedInstall: true }),
+    ).toBe("/opt/custom");
+  });
+
+  test("help does not acquire the lifecycle lock", async () => {
+    const path = lifecycleLockPath();
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+    writeFileSync(join(path, "owner.json"), "malformed lock", { mode: 0o600 });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(commandUpgrade(["--help"])).resolves.toBeUndefined();
+  });
+
+  test("serializes check-only upgrades", async () => {
+    vi.useFakeTimers();
+    const path = lifecycleLockPath();
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+    writeFileSync(join(path, "owner.json"), "malformed lock", { mode: 0o600 });
+    const check = commandUpgrade(["--check"]);
+    const rejection = expect(check).rejects.toBeInstanceOf(
+      LifecycleLockBusyError,
+    );
+    await vi.advanceTimersByTimeAsync(5000);
+    await rejection;
+  });
+});
+
+describe("standalone upgrade crash recovery", () => {
+  test("cleans a durable journal before binary publication", () => {
+    const fixture = upgradeFixture();
+    stageRecovery(fixture);
+    expect(
+      recoverStandaloneUpgradePublication({
+        executable: fixture.executable,
+        receiptPath: fixture.receipt,
+        home: fixture.home,
+      }),
+    ).toEqual({ executable: fixture.executable, action: "cleaned" });
+    expect(readFileSync(fixture.executable, "utf8")).toBe("old binary");
+    expectNoRecoveryArtifacts(fixture);
+  });
+
+  test("completes receipt publication for the authenticated replacement", () => {
+    const fixture = upgradeFixture();
+    const staged = stageRecovery(fixture);
+    renameSync(staged.replacement, fixture.executable);
+    expect(
+      recoverStandaloneUpgradePublication({
+        executable: fixture.executable,
+        receiptPath: fixture.receipt,
+        home: fixture.home,
+      }),
+    ).toEqual({ executable: fixture.executable, action: "completed" });
+    expect(readFileSync(fixture.executable, "utf8")).toBe("new binary");
+    expect(
+      standaloneInstallProvenance(fixture.executable, {
+        seaBinary: true,
+        home: fixture.home,
+      }),
+    ).toMatchObject({
+      hostedInstall: true,
+      executableIdentity: fileIdentity(fixture.executable),
+    });
+    expectNoRecoveryArtifacts(fixture);
+  });
+
+  test("restores the old pair when an unjournaled replacement wins", () => {
+    const fixture = upgradeFixture();
+    const staged = stageRecovery(fixture, "expected replacement");
+    const attacker = join(fixture.installDir, "attacker");
+    writeFileSync(attacker, "unjournaled replacement", { mode: 0o700 });
+    renameSync(attacker, fixture.executable);
+    expect(
+      recoverStandaloneUpgradePublication({
+        executable: fixture.executable,
+        receiptPath: fixture.receipt,
+        home: fixture.home,
+      }).action,
+    ).toBe("restored");
+    expect(fileIdentity(fixture.executable)).toEqual(fixture.oldExecutable);
+    expect(
+      readFileSync(
+        join(
+          fixture.installDir,
+          `.${basename(fixture.executable)}.upgrade-recovery-displaced-${staged.token}`,
+        ),
+        "utf8",
+      ),
+    ).toBe("unjournaled replacement");
+  });
+
+  test("preserves a coherent successor generation", () => {
+    const fixture = upgradeFixture();
+    stageRecovery(fixture);
+    const successor = join(fixture.installDir, "successor");
+    writeFileSync(successor, "coherent successor", { mode: 0o700 });
+    renameSync(successor, fixture.executable);
+    const successorReceipt = join(
+      dirname(fixture.receipt),
+      "successor-receipt",
+    );
+    writeFileSync(
+      successorReceipt,
+      formatStandaloneInstallReceipt({
+        executable: fixture.executable,
+        pathInstallDir: fixture.installDir,
+        executableIdentity: fileIdentity(fixture.executable),
+      }),
+      { mode: 0o600 },
+    );
+    renameSync(successorReceipt, fixture.receipt);
+    expect(
+      recoverStandaloneUpgradePublication({
+        executable: fixture.executable,
+        receiptPath: fixture.receipt,
+        home: fixture.home,
+      }).action,
+    ).toBe("cleaned");
+    expect(readFileSync(fixture.executable, "utf8")).toBe("coherent successor");
+    expectNoRecoveryArtifacts(fixture);
+  });
+
+  test("requires backup-path invocation when canonical publication is empty", () => {
+    const fixture = upgradeFixture();
+    const staged = stageRecovery(fixture);
+    renameSync(fixture.executable, join(fixture.installDir, "quarantined"));
+    expect(() =>
+      recoverStandaloneUpgradePublication({
+        executable: fixture.executable,
+        receiptPath: fixture.receipt,
+        home: fixture.home,
+      }),
+    ).toThrow(/invoke the authenticated upgrade backup path/i);
+    expect(existsSync(staged.executableBackup)).toBe(true);
+    expect(existsSync(staged.journal)).toBe(true);
+  });
+
+  test("recovers an empty canonical path when invoked through its backup", () => {
+    const fixture = upgradeFixture();
+    const staged = stageRecovery(fixture);
+    renameSync(fixture.executable, join(fixture.installDir, "quarantined"));
+    expect(
+      recoverStandaloneUpgradePublication({
+        executable: staged.executableBackup,
+        receiptPath: fixture.receipt,
+        home: fixture.home,
+      }),
+    ).toEqual({ executable: fixture.executable, action: "restored" });
+    expect(fileIdentity(fixture.executable)).toEqual(fixture.oldExecutable);
+  });
+
+  test("refuses ambiguous valid generations without consuming artifacts", () => {
+    const fixture = upgradeFixture();
+    const staged = stageRecovery(fixture);
+    const token = `2-${"f".repeat(16)}`;
+    linkSync(
+      staged.executableBackup,
+      join(
+        fixture.installDir,
+        `.${basename(fixture.executable)}.upgrade-backup-${token}`,
+      ),
+    );
+    linkSync(
+      staged.receiptBackup,
+      join(
+        dirname(fixture.receipt),
+        `.${basename(fixture.receipt)}.upgrade-backup-${token}`,
+      ),
+    );
+    expect(() =>
+      recoverStandaloneUpgradePublication({
+        executable: fixture.executable,
+        receiptPath: fixture.receipt,
+        home: fixture.home,
+      }),
+    ).toThrow(/ambiguous with another valid backup generation/i);
+    expect(standaloneUpgradeBackupTokens(fixture.executable).size).toBe(2);
+    expect(existsSync(staged.journal)).toBe(true);
+  });
+});

--- a/packages/gateway/test/upstream-extra-header-routing.test.ts
+++ b/packages/gateway/test/upstream-extra-header-routing.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MockAgent } from "undici";
+import { loadConfig } from "../src/config";
+import {
+  getActiveSessions,
+  handleRequest,
+  resetPipelineState,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+import { setUpstreamDispatcherForTest } from "../src/fetch";
+import type { GatewayRequest } from "../src/translate/types";
+
+describe("foreground upstream extra-header base-path binding", () => {
+  let mock: MockAgent | undefined;
+
+  afterEach(async () => {
+    setUpstreamInterceptor(undefined);
+    setUpstreamDispatcherForTest(null);
+    await mock?.close();
+    mock = undefined;
+    await resetPipelineState({ fast: true });
+  });
+
+  it("never attaches admin credentials to a hostile X-Lore-Upstream-URL", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let capturedHeaders: Record<string, string> = {};
+    mock
+      .get("https://attacker.example")
+      .intercept({ path: "/v1/responses", method: "POST" })
+      .reply((opts) => {
+        capturedHeaders = opts.headers as Record<string, string>;
+        return {
+          statusCode: 200,
+          data: JSON.stringify({
+            id: "resp_hostile",
+            object: "response",
+            status: "completed",
+            model: "gpt-5.4",
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          responseOptions: {
+            headers: { "content-type": "application/json" },
+          },
+        };
+      });
+    setUpstreamDispatcherForTest(mock);
+
+    const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
+    config.upstreamExtraHeaders = {
+      authorization: "Bearer admin-secret",
+      "x-corp-secret": "gateway-secret",
+    };
+    config.upstreamExtraHeaderBases = ["https://api.openai.com"];
+    const req: GatewayRequest = {
+      protocol: "openai-responses",
+      model: "gpt-5.4",
+      system: "Generate a short title for this conversation.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "title me" }] },
+      ],
+      tools: [],
+      stream: false,
+      maxTokens: 64,
+      metadata: {},
+      rawHeaders: {
+        authorization: "Bearer client-token",
+        "x-lore-upstream-url": "https://attacker.example",
+      },
+    };
+
+    const response = await handleRequest(req, config);
+    expect(response.status).toBe(200);
+    expect(capturedHeaders.authorization ?? capturedHeaders.Authorization).toBe(
+      "Bearer client-token",
+    );
+    expect(capturedHeaders["x-corp-secret"]).toBeUndefined();
+  });
+
+  it("does not attach tenant-a admin credentials to a sibling base path", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let capturedHeaders: Record<string, string> = {};
+    mock
+      .get("https://corp.example")
+      .intercept({ path: "/tenant-b/v1/responses", method: "POST" })
+      .reply((opts) => {
+        capturedHeaders = opts.headers as Record<string, string>;
+        return {
+          statusCode: 200,
+          data: JSON.stringify({
+            id: "resp_sibling",
+            object: "response",
+            status: "completed",
+            model: "gpt-5.4",
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          responseOptions: {
+            headers: { "content-type": "application/json" },
+          },
+        };
+      });
+    setUpstreamDispatcherForTest(mock);
+
+    const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
+    config.upstreamExtraHeaders = {
+      authorization: "Bearer tenant-a-admin",
+      "x-corp-secret": "tenant-a-secret",
+    };
+    config.upstreamExtraHeaderBases = ["https://corp.example/tenant-a"];
+    const response = await handleRequest(
+      {
+        protocol: "openai-responses",
+        model: "gpt-5.4",
+        system: "Generate a short title for this conversation.",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "title me" }] },
+        ],
+        tools: [],
+        stream: false,
+        maxTokens: 64,
+        metadata: {},
+        rawHeaders: {
+          authorization: "Bearer client-token",
+          "x-lore-provider": "openai",
+          "x-lore-upstream-url": "https://corp.example/tenant-b",
+        },
+      },
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedHeaders.authorization ?? capturedHeaders.Authorization).toBe(
+      "Bearer client-token",
+    );
+    expect(capturedHeaders["x-corp-secret"]).toBeUndefined();
+  });
+
+  it("never retains client or admin credentials in routing snapshots", async () => {
+    setUpstreamInterceptor(
+      async () =>
+        new Response(
+          JSON.stringify({
+            id: "msg_snapshot_safe",
+            type: "message",
+            role: "assistant",
+            model: "claude-test",
+            content: [{ type: "text", text: "ok" }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const config = loadConfig();
+    config.upstreamExtraHeaders = {
+      authorization: "Bearer admin-secret",
+      "x-corp-secret": "gateway-secret",
+    };
+    config.upstreamExtraHeaderBases = ["https://api.anthropic.com"];
+    const response = await handleRequest(
+      {
+        protocol: "anthropic",
+        model: "claude-test",
+        system: "You are a coding assistant.",
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hello" }] },
+        ],
+        tools: [{ name: "noop", description: "noop", inputSchema: {} }],
+        stream: false,
+        maxTokens: 64,
+        metadata: {},
+        rawHeaders: {
+          "x-api-key": "client-secret",
+          "x-lore-agent": "coder",
+          "x-lore-project": process.cwd(),
+          "x-lore-session-id": "snapshot-safe-session",
+        },
+      },
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    const snapshot = [...getActiveSessions().values()][0]?.lastUpstream;
+    expect(snapshot?.headers).toEqual({});
+    expect(JSON.stringify(snapshot)).not.toContain("client-secret");
+    expect(JSON.stringify(snapshot)).not.toContain("admin-secret");
+    expect(JSON.stringify(snapshot)).not.toContain("gateway-secret");
+  });
+
+  it("clears a prior warmup body before a failed request captures a new URL", async () => {
+    let failNextRequest = false;
+    setUpstreamInterceptor(async () => {
+      if (failNextRequest) throw new Error("simulated route failure");
+      return new Response(
+        JSON.stringify({
+          id: "msg_warmup_route",
+          type: "message",
+          role: "assistant",
+          model: "claude-test",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
+    config.upstreamExtraHeaders = { authorization: "Bearer admin-secret" };
+    config.upstreamExtraHeaderBases = ["https://api.anthropic.com"];
+    const request = (rawHeaders: Record<string, string>): GatewayRequest => ({
+      protocol: "anthropic",
+      model: "claude-test",
+      system: "You are a coding assistant.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "private turn" }] },
+      ],
+      tools: [{ name: "noop", description: "noop", inputSchema: {} }],
+      stream: false,
+      maxTokens: 64,
+      metadata: {},
+      rawHeaders: {
+        "x-api-key": "client-secret",
+        "x-lore-agent": "coder",
+        "x-lore-project": process.cwd(),
+        "x-lore-session-id": "warmup-route-session",
+        ...rawHeaders,
+      },
+    });
+
+    const first = await handleRequest(request({}), config);
+    expect(first.status).toBe(200);
+    const state = [...getActiveSessions().values()][0];
+    expect(state.cacheAnalytics.lastRequestBody).not.toBeNull();
+
+    failNextRequest = true;
+    const failed = await handleRequest(
+      request({ "x-lore-upstream-url": "https://attacker.example" }),
+      config,
+    );
+    expect(failed.status).toBe(502);
+    expect(state.lastUpstream?.url).toBe("https://attacker.example");
+    expect(state.cacheAnalytics.lastRequestBody).toBeNull();
+  });
+
+  it.each(["unknown-provider", "vllm"])(
+    "fails closed before network for explicit provider %s",
+    async (provider) => {
+      mock = new MockAgent();
+      mock.disableNetConnect();
+      setUpstreamDispatcherForTest(mock);
+      const response = await handleRequest(
+        {
+          protocol: "openai-responses",
+          model: "gpt-5.4",
+          system: "Generate a short title for this conversation.",
+          messages: [
+            { role: "user", content: [{ type: "text", text: "title me" }] },
+          ],
+          tools: [],
+          stream: false,
+          maxTokens: 64,
+          metadata: {},
+          rawHeaders: {
+            authorization: "Bearer provider-token",
+            "x-lore-provider": provider,
+          },
+        },
+        loadConfig(),
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toMatch(
+        /Unsupported provider|requires an explicit upstream URL/,
+      );
+    },
+  );
+
+  it.each(["api-key-token", ""])(
+    "rejects conflicting auth mechanisms before routing (api key %s)",
+    async (apiKey) => {
+      const response = await handleRequest(
+        {
+          protocol: "openai-responses",
+          model: "gpt-5.4",
+          system: "Generate a title.",
+          messages: [
+            { role: "user", content: [{ type: "text", text: "title me" }] },
+          ],
+          tools: [],
+          stream: false,
+          maxTokens: 64,
+          metadata: {},
+          rawHeaders: {
+            authorization: "Bearer bearer-token",
+            "x-api-key": apiKey,
+            "x-lore-upstream-url": "https://attacker.example",
+          },
+        },
+        loadConfig(),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain(
+        "Conflicting authentication headers",
+      );
+    },
+  );
+});

--- a/packages/gateway/test/upstream-url-policy.test.ts
+++ b/packages/gateway/test/upstream-url-policy.test.ts
@@ -1,0 +1,414 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MockAgent } from "undici";
+import { loadConfig, parseCallerUpstreamAllowlist } from "../src/config";
+import {
+  handleRequest,
+  passthroughResponsesCompact,
+  resetPipelineState,
+  restoreUpstreamStateForTest,
+  setUpstreamInterceptor,
+} from "../src/pipeline";
+import { setUpstreamDispatcherForTest } from "../src/fetch";
+import type { GatewayRequest } from "../src/translate/types";
+
+function request(upstreamUrl: string): GatewayRequest {
+  return {
+    protocol: "openai-responses",
+    model: "gpt-5.4",
+    system: "Generate a short title for this conversation.",
+    messages: [
+      { role: "user", content: [{ type: "text", text: "private body" }] },
+    ],
+    tools: [],
+    stream: false,
+    maxTokens: 64,
+    metadata: {},
+    rawHeaders: {
+      authorization: "Bearer client-secret",
+      "x-lore-upstream-url": upstreamUrl,
+      // Unknown headers must never be able to downgrade server-side policy.
+      "x-lore-hosted-mode": "0",
+      "x-lore-remote-gateway": "0",
+    },
+  };
+}
+
+const BLOCKED_DESTINATIONS = [
+  "http://127.0.0.1:8080",
+  "http://10.23.45.67:8080",
+  "http://169.254.169.254/latest/meta-data",
+  "http://[::1]:8080",
+  "https://192.168.10.20",
+  "https://[::ffff:127.0.0.1]",
+  "https://[::1",
+] as const;
+
+describe("caller-selected upstream policy", () => {
+  let mock: MockAgent | undefined;
+
+  afterEach(async () => {
+    setUpstreamInterceptor(undefined);
+    setUpstreamDispatcherForTest(null);
+    await mock?.close();
+    mock = undefined;
+    await resetPipelineState({ fast: true });
+  });
+
+  it.each([
+    { mode: "remote", remoteGateway: true, hostedMode: false },
+    { mode: "hosted", remoteGateway: false, hostedMode: true },
+  ])(
+    "rejects loopback, private, link-local, IPv6, and malformed URLs in $mode mode before forwarding",
+    async ({ remoteGateway, hostedMode }) => {
+      let forwardCount = 0;
+      const forwarded = { body: "" };
+      setUpstreamInterceptor(async (body) => {
+        forwardCount++;
+        forwarded.body = JSON.stringify(body);
+        return new Response(
+          JSON.stringify({
+            id: "resp_ssrf",
+            object: "response",
+            status: "completed",
+            model: "gpt-5.4",
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      });
+      const config = loadConfig();
+      config.remoteGateway = remoteGateway;
+      config.hostedMode = hostedMode;
+
+      for (const destination of BLOCKED_DESTINATIONS) {
+        const response = await handleRequest(request(destination), config);
+        expect(response.status, destination).toBe(400);
+      }
+
+      expect(forwardCount).toBe(0);
+      expect(forwarded.body).not.toContain("private body");
+      expect(forwarded.body).not.toContain("client-secret");
+    },
+  );
+
+  it("allows an explicitly allowlisted HTTPS origin in remote mode", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let capturedHeaders: Record<string, string> = {};
+    let capturedBody = "";
+    mock
+      .get("https://allowed.example:8443")
+      .intercept({ path: "/tenant/v1/responses", method: "POST" })
+      .reply((opts) => {
+        capturedHeaders = opts.headers as Record<string, string>;
+        capturedBody =
+          typeof opts.body === "string"
+            ? opts.body
+            : (JSON.stringify(opts.body) ?? "");
+        return {
+          statusCode: 200,
+          data: JSON.stringify({
+            id: "resp_allowed",
+            object: "response",
+            status: "completed",
+            model: "gpt-5.4",
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          responseOptions: {
+            headers: { "content-type": "application/json" },
+          },
+        };
+      });
+    setUpstreamDispatcherForTest(mock);
+    const config = loadConfig();
+    config.remoteGateway = true;
+    config.callerUpstreamAllowlist = ["https://allowed.example:8443"];
+
+    const response = await handleRequest(
+      request("https://allowed.example:8443/tenant"),
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedHeaders.authorization ?? capturedHeaders.Authorization).toBe(
+      "Bearer client-secret",
+    );
+    expect(capturedBody).toContain("private body");
+  });
+
+  it("matches allowlisted origins exactly", async () => {
+    let forwardCount = 0;
+    setUpstreamInterceptor(async () => {
+      forwardCount++;
+      return new Response("unreachable", { status: 200 });
+    });
+    const config = loadConfig();
+    config.remoteGateway = true;
+    config.callerUpstreamAllowlist = ["https://allowed.example"];
+
+    for (const destination of [
+      "https://sub.allowed.example",
+      "https://allowed.example:8443",
+      "http://allowed.example",
+    ]) {
+      const response = await handleRequest(request(destination), config);
+      expect(response.status, destination).toBe(400);
+    }
+    expect(forwardCount).toBe(0);
+  });
+
+  it("never permits HTTP in remote mode through a manually constructed config", async () => {
+    let forwardCount = 0;
+    setUpstreamInterceptor(async () => {
+      forwardCount++;
+      return new Response("unreachable", { status: 200 });
+    });
+    const config = loadConfig();
+    config.remoteGateway = true;
+    config.callerUpstreamAllowlist = ["http://127.0.0.1:8080"];
+
+    const response = await handleRequest(
+      request("http://127.0.0.1:8080"),
+      config,
+    );
+
+    expect(response.status).toBe(400);
+    expect(forwardCount).toBe(0);
+  });
+
+  it("allows an administrator-configured private upstream in remote mode", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let capturedAuthorization = "";
+    mock
+      .get("http://10.23.45.67:8080")
+      .intercept({ path: "/v1/responses", method: "POST" })
+      .reply((opts) => {
+        const headers = opts.headers as Record<string, string>;
+        capturedAuthorization =
+          headers.authorization ?? headers.Authorization ?? "";
+        return {
+          statusCode: 200,
+          data: JSON.stringify({
+            id: "resp_configured",
+            object: "response",
+            status: "completed",
+            model: "custom-model",
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          responseOptions: {
+            headers: { "content-type": "application/json" },
+          },
+        };
+      });
+    setUpstreamDispatcherForTest(mock);
+    const config = loadConfig();
+    config.remoteGateway = true;
+    config.upstreamOpenAI = "http://10.23.45.67:8080";
+    const req = request("https://unused.example");
+    req.model = "custom-model";
+    delete req.rawHeaders["x-lore-upstream-url"];
+
+    const response = await handleRequest(req, config);
+
+    expect(response.status).toBe(200);
+    expect(capturedAuthorization).toBe("Bearer client-secret");
+  });
+
+  it("preserves caller-selected private upstreams for local gateways", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let forwarded = false;
+    mock
+      .get("http://192.168.10.20:11434")
+      .intercept({ path: "/v1/responses", method: "POST" })
+      .reply(() => {
+        forwarded = true;
+        return {
+          statusCode: 200,
+          data: JSON.stringify({
+            id: "resp_local",
+            object: "response",
+            status: "completed",
+            model: "gpt-5.4",
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          responseOptions: {
+            headers: { "content-type": "application/json" },
+          },
+        };
+      });
+    setUpstreamDispatcherForTest(mock);
+    const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
+
+    const response = await handleRequest(
+      request("http://192.168.10.20:11434"),
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwarded).toBe(true);
+  });
+
+  it("rejects compact fallback routing before forwarding credentials or body", async () => {
+    mock = new MockAgent();
+    mock.disableNetConnect();
+    let forwardCount = 0;
+    let capturedHeaders: Record<string, string> = {};
+    let capturedBody = "";
+    mock
+      .get("http://127.0.0.1:8080")
+      .intercept({ path: "/v1/responses/compact", method: "POST" })
+      .reply((opts) => {
+        forwardCount++;
+        capturedHeaders = opts.headers as Record<string, string>;
+        capturedBody =
+          typeof opts.body === "string"
+            ? opts.body
+            : (JSON.stringify(opts.body) ?? "");
+        return { statusCode: 200, data: JSON.stringify({ output: [] }) };
+      });
+    setUpstreamDispatcherForTest(mock);
+    const config = loadConfig();
+    config.remoteGateway = true;
+
+    const response = await passthroughResponsesCompact(
+      '{"private":"compact body"}',
+      {
+        authorization: "Bearer compact-secret",
+        "x-lore-upstream-url": "http://127.0.0.1:8080",
+      },
+      config,
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toContain("not allowed");
+    expect(forwardCount).toBe(0);
+    expect(capturedHeaders.authorization).toBeUndefined();
+    expect(capturedBody).not.toContain("compact body");
+  });
+});
+
+describe("parseCallerUpstreamAllowlist", () => {
+  it("normalizes comma-separated HTTPS origins", () => {
+    expect(
+      parseCallerUpstreamAllowlist(
+        " HTTPS://Allowed.Example:443/ , https://api.example:8443 ",
+      ),
+    ).toEqual(["https://allowed.example", "https://api.example:8443"]);
+  });
+
+  it.each([
+    "http://allowed.example",
+    "https://user:pass@allowed.example",
+    "https://allowed.example/path",
+    "https://allowed.example/%2e",
+    "https://*.allowed.example",
+    "https://allowed.example?tenant=a",
+    "https://allowed.example#fragment",
+    "https://allowed.example:",
+    "https://allowed.example,",
+    "not-an-origin",
+  ])("rejects invalid entry %s", (entry) => {
+    expect(() => parseCallerUpstreamAllowlist(entry)).toThrow(
+      /expected a unique HTTPS origin/,
+    );
+  });
+
+  it("rejects duplicate origins after normalization", () => {
+    expect(() =>
+      parseCallerUpstreamAllowlist(
+        "https://allowed.example,HTTPS://ALLOWED.EXAMPLE:443/",
+      ),
+    ).toThrow(/duplicate normalized origin/);
+  });
+
+  it("loads the explicit allowlist and defaults to deny-all", () => {
+    const saved = process.env.LORE_CALLER_UPSTREAM_ALLOWLIST;
+    try {
+      delete process.env.LORE_CALLER_UPSTREAM_ALLOWLIST;
+      expect(loadConfig().callerUpstreamAllowlist).toEqual([]);
+      process.env.LORE_CALLER_UPSTREAM_ALLOWLIST =
+        "https://one.example,https://two.example:8443";
+      expect(loadConfig().callerUpstreamAllowlist).toEqual([
+        "https://one.example",
+        "https://two.example:8443",
+      ]);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.LORE_CALLER_UPSTREAM_ALLOWLIST;
+      } else {
+        process.env.LORE_CALLER_UPSTREAM_ALLOWLIST = saved;
+      }
+    }
+  });
+});
+
+describe("persisted caller-selected upstream policy", () => {
+  function persistedState(url: string, callerSelected?: boolean): string {
+    const snapshot = {
+      url,
+      ...(callerSelected === undefined ? {} : { callerSelected }),
+      protocol: "anthropic",
+      providerID: "anthropic",
+      model: "claude-test",
+      headers: {},
+    };
+    return JSON.stringify({
+      version: 2,
+      lastUpstream: snapshot,
+      upstreamByProvider: { anthropic: snapshot },
+    });
+  }
+
+  it.each([
+    { name: "legacy", callerSelected: undefined },
+    { name: "caller-selected", callerSelected: true },
+  ])(
+    "drops a $name arbitrary snapshot before remote workers can reuse it",
+    ({ callerSelected }) => {
+      const config = loadConfig();
+      config.remoteGateway = true;
+      config.hostedMode = false;
+      config.callerUpstreamAllowlist = [];
+
+      const restored = restoreUpstreamStateForTest(
+        persistedState(
+          "http://169.254.169.254/latest/meta-data",
+          callerSelected,
+        ),
+        config,
+      );
+
+      expect(restored.lastUpstream).toBeUndefined();
+      expect(restored.upstreamByProvider.size).toBe(0);
+    },
+  );
+
+  it("retains administrator-selected and currently allowlisted snapshots", () => {
+    const config = loadConfig();
+    config.remoteGateway = true;
+    config.hostedMode = false;
+    config.callerUpstreamAllowlist = ["https://allowed.example"];
+
+    const configured = restoreUpstreamStateForTest(
+      persistedState("http://10.23.45.67:8080", false),
+      config,
+    );
+    const allowlisted = restoreUpstreamStateForTest(
+      persistedState("https://allowed.example/tenant", true),
+      config,
+    );
+
+    expect(configured.lastUpstream?.url).toBe("http://10.23.45.67:8080");
+    expect(allowlisted.lastUpstream?.url).toBe(
+      "https://allowed.example/tenant",
+    );
+  });
+});

--- a/packages/gateway/test/vertex-routing.test.ts
+++ b/packages/gateway/test/vertex-routing.test.ts
@@ -33,10 +33,10 @@ function vertexJSONResponse(): Response {
   );
 }
 
-let teardownFn: (() => void) | undefined;
+let teardownFn: (() => Promise<void>) | undefined;
 
-afterEach(() => {
-  teardownFn?.();
+afterEach(async () => {
+  await teardownFn?.();
   teardownFn = undefined;
 });
 
@@ -74,11 +74,13 @@ describe("X-Lore-Provider: vertex routing (Vertex AI Claude)", () => {
     });
 
     const config = loadConfig();
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await startServer(config);
     const baseURL = `http://127.0.0.1:${server.port}`;
 
-    teardownFn = () => {
-      server.stop();
+    teardownFn = async () => {
+      await server.stop();
       closeDB();
       setUpstreamInterceptor(undefined);
       _setTestVertexTokenProvider(null);

--- a/packages/gateway/test/warmup-execute.test.ts
+++ b/packages/gateway/test/warmup-execute.test.ts
@@ -14,6 +14,7 @@
  * vi.fn() can intercept the warmup request.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { log } from "@loreai/core";
 
 vi.mock("../src/fetch", () => ({
   upstreamFetch: (...args: Parameters<typeof fetch>) =>
@@ -30,6 +31,7 @@ import {
 import { setSessionAuth, _resetAuthForTest } from "../src/auth";
 import { clearAllCosts } from "../src/cost-tracker";
 import { compressBody } from "../src/cache-analytics";
+import { loadConfig } from "../src/config";
 import type { SessionState, CacheAnalytics } from "../src/translate/types";
 
 const SESSION_ID = "warmup-exec-session-1";
@@ -96,6 +98,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
 });
 
 describe("executeWarmup → lastWarmupRefreshTokens (Bug B producer)", () => {
@@ -150,6 +153,197 @@ describe("executeWarmup → lastWarmupRefreshTokens (Bug B producer)", () => {
     // refresh credit must be 0 so creditWarmupHit later denies a bogus hit.
     expect(state.warmup?.lastWarmupRefreshTokens).toBe(0);
     expect(state.warmup?.totalWarmups).toBe(1);
+  });
+
+  test("a rejected warmup logs status but never response text or statusText", async () => {
+    const bodyMarker = "PRIVATE_WARMUP_RESPONSE_BODY_MARKER";
+    const reasonMarker = "PRIVATE_WARMUP_REASON_MARKER";
+    const messages: string[] = [];
+    vi.spyOn(log, "error").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(bodyMarker, { status: 422, statusText: reasonMarker }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await executeWarmup(
+      makeState(),
+      buildAnthropicProfile(MODEL, "5m"),
+    );
+
+    expect(result.ok).toBe(false);
+    const output = messages.join("\n");
+    expect(output).toContain("422");
+    expect(output).not.toContain(bodyMarker);
+    expect(output).not.toContain(reasonMarker);
+  });
+
+  test("malformed warmup JSON never reaches diagnostics", async () => {
+    const bodyMarker = "PRIVATE_WARMUP_MALFORMED_PREFIX";
+    const messages: string[] = [];
+    vi.spyOn(log, "error").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(new Response(`${bodyMarker} not-json`, { status: 200 })),
+    ) as unknown as typeof fetch;
+
+    const result = await executeWarmup(
+      makeState(),
+      buildAnthropicProfile(MODEL, "5m"),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(messages.join("\n")).not.toContain(bodyMarker);
+  });
+
+  test("body-controlled usage fields never reach warmup logs", async () => {
+    const bodyMarker = "PRIVATE_WARMUP_USAGE_FIELD_MARKER";
+    const messages: string[] = [];
+    vi.spyOn(log, "info").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    vi.spyOn(log, "warn").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            usage: {
+              input_tokens: bodyMarker,
+              cache_read_input_tokens: bodyMarker,
+              cache_creation_input_tokens: bodyMarker,
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await executeWarmup(
+      makeState(),
+      buildAnthropicProfile(MODEL, "5m"),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    expect(messages.join("\n")).not.toContain(bodyMarker);
+  });
+
+  test("thrown warmup errors do not log URL secrets", async () => {
+    const userinfoMarker = "PRIVATE_WARMUP_THROWN_USERINFO";
+    const queryMarker = "PRIVATE_WARMUP_THROWN_QUERY";
+    const fragmentMarker = "PRIVATE_WARMUP_THROWN_FRAGMENT";
+    const messages: string[] = [];
+    vi.spyOn(log, "error").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.reject(
+        new Error(
+          `fetch https://user:${userinfoMarker}@example.com/warm?token=${queryMarker}#${fragmentMarker} failed`,
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    const result = await executeWarmup(
+      makeState(),
+      buildAnthropicProfile(MODEL, "5m"),
+    );
+
+    expect(result.ok).toBe(false);
+    const output = messages.join("\n");
+    expect(output).not.toContain(userinfoMarker);
+    expect(output).not.toContain(queryMarker);
+    expect(output).not.toContain(fragmentMarker);
+  });
+
+  test("does not attach admin extras to an untrusted warmup URL", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = vi.fn((_input, init) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            usage: {
+              input_tokens: 5,
+              cache_read_input_tokens: 168_000,
+              cache_creation_input_tokens: 0,
+            },
+            stop_reason: "end_turn",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as unknown as typeof fetch;
+    const config = loadConfig();
+    config.upstreamExtraHeaders = {
+      authorization: "Bearer admin-secret",
+      "x-corp-secret": "gateway-secret",
+    };
+    config.upstreamExtraHeaderBases = ["https://api.anthropic.com"];
+    const state = makeState();
+    const lastUpstream = state.lastUpstream;
+    if (!lastUpstream) throw new Error("expected warmup upstream snapshot");
+    state.lastUpstream = {
+      ...lastUpstream,
+      url: "https://attacker.example",
+    };
+
+    const result = await executeWarmup(
+      state,
+      buildAnthropicProfile(MODEL, "5m", "https://attacker.example"),
+      config,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(capturedHeaders.Authorization ?? capturedHeaders.authorization).toBe(
+      "Bearer test-token",
+    );
+    expect(capturedHeaders["x-corp-secret"]).toBeUndefined();
+  });
+
+  test("applies admin extras to a configured trusted warmup URL", async () => {
+    let capturedHeaders: Record<string, string> = {};
+    globalThis.fetch = vi.fn((_input, init) => {
+      capturedHeaders = init?.headers as Record<string, string>;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            usage: {
+              input_tokens: 5,
+              cache_read_input_tokens: 168_000,
+              cache_creation_input_tokens: 0,
+            },
+            stop_reason: "end_turn",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }) as unknown as typeof fetch;
+    const config = loadConfig();
+    config.upstreamExtraHeaders = {
+      authorization: "Bearer admin-secret",
+      "x-corp-secret": "gateway-secret",
+    };
+    config.upstreamExtraHeaderBases = ["https://api.anthropic.com"];
+
+    const result = await executeWarmup(
+      makeState(),
+      buildAnthropicProfile(MODEL, "5m"),
+      config,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(capturedHeaders.Authorization).toBeUndefined();
+    expect(capturedHeaders.authorization).toBe("Bearer admin-secret");
+    expect(capturedHeaders["x-corp-secret"]).toBe("gateway-secret");
   });
 });
 

--- a/packages/gateway/test/worker-model.test.ts
+++ b/packages/gateway/test/worker-model.test.ts
@@ -214,6 +214,96 @@ describe("fetchModelData", () => {
     expect(data.size).toBe(0);
   });
 
+  test("malformed models.dev JSON never reaches diagnostics", async () => {
+    const bodyMarker = "PRIVATE_MODELS_DEV_MALFORMED_PREFIX";
+    const reasonMarker = "PRIVATE_MODELS_DEV_REASON_MARKER";
+    const messages: string[] = [];
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(`${bodyMarker} not-json`, {
+          status: 200,
+          statusText: reasonMarker,
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const data = await fetchModelData();
+
+    expect(data.size).toBe(0);
+    expect(messages.join("\n")).toContain("models.dev API");
+    expect(messages.join("\n")).not.toContain(bodyMarker);
+    expect(messages.join("\n")).not.toContain(reasonMarker);
+    warnSpy.mockRestore();
+  });
+
+  test("models.dev network diagnostics do not log thrown URL secrets", async () => {
+    const userinfoMarker = "PRIVATE_MODELS_DEV_THROWN_USERINFO";
+    const queryMarker = "PRIVATE_MODELS_DEV_THROWN_QUERY";
+    const fragmentMarker = "PRIVATE_MODELS_DEV_THROWN_FRAGMENT";
+    const messages: string[] = [];
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+    globalThis.fetch = vi.fn(() =>
+      Promise.reject(
+        new Error(
+          `fetch https://user:${userinfoMarker}@models.example/api?token=${queryMarker}#${fragmentMarker} failed`,
+        ),
+      ),
+    ) as unknown as typeof fetch;
+
+    expect((await fetchModelData()).size).toBe(0);
+    const output = messages.join("\n");
+    expect(output).not.toContain(userinfoMarker);
+    expect(output).not.toContain(queryMarker);
+    expect(output).not.toContain(fragmentMarker);
+    warnSpy.mockRestore();
+  });
+
+  test("models.dev-derived model IDs never reach resolution logs", async () => {
+    const modelMarker = "private-model-response-marker";
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            anthropic: { models: {} },
+            private_provider: {
+              models: {
+                "expensive-session-model": {
+                  id: "expensive-session-model",
+                  cost: { input: 4, output: 8 },
+                },
+                [modelMarker]: {
+                  id: modelMarker,
+                  cost: { input: 0.1, output: 0.2 },
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch;
+    await fetchModelData();
+    const messages: string[] = [];
+    const infoSpy = vi.spyOn(log, "info").mockImplementation((...args) => {
+      messages.push(args.join(" "));
+    });
+
+    const selected = getWorkerModel({
+      providerID: "private_provider",
+      model: "expensive-session-model",
+    });
+
+    expect(selected?.modelID).toBe(modelMarker);
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(messages.join("\n")).not.toContain(modelMarker);
+    infoSpy.mockRestore();
+  });
+
   test("deduplicates concurrent in-flight requests", async () => {
     globalThis.fetch = vi.fn(() =>
       Promise.resolve(
@@ -581,6 +671,15 @@ describe("lookupProviderRoute", () => {
     expect(route).toBeNull();
     // Background fetch was triggered.
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("can fail closed on a cold cache without triggering a refresh", () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(new Response("{}", { status: 200 })),
+    ) as unknown as typeof fetch;
+
+    expect(lookupProviderRoute("untrusted-provider", false)).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });
 
@@ -1860,7 +1959,7 @@ describe("openai worker selection: ChatGPT-backend reuse + luna preference", () 
 });
 
 // ---------------------------------------------------------------------------
-// resolution memoization (skip rescan + collapse the per-call INFO log)
+// resolution memoization (skip rescans without logging remote model IDs)
 // ---------------------------------------------------------------------------
 
 describe("worker-model resolution memoization", () => {
@@ -1919,14 +2018,7 @@ describe("worker-model resolution memoization", () => {
     };
   }
 
-  const familyLines = (spy: ReturnType<typeof vi.spyOn>): unknown[][] =>
-    (spy.mock.calls as unknown[][]).filter(
-      (c) =>
-        typeof c[0] === "string" &&
-        c[0].includes("worker model: newest in family"),
-    );
-
-  test("family path: the 'newest in family' line is logged once per snapshot despite repeated getWorkerModel calls", async () => {
+  test("family path stays silent despite repeated getWorkerModel calls", async () => {
     await warmCache(anthropicSnapshot("claude-sonnet-6"));
 
     // Spy AFTER warming so we only observe resolution logs, not fetch logs.
@@ -1940,11 +2032,10 @@ describe("worker-model resolution memoization", () => {
       expect(r?.modelID).toBe("claude-sonnet-6");
     }
 
-    // Without memoization this fires 5×; memoized it collapses to exactly 1.
-    expect(familyLines(infoSpy)).toHaveLength(1);
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 
-  test("unknown-provider path: the 'dynamic worker model' line is logged once per snapshot despite repeated calls", async () => {
+  test("unknown-provider path stays silent despite repeated calls", async () => {
     await warmCache({
       anthropic: { api: "https://api.anthropic.com/v1", models: {} },
       google: {
@@ -1978,16 +2069,13 @@ describe("worker-model resolution memoization", () => {
       expect(r?.modelID).toBe("gemini-3-flash-lite");
     }
 
-    const dynamicLines = infoSpy.mock.calls.filter(
-      (c) => typeof c[0] === "string" && c[0].includes("dynamic worker model:"),
-    );
-    expect(dynamicLines).toHaveLength(1);
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 
   test("distinct query inputs are memoized independently (no cross-key collision)", async () => {
     // One snapshot serving both the family path (anthropic) and the
-    // cheaper path (google) — repeated calls to each must each log once,
-    // proving the memo key discriminates rather than sharing one slot.
+    // cheaper path (google) — repeated calls to each stay independently
+    // memoized and silent.
     await warmCache({
       anthropic: anthropicSnapshot("claude-sonnet-6").anthropic,
       google: {
@@ -2018,11 +2106,7 @@ describe("worker-model resolution memoization", () => {
     getWorkerModel({ providerID: "google", model: "gemini-3.1-pro" });
     getWorkerModel({ providerID: "google", model: "gemini-3.1-pro" });
 
-    expect(familyLines(infoSpy)).toHaveLength(1);
-    const dynamicLines = infoSpy.mock.calls.filter(
-      (c) => typeof c[0] === "string" && c[0].includes("dynamic worker model:"),
-    );
-    expect(dynamicLines).toHaveLength(1);
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 
   test("a new models.dev snapshot re-resolves (memo is snapshot-scoped, never permanently stale)", async () => {
@@ -2033,15 +2117,17 @@ describe("worker-model resolution memoization", () => {
     ).toBe("claude-sonnet-6");
 
     // A later refresh introduces an even newer sonnet. The memo must not pin
-    // the stale answer — resolution reflects the new snapshot and re-announces.
+    // the stale answer — resolution reflects the new snapshot without logging
+    // the body-derived model ID.
     const infoSpy = vi.spyOn(log, "info").mockImplementation(() => {});
     await warmCache(anthropicSnapshot("claude-sonnet-7"));
+    infoSpy.mockClear();
 
     expect(
       getWorkerModel({ providerID: "anthropic", model: "claude-opus-4-6" })
         ?.modelID,
     ).toBe("claude-sonnet-7");
-    expect(familyLines(infoSpy).length).toBeGreaterThanOrEqual(1);
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -56,6 +56,17 @@ The URL should be the **server root** — do not include `/v1` (the gateway appe
 
 Cloud providers (Anthropic, OpenAI, etc.) are routed automatically by model name and don't need this.
 
+## Remote gateway access
+
+Remote/hosted gateways require a separate access token in addition to the model provider's API key or bearer token:
+
+```bash
+export LORE_REMOTE_URL=https://lore.example.com
+export LORE_GATEWAY_AUTH_TOKEN='<token configured on the gateway>'
+```
+
+The plugin injects the token as `x-lore-gateway-token` only for `LORE_REMOTE_URL`. It is never used as provider authentication or put in the URL.
+
 ## Companion packages
 
 Lore ships as three packages sharing the same SQLite database at `~/.local/share/lore/lore.db`:

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -12,7 +12,9 @@ import {
 // (`undefined is not an object (evaluating 'A.event')`). See ./internal.ts.
 import {
   applyLoreProviderConfig,
+  gatewayAccessHeadersForRemote,
   probeGateway,
+  shouldForwardUpstreamExtraHeader,
   surfaceGatewayUnavailable,
 } from "./internal";
 
@@ -375,6 +377,10 @@ export const LorePlugin: Plugin = async (ctx) => {
       // Project path, git remote, and upstream URL are injected by the
       // fetch interceptor (installed once per process).
       "chat.headers": async (input, output) => {
+        Object.assign(
+          output.headers,
+          gatewayAccessHeadersForRemote(gatewayBase),
+        );
         // Inject stable session ID — OpenCode's DB session ID survives restarts,
         // unlike x-session-affinity (nanoid regenerated per process).
         output.headers["x-lore-session-id"] = input.sessionID;
@@ -441,12 +447,7 @@ export const LorePlugin: Plugin = async (ctx) => {
             const value = line.slice(colonIdx + 1).trim();
             if (name) {
               // Don't clobber headers the gateway already manages.
-              const lower = name.toLowerCase();
-              if (
-                !lower.startsWith("x-lore-") &&
-                lower !== "x-api-key" &&
-                lower !== "authorization"
-              ) {
+              if (shouldForwardUpstreamExtraHeader(name)) {
                 output.headers[name] = value;
               }
             }
@@ -469,7 +470,9 @@ export const LorePlugin: Plugin = async (ctx) => {
         installFetchInterceptor({
           gatewayBase,
           getHeaders: () => {
-            const headers: Record<string, string> = {};
+            const headers: Record<string, string> = {
+              ...gatewayAccessHeadersForRemote(gatewayBase),
+            };
             const cur = currentProject;
             if (cur?.path) {
               headers["x-lore-project"] = cur.path;

--- a/packages/opencode/src/internal.ts
+++ b/packages/opencode/src/internal.ts
@@ -15,7 +15,66 @@
  */
 
 import type { PluginInput } from "@opencode-ai/plugin";
-import { log } from "@loreai/core";
+import { GATEWAY_AUTH_HEADER, log } from "@loreai/core";
+import * as http from "node:http";
+import * as https from "node:https";
+
+function isLoopbackUrl(value: string): boolean {
+  try {
+    const hostname = new URL(value).hostname
+      .replace(/^\[/, "")
+      .replace(/\]$/, "")
+      .toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "localhost." ||
+      hostname === "::1" ||
+      /^127(?:\.\d{1,3}){3}$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Access headers are injected only for the URL selected by LORE_REMOTE_URL. */
+export function gatewayAccessHeadersForRemote(
+  gatewayBase: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const remoteUrl = env.LORE_REMOTE_URL?.replace(/\/+$/, "");
+  const token = env.LORE_GATEWAY_AUTH_TOKEN;
+  return remoteUrl === gatewayBase.replace(/\/+$/, "") && token
+    ? { [GATEWAY_AUTH_HEADER]: token }
+    : {};
+}
+
+/** Provider and Lore credentials are applied by the gateway, never this hop. */
+export function shouldForwardUpstreamExtraHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    !lower.startsWith("x-lore-") &&
+    lower !== "x-api-key" &&
+    lower !== "x-goog-api-key" &&
+    lower !== "authorization"
+  );
+}
+
+function probeLoopback(url: string, signal: AbortSignal): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const request = (parsed.protocol === "https:" ? https : http).request(
+      parsed,
+      { method: "GET", signal },
+      (response) => {
+        response.resume();
+        const status = response.statusCode ?? 0;
+        resolve(status >= 200 && status < 300);
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+}
 
 /**
  * Pin every opencode provider's `options.baseURL` to the Lore gateway.
@@ -70,14 +129,16 @@ export async function probeGateway(
   baseURL: string,
   timeoutMs = 1500,
 ): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(`${baseURL}/health`, { signal: controller.signal });
-    clearTimeout(timer);
-    return res.ok;
+    const url = `${baseURL}/health`;
+    if (isLoopbackUrl(url)) return await probeLoopback(url, controller.signal);
+    return (await fetch(url, { signal: controller.signal })).ok;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/packages/opencode/test/gateway-smoke.test.ts
+++ b/packages/opencode/test/gateway-smoke.test.ts
@@ -38,6 +38,8 @@ describe("in-process gateway startup", () => {
     const gw = (await import(gwPkg)) as unknown as GatewayModule;
     const config = gw.loadConfig();
     config.port = 0; // ephemeral
+    config.remoteGateway = false;
+    config.hostedMode = false;
 
     const server = await gw.startServer(config);
     shutdowns.push(async () => server.stop());
@@ -85,6 +87,8 @@ describe("in-process gateway startup", () => {
 
     const config = gw.loadConfig();
     config.port = freePort;
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await gw.startServer(config);
     shutdowns.push(async () => server.stop());
 

--- a/packages/opencode/test/internal.test.ts
+++ b/packages/opencode/test/internal.test.ts
@@ -1,7 +1,53 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { PluginInput } from "@opencode-ai/plugin";
 import { log } from "@loreai/core";
-import { surfaceGatewayUnavailable } from "../src/internal";
+import {
+  gatewayAccessHeadersForRemote,
+  shouldForwardUpstreamExtraHeader,
+  surfaceGatewayUnavailable,
+} from "../src/internal";
+
+describe("remote gateway access headers", () => {
+  const token = "opencode-remote-gateway-token-at-least-32";
+
+  test("injects the access token only for the matching LORE_REMOTE_URL", () => {
+    expect(
+      gatewayAccessHeadersForRemote("https://lore.example", {
+        LORE_REMOTE_URL: "https://lore.example/",
+        LORE_GATEWAY_AUTH_TOKEN: token,
+      }),
+    ).toEqual({ "x-lore-gateway-token": token });
+
+    expect(
+      gatewayAccessHeadersForRemote("http://127.0.0.1:3207", {
+        LORE_REMOTE_URL: "https://lore.example",
+        LORE_GATEWAY_AUTH_TOKEN: token,
+      }),
+    ).toEqual({});
+  });
+
+  test("does not confuse provider credentials with gateway access", () => {
+    expect(
+      gatewayAccessHeadersForRemote("https://lore.example", {
+        LORE_REMOTE_URL: "https://lore.example",
+        ANTHROPIC_API_KEY: "provider-key",
+      }),
+    ).toEqual({});
+  });
+
+  test.each([
+    "x-api-key",
+    "X-Goog-Api-Key",
+    "Authorization",
+    "X-Lore-Gateway-Token",
+  ])("does not forward managed credential header %s from extras", (name) => {
+    expect(shouldForwardUpstreamExtraHeader(name)).toBe(false);
+  });
+
+  test("still forwards non-credential upstream extras", () => {
+    expect(shouldForwardUpstreamExtraHeader("CF-Access-Client-Id")).toBe(true);
+  });
+});
 
 /**
  * `surfaceGatewayUnavailable` is the one user-visible signal left when the

--- a/packages/opencode/test/routing.e2e.test.ts
+++ b/packages/opencode/test/routing.e2e.test.ts
@@ -103,6 +103,8 @@ describe("opencode plugin — e2e routing against a real gateway", () => {
     const config = gw.loadConfig();
     config.port = 0;
     config.hosts = ["127.0.0.1"];
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await gw.startServer(config);
     stopServer = () => server.stop();
     baseURL = `http://127.0.0.1:${server.port}`;

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -58,6 +58,17 @@ The URL should be the **server root** — do not include `/v1` (the gateway appe
 
 Cloud providers (Anthropic, OpenAI, etc.) are routed automatically by model name and don't need this.
 
+## Remote gateway access
+
+Remote/hosted gateways require a separate access token in addition to the model provider's API key or bearer token:
+
+```bash
+export LORE_REMOTE_URL=https://lore.example.com
+export LORE_GATEWAY_AUTH_TOKEN='<token configured on the gateway>'
+```
+
+The extension injects the token as `x-lore-gateway-token` on provider calls and `/v1/compact`. It is never used as provider authentication or put in the URL.
+
 ## Companion packages
 
 Lore ships as three packages sharing the same SQLite database at `~/.local/share/lore/lore.db`:

--- a/packages/pi/src/index.ts
+++ b/packages/pi/src/index.ts
@@ -36,6 +36,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import {
   buildProviderRegistrations,
+  gatewayAccessHeadersForRemote,
   resolveGatewayUrl,
   runCompaction,
   type SessionBeforeCompactResult,
@@ -115,6 +116,7 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
   let projectPath = process.cwd();
   let currentSessionID = sessionIDFor(undefined);
   let compactAuthHeaders: Record<string, string> = {};
+  const gatewayAccessHeaders = gatewayAccessHeadersForRemote(gatewayBase);
 
   let cachedGitRemote = getGitRemote(projectPath) ?? "";
 
@@ -131,6 +133,7 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
       gatewayBase,
       getHeaders: () => {
         const headers: Record<string, string> = {
+          ...gatewayAccessHeaders,
           "x-lore-session-id": currentSessionID,
           "x-lore-project": projectPath,
         };
@@ -145,12 +148,15 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
           return;
         }
         const apiKey = headers.get("x-api-key");
+        const googleApiKey = headers.get("x-goog-api-key");
         const authorization = headers.get("authorization");
         compactAuthHeaders = apiKey
           ? { "x-api-key": apiKey }
-          : authorization
-            ? { authorization }
-            : {};
+          : googleApiKey
+            ? { "x-goog-api-key": googleApiKey }
+            : authorization
+              ? { authorization }
+              : {};
       },
     });
     fetchInterceptorInstalled = true;
@@ -215,7 +221,7 @@ export default async function lorePiExtension(pi: ExtensionAPI): Promise<void> {
         previousSummary: event.preparation.previousSummary,
         firstKeptEntryId: event.preparation.firstKeptEntryId,
         tokensBefore: event.preparation.tokensBefore,
-        authHeaders: compactAuthHeaders,
+        authHeaders: { ...gatewayAccessHeaders, ...compactAuthHeaders },
       }),
   );
 }

--- a/packages/pi/src/internal.ts
+++ b/packages/pi/src/internal.ts
@@ -10,7 +10,10 @@
  * relying on the `NODE_ENV=test` inert path.
  */
 import { createHash } from "node:crypto";
+import { GATEWAY_AUTH_HEADER } from "@loreai/core";
 import { log } from "@loreai/core";
+import * as http from "node:http";
+import * as https from "node:https";
 
 /**
  * Pi-side shape of a `session_before_compact` result. Pi doesn't re-export
@@ -95,6 +98,51 @@ export const GATEWAY_PROVIDERS: readonly string[] = [
 /** Default ports to probe when looking for a running gateway (must match gateway defaults). */
 export const KNOWN_GATEWAY_PORTS = [3207, 5673];
 
+function isLoopbackUrl(value: string): boolean {
+  try {
+    const hostname = new URL(value).hostname
+      .replace(/^\[/, "")
+      .replace(/\]$/, "")
+      .toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "localhost." ||
+      hostname === "::1" ||
+      /^127(?:\.\d{1,3}){3}$/.test(hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function probeLoopback(url: string, signal: AbortSignal): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const request = (parsed.protocol === "https:" ? https : http).request(
+      parsed,
+      { method: "GET", signal },
+      (response) => {
+        response.resume();
+        const status = response.statusCode ?? 0;
+        resolve(status >= 200 && status < 300);
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+/** Strip URL components that may carry credentials before diagnostics. */
+function gatewayUrlForLog(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "invalid";
+    return url.origin + (url.pathname === "/" ? "" : url.pathname);
+  } catch {
+    return "invalid";
+  }
+}
+
 /** A provider registration as passed to `pi.registerProvider`. */
 export interface ProviderRegistration {
   provider: string;
@@ -110,14 +158,16 @@ export async function probeGateway(
   baseURL: string,
   timeoutMs = 1500,
 ): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(`${baseURL}/health`, { signal: controller.signal });
-    clearTimeout(timer);
-    return res.ok;
+    const url = `${baseURL}/health`;
+    if (isLoopbackUrl(url)) return await probeLoopback(url, controller.signal);
+    return (await fetch(url, { signal: controller.signal })).ok;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -131,8 +181,10 @@ export async function probeGateway(
 export async function resolveGatewayUrl(): Promise<string | null> {
   // 0. Remote gateway — skip local discovery/startup entirely.
   if (process.env.LORE_REMOTE_URL) {
-    const url = process.env.LORE_REMOTE_URL.replace(/\/$/, "");
-    if (await probeGateway(url)) return url;
+    const url = gatewayUrlForLog(
+      process.env.LORE_REMOTE_URL.replace(/\/$/, ""),
+    );
+    if (url !== "invalid" && (await probeGateway(url))) return url;
     log.info(
       `pi: remote gateway at ${url} not reachable, falling through to local discovery`,
     );
@@ -140,8 +192,10 @@ export async function resolveGatewayUrl(): Promise<string | null> {
 
   // 1. Explicit env var — probe it to verify it's actually reachable.
   if (process.env.LORE_GATEWAY_URL) {
-    const url = process.env.LORE_GATEWAY_URL.replace(/\/$/, "");
-    if (await probeGateway(url)) return url;
+    const url = gatewayUrlForLog(
+      process.env.LORE_GATEWAY_URL.replace(/\/$/, ""),
+    );
+    if (url !== "invalid" && (await probeGateway(url))) return url;
     // env var set but gateway unreachable — fall through to discovery
   }
 
@@ -187,13 +241,12 @@ export async function startInProcess(): Promise<string | null> {
     const url = `http://127.0.0.1:${handle.port}`;
 
     if (!handle.owned) {
-      log.info(`pi: reusing existing gateway at ${url}`);
+      log.info(`pi: reusing existing gateway at ${gatewayUrlForLog(url)}`);
     }
 
     return url;
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    log.warn("pi: failed to start gateway in-process:", msg);
+  } catch {
+    log.warn("pi: failed to start gateway in-process");
     return null;
   }
 }
@@ -205,6 +258,18 @@ export async function startInProcess(): Promise<string | null> {
 export function sessionIDFor(sessionFile: string | undefined): string {
   if (!sessionFile) return `pi-ephemeral-${process.pid}`;
   return `pi-${createHash("sha256").update(sessionFile).digest("hex").slice(0, 24)}`;
+}
+
+/** Access headers are injected only for the URL selected by LORE_REMOTE_URL. */
+export function gatewayAccessHeadersForRemote(
+  gatewayBase: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const remoteUrl = env.LORE_REMOTE_URL?.replace(/\/+$/, "");
+  const token = env.LORE_GATEWAY_AUTH_TOKEN;
+  return remoteUrl === gatewayBase.replace(/\/+$/, "") && token
+    ? { [GATEWAY_AUTH_HEADER]: token }
+    : {};
 }
 
 /**
@@ -242,6 +307,7 @@ export function buildProviderRegistrations(opts: {
   const registrations: ProviderRegistration[] = [];
   for (const provider of GATEWAY_PROVIDERS) {
     const headers: Record<string, string> = {
+      ...gatewayAccessHeadersForRemote(gatewayBase, env),
       "x-lore-session-id": sessionID,
       "x-lore-project": projectPath,
       // Inject provider ID so the gateway uses provider-based routing
@@ -331,19 +397,24 @@ export async function runCompaction(opts: {
 
     if (!res.ok) {
       // Gateway returned an error — fall back to Pi's default compaction.
-      const errBody = await res.text().catch(() => "");
+      const sessionNotFound =
+        res.status === 404 &&
+        (await res
+          .text()
+          .then((body) => body.includes("session_not_found"))
+          .catch(() => false));
       // A 404 `session_not_found` is expected when this session was never
       // routed through Lore (e.g. a provider Lore doesn't proxy, or a
       // websocket-only transport that bypassed the gateway). That's not a
       // failure — log it quietly and let Pi's default compaction run.
-      if (res.status === 404 && errBody.includes("session_not_found")) {
+      if (sessionNotFound) {
         log.info(
           "pi: lore compaction unavailable — this session was not routed " +
             "through Lore; falling back to Pi compaction.",
         );
         return undefined;
       }
-      log.warn(`pi: compaction endpoint returned ${res.status}: ${errBody}`);
+      log.warn(`pi: compaction endpoint returned HTTP ${res.status}`);
       return undefined;
     }
 
@@ -368,8 +439,8 @@ export async function runCompaction(opts: {
         tokensBefore,
       },
     };
-  } catch (err) {
-    log.warn("pi: custom compaction failed, falling back to default:", err);
+  } catch {
+    log.warn("pi: custom compaction failed, falling back to default");
     return undefined;
   }
 }

--- a/packages/pi/test/extension.e2e.test.ts
+++ b/packages/pi/test/extension.e2e.test.ts
@@ -98,6 +98,8 @@ describe("pi extension — e2e against a real gateway", () => {
     const config = gw.loadConfig();
     config.port = 0;
     config.hosts = ["127.0.0.1"];
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await gw.startServer(config);
     stopServer = () => server.stop();
     baseURL = `http://127.0.0.1:${server.port}`;

--- a/packages/pi/test/internal.test.ts
+++ b/packages/pi/test/internal.test.ts
@@ -1,14 +1,29 @@
-import { describe, expect, test, vi } from "vitest";
+import { log } from "@loreai/core";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   ANTHROPIC_PROVIDERS,
   buildProviderRegistrations,
+  gatewayAccessHeadersForRemote,
   GATEWAY_PROVIDERS,
   OPENAI_PROVIDERS,
+  resolveGatewayUrl,
   runCompaction,
   sessionIDFor,
 } from "../src/internal";
 
 const GW = "http://127.0.0.1:31234";
+
+const silentSink = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  captureException: vi.fn(),
+};
+
+afterEach(() => {
+  log.registerSink(silentSink);
+  vi.restoreAllMocks();
+});
 
 describe("buildProviderRegistrations", () => {
   test("routes Anthropic providers to the gateway root, OpenAI to /v1", () => {
@@ -84,6 +99,39 @@ describe("buildProviderRegistrations", () => {
       byProvider.get("ollama")?.headers["x-lore-upstream-url"],
     ).toBeUndefined();
   });
+
+  test("injects remote gateway access into every provider registration", () => {
+    const token = "pi-remote-gateway-access-token-at-least-32";
+    const regs = buildProviderRegistrations({
+      gatewayBase: "https://lore.example",
+      sessionID: "s",
+      projectPath: "/p",
+      env: {
+        LORE_REMOTE_URL: "https://lore.example/",
+        LORE_GATEWAY_AUTH_TOKEN: token,
+      },
+    });
+    for (const reg of regs) {
+      expect(reg.headers["x-lore-gateway-token"]).toBe(token);
+    }
+  });
+
+  test("keeps local/non-matching gateways free of the remote access token", () => {
+    const env = {
+      LORE_REMOTE_URL: "https://lore.example",
+      LORE_GATEWAY_AUTH_TOKEN: "pi-remote-gateway-access-token-at-least-32",
+    };
+    expect(gatewayAccessHeadersForRemote(GW, env)).toEqual({});
+    const regs = buildProviderRegistrations({
+      gatewayBase: GW,
+      sessionID: "s",
+      projectPath: "/p",
+      env,
+    });
+    expect(regs.every((reg) => !reg.headers["x-lore-gateway-token"])).toBe(
+      true,
+    );
+  });
 });
 
 describe("sessionIDFor", () => {
@@ -112,6 +160,30 @@ describe("runCompaction", () => {
     authHeaders: { authorization: "Bearer pi-auth" },
   };
 
+  test("passes gateway access separately from provider authorization", async () => {
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, _init?: RequestInit) =>
+        new Response(JSON.stringify({ cancel: true }), { status: 200 }),
+    );
+    await runCompaction({
+      ...base,
+      authHeaders: {
+        authorization: "Bearer pi-provider-auth",
+        "x-lore-gateway-token": "pi-gateway-access-token-at-least-32",
+      },
+      fetchImpl,
+    });
+
+    const headers = fetchImpl.mock.calls[0][1]?.headers as Record<
+      string,
+      string
+    >;
+    expect(headers.authorization).toBe("Bearer pi-provider-auth");
+    expect(headers["x-lore-gateway-token"]).toBe(
+      "pi-gateway-access-token-at-least-32",
+    );
+  });
+
   test("POSTs to /v1/compact with session header + body, returns shaped result", async () => {
     const fetchImpl = vi.fn(
       async (_url: string | URL | Request, _init?: RequestInit) =>
@@ -123,12 +195,15 @@ describe("runCompaction", () => {
     const result = await runCompaction({ ...base, fetchImpl });
 
     expect(fetchImpl).toHaveBeenCalledOnce();
-    const [url, init] = fetchImpl.mock.calls[0];
+    const call = fetchImpl.mock.calls[0];
+    if (!call) throw new Error("missing compaction fetch call");
+    const [url, init] = call;
+    if (!init) throw new Error("missing compaction fetch options");
     expect(url).toBe(`${GW}/v1/compact`);
-    expect((init!.headers as Record<string, string>)["x-lore-session-id"]).toBe(
+    expect((init.headers as Record<string, string>)["x-lore-session-id"]).toBe(
       "sess-c",
     );
-    expect((init!.headers as Record<string, string>).authorization).toBe(
+    expect((init.headers as Record<string, string>).authorization).toBe(
       "Bearer pi-auth",
     );
     expect(JSON.parse(init?.body as string)).toEqual({
@@ -193,6 +268,66 @@ describe("runCompaction", () => {
     expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
   });
 
+  test("logs only status diagnostics for rejected compactions, never response text or statusText", async () => {
+    const bodyMarker = "PRIVATE_PI_RESPONSE_BODY_MARKER";
+    const reasonMarker = "PRIVATE_PI_REASON_MARKER";
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      captureException: vi.fn(),
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(bodyMarker, {
+          status: 502,
+          statusText: reasonMarker,
+        }),
+    );
+
+    expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+
+    const output = messages.join("\n");
+    expect(output).toContain("502");
+    expect(output).not.toContain(bodyMarker);
+    expect(output).not.toContain(reasonMarker);
+  });
+
+  test("does not log thrown request details", async () => {
+    const thrownMarker = "PRIVATE_PI_THROWN_ERROR_MARKER";
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      captureException: vi.fn(),
+    });
+    const fetchImpl = vi.fn(async () => {
+      throw new Error(thrownMarker);
+    });
+
+    expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+    expect(messages.join("\n")).not.toContain(thrownMarker);
+  });
+
+  test("does not log a malformed successful response prefix", async () => {
+    const bodyMarker = "PRIVATE_PI_MALFORMED_PREFIX";
+    const messages: string[] = [];
+    log.registerSink({
+      info: (message) => messages.push(message),
+      warn: (message) => messages.push(message),
+      error: (message) => messages.push(message),
+      captureException: vi.fn(),
+    });
+    const fetchImpl = vi.fn(
+      async () => new Response(`${bodyMarker} not-json`, { status: 200 }),
+    );
+
+    expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+    expect(messages.join("\n")).not.toContain(bodyMarker);
+  });
+
   test("returns undefined when the request throws", async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error("ECONNREFUSED");
@@ -206,5 +341,74 @@ describe("runCompaction", () => {
         new Response(JSON.stringify({ summary: "" }), { status: 200 }),
     );
     expect(await runCompaction({ ...base, fetchImpl })).toBeUndefined();
+  });
+});
+
+describe("resolveGatewayUrl diagnostics", () => {
+  test("returns and probes a remote URL without userinfo, query, or fragment", async () => {
+    const previousRemote = process.env.LORE_REMOTE_URL;
+    const previousGateway = process.env.LORE_GATEWAY_URL;
+    const previousFetch = globalThis.fetch;
+    try {
+      process.env.LORE_REMOTE_URL =
+        "https://user:PRIVATE_PI_SUCCESS_USERINFO@example.com/gateway" +
+        "?token=PRIVATE_PI_SUCCESS_QUERY#PRIVATE_PI_SUCCESS_FRAGMENT";
+      delete process.env.LORE_GATEWAY_URL;
+      const fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
+      globalThis.fetch = fetchMock;
+
+      await expect(resolveGatewayUrl()).resolves.toBe(
+        "https://example.com/gateway",
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.com/gateway/health",
+        expect.anything(),
+      );
+    } finally {
+      if (previousRemote === undefined) delete process.env.LORE_REMOTE_URL;
+      else process.env.LORE_REMOTE_URL = previousRemote;
+      if (previousGateway === undefined) delete process.env.LORE_GATEWAY_URL;
+      else process.env.LORE_GATEWAY_URL = previousGateway;
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test("strips URL userinfo, query, and fragment from the remote failure log", async () => {
+    const previousRemote = process.env.LORE_REMOTE_URL;
+    const previousGateway = process.env.LORE_GATEWAY_URL;
+    const previousFetch = globalThis.fetch;
+    const userinfoMarker = "PRIVATE_PI_URL_USERINFO";
+    const queryMarker = "PRIVATE_PI_URL_QUERY";
+    const fragmentMarker = "PRIVATE_PI_URL_FRAGMENT";
+    const messages: string[] = [];
+    try {
+      process.env.LORE_REMOTE_URL =
+        `https://user:${userinfoMarker}@example.com/gateway` +
+        `?token=${queryMarker}#${fragmentMarker}`;
+      delete process.env.LORE_GATEWAY_URL;
+      globalThis.fetch = vi.fn(async () => {
+        throw new Error("unreachable");
+      });
+      log.registerSink({
+        info: (message) => messages.push(message),
+        warn: (message) => messages.push(message),
+        error: (message) => messages.push(message),
+        captureException: vi.fn(),
+      });
+
+      await resolveGatewayUrl();
+
+      const output = messages.join("\n");
+      expect(output).toContain("https://example.com/gateway");
+      expect(output).not.toContain(userinfoMarker);
+      expect(output).not.toContain(queryMarker);
+      expect(output).not.toContain(fragmentMarker);
+    } finally {
+      if (previousRemote === undefined) delete process.env.LORE_REMOTE_URL;
+      else process.env.LORE_REMOTE_URL = previousRemote;
+      if (previousGateway === undefined) delete process.env.LORE_GATEWAY_URL;
+      else process.env.LORE_GATEWAY_URL = previousGateway;
+      globalThis.fetch = previousFetch;
+    }
   });
 });

--- a/packages/pi/test/real-runtime.e2e.test.ts
+++ b/packages/pi/test/real-runtime.e2e.test.ts
@@ -120,6 +120,8 @@ describe("pi extension — e2e against the real Pi runtime", () => {
     const config = gw.loadConfig();
     config.port = 0;
     config.hosts = ["127.0.0.1"];
+    config.remoteGateway = false;
+    config.hostedMode = false;
     const server = await gw.startServer(config);
     stopServer = () => server.stop();
     const baseURL = `http://127.0.0.1:${server.port}`;

--- a/packages/website/public/install
+++ b/packages/website/public/install
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+umask 077
 
 RED='\033[0;31m'
 MUTED='\033[0;2m'
@@ -89,9 +90,1328 @@ fi
 # ---------------------------------------------------------------------------
 
 tmpdir="${TMPDIR:-${TMP:-${TEMP:-/tmp}}}"
-tmp_binary="${tmpdir}/lore-install-$$${suffix}"
+tmp_workdir=""
+tmp_binary=""
+tmp_archive=""
+install_tmp=""
+installed_dest=""
+receipt_tmp=""
+receipt_path=""
+receipt_committed=false
+receipt_publication_started=false
+previous_receipt=""
+previous_dest=""
+binary_publication_started=false
+channel_tmp=""
+channel_path=""
+channel_sha256=""
+channel_identity=""
+channel_committed=false
+channel_publication_started=false
+previous_channel=""
+previous_channel_sha256=""
+previous_channel_identity=""
+executable_sha256=""
+expected_download_sha256=""
+installed_identity=""
+receipt_sha256=""
+receipt_identity=""
+installed_device=""
+installed_inode=""
+installed_size=""
+installed_mtime_ns=""
+dest=""
+lifecycle_lock_path=""
+lifecycle_lock_token=""
+lifecycle_lock_held=false
+lifecycle_lock_bash_pid=""
+lifecycle_lock_pid=""
+lifecycle_lock_process_identity=""
+lifecycle_lock_directory_identity=""
+lifecycle_lock_owner_identity=""
+lifecycle_lock_owner_content=""
+lifecycle_initialization_claim_path=""
+lifecycle_initialization_claim_identity=""
+lifecycle_initialization_claim_content=""
+lifecycle_initialization_stage_identity=""
+lifecycle_initialization_claim_held=false
+lifecycle_initialization_claim_bash_pid=""
+lifecycle_initialization_stage_path=""
+lifecycle_initialization_lease_seconds=10
+lifecycle_state_dir=""
+lifecycle_state_dir_identity=""
+lifecycle_state_dir_fd=""
+lifecycle_state_dir_fd_path=""
+inspected_lock_token=""
+inspected_lock_pid=""
+inspected_lock_process_identity=""
+inspected_lock_directory_identity=""
+inspected_lock_owner_identity=""
+inspected_lock_owner_content=""
+uninstall_tombstone_path=""
+observed_tombstone_present=false
+observed_tombstone_token=""
+install_tombstone_present=false
+install_tombstone_token=""
+read_tombstone_present=false
+read_tombstone_token=""
+read_tombstone_identity=""
 
-trap 'rm -f "$tmp_binary"' EXIT
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    die "Could not hash installed files (sha256sum or shasum is required)"
+  fi
+}
+
+# Releases through 0.40.0 predate publisher checksum assets. Keep those
+# concrete historical versions installable; unknown/non-semver versions and
+# every later release use the fail-closed policy.
+stable_release_requires_checksums() {
+  local value=$1 major minor patch
+  if [[ ! "$value" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)([-+][A-Za-z0-9.-]+)?$ ]]; then
+    return 0
+  fi
+  major=${BASH_REMATCH[1]}
+  minor=${BASH_REMATCH[2]}
+  patch=${BASH_REMATCH[3]}
+  (( 10#$major > 0 || 10#$minor > 40 || (10#$minor == 40 && 10#$patch > 0) ))
+}
+
+checksum_entry=""
+read_checksum_entry() {
+  local path=$1 target=$2 line digest name count=0
+  checksum_entry=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ ! "$line" =~ ^([a-f0-9]{64})[[:space:]][[:space:]]([A-Za-z0-9][A-Za-z0-9._-]*)$ ]]; then
+      die "Stable release checksum metadata is malformed"
+    fi
+    digest=${BASH_REMATCH[1]}
+    name=${BASH_REMATCH[2]}
+    if [[ "$name" == "$target" ]]; then
+      checksum_entry=$digest
+      count=$((count + 1))
+    fi
+  done < "$path"
+  if (( count != 1 )); then
+    die "Stable release checksum metadata must contain exactly one entry for ${target}"
+  fi
+}
+
+sync_path() {
+  local path=$1
+  if [[ "$os" == "darwin" ]]; then
+    # macOS sync(8) has no per-path form. A global sync still provides the
+    # required durability before the transaction advances.
+    sync
+  else
+    if [[ -d "$path" ]]; then
+      sync -f "$path"
+    else
+      sync "$path"
+    fi
+  fi
+}
+
+file_identity() {
+  if [[ "$os" == "darwin" ]]; then
+    stat -f '%d:%i' "$1"
+  else
+    stat -c '%d:%i' "$1"
+  fi
+}
+
+stable_file_identity() {
+  local path=$1
+  local identity device inode
+  identity=$(file_identity "$path") || return 1
+  IFS=: read -r device inode <<< "$identity"
+  if [[ ! "$device" =~ ^[1-9][0-9]*$ || ! "$inode" =~ ^[1-9][0-9]*$ ]]; then
+    return 1
+  fi
+  printf '%s' "$identity"
+}
+
+stable_followed_file_identity() {
+  local path=$1 identity device inode
+  if [[ "$os" == "darwin" ]]; then
+    identity=$(stat -Lf '%d:%i' "$path") || return 1
+  else
+    identity=$(stat -Lc '%d:%i' "$path") || return 1
+  fi
+  IFS=: read -r device inode <<< "$identity"
+  if [[ ! "$device" =~ ^[1-9][0-9]*$ || ! "$inode" =~ ^[1-9][0-9]*$ ]]; then
+    return 1
+  fi
+  printf '%s' "$identity"
+}
+
+require_file_identity() {
+  local path=$1
+  local description=$2
+  local identity
+  if ! identity=$(stable_file_identity "$path"); then
+    die "Could not capture a stable ${description} identity"
+  fi
+  printf '%s' "$identity"
+}
+
+preflight_stable_file_identity() {
+  local directory=$1
+  local probe
+  probe=$(mktemp "${directory}/.lore.identity-probe.XXXXXX")
+  chmod 600 "$probe"
+  if ! stable_file_identity "$probe" >/dev/null; then
+    rm -f -- "$probe"
+    die "This filesystem does not expose stable file IDs; install is unavailable and any existing binary must be removed manually"
+  fi
+  rm -f -- "$probe"
+}
+
+capture_receipt_identity() {
+  local path=$1
+  local seconds identity after_identity after_sha256
+  assert_lifecycle_lock_owned
+  [[ -f "$path" && ! -L "$path" ]] || die "Installed executable is not a regular file: ${path}"
+  # Normalize the freshly installed file to whole-second mtime so Bash can
+  # publish an exact nanosecond identity consumed by Node on every platform,
+  # including macOS stat(1), which does not expose fractional mtime portably.
+  if [[ "$os" == "darwin" ]]; then
+    seconds=$(stat -f '%m' "$path")
+    touch -t "$(date -r "$seconds" '+%Y%m%d%H%M.%S')" "$path"
+    identity=$(stat -f '%d:%i:%z:%m' "$path")
+  else
+    seconds=$(stat -c '%Y' "$path")
+    touch -d "@${seconds}" "$path"
+    identity=$(stat -c '%d:%i:%s:%Y' "$path")
+  fi
+  IFS=: read -r installed_device installed_inode installed_size seconds <<< "$identity"
+  installed_mtime_ns="${seconds}000000000"
+  if [[ ! "$installed_device" =~ ^[1-9][0-9]*$ ||
+        ! "$installed_inode" =~ ^[1-9][0-9]*$ ||
+        ! "$installed_size" =~ ^[0-9]+$ ||
+        ! "$installed_mtime_ns" =~ ^[0-9]+$ ]]; then
+    die "Could not capture a stable installed executable identity"
+  fi
+  after_sha256=$(hash_file "$path")
+  after_identity=$(require_file_identity "$path" "installed executable")
+  if [[ "$after_sha256" != "$executable_sha256" || "$after_identity" != "$installed_identity" ]]; then
+    die "Installed executable changed while its receipt identity was captured: ${path}"
+  fi
+  assert_lifecycle_lock_owned
+}
+
+file_matches_receipt_identity() {
+  local path=$1
+  local sha256=$2
+  local identity
+  [[ -f "$path" && ! -L "$path" ]] || return 1
+  if [[ "$os" == "darwin" ]]; then
+    identity=$(stat -f '%d:%i:%z:%m' "$path") || return 1
+  else
+    identity=$(stat -c '%d:%i:%s:%Y' "$path") || return 1
+  fi
+  [[ "$identity" == "${installed_device}:${installed_inode}:${installed_size}:${installed_mtime_ns%000000000}" ]] || return 1
+  [[ "$(hash_file "$path")" == "$sha256" ]]
+}
+
+file_is_generation() {
+  local path=$1
+  local identity=$2
+  local sha256=$3
+  [[ -f "$path" && ! -L "$path" ]] || return 1
+  [[ "$(file_identity "$path")" == "$identity" ]] || return 1
+  [[ "$(hash_file "$path")" == "$sha256" ]]
+}
+
+read_trusted_uninstall_tombstone() {
+  local path=$1
+  local before after size mode content token
+  read_tombstone_present=false
+  read_tombstone_token=""
+  read_tombstone_identity=""
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    return 0
+  fi
+  if [[ -L "$path" || ! -f "$path" ]]; then
+    die "Refusing unsafe uninstall marker: ${path}"
+  fi
+  if [[ "$os" != "windows" && ! -O "$path" ]]; then
+    die "Refusing uninstall marker owned by another user: ${path}"
+  fi
+  if [[ "$os" == "darwin" ]]; then
+    size=$(stat -f '%z' "$path")
+    mode=$(stat -f '%Lp' "$path")
+  else
+    size=$(stat -c '%s' "$path")
+    mode=$(stat -c '%a' "$path")
+  fi
+  if [[ ! "$size" =~ ^[0-9]+$ ]] || (( size > 16384 )); then
+    die "Uninstall marker is too large: ${path}"
+  fi
+  if [[ "$os" != "windows" ]]; then
+    if [[ ! "$mode" =~ ^[0-7]{3,4}$ ]] || (( (8#$mode & 077) != 0 )); then
+      die "Uninstall marker is not owner-only: ${path}"
+    fi
+  fi
+  before=$(require_file_identity "$path" "uninstall marker")
+  content=$(<"$path")
+  after=$(require_file_identity "$path" "uninstall marker")
+  if [[ "$before" != "$after" ]]; then
+    die "Uninstall marker changed while it was read: ${path}"
+  fi
+  token=$(printf '%s\n' "$content" | sed -n \
+    's/^{"version":1,"token":"\([A-Za-z0-9_-]\{32,256\}\)","createdAt":"[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}T[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}\.[0-9]\{3\}Z"}$/\1/p')
+  if [[ -z "$token" ]]; then
+    die "Uninstall marker is malformed or invalid: ${path}"
+  fi
+  read_tombstone_present=true
+  read_tombstone_token="$token"
+  read_tombstone_identity="$after"
+}
+
+same_tombstone_observation() {
+  [[ "$observed_tombstone_present" == "$read_tombstone_present" ]] || return 1
+  if [[ "$observed_tombstone_present" == "true" ]]; then
+    [[ "$observed_tombstone_token" == "$read_tombstone_token" ]]
+  fi
+}
+
+lifecycle_iso_timestamp_is_valid() {
+  local value=$1 year month day hour minute second
+  [[ "$value" =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})\.[0-9]{3}Z$ ]] || return 1
+  year=${BASH_REMATCH[1]}
+  month=${BASH_REMATCH[2]}
+  day=${BASH_REMATCH[3]}
+  hour=${BASH_REMATCH[4]}
+  minute=${BASH_REMATCH[5]}
+  second=${BASH_REMATCH[6]}
+  lifecycle_calendar_date_is_valid "$year" "$month" "$day" &&
+    (( 10#$hour <= 23 && 10#$minute <= 59 && 10#$second <= 59 ))
+}
+
+lifecycle_calendar_date_is_valid() {
+  local year=$1 month=$2 day=$3 max_day
+  [[ "$year" =~ ^[0-9]{4}$ && "$month" =~ ^[0-9]{2}$ && "$day" =~ ^[0-9]{2}$ ]] || return 1
+  (( 10#$month >= 1 && 10#$month <= 12 && 10#$day >= 1 )) || return 1
+  case $((10#$month)) in
+    2)
+      max_day=28
+      if (( 10#$year % 400 == 0 || (10#$year % 4 == 0 && 10#$year % 100 != 0) )); then
+        max_day=29
+      fi
+      ;;
+    4|6|9|11) max_day=30 ;;
+    *) max_day=31 ;;
+  esac
+  (( 10#$day <= max_day ))
+}
+
+lifecycle_process_timestamp_is_valid() {
+  local value=$1 month_name month day hour minute second year
+  lifecycle_iso_timestamp_is_valid "$value" && return 0
+  [[ "$value" =~ ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)[[:space:]]+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[[:space:]]+([0-9]{1,2})[[:space:]]+([0-9]{2}):([0-9]{2}):([0-9]{2})[[:space:]]+([0-9]{4})$ ]] || return 1
+  month_name=${BASH_REMATCH[2]}
+  day=${BASH_REMATCH[3]}
+  hour=${BASH_REMATCH[4]}
+  minute=${BASH_REMATCH[5]}
+  second=${BASH_REMATCH[6]}
+  year=${BASH_REMATCH[7]}
+  case "$month_name" in
+    Jan) month=01 ;; Feb) month=02 ;; Mar) month=03 ;; Apr) month=04 ;;
+    May) month=05 ;; Jun) month=06 ;; Jul) month=07 ;; Aug) month=08 ;;
+    Sep) month=09 ;; Oct) month=10 ;; Nov) month=11 ;; Dec) month=12 ;;
+  esac
+  printf -v day '%02d' "$((10#$day))"
+  lifecycle_calendar_date_is_valid "$year" "$month" "$day" &&
+    (( 10#$hour <= 23 && 10#$minute <= 59 && 10#$second <= 59 ))
+}
+
+lifecycle_pid_is_valid() {
+  local pid=$1 max_pid=9007199254740991
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  (( ${#pid} < ${#max_pid} )) && return 0
+  (( ${#pid} == ${#max_pid} )) || return 1
+  (( 10#$pid <= max_pid ))
+}
+
+path_owner_only_mode() {
+  local path=$1 mode
+  [[ "$os" == "windows" ]] && return 0
+  if [[ "$os" == "darwin" ]]; then
+    mode=$(stat -f '%Lp' "$path") || return 1
+  else
+    mode=$(stat -c '%a' "$path") || return 1
+  fi
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  (( (8#$mode & 077) == 0 ))
+}
+
+path_has_exact_mode() {
+  local path=$1 expected=$2 mode
+  [[ "$os" == "windows" ]] && return 0
+  if [[ "$os" == "darwin" ]]; then
+    mode=$(stat -f '%Lp' "$path") || return 1
+  else
+    mode=$(stat -c '%a' "$path") || return 1
+  fi
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  (( 8#$mode == 8#$expected ))
+}
+
+followed_path_has_exact_mode() {
+  local path=$1 expected=$2 mode
+  [[ "$os" == "windows" ]] && return 0
+  if [[ "$os" == "darwin" ]]; then
+    mode=$(stat -Lf '%Lp' "$path") || return 1
+  else
+    mode=$(stat -Lc '%a' "$path") || return 1
+  fi
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  (( 8#$mode == 8#$expected ))
+}
+
+lifecycle_state_dir_is_trusted() {
+  local path_identity fd_identity
+  [[ -n "$lifecycle_state_dir" && -n "$lifecycle_state_dir_identity" ]] || return 1
+  [[ -n "$lifecycle_state_dir_fd_path" ]] || return 1
+  [[ -d "$lifecycle_state_dir" && ! -L "$lifecycle_state_dir" ]] || return 1
+  [[ -d "$lifecycle_state_dir_fd_path" ]] || return 1
+  if [[ "$os" != "windows" ]] &&
+     { [[ ! -O "$lifecycle_state_dir" ]] ||
+       ! path_has_exact_mode "$lifecycle_state_dir" 700 ||
+       ! followed_path_has_exact_mode "$lifecycle_state_dir_fd_path" 700; }; then
+    return 1
+  fi
+  path_identity=$(stable_file_identity "$lifecycle_state_dir") || return 1
+  fd_identity=$(stable_followed_file_identity "$lifecycle_state_dir_fd_path") || return 1
+  [[ "$path_identity" == "$lifecycle_state_dir_identity" &&
+     "$fd_identity" == "$lifecycle_state_dir_identity" ]]
+}
+
+assert_lifecycle_state_dir_trusted() {
+  lifecycle_state_dir_is_trusted ||
+    die "Installer state directory changed during lifecycle acquisition"
+}
+
+secure_lifecycle_state_dir() {
+  local state_dir=$1 before opened after_path after_fd
+  if [[ -L "$state_dir" || ( -e "$state_dir" && ! -d "$state_dir" ) ]]; then
+    die "Refusing unsafe installer state directory: ${state_dir}"
+  fi
+  if [[ ! -e "$state_dir" ]]; then
+    mkdir -m 700 "$state_dir" ||
+      die "Could not create installer state directory: ${state_dir}"
+  fi
+  [[ -d "$state_dir" && ! -L "$state_dir" ]] ||
+    die "Refusing unsafe installer state directory: ${state_dir}"
+  if [[ "$os" != "windows" && ! -O "$state_dir" ]]; then
+    die "Refusing installer state directory owned by another user: ${state_dir}"
+  fi
+  before=$(require_file_identity "$state_dir" "installer state directory")
+  if ! exec {lifecycle_state_dir_fd}<"$state_dir"; then
+    die "Could not open installer state directory safely: ${state_dir}"
+  fi
+  lifecycle_state_dir_fd_path="/dev/fd/${lifecycle_state_dir_fd}"
+  opened=$(stable_followed_file_identity "$lifecycle_state_dir_fd_path") ||
+    die "Could not capture opened installer state directory identity"
+  if [[ "$before" != "$opened" ]]; then
+    die "Installer state directory changed while it was opened"
+  fi
+  # Tightening happens before lifecycle.lock can be created. The held directory
+  # descriptor pins the generation so a path replacement during chmod is
+  # detected instead of being trusted as the secured parent.
+  if [[ "$os" != "windows" ]] && ! chmod 700 "$lifecycle_state_dir_fd_path"; then
+    die "Could not secure installer state directory: ${state_dir}"
+  fi
+  after_path=$(require_file_identity "$state_dir" "secured installer state directory")
+  after_fd=$(stable_followed_file_identity "$lifecycle_state_dir_fd_path") ||
+    die "Could not recapture opened installer state directory identity"
+  if [[ "$before" != "$after_path" ]] || [[ "$before" != "$after_fd" ]]; then
+    die "Installer state directory was replaced while permissions were tightened"
+  fi
+  if [[ "$os" != "windows" ]] &&
+     { [[ ! -O "$state_dir" ]] ||
+       ! path_has_exact_mode "$state_dir" 700 ||
+       ! followed_path_has_exact_mode "$lifecycle_state_dir_fd_path" 700; }; then
+    die "Installer state directory is not current-owner mode 0700: ${state_dir}"
+  fi
+  lifecycle_state_dir="$state_dir"
+  lifecycle_state_dir_identity="$before"
+  assert_lifecycle_state_dir_trusted
+}
+
+lifecycle_owner_file_identity() {
+  if [[ "$os" == "darwin" ]]; then
+    stat -f '%d:%i:%z:%m:%c:%Lp:%u' "$1"
+  else
+    stat -c '%d:%i:%s:%Y:%Z:%a:%u' "$1"
+  fi
+}
+
+# Capture one immutable, strictly validated lifecycle owner record. This
+# accepts only the compact v1 record emitted by the TypeScript lifecycle helper
+# and by this installer: no extra JSON fields, escaping, links, loose modes, or
+# owner changes are tolerated.
+inspect_lifecycle_owner_record() {
+  local owner_path=$1 before_owner after_owner
+  local owner_size owner_content owner_content_size owner_token owner_pid owner_operation
+  local owner_created_at owner_process_started_at owner_process_identity
+  local unix_process_start
+  local owner_pattern
+
+  inspected_lock_token=""
+  inspected_lock_pid=""
+  inspected_lock_process_identity=""
+  inspected_lock_owner_identity=""
+  inspected_lock_owner_content=""
+
+  [[ -f "$owner_path" && ! -L "$owner_path" ]] || return 1
+  if [[ "$os" != "windows" && ! -O "$owner_path" ]]; then
+    return 1
+  fi
+  path_owner_only_mode "$owner_path" || return 1
+  if [[ "$os" == "darwin" ]]; then
+    owner_size=$(stat -f '%z' "$owner_path") || return 1
+  else
+    owner_size=$(stat -c '%s' "$owner_path") || return 1
+  fi
+  [[ "$owner_size" =~ ^[0-9]+$ ]] || return 1
+  (( owner_size > 0 && owner_size <= 16384 )) || return 1
+  before_owner=$(lifecycle_owner_file_identity "$owner_path") || return 1
+  owner_content=$(<"$owner_path") || return 1
+  [[ "$(wc -l < "$owner_path")" == "1" ]] || return 1
+  owner_content_size=$(LC_ALL=C printf '%s' "$owner_content" | wc -c)
+  [[ "$owner_content_size" =~ ^[0-9]+$ ]] || return 1
+  (( owner_content_size + 1 == owner_size )) || return 1
+  [[ -f "$owner_path" && ! -L "$owner_path" ]] || return 1
+  if [[ "$os" != "windows" ]] &&
+     { [[ ! -O "$owner_path" ]] || ! path_owner_only_mode "$owner_path"; }; then
+    return 1
+  fi
+  after_owner=$(lifecycle_owner_file_identity "$owner_path") || return 1
+  [[ "$before_owner" == "$after_owner" ]] || return 1
+
+  owner_pattern='^\{"version":1,"token":"([A-Za-z0-9_-]{32,256})","pid":([1-9][0-9]*),"operation":"(gateway-start|gateway-shutdown|upgrade|setup|uninstall|hosted-install)","createdAt":"([^"]{1,64})","processStartedAt":"([^"]{1,64})","processIdentity":"([^"]{1,1024})"\}$'
+  [[ "$owner_content" =~ $owner_pattern ]] || return 1
+  owner_token=${BASH_REMATCH[1]}
+  owner_pid=${BASH_REMATCH[2]}
+  owner_operation=${BASH_REMATCH[3]}
+  owner_created_at=${BASH_REMATCH[4]}
+  owner_process_started_at=${BASH_REMATCH[5]}
+  owner_process_identity=${BASH_REMATCH[6]}
+  [[ -n "$owner_operation" ]] || return 1
+  lifecycle_pid_is_valid "$owner_pid" || return 1
+  [[ "$owner_created_at" != *'\'* && "$owner_process_started_at" != *'\'* && "$owner_process_identity" != *'\'* ]] || return 1
+  lifecycle_iso_timestamp_is_valid "$owner_created_at" || return 1
+  lifecycle_process_timestamp_is_valid "$owner_process_started_at" || return 1
+  case "$owner_process_identity" in
+    linux:*)
+      [[ "$owner_process_identity" =~ ^linux:[A-Za-z0-9-]{1,128}:[0-9]+$ ]] || return 1
+      ;;
+    unix:*)
+      unix_process_start=${owner_process_identity#unix:}
+      lifecycle_process_timestamp_is_valid "$unix_process_start" || return 1
+      ;;
+    unverified:*)
+      [[ "$owner_process_identity" == "unverified:${owner_token}" ]] || return 1
+      ;;
+    *) return 1 ;;
+  esac
+
+  inspected_lock_token=$owner_token
+  inspected_lock_pid=$owner_pid
+  inspected_lock_process_identity=$owner_process_identity
+  inspected_lock_owner_identity=$before_owner
+  inspected_lock_owner_content=$owner_content
+}
+
+# Capture one immutable lifecycle directory + owner generation.
+inspect_lifecycle_lock_generation() {
+  local lock_path=$1 before_dir after_dir
+  inspected_lock_directory_identity=""
+  [[ -d "$lock_path" && ! -L "$lock_path" ]] || return 1
+  if [[ "$os" != "windows" && ! -O "$lock_path" ]]; then
+    return 1
+  fi
+  path_owner_only_mode "$lock_path" || return 1
+  before_dir=$(stable_file_identity "$lock_path") || return 1
+  inspect_lifecycle_owner_record "${lock_path}/owner.json" || return 1
+  [[ -d "$lock_path" && ! -L "$lock_path" ]] || return 1
+  if [[ "$os" != "windows" ]] &&
+     { [[ ! -O "$lock_path" ]] || ! path_owner_only_mode "$lock_path"; }; then
+    return 1
+  fi
+  after_dir=$(stable_file_identity "$lock_path") || return 1
+  [[ "$before_dir" == "$after_dir" ]] || return 1
+  inspected_lock_directory_identity=$before_dir
+}
+
+lifecycle_owner_is_definitively_dead() {
+  local pid=$1 process_identity=$2 stat_line stat_suffix boot_id live_identity process_start ps_status kill_error
+  local -a stat_fields
+  lifecycle_pid_is_valid "$pid" || return 1
+  if ! kill -0 "$pid" 2>/dev/null; then
+    # Portable fallback used on macOS/MSYS and when procfs is unavailable.
+    # In the C locale, require kill itself to identify ESRCH before consulting
+    # ps. EPERM or an unknown diagnostic is unverifiable and remains busy.
+    kill_error=$(LC_ALL=C kill -0 "$pid" 2>&1 || true)
+    [[ "$kill_error" == *"No such process"* ]] || return 1
+    # Reclaim only when ps independently reports its specific "PID absent"
+    # result. Unavailable/unexpected ps results remain conservatively busy.
+    if process_start=$(ps -o pid= -p "$pid" 2>/dev/null); then
+      return 1
+    else
+      ps_status=$?
+    fi
+    [[ "$ps_status" == "1" && -z "$process_start" ]]
+    return
+  fi
+  if [[ "$process_identity" == linux:* &&
+        -r "/proc/${pid}/stat" && -r /proc/sys/kernel/random/boot_id ]]; then
+    stat_line=$(<"/proc/${pid}/stat") || return 1
+    stat_suffix=${stat_line##*) }
+    read -r -a stat_fields <<< "$stat_suffix"
+    boot_id=$(< /proc/sys/kernel/random/boot_id) || return 1
+    [[ "${stat_fields[19]:-}" =~ ^[0-9]+$ &&
+       "$boot_id" =~ ^[A-Za-z0-9-]{1,128}$ ]] || return 1
+    live_identity="linux:${boot_id}:${stat_fields[19]}"
+    # A present PID with a different boot/start-tick generation is a reused PID:
+    # the recorded owner is dead even though the numeric PID remains live.
+    [[ "$live_identity" != "$process_identity" ]]
+    return
+  fi
+  # unix: identities contain timezone-rendered, one-second ps lstart output.
+  # They are useful diagnostics but are not stable generation identifiers: the
+  # same live process renders differently under another TZ. A live PID without
+  # Linux boot/start ticks therefore remains conservatively busy.
+  return 1
+}
+
+same_inspected_lifecycle_generation() {
+  local expected_token=$1 expected_pid=$2 expected_process_identity=$3
+  local expected_dir=$4 expected_owner=$5 expected_content=$6 path=$7
+  inspect_lifecycle_lock_generation "$path" || return 1
+  [[ "$inspected_lock_token" == "$expected_token" &&
+     "$inspected_lock_pid" == "$expected_pid" &&
+     "$inspected_lock_process_identity" == "$expected_process_identity" &&
+     "$inspected_lock_directory_identity" == "$expected_dir" &&
+     "$inspected_lock_owner_identity" == "$expected_owner" &&
+      "$inspected_lock_owner_content" == "$expected_content" ]]
+}
+
+same_inspected_lifecycle_owner_record() {
+  local expected_token=$1 expected_pid=$2 expected_process_identity=$3
+  local expected_owner=$4 expected_content=$5 path=$6
+  inspect_lifecycle_owner_record "$path" || return 1
+  [[ "$inspected_lock_token" == "$expected_token" &&
+     "$inspected_lock_pid" == "$expected_pid" &&
+     "$inspected_lock_process_identity" == "$expected_process_identity" &&
+     "$inspected_lock_owner_identity" == "$expected_owner" &&
+     "$inspected_lock_owner_content" == "$expected_content" ]]
+}
+
+release_lifecycle_initialization_claim() {
+  [[ "$lifecycle_initialization_claim_held" == "true" ]] || return 0
+  [[ "$BASHPID" == "$lifecycle_initialization_claim_bash_pid" ]] || return 0
+  if same_inspected_lifecycle_owner_record \
+    "$lifecycle_lock_token" "$lifecycle_lock_pid" "$lifecycle_lock_process_identity" \
+    "$lifecycle_initialization_claim_identity" \
+    "$lifecycle_initialization_claim_content" \
+    "$lifecycle_initialization_claim_path"; then
+    rm -f -- "$lifecycle_initialization_claim_path" || return 0
+  else
+    return 0
+  fi
+  lifecycle_initialization_claim_held=false
+}
+
+remove_lifecycle_initialization_stage() {
+  [[ -n "$lifecycle_initialization_stage_path" ]] || return 0
+  if [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" == \
+        "$lifecycle_initialization_stage_identity" ]]; then
+    rm -f -- "$lifecycle_initialization_stage_path" || return 0
+  fi
+  lifecycle_initialization_stage_path=""
+}
+
+quarantine_dead_lifecycle_initialization_claim() {
+  local claim_path=$1 expected_token=$inspected_lock_token
+  local expected_pid=$inspected_lock_pid
+  local expected_process_identity=$inspected_lock_process_identity
+  local expected_owner=$inspected_lock_owner_identity
+  local expected_content=$inspected_lock_owner_content
+  local archive_path expected_file
+  lifecycle_owner_is_definitively_dead \
+    "$expected_pid" "$expected_process_identity" || return 1
+  archive_path="$(dirname "$claim_path")/.lifecycle.lock.claim.init.${expected_token}"
+  if [[ -e "$archive_path" || -L "$archive_path" ]]; then
+    return 1
+  fi
+  same_inspected_lifecycle_owner_record \
+    "$expected_token" "$expected_pid" "$expected_process_identity" \
+    "$expected_owner" "$expected_content" "$claim_path" || return 1
+  expected_file=$(stable_file_identity "$claim_path") || return 1
+  lifecycle_owner_is_definitively_dead \
+    "$expected_pid" "$expected_process_identity" || return 1
+  assert_lifecycle_state_dir_trusted
+  # mv -n is portable across GNU/BSD/MSYS and gives a regular-file claim
+  # compare-and-swap: a delayed reclaimer cannot overwrite an archived claim
+  # or move a successor claim beneath it.
+  mv -n "$claim_path" "$archive_path" || return 1
+  if inspect_lifecycle_owner_record "$archive_path" &&
+     [[ "$inspected_lock_token" == "$expected_token" &&
+        "$inspected_lock_pid" == "$expected_pid" &&
+        "$inspected_lock_process_identity" == "$expected_process_identity" &&
+        "$inspected_lock_owner_content" == "$expected_content" &&
+        "$(stable_file_identity "$archive_path" 2>/dev/null || true)" == "$expected_file" ]]; then
+    [[ ! -e "$claim_path" && ! -L "$claim_path" ]]
+    return
+  fi
+  die "Lifecycle initialization claim changed during stale-owner quarantine"
+}
+
+directory_has_only_entry() {
+  local directory=$1 expected=$2
+  local -a entries
+  shopt -s dotglob nullglob
+  entries=("$directory"/*)
+  shopt -u dotglob nullglob
+  [[ ${#entries[@]} -eq 1 && "${entries[0]}" == "$expected" ]]
+}
+
+directory_is_empty() {
+  local directory=$1
+  local -a entries
+  shopt -s dotglob nullglob
+  entries=("$directory"/*)
+  shopt -u dotglob nullglob
+  [[ ${#entries[@]} -eq 0 ]]
+}
+
+lifecycle_reclaim_guard_is_valid() {
+  local guard=$1 nested="${1}/lifecycle.lock" sentinel="${1}/lifecycle.lock/sentinel"
+  [[ -d "$guard" && ! -L "$guard" &&
+     -d "$nested" && ! -L "$nested" &&
+     -d "$sentinel" && ! -L "$sentinel" ]] || return 1
+  if [[ "$os" != "windows" ]] &&
+     { [[ ! -O "$guard" || ! -O "$nested" || ! -O "$sentinel" ]] ||
+       ! path_has_exact_mode "$guard" 700 ||
+       ! path_has_exact_mode "$nested" 700 ||
+       ! path_has_exact_mode "$sentinel" 700; }; then
+    return 1
+  fi
+  directory_has_only_entry "$guard" "$nested" &&
+    directory_has_only_entry "$nested" "$sentinel" &&
+    directory_is_empty "$sentinel"
+}
+
+lifecycle_portable_reclaim_guard_is_valid() {
+  local guard=$1 size
+  [[ -f "$guard" && ! -L "$guard" ]] || return 1
+  if [[ "$os" != "windows" ]] &&
+     { [[ ! -O "$guard" ]] || ! path_owner_only_mode "$guard"; }; then
+    return 1
+  fi
+  if [[ "$os" == "darwin" ]]; then
+    size=$(stat -f '%z' "$guard") || return 1
+  else
+    size=$(stat -c '%s' "$guard") || return 1
+  fi
+  [[ "$size" == "0" ]]
+}
+
+quarantine_definitively_stale_lifecycle_lock() {
+  local lock_path=$1 expected_token=$inspected_lock_token
+  local expected_pid=$inspected_lock_pid
+  local expected_process_identity=$inspected_lock_process_identity
+  local expected_dir=$inspected_lock_directory_identity
+  local expected_owner=$inspected_lock_owner_identity
+  local expected_content=$inspected_lock_owner_content
+  local claim_path guard_tmp portable_guard stale_fd stale_fd_path
+
+  lifecycle_owner_is_definitively_dead \
+    "$expected_pid" "$expected_process_identity" || return 1
+  claim_path="$(dirname "$lock_path")/.$(basename "$lock_path").claim.${expected_token}"
+  assert_lifecycle_state_dir_trusted
+  if [[ -e "$claim_path" || -L "$claim_path" ]]; then
+    # Legacy/pre-move reservation crashes could leave only an empty private
+    # claim. Remove exactly that inert shape; never reclaim populated claims.
+    if [[ ! -d "$claim_path" || -L "$claim_path" ]] ||
+       { [[ "$os" != "windows" && ! -O "$claim_path" ]] ||
+         ! path_has_exact_mode "$claim_path" 700; } ||
+       ! rmdir "$claim_path" 2>/dev/null; then
+      return 1
+    fi
+  fi
+  same_inspected_lifecycle_generation \
+    "$expected_token" "$expected_pid" "$expected_process_identity" \
+    "$expected_dir" "$expected_owner" "$expected_content" "$lock_path" || return 1
+  lifecycle_owner_is_definitively_dead \
+    "$expected_pid" "$expected_process_identity" || return 1
+  assert_lifecycle_state_dir_trusted
+  # Pin the stale directory before adding a compatibility guard. An older Bash
+  # reclaimer that already reserved claim/lock must not be able to wake later
+  # and move a canonical successor beneath the archived token claim.
+  if ! exec {stale_fd}<"$lock_path"; then
+    return 1
+  fi
+  stale_fd_path="/dev/fd/${stale_fd}"
+  if [[ "$(stable_followed_file_identity "$stale_fd_path" 2>/dev/null || true)" != "$expected_dir" ]]; then
+    exec {stale_fd}<&-
+    return 1
+  fi
+  # Portable mv treats an existing directory as a parent. Reserve the source
+  # basename inside the stale generation with a non-directory entry, so a
+  # delayed same-generation move cannot nest a live successor under the claim.
+  portable_guard="$stale_fd_path/lifecycle.lock"
+  if [[ -e "$portable_guard" || -L "$portable_guard" ]]; then
+    if ! lifecycle_portable_reclaim_guard_is_valid "$portable_guard"; then
+      exec {stale_fd}<&-
+      return 1
+    fi
+  else
+    set -o noclobber
+    if ! : > "$portable_guard"; then
+      set +o noclobber
+      exec {stale_fd}<&-
+      return 1
+    fi
+    set +o noclobber
+  fi
+  # Preserve the legacy GNU-mv guard where -T exists. The direct portable
+  # source-basename guard above is sufficient on BSD/macOS.
+  if [[ "$os" != "darwin" ]]; then
+    if [[ -e "$stale_fd_path/lock" || -L "$stale_fd_path/lock" ]]; then
+      if ! lifecycle_reclaim_guard_is_valid "$stale_fd_path/lock"; then
+        exec {stale_fd}<&-
+        return 1
+      fi
+    else
+      guard_tmp=$(mktemp -d "$(dirname "$lock_path")/.lifecycle.guard.${expected_token}.XXXXXX")
+      chmod 700 "$guard_tmp"
+      mkdir -m 700 "$guard_tmp/lifecycle.lock"
+      mkdir -m 700 "$guard_tmp/lifecycle.lock/sentinel"
+      if ! mv -T "$guard_tmp" "$stale_fd_path/lock"; then
+        rmdir "$guard_tmp/lifecycle.lock/sentinel" 2>/dev/null || true
+        rmdir "$guard_tmp/lifecycle.lock" 2>/dev/null || true
+        rmdir "$guard_tmp" 2>/dev/null || true
+        exec {stale_fd}<&-
+        return 1
+      fi
+    fi
+  fi
+  exec {stale_fd}<&-
+  same_inspected_lifecycle_generation \
+    "$expected_token" "$expected_pid" "$expected_process_identity" \
+    "$expected_dir" "$expected_owner" "$expected_content" "$lock_path" || return 1
+  lifecycle_owner_is_definitively_dead \
+    "$expected_pid" "$expected_process_identity" || return 1
+  # The direct portable guard above gives plain mv the same no-nesting safety
+  # as GNU mv -T while remaining available on macOS and MSYS.
+  if ! mv "$lock_path" "$claim_path"; then
+    if [[ ! -e "$lock_path" && ! -L "$lock_path" ]]; then
+      if same_inspected_lifecycle_generation \
+           "$expected_token" "$expected_pid" "$expected_process_identity" \
+           "$expected_dir" "$expected_owner" "$expected_content" "$claim_path"; then
+        return 0
+      fi
+      die "Lifecycle lock disappeared during stale-owner quarantine"
+    fi
+    return 1
+  fi
+  if same_inspected_lifecycle_generation \
+    "$expected_token" "$expected_pid" "$expected_process_identity" \
+    "$expected_dir" "$expected_owner" "$expected_content" "$claim_path"; then
+    return 0
+  fi
+  if [[ ! -e "$lock_path" && ! -L "$lock_path" ]]; then
+    # The source changed in the final inspection/rename window. Restore that
+    # exact moved generation only if the canonical name is still absent; -n
+    # must never overwrite a successor that has already published there.
+    mv -n "$claim_path" "$lock_path" 2>/dev/null || true
+  fi
+  die "Lifecycle lock changed during stale-owner quarantine"
+}
+
+lifecycle_lock_is_owned() {
+  [[ "$lifecycle_lock_held" == "true" ]] || return 1
+  lifecycle_state_dir_is_trusted || return 1
+  same_inspected_lifecycle_generation \
+    "$lifecycle_lock_token" "$lifecycle_lock_pid" "$lifecycle_lock_process_identity" \
+    "$lifecycle_lock_directory_identity" "$lifecycle_lock_owner_identity" \
+    "$lifecycle_lock_owner_content" "$lifecycle_lock_path"
+}
+
+assert_lifecycle_lock_owned() {
+  lifecycle_lock_is_owned || die "Lore lifecycle lock was lost during install"
+}
+
+release_lifecycle_lock() {
+  [[ "$lifecycle_lock_held" == "true" ]] || return 0
+  # EXIT traps can run in command subshells. Only the Bash process that
+  # acquired the lock may release it.
+  [[ "$BASHPID" == "$lifecycle_lock_bash_pid" ]] || return 0
+  # A predecessor must never remove a successor's lock or an owner file that
+  # was swapped while retaining the predecessor token.
+  lifecycle_lock_is_owned || return 0
+  rm -f -- "${lifecycle_lock_path}/owner.json" || return 0
+  rmdir "$lifecycle_lock_path" 2>/dev/null || return 0
+  lifecycle_lock_held=false
+}
+
+incomplete_lifecycle_lock_is_lease_expired() {
+  local lock_path=$1 expected_identity=${2:-} before after modified now
+  [[ -d "$lock_path" && ! -L "$lock_path" ]] || return 1
+  if [[ "$os" != "windows" ]] &&
+     { [[ ! -O "$lock_path" ]] || ! path_has_exact_mode "$lock_path" 700; }; then
+    return 1
+  fi
+  before=$(stable_file_identity "$lock_path") || return 1
+  [[ -z "$expected_identity" || "$before" == "$expected_identity" ]] || return 1
+  directory_is_empty "$lock_path" || return 1
+  if [[ "$os" == "darwin" ]]; then
+    modified=$(stat -f '%m' "$lock_path") || return 1
+  else
+    modified=$(stat -c '%Y' "$lock_path") || return 1
+  fi
+  now=$(date '+%s') || return 1
+  [[ "$modified" =~ ^[0-9]+$ && "$now" =~ ^[0-9]+$ ]] || return 1
+  (( 10#$now >= 10#$modified + lifecycle_initialization_lease_seconds )) || return 1
+  after=$(stable_file_identity "$lock_path") || return 1
+  [[ "$before" == "$after" ]] && directory_is_empty "$lock_path"
+}
+
+claim_expired_incomplete_lifecycle_lock() {
+  local lock_path=$1 lock_identity claim claim_token
+  local -a initialization_claims
+  incomplete_lifecycle_lock_is_lease_expired "$lock_path" || return 1
+  lock_identity=$(stable_file_identity "$lock_path") || return 1
+
+  shopt -s nullglob
+  initialization_claims=("$(dirname "$lock_path")"/.lifecycle.lock.init.*)
+  shopt -u nullglob
+  for claim in "${initialization_claims[@]}"; do
+    claim_token=${claim##*.lifecycle.lock.init.}
+    [[ "$claim_token" =~ ^[A-Za-z0-9_-]{32,256}$ ]] || return 1
+    inspect_lifecycle_owner_record "$claim" || return 1
+    [[ "$inspected_lock_token" == "$claim_token" ]] || return 1
+    if [[ "$claim" == "$lifecycle_initialization_claim_path" ]]; then
+      same_inspected_lifecycle_owner_record \
+        "$lifecycle_lock_token" "$lifecycle_lock_pid" \
+        "$lifecycle_lock_process_identity" \
+        "$lifecycle_initialization_claim_identity" \
+        "$lifecycle_initialization_claim_content" "$claim" || return 1
+      continue
+    fi
+    # A live (or unverifiable) claim may be the initializer between mkdir and
+    # owner publication. It remains authoritative regardless of lock age.
+    if ! quarantine_dead_lifecycle_initialization_claim "$claim"; then
+      return 1
+    fi
+  done
+
+  incomplete_lifecycle_lock_is_lease_expired "$lock_path" "$lock_identity" || return 1
+  assert_lifecycle_state_dir_trusted
+  # Hard-link publication is the atomic takeover point. It succeeds only while
+  # owner.json is still absent, and publishes the already-complete tokenized
+  # record without a partially-written owner file.
+  ln "$lifecycle_initialization_stage_path" "${lock_path}/owner.json" || return 1
+  [[ "$(stable_file_identity "$lock_path" 2>/dev/null || true)" == "$lock_identity" ]] ||
+    die "Lifecycle lock changed during incomplete-lock recovery"
+  if ! inspect_lifecycle_owner_record "${lock_path}/owner.json" ||
+     [[ "$inspected_lock_token" != "$lifecycle_lock_token" ||
+        "$inspected_lock_pid" != "$lifecycle_lock_pid" ||
+        "$inspected_lock_process_identity" != "$lifecycle_lock_process_identity" ||
+        "$inspected_lock_owner_content" != "$lifecycle_initialization_claim_content" ||
+        "$(stable_file_identity "${lock_path}/owner.json" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]]; then
+    die "Lifecycle lock owner changed during incomplete-lock recovery"
+  fi
+  lifecycle_initialization_claim_identity="$inspected_lock_owner_identity"
+  return 0
+}
+
+acquire_lifecycle_lock() {
+  local state_dir created_at process_started_at process_identity owner owner_pid
+  local acquired_lock_identity owner_content owner_path_identity
+  local owner_fd owner_fd_path
+  state_dir="${HOME}/.lore"
+  secure_lifecycle_state_dir "$state_dir"
+  state_dir=$(cd "$state_dir" && pwd -P)
+  if [[ "$state_dir" != "$canonical_home" && "$state_dir" != "$canonical_home/"* ]]; then
+    die "Refusing installer state directory outside HOME: ${state_dir}"
+  fi
+  lifecycle_state_dir="$state_dir"
+  assert_lifecycle_state_dir_trusted
+
+  lifecycle_lock_path="${state_dir}/lifecycle.lock"
+  uninstall_tombstone_path="${state_dir}/uninstalled.json"
+  assert_lifecycle_state_dir_trusted
+  read_trusted_uninstall_tombstone "$uninstall_tombstone_path"
+  assert_lifecycle_state_dir_trusted
+  observed_tombstone_present="$read_tombstone_present"
+  observed_tombstone_token="$read_tombstone_token"
+  if ! lifecycle_lock_token=$(od -An -N32 -tx1 /dev/urandom | tr -d '[:space:]'); then
+    die "Could not generate a lifecycle lock token"
+  fi
+  if [[ ! "$lifecycle_lock_token" =~ ^[a-f0-9]{64}$ ]]; then
+    die "Could not generate a lifecycle lock token"
+  fi
+  if ! created_at=$(date -u '+%Y-%m-%dT%H:%M:%S.000Z'); then
+    die "Could not timestamp Lore lifecycle lock"
+  fi
+  process_started_at="$created_at"
+  owner_pid=$$
+  if [[ "$os" == "windows" && -r "/proc/$$/winpid" ]]; then
+    owner_pid=$(<"/proc/$$/winpid")
+  fi
+  [[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || owner_pid=$$
+  local process_start
+  process_start=$(ps -o lstart= -p "$$" 2>/dev/null || true)
+  [[ -n "$process_start" ]] && process_started_at="$process_start"
+  process_identity="unverified:${lifecycle_lock_token}"
+  if [[ "$os" == "linux" && -r "/proc/$$/stat" && -r /proc/sys/kernel/random/boot_id ]]; then
+    local stat_line stat_suffix boot_id
+    local -a stat_fields
+    stat_line=$(<"/proc/$$/stat")
+    stat_suffix=${stat_line##*) }
+    read -r -a stat_fields <<< "$stat_suffix"
+    boot_id=$(< /proc/sys/kernel/random/boot_id)
+    if [[ "${stat_fields[19]:-}" =~ ^[0-9]+$ && -n "$boot_id" ]]; then
+      process_identity="linux:${boot_id}:${stat_fields[19]}"
+    fi
+  elif [[ "$os" != "windows" ]]; then
+    [[ -n "$process_start" ]] && process_identity="unix:${process_start}"
+  fi
+  owner="${lifecycle_lock_path}/owner.json"
+  printf -v owner_content '{"version":1,"token":"%s","pid":%s,"operation":"hosted-install","createdAt":"%s","processStartedAt":"%s","processIdentity":"%s"}' \
+    "$lifecycle_lock_token" "$owner_pid" "$created_at" "$process_started_at" "$process_identity"
+  lifecycle_lock_pid="$owner_pid"
+  lifecycle_lock_process_identity="$process_identity"
+  lifecycle_initialization_stage_path="${state_dir}/.lifecycle.lock.owner.${lifecycle_lock_token}.tmp"
+  lifecycle_initialization_claim_path="${state_dir}/.lifecycle.lock.init.${lifecycle_lock_token}"
+  # Prepare and validate the complete owner generation before mkdir. The
+  # tokenized initialization claim is published before the canonical directory
+  # can exist, leaving only mkdir -> hard-link as the crash-sensitive window.
+  set -o noclobber
+  if ! exec {owner_fd}>"$lifecycle_initialization_stage_path"; then
+    set +o noclobber
+    die "Could not stage Lore lifecycle lock owner"
+  fi
+  set +o noclobber
+  owner_fd_path="/dev/fd/${owner_fd}"
+  if ! chmod 600 "$owner_fd_path" ||
+     ! printf '%s\n' "$owner_content" >&"$owner_fd" ||
+     ! lifecycle_initialization_stage_identity=$(stable_followed_file_identity "$owner_fd_path") ||
+     [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]] ||
+     { [[ "$os" != "windows" && ! -O "$lifecycle_initialization_stage_path" ]] ||
+        ! followed_path_has_exact_mode "$owner_fd_path" 600; }; then
+    exec {owner_fd}>&- 2>/dev/null || true
+    remove_lifecycle_initialization_stage
+    die "Could not stage Lore lifecycle lock owner"
+  fi
+  sync_path "$owner_fd_path" 2>/dev/null || true
+  if ! lifecycle_state_dir_is_trusted ||
+     [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]]; then
+    exec {owner_fd}>&- 2>/dev/null || true
+    remove_lifecycle_initialization_stage
+    die "Lifecycle owner generation changed before claim publication"
+  fi
+  if ! ln "$lifecycle_initialization_stage_path" "$lifecycle_initialization_claim_path"; then
+    exec {owner_fd}>&- 2>/dev/null || true
+    remove_lifecycle_initialization_stage
+    die "Could not publish Lore lifecycle initialization claim"
+  fi
+  lifecycle_initialization_claim_content="$owner_content"
+  lifecycle_initialization_claim_bash_pid=$BASHPID
+  lifecycle_initialization_claim_held=true
+  if ! inspect_lifecycle_owner_record "$lifecycle_initialization_claim_path" ||
+     [[ "$inspected_lock_token" != "$lifecycle_lock_token" ||
+        "$inspected_lock_pid" != "$owner_pid" ||
+        "$inspected_lock_process_identity" != "$process_identity" ||
+        "$inspected_lock_owner_content" != "$owner_content" ||
+        "$(stable_file_identity "$lifecycle_initialization_claim_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]]; then
+    exec {owner_fd}>&- 2>/dev/null || true
+    release_lifecycle_initialization_claim
+    remove_lifecycle_initialization_stage
+    die "Lore lifecycle initialization claim changed during publication"
+  fi
+  lifecycle_initialization_claim_identity="$inspected_lock_owner_identity"
+  exec {owner_fd}>&-
+  sync_path "$lifecycle_initialization_claim_path" 2>/dev/null || true
+
+  while true; do
+    assert_lifecycle_state_dir_trusted
+    if mkdir -m 700 "$lifecycle_lock_path" 2>/dev/null; then
+      # Keep this the first operation after atomic mkdir: owner.json becomes a
+      # complete hard link, never a partially-written record.
+      if ! ln "$lifecycle_initialization_stage_path" "$owner"; then
+        rmdir "$lifecycle_lock_path" 2>/dev/null || true
+        die "Could not publish Lore lifecycle lock owner"
+      fi
+      acquired_lock_identity=$(require_file_identity "$lifecycle_lock_path" "new lifecycle lock")
+    elif [[ ! -e "$lifecycle_lock_path" && ! -L "$lifecycle_lock_path" ]]; then
+      die "Could not acquire Lore lifecycle lock"
+    elif lifecycle_state_dir_is_trusted &&
+         inspect_lifecycle_lock_generation "$lifecycle_lock_path" &&
+         quarantine_definitively_stale_lifecycle_lock "$lifecycle_lock_path"; then
+      continue
+    elif claim_expired_incomplete_lifecycle_lock "$lifecycle_lock_path"; then
+      acquired_lock_identity=$(require_file_identity "$lifecycle_lock_path" "recovered lifecycle lock")
+    else
+      die "Lore lifecycle is busy; retry after the active operation completes"
+    fi
+    assert_lifecycle_state_dir_trusted
+    if [[ ! -d "$lifecycle_lock_path" || -L "$lifecycle_lock_path" ]] ||
+       [[ "$(stable_file_identity "$lifecycle_lock_path" 2>/dev/null || true)" != "$acquired_lock_identity" ]] ||
+       { [[ "$os" != "windows" && ! -O "$lifecycle_lock_path" ]] ||
+         ! path_has_exact_mode "$lifecycle_lock_path" 700; }; then
+      die "Could not validate new Lore lifecycle lock"
+    fi
+    break
+  done
+  owner_path_identity=$(stable_file_identity "$owner" 2>/dev/null || true)
+  if [[ "$owner_path_identity" != "$lifecycle_initialization_stage_identity" ]] ||
+     { [[ "$os" != "windows" && ! -O "$owner" ]] || ! path_has_exact_mode "$owner" 600; }; then
+    die "Lore lifecycle lock owner changed during publication"
+  fi
+  sync_path "$owner" 2>/dev/null || true
+  if ! inspect_lifecycle_owner_record "$owner" ||
+     [[ "$inspected_lock_token" != "$lifecycle_lock_token" ||
+        "$inspected_lock_pid" != "$owner_pid" ||
+        "$inspected_lock_process_identity" != "$process_identity" ||
+        "$inspected_lock_owner_content" != "$owner_content" ]]; then
+    die "Lore lifecycle lock owner changed during publication"
+  fi
+  # Hard-link creation/removal updates inode ctime. Refresh the claim identity,
+  # remove both temporary names by token, then snapshot the final owner inode.
+  lifecycle_initialization_claim_identity="$inspected_lock_owner_identity"
+  release_lifecycle_initialization_claim
+  remove_lifecycle_initialization_stage
+  assert_lifecycle_state_dir_trusted
+  if ! inspect_lifecycle_lock_generation "$lifecycle_lock_path" ||
+     [[ "$inspected_lock_token" != "$lifecycle_lock_token" ||
+        "$inspected_lock_pid" != "$owner_pid" ||
+        "$inspected_lock_process_identity" != "$process_identity" ||
+        "$inspected_lock_owner_content" != "$owner_content" ]]; then
+    die "Lore lifecycle lock owner changed during publication"
+  fi
+  lifecycle_lock_directory_identity="$inspected_lock_directory_identity"
+  lifecycle_lock_owner_identity="$inspected_lock_owner_identity"
+  lifecycle_lock_owner_content="$inspected_lock_owner_content"
+  lifecycle_lock_bash_pid=$BASHPID
+  lifecycle_lock_held=true
+  assert_lifecycle_lock_owned
+  read_trusted_uninstall_tombstone "$uninstall_tombstone_path"
+  if ! same_tombstone_observation; then
+    release_lifecycle_lock
+    die "Refusing stale hosted-install invocation because uninstall state changed while it was waiting"
+  fi
+  install_tombstone_present="$read_tombstone_present"
+  install_tombstone_token="$read_tombstone_token"
+}
+
+clear_uninstall_tombstone_for_verified_install() {
+  local current_identity claim claim_identity claim_token
+  assert_lifecycle_lock_owned
+  if ! file_matches_receipt_identity "$dest" "$executable_sha256" || \
+     ! file_is_generation "$receipt_path" "$receipt_identity" "$receipt_sha256"; then
+    die "Refusing to clear uninstall marker before binary/receipt verification"
+  fi
+  read_trusted_uninstall_tombstone "$uninstall_tombstone_path"
+  if [[ "$read_tombstone_present" != "$install_tombstone_present" ]] || \
+     { [[ "$install_tombstone_present" == "true" ]] && \
+       [[ "$read_tombstone_token" != "$install_tombstone_token" ]]; }; then
+    die "Fresh install no longer matches the current uninstall generation"
+  fi
+  if [[ "$install_tombstone_present" == "true" ]]; then
+    current_identity="$read_tombstone_identity"
+    if [[ "$(require_file_identity "$uninstall_tombstone_path" "uninstall marker")" != "$current_identity" ]]; then
+      die "Fresh install no longer matches the current uninstall generation"
+    fi
+    assert_lifecycle_lock_owned
+    claim="${uninstall_tombstone_path}.clear-${lifecycle_lock_token}"
+    if [[ -e "$claim" || -L "$claim" ]]; then
+      die "Refusing occupied uninstall marker recovery path: ${claim}"
+    fi
+    mv "$uninstall_tombstone_path" "$claim"
+    claim_identity=$(require_file_identity "$claim" "claimed uninstall marker")
+    read_trusted_uninstall_tombstone "$claim"
+    claim_token="$read_tombstone_token"
+    if [[ "$claim_identity" != "$current_identity" || \
+          "$claim_token" != "$install_tombstone_token" ]]; then
+      if [[ ! -e "$uninstall_tombstone_path" && ! -L "$uninstall_tombstone_path" ]]; then
+        ln "$claim" "$uninstall_tombstone_path" || true
+      fi
+      die "Refusing to remove a successor uninstall marker"
+    fi
+    if [[ -e "$uninstall_tombstone_path" || -L "$uninstall_tombstone_path" ]]; then
+      die "A successor uninstall marker appeared during verified install"
+    fi
+    if ! rm -f -- "$claim"; then
+      ln "$claim" "$uninstall_tombstone_path" || true
+      die "Could not clear the verified uninstall marker"
+    fi
+  fi
+}
+
+cleanup_failed_install() {
+  [[ -n "$tmp_workdir" ]] && rm -rf -- "$tmp_workdir"
+  # Once ownership is lost, never mutate live installation paths, transaction
+  # temporaries, or recovery copies that may now belong to a successor.
+  if [[ "$lifecycle_lock_held" == "true" ]] && ! lifecycle_lock_is_owned; then
+    return
+  fi
+  if [[ -n "$receipt_tmp" ]]; then
+    rm -f -- "$receipt_tmp"
+  fi
+  if [[ -n "$install_tmp" ]]; then
+    rm -f -- "$install_tmp"
+  fi
+  if [[ -n "$channel_tmp" ]]; then
+    rm -f -- "$channel_tmp"
+  fi
+  concurrent_install=false
+  if [[ "$binary_publication_started" == "true" && -z "$installed_dest" && \
+        -n "$dest" && ( -e "$dest" || -L "$dest" ) ]]; then
+    concurrent_install=true
+  fi
+  if [[ "$receipt_publication_started" == "true" && "$receipt_committed" != "true" && \
+        -n "$receipt_path" && ( -e "$receipt_path" || -L "$receipt_path" ) ]]; then
+    concurrent_install=true
+  fi
+  if [[ -n "$installed_dest" && ( -e "$installed_dest" || -L "$installed_dest" ) ]] && \
+     ! file_is_generation "$installed_dest" "$installed_identity" "$executable_sha256"; then
+    concurrent_install=true
+  fi
+  if [[ "$receipt_committed" == "true" && -n "$receipt_path" && ( -e "$receipt_path" || -L "$receipt_path" ) ]] && \
+     ! file_is_generation "$receipt_path" "$receipt_identity" "$receipt_sha256"; then
+    concurrent_install=true
+  fi
+  if [[ "$channel_publication_started" == "true" && "$channel_committed" != "true" && \
+        -n "$channel_path" && ( -e "$channel_path" || -L "$channel_path" ) ]]; then
+    concurrent_install=true
+  fi
+  if [[ "$channel_committed" == "true" && -n "$channel_path" && ( -e "$channel_path" || -L "$channel_path" ) ]] && \
+     ! file_is_generation "$channel_path" "$channel_identity" "$channel_sha256"; then
+    concurrent_install=true
+  fi
+  if [[ "$concurrent_install" == "true" ]]; then
+    # Preserve every displaced generation when a non-cooperating writer wins.
+    # The canonical replacements and hidden recovery files are safer than
+    # deleting state whose ownership can no longer be proven.
+    return
+  fi
+  if [[ "$channel_committed" == "true" && -n "$channel_path" ]]; then
+    if file_is_generation "$channel_path" "$channel_identity" "$channel_sha256"; then
+      assert_lifecycle_lock_owned
+      rm -f -- "$channel_path"
+      sync_path "$(dirname "$channel_path")"
+    fi
+    if [[ ! -e "$channel_path" && ! -L "$channel_path" && \
+          -n "$previous_channel" && -e "$previous_channel" ]] && \
+       file_is_generation "$previous_channel" "$previous_channel_identity" "$previous_channel_sha256"; then
+      assert_lifecycle_lock_owned
+      if ln "$previous_channel" "$channel_path" && \
+         file_is_generation "$channel_path" "$previous_channel_identity" "$previous_channel_sha256"; then
+        sync_path "$channel_path"
+        sync_path "$(dirname "$channel_path")"
+        rm -f -- "$previous_channel"
+        sync_path "$(dirname "$channel_path")"
+      fi
+    fi
+  elif [[ -n "$previous_channel" && -e "$previous_channel" && \
+          ! -e "$channel_path" && ! -L "$channel_path" ]] && \
+       file_is_generation "$previous_channel" "$previous_channel_identity" "$previous_channel_sha256"; then
+    assert_lifecycle_lock_owned
+    if ln "$previous_channel" "$channel_path" && \
+       file_is_generation "$channel_path" "$previous_channel_identity" "$previous_channel_sha256"; then
+      sync_path "$channel_path"
+      sync_path "$(dirname "$channel_path")"
+      rm -f -- "$previous_channel"
+      sync_path "$(dirname "$channel_path")"
+    fi
+  fi
+  if [[ "$receipt_committed" == "true" && -n "$receipt_path" ]]; then
+    if file_is_generation "$receipt_path" "$receipt_identity" "$receipt_sha256"; then
+      assert_lifecycle_lock_owned
+      rm -f -- "$receipt_path"
+      if [[ -n "$previous_receipt" && -e "$previous_receipt" ]]; then
+        assert_lifecycle_lock_owned
+        mv "$previous_receipt" "$receipt_path"
+      fi
+    elif [[ ! -e "$receipt_path" && ! -L "$receipt_path" ]]; then
+      if [[ -n "$previous_receipt" && -e "$previous_receipt" ]]; then
+        assert_lifecycle_lock_owned
+        mv "$previous_receipt" "$receipt_path"
+      fi
+    elif [[ -n "$previous_receipt" ]]; then
+      rm -f -- "$previous_receipt"
+    fi
+  elif [[ -n "$previous_receipt" && -e "$previous_receipt" ]]; then
+    if [[ ! -e "$receipt_path" && ! -L "$receipt_path" ]]; then
+      assert_lifecycle_lock_owned
+      mv "$previous_receipt" "$receipt_path"
+    fi
+    # If a replacement occupies the canonical path, preserve the prior receipt
+    # under its recovery name rather than deleting an uncommitted generation.
+  fi
+  if [[ -n "$installed_dest" ]]; then
+    if file_is_generation "$installed_dest" "$installed_identity" "$executable_sha256"; then
+      assert_lifecycle_lock_owned
+      rm -f -- "$installed_dest"
+      if [[ -n "$previous_dest" && -e "$previous_dest" ]]; then
+        assert_lifecycle_lock_owned
+        mv "$previous_dest" "$dest"
+      fi
+    elif [[ ! -e "$installed_dest" && ! -L "$installed_dest" ]]; then
+      if [[ -n "$previous_dest" && -e "$previous_dest" ]]; then
+        assert_lifecycle_lock_owned
+        mv "$previous_dest" "$dest"
+      fi
+    elif [[ -n "$previous_dest" ]]; then
+      rm -f -- "$previous_dest"
+    fi
+  elif [[ -n "$previous_dest" && -e "$previous_dest" ]]; then
+    if [[ ! -e "$dest" && ! -L "$dest" ]]; then
+      assert_lifecycle_lock_owned
+      mv "$previous_dest" "$dest"
+    fi
+    # Preserve the displaced binary if a successor occupies the canonical path.
+  fi
+}
+
+cleanup_installer() {
+  local status=${1:-$?}
+  set +e
+  cleanup_failed_install
+  release_lifecycle_lock
+  release_lifecycle_initialization_claim
+  remove_lifecycle_initialization_stage
+  if [[ -n "$lifecycle_state_dir_fd" ]]; then
+    exec {lifecycle_state_dir_fd}<&-
+    lifecycle_state_dir_fd=""
+    lifecycle_state_dir_fd_path=""
+  fi
+  return "$status"
+}
+
+trap 'cleanup_installer "$?"' EXIT
+
+# The lock parent is fixed at ~/.lore so the Bash installer interoperates with
+# the gateway's lifecycle protocol regardless of LORE_CONFIG_DIR. Acquisition
+# precedes download and every persistent mutation, so an active uninstall makes
+# install fail immediately without even preparing a candidate generation.
+canonical_home=$(cd "$HOME" && pwd -P)
+if [[ "$canonical_home" == "/" ]]; then
+  die "Refusing to install with HOME set to the filesystem root"
+fi
+acquire_lifecycle_lock
+tmp_workdir=$(mktemp -d "${tmpdir%/}/lore-install.XXXXXX")
+tmp_binary="${tmp_workdir}/lore${suffix}"
 
 version=""
 if [[ "$requested_version" == "nightly" ]]; then
@@ -137,21 +1457,33 @@ if [[ "$requested_version" == "nightly" ]]; then
           if($i=="org.opencontainers.image.title"&&$(i+2)==target){print d;exit}
         }
       }')
-  if [[ -z "$digest" ]]; then
+  if [[ ! "$digest" =~ ^sha256:([a-f0-9]{64})$ ]]; then
     die "No nightly build found for ${gz_filename}"
   fi
+  expected_blob_sha256=${BASH_REMATCH[1]}
 
   # Step 5: Get the redirect URL (don't follow — auth must not reach Azure)
   redir_url=$(curl -s -w '\n%{redirect_url}' -o /dev/null \
     -H "Authorization: Bearer $GHCR_TOKEN" \
     "https://ghcr.io/v2/byk/loreai/blobs/${digest}" | tail -1)
-  if [[ -z "$redir_url" ]]; then
+  if [[ "$redir_url" != https://* ]]; then
     die "Failed to get blob redirect URL from GHCR"
   fi
 
-  # Step 6: Download the .gz blob and decompress (without auth header)
-  if ! curl -sf "$redir_url" | gunzip > "$tmp_binary"; then
-    die "Failed to download or decompress nightly binary for ${gz_filename}"
+  # Step 6: Download without the registry Authorization header, then verify the
+  # exact compressed bytes against the OCI layer digest before decompression.
+  # OCI content addressing is the nightly integrity boundary; GHCR package
+  # write access remains the publisher-identity boundary.
+  tmp_archive="${tmp_workdir}/${gz_filename}"
+  if ! curl -sf "$redir_url" > "$tmp_archive"; then
+    die "Failed to download nightly binary for ${gz_filename}"
+  fi
+  actual_blob_sha256=$(hash_file "$tmp_archive")
+  if [[ "$actual_blob_sha256" != "$expected_blob_sha256" ]]; then
+    die "Nightly OCI blob digest mismatch for ${gz_filename}"
+  fi
+  if ! gunzip -c "$tmp_archive" > "$tmp_binary"; then
+    die "Failed to decompress nightly binary for ${gz_filename}"
   fi
 
 else
@@ -171,17 +1503,97 @@ else
   # Strip leading 'v' if present
   version="${version#v}"
 
+  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.-]+)?$ ]]; then
+    die "Invalid stable release version: ${version}"
+  fi
+
   echo -e "${MUTED}Installing lore v${version} (${os}-${arch})...${NC}"
 
   filename="lore-${os}-${arch}${suffix}"
-  url="https://github.com/BYK/loreai/releases/download/${version}/${filename}"
+  release_metadata="${tmp_workdir}/release.json"
+  checksums_file="${tmp_workdir}/lore-checksums.txt"
+  checksum_asset_record=""
+  download_tag="$version"
+
+  # GitHub's HTTPS Releases API authenticates repository release metadata and
+  # exposes a server-computed digest for each uploaded asset. Authenticate the
+  # deterministic checksum asset with that digest, then use its platform entry
+  # to authenticate the decompressed binary. This does not replace an offline
+  # publisher signature: GitHub/release-credential compromise remains trusted.
+  if curl -fsSL \
+      -H "Accept: application/vnd.github.v3+json" \
+      "https://api.github.com/repos/BYK/loreai/releases/tags/${version}" \
+      > "$release_metadata"; then
+    release_tag=$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' "$release_metadata")
+    if [[ "$release_tag" != "$version" && "$release_tag" != "v${version}" ]]; then
+      die "Stable release metadata tag does not match requested version ${version}"
+    fi
+    download_tag="$release_tag"
+    compact_release=$(tr -d '\n\r\t ' < "$release_metadata")
+    checksum_asset_record=$(printf '%s' "$compact_release" \
+      | sed 's/},{/}\n{/g' \
+      | sed -n '/"name":"lore-checksums.txt"/p')
+  elif stable_release_requires_checksums "$version"; then
+    die "Could not fetch checksum metadata for stable release ${version}"
+  fi
+
+  if [[ -n "$checksum_asset_record" ]]; then
+    if [[ "$checksum_asset_record" == *$'\n'* ]]; then
+      die "Stable release contains ambiguous checksum metadata assets"
+    fi
+    checksum_asset_sha256=$(printf '%s' "$checksum_asset_record" \
+      | sed -n 's/.*"digest":"sha256:\([a-f0-9]\{64\}\)".*/\1/p')
+    if [[ ! "$checksum_asset_sha256" =~ ^[a-f0-9]{64}$ ]]; then
+      die "Stable release checksum metadata has no authenticated SHA-256 asset digest"
+    fi
+    checksum_asset_url=$(printf '%s' "$checksum_asset_record" \
+      | sed -n 's/.*"browser_download_url":"\([^"]*\)".*/\1/p')
+    case "$checksum_asset_url" in
+      "https://github.com/BYK/loreai/releases/download/${download_tag}/lore-checksums.txt") ;;
+      *) die "Stable release checksum metadata has an invalid download URL" ;;
+    esac
+    if ! curl -fsSL "$checksum_asset_url" > "$checksums_file"; then
+      die "Failed to download stable release checksum metadata"
+    fi
+    checksum_metadata_size=$(wc -c < "$checksums_file")
+    if [[ ! "$checksum_metadata_size" =~ ^[0-9]+$ ]] || (( checksum_metadata_size > 65536 )); then
+      die "Stable release checksum metadata is too large"
+    fi
+    actual_checksum_asset_sha256=$(hash_file "$checksums_file")
+    if [[ "$actual_checksum_asset_sha256" != "$checksum_asset_sha256" ]]; then
+      die "Stable release checksum metadata digest mismatch"
+    fi
+    read_checksum_entry "$checksums_file" "$filename"
+    expected_download_sha256=$checksum_entry
+  elif stable_release_requires_checksums "$version"; then
+    die "Stable release ${version} is missing required checksum metadata"
+  fi
 
   # Try gzip-compressed first (~60% smaller), fall back to raw binary
-  if curl -fsSL "${url}.gz" 2>/dev/null | gunzip > "$tmp_binary" 2>/dev/null; then
-    : # Compressed download succeeded
+  url="https://github.com/BYK/loreai/releases/download/${download_tag}/${filename}"
+  tmp_archive="${tmp_workdir}/${filename}.gz"
+  if curl -fsSL "${url}.gz" > "$tmp_archive" 2>/dev/null; then
+    if [[ -n "$expected_download_sha256" ]]; then
+      read_checksum_entry "$checksums_file" "${filename}.gz"
+      actual_archive_sha256=$(hash_file "$tmp_archive")
+      if [[ "$actual_archive_sha256" != "$checksum_entry" ]]; then
+        die "Stable release archive checksum mismatch for ${filename}.gz"
+      fi
+    fi
+    if ! gunzip -c "$tmp_archive" > "$tmp_binary" 2>/dev/null; then
+      die "Failed to decompress stable binary for ${filename}"
+    fi
   else
-    curl -fsSL --progress-bar "$url" -o "$tmp_binary"
+    curl -fsSL --progress-bar "$url" > "$tmp_binary"
   fi
+fi
+
+executable_sha256=$(hash_file "$tmp_binary")
+if [[ ! "$executable_sha256" =~ ^[a-f0-9]{64}$ ]]; then
+  die "Could not verify the downloaded executable digest"
+fi
+if [[ -n "$expected_download_sha256" && "$executable_sha256" != "$expected_download_sha256" ]]; then
+  die "Downloaded binary checksum mismatch for lore-${os}-${arch}${suffix}"
 fi
 
 chmod +x "$tmp_binary"
@@ -196,51 +1608,409 @@ fi
 if ! "$tmp_binary" --version >/dev/null 2>&1; then
   die "Downloaded binary failed sanity check. Platform: ${os}-${arch}"
 fi
-
 # ---------------------------------------------------------------------------
 # Install to destination
 # ---------------------------------------------------------------------------
 
 install_dir="${LORE_INSTALL_DIR:-$HOME/.local/bin}"
+if [[ "$install_dir" == *$'\n'* || "$install_dir" == *$'\r'* ]]; then
+  die "LORE_INSTALL_DIR must not contain newline characters"
+fi
+install_dir_existed=false
+if [[ -d "$install_dir" ]]; then
+  install_dir_existed=true
+fi
 mkdir -p "$install_dir"
+install_dir=$(cd "$install_dir" && pwd -P)
+if [[ "$install_dir" == *$'\n'* || "$install_dir" == *$'\r'* ]]; then
+  die "Canonical install directory must not contain newline characters"
+fi
+
+quote_posix() {
+  local value=${1//\'/\'"\'"\'}
+  printf "'%s'" "$value"
+}
+
+quote_fish() {
+  local value=${1//\\/\\\\}
+  value=${value//\'/\\\'}
+  printf "'%s'" "$value"
+}
+
+path_is_in_home() {
+  [[ "$1" == "$canonical_home" || "$1" == "$canonical_home/"* ]]
+}
+
+if [[ "$install_dir_existed" == "false" ]] && path_is_in_home "$install_dir"; then
+  assert_lifecycle_lock_owned
+  chmod 700 "$install_dir"
+fi
+if [[ "$os" != "windows" ]]; then
+  if [[ ! -O "$install_dir" ]]; then
+    die "Refusing install directory owned by another user: ${install_dir}"
+  fi
+  if [[ "$os" == "darwin" ]]; then
+    install_dir_mode=$(stat -f '%Lp' "$install_dir")
+  else
+    install_dir_mode=$(stat -c '%a' "$install_dir")
+  fi
+  if [[ ! "$install_dir_mode" =~ ^[0-7]{3,4}$ ]]; then
+    die "Could not validate install directory permissions: ${install_dir}"
+  fi
+  if (( (8#$install_dir_mode & 022) != 0 )); then
+    die "Refusing group/world-writable install directory: ${install_dir}"
+  fi
+fi
+preflight_stable_file_identity "$install_dir"
 
 dest="${install_dir}/lore${suffix}"
-mv "$tmp_binary" "$dest"
-trap - EXIT  # Clear the temp-file cleanup trap
+assert_lifecycle_lock_owned
+if [[ -L "$dest" || ( -e "$dest" && ! -f "$dest" ) ]]; then
+  die "Refusing unsafe install destination: ${dest}"
+fi
+install_tmp=$(mktemp "${install_dir}/.lore.installing.XXXXXX")
+if ! cp "$tmp_binary" "$install_tmp" || ! chmod 755 "$install_tmp"; then
+  die "Failed to stage binary in ${install_dir}"
+fi
+if [[ "$(hash_file "$install_tmp")" != "$executable_sha256" ]]; then
+  die "Staged executable changed before publication: ${install_tmp}"
+fi
+if [[ -f "$dest" ]]; then
+  previous_dest=$(mktemp "${install_dir}/.lore.previous.XXXXXX")
+  rm -f -- "$previous_dest"
+  assert_lifecycle_lock_owned
+  mv "$dest" "$previous_dest"
+fi
+assert_lifecycle_lock_owned
+binary_publication_started=true
+if ! ln "$install_tmp" "$dest"; then
+  die "Failed to install binary to ${dest}"
+fi
+installed_dest="$dest"
+installed_identity=$(require_file_identity "$dest" "installed executable")
+if [[ "$(require_file_identity "$install_tmp" "staged executable")" != "$installed_identity" ]]; then
+  die "Installed executable generation changed during publication: ${dest}"
+fi
+capture_receipt_identity "$dest"
+rm -f -- "$install_tmp"
+install_tmp=""
+sync_path "$dest"
+sync_path "$install_dir"
+rm -rf -- "$tmp_workdir"
+tmp_workdir=""
 
 installed_version=$("$dest" --version 2>/dev/null || echo "$version")
-echo -e "${GREEN}✓ lore v${installed_version} installed to ${dest}${NC}"
+
+# Record standalone-installer ownership so `lore uninstall` can distinguish
+# this binary from Homebrew/distro/package-managed executables. This fixed
+# location is intentionally independent of LORE_CONFIG_DIR: it is install
+# provenance, not runtime configuration.
+install_state_dir="${HOME}/.lore"
+if [[ -L "$install_state_dir" ]]; then
+  die "Refusing symlinked installer state directory: ${install_state_dir}"
+fi
+mkdir -p "$install_state_dir"
+canonical_install_state_dir=$(cd "$install_state_dir" && pwd -P)
+if ! path_is_in_home "$canonical_install_state_dir"; then
+  die "Refusing installer state directory outside HOME: ${install_state_dir}"
+fi
+chmod 700 "$install_state_dir"
+receipt_path="${install_state_dir}/install-path"
+assert_lifecycle_lock_owned
+if [[ -L "$receipt_path" || ( -e "$receipt_path" && ! -f "$receipt_path" ) ]]; then
+  die "Refusing unsafe installer receipt path: ${receipt_path}"
+fi
+receipt_tmp=$(mktemp "${install_state_dir}/.install-path.XXXXXX")
+receipt_dest="$dest"
+if [[ "$os" == "windows" ]]; then
+  command -v cygpath >/dev/null 2>&1 || die "Could not convert the Windows install path (cygpath is required)"
+  receipt_dest=$(cygpath -w "$dest")
+fi
+if [[ "$receipt_dest" == *$'\n'* || "$receipt_dest" == *$'\r'* ]]; then
+  die "Converted install path must not contain newline characters"
+fi
+if ! file_matches_receipt_identity "$dest" "$executable_sha256"; then
+  die "Installed executable changed before receipt commit: ${dest}"
+fi
+printf 'lore-install-receipt-v3\nexecutable=%s\npath-install-dir=%s\nsha256=%s\ndevice=%s\ninode=%s\nsize=%s\nmtime-ns=%s\n' \
+  "$receipt_dest" "$install_dir" "$executable_sha256" "$installed_device" \
+  "$installed_inode" "$installed_size" "$installed_mtime_ns" > "$receipt_tmp"
+chmod 600 "$receipt_tmp"
+sync_path "$receipt_tmp"
+receipt_sha256=$(hash_file "$receipt_tmp")
+receipt_identity=$(require_file_identity "$receipt_tmp" "install receipt")
+if [[ -f "$receipt_path" ]]; then
+  previous_receipt=$(mktemp "${install_state_dir}/.install-path.previous.XXXXXX")
+  rm -f -- "$previous_receipt"
+  assert_lifecycle_lock_owned
+  mv "$receipt_path" "$previous_receipt"
+fi
+if ! file_matches_receipt_identity "$dest" "$executable_sha256"; then
+  die "Installed executable changed before receipt commit: ${dest}"
+fi
+assert_lifecycle_lock_owned
+receipt_publication_started=true
+if ! ln "$receipt_tmp" "$receipt_path"; then
+  die "Failed to publish install receipt: ${receipt_path}"
+fi
+receipt_committed=true
+rm -f -- "$receipt_tmp"
+receipt_tmp=""
+sync_path "$receipt_path"
+sync_path "$install_state_dir"
+if ! file_is_generation "$receipt_path" "$receipt_identity" "$receipt_sha256"; then
+  die "Install receipt changed during commit: ${receipt_path}"
+fi
 
 # ---------------------------------------------------------------------------
 # Persist release channel
 # ---------------------------------------------------------------------------
 
-if [[ "$requested_version" == "nightly" ]]; then
-  lore_config_dir="${LORE_CONFIG_DIR:-${HOME}/.lore}"
-  mkdir -p "$lore_config_dir"
-  echo -n "nightly" > "${lore_config_dir}/channel"
+lore_config_dir="${LORE_CONFIG_DIR:-${HOME}/.lore}"
+assert_lifecycle_lock_owned
+if [[ -L "$lore_config_dir" ]]; then
+  die "Refusing symlinked Lore config directory: ${lore_config_dir}"
 fi
+mkdir -p "$lore_config_dir"
+channel_path="${lore_config_dir}/channel"
+if [[ -L "$channel_path" || ( -e "$channel_path" && ! -f "$channel_path" ) ]]; then
+  die "Refusing unsafe release channel path: ${channel_path}"
+fi
+channel_tmp=$(mktemp "${lore_config_dir}/.channel.XXXXXX")
+printf '%s' "$([[ "$requested_version" == "nightly" ]] && echo nightly || echo stable)" > "$channel_tmp"
+chmod 600 "$channel_tmp"
+sync_path "$channel_tmp"
+channel_sha256=$(hash_file "$channel_tmp")
+channel_identity=$(require_file_identity "$channel_tmp" "release channel")
+if [[ -f "$channel_path" ]]; then
+  previous_channel_identity=$(require_file_identity "$channel_path" "previous release channel")
+  previous_channel_sha256=$(hash_file "$channel_path")
+  if ! file_is_generation "$channel_path" "$previous_channel_identity" "$previous_channel_sha256"; then
+    die "Release channel changed before replacement: ${channel_path}"
+  fi
+  previous_channel=$(mktemp "${lore_config_dir}/.channel.previous.XXXXXX")
+  rm -f -- "$previous_channel"
+  assert_lifecycle_lock_owned
+  mv "$channel_path" "$previous_channel"
+  if ! file_is_generation "$previous_channel" "$previous_channel_identity" "$previous_channel_sha256"; then
+    if [[ ! -e "$channel_path" && ! -L "$channel_path" ]]; then
+      ln "$previous_channel" "$channel_path" || true
+    fi
+    die "Release channel changed during replacement: ${channel_path}"
+  fi
+fi
+assert_lifecycle_lock_owned
+channel_publication_started=true
+if ! ln "$channel_tmp" "$channel_path"; then
+  die "Failed to publish release channel: ${channel_path}"
+fi
+channel_committed=true
+rm -f -- "$channel_tmp"
+channel_tmp=""
+sync_path "$channel_path"
+sync_path "$lore_config_dir"
+if ! file_is_generation "$channel_path" "$channel_identity" "$channel_sha256"; then
+  die "Release channel changed during commit: ${channel_path}"
+fi
+
+# Binary, ownership receipt, and channel are now durable. PATH setup below is
+# an optional convenience and does not determine installation provenance.
+if ! file_matches_receipt_identity "$dest" "$executable_sha256" || \
+   ! file_is_generation "$receipt_path" "$receipt_identity" "$receipt_sha256"; then
+  die "Installed executable or receipt changed before install commit"
+fi
+clear_uninstall_tombstone_for_verified_install
+set +e
+trap - ERR
+if [[ -n "$previous_dest" ]] && ! rm -f "$previous_dest"; then
+  echo "Warning: could not remove old binary backup: ${previous_dest}" >&2
+fi
+if [[ -n "$previous_receipt" ]] && ! rm -f "$previous_receipt"; then
+  echo "Warning: could not remove old receipt backup: ${previous_receipt}" >&2
+fi
+if [[ -n "$previous_channel" ]]; then
+  if file_is_generation "$previous_channel" "$previous_channel_identity" "$previous_channel_sha256"; then
+    if ! rm -f "$previous_channel"; then
+      echo "Warning: could not remove old channel backup: ${previous_channel}" >&2
+    fi
+  else
+    echo "Warning: old channel backup changed and was preserved: ${previous_channel}" >&2
+  fi
+fi
+previous_dest=""
+previous_receipt=""
+previous_channel=""
+installed_dest=""
+receipt_committed=false
+channel_committed=false
+binary_publication_started=false
+receipt_publication_started=false
+channel_publication_started=false
+echo -e "${GREEN}✓ lore v${installed_version} installed to ${dest}${NC}"
 
 # ---------------------------------------------------------------------------
 # PATH setup
 # ---------------------------------------------------------------------------
 
+configure_path() {
 if [[ "$no_modify_path" == "true" ]]; then
-  if ! echo "$PATH" | tr ':' '\n' | grep -qx "$install_dir"; then
+  if ! echo "$PATH" | tr ':' '\n' | grep -Fqx "$install_dir"; then
     echo ""
     echo "Add lore to your PATH:"
-    echo "  export PATH=\"${install_dir}:\$PATH\""
+    printf '  export PATH=%s:"%sPATH"\n' "$(quote_posix "$install_dir")" '$'
   fi
   exit 0
 fi
 
 # Check if install_dir is already in PATH
-if echo "$PATH" | tr ':' '\n' | grep -qx "$install_dir"; then
+if echo "$PATH" | tr ':' '\n' | grep -Fqx "$install_dir"; then
   exit 0
 fi
 
-path_line="export PATH=\"${install_dir}:\$PATH\""
+path_line="export PATH=$(quote_posix "$install_dir"):\"\$PATH\""
+fish_path_line="set -gx PATH $(quote_fish "$install_dir") \$PATH"
 modified=false
+
+append_path_block() {
+  local rc=$1
+  local line=$2
+  local parent canonical_parent temp before_identity before_sha256
+  local current_identity current_sha256 claim temp_identity temp_sha256
+
+  if [[ -L "$rc" ]]; then
+    die "Shell profile became a symlink during install: ${rc}"
+  fi
+  if [[ -e "$rc" && ! -f "$rc" ]]; then
+    die "Refusing non-file shell profile: ${rc}"
+  fi
+
+  assert_lifecycle_lock_owned
+  parent=$(dirname "$rc")
+  mkdir -p "$parent"
+  canonical_parent=$(cd "$parent" && pwd -P)
+  if ! path_is_in_home "$canonical_parent"; then
+    die "Refusing shell profile outside HOME: ${rc}"
+  fi
+
+  # A hard kill can leave the previous profile under its generation-bound
+  # claim after the canonical name was moved away. Recover exactly one trusted
+  # claim before deciding that the profile is new; ambiguous state is unsafe.
+  if [[ ! -e "$rc" && ! -L "$rc" ]]; then
+    local -a recovery_claims=()
+    local recovery_claim recovery_suffix recovery_identity recovery_sha256
+    for recovery_claim in "${rc}.lore-original."*; do
+      if [[ -e "$recovery_claim" || -L "$recovery_claim" ]]; then
+        recovery_claims+=("$recovery_claim")
+      fi
+    done
+    if (( ${#recovery_claims[@]} > 1 )); then
+      die "Refusing ambiguous shell profile recovery claims: ${rc}"
+    fi
+    if (( ${#recovery_claims[@]} == 1 )); then
+      recovery_claim=${recovery_claims[0]}
+      recovery_suffix=${recovery_claim#"${rc}.lore-original."}
+      if [[ ! "$recovery_suffix" =~ ^[A-Za-z0-9_-]{32,256}\.([1-9][0-9]*)\.([1-9][0-9]*)\.([a-f0-9]{64})$ ||
+            -L "$recovery_claim" || ! -f "$recovery_claim" ||
+            ( "$os" != "windows" && ! -O "$recovery_claim" ) ]]; then
+        die "Refusing unsafe shell profile recovery claim: ${recovery_claim}"
+      fi
+      recovery_identity="${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
+      recovery_sha256=${BASH_REMATCH[3]}
+      if ! file_is_generation "$recovery_claim" "$recovery_identity" "$recovery_sha256"; then
+        die "Shell profile recovery claim changed: ${recovery_claim}"
+      fi
+      assert_lifecycle_lock_owned
+      if ! ln "$recovery_claim" "$rc"; then
+        die "Shell profile was replaced during recovery: ${rc}"
+      fi
+      if ! file_is_generation "$rc" "$recovery_identity" "$recovery_sha256"; then
+        die "Shell profile changed during recovery: ${rc}"
+      fi
+      sync_path "$rc"
+      sync_path "$parent"
+      if file_is_generation "$recovery_claim" "$recovery_identity" "$recovery_sha256"; then
+        rm -f -- "$recovery_claim"
+      elif [[ -e "$recovery_claim" || -L "$recovery_claim" ]]; then
+        die "Shell profile recovery claim was replaced: ${recovery_claim}"
+      fi
+      sync_path "$parent"
+    fi
+  fi
+
+  temp=$(mktemp "${rc}.lore-install.XXXXXX")
+  chmod 600 "$temp"
+  if [[ -f "$rc" ]]; then
+    before_identity=$(require_file_identity "$rc" "shell profile")
+    before_sha256=$(hash_file "$rc")
+    cp -p "$rc" "$temp"
+  else
+    before_identity="missing"
+    before_sha256="missing"
+  fi
+  printf '\n# Added by lore installer\n%s\n' "$line" >> "$temp"
+  temp_identity=$(require_file_identity "$temp" "staged shell profile")
+  temp_sha256=$(hash_file "$temp")
+
+  if [[ -L "$rc" ]]; then
+    rm -f "$temp"
+    die "Shell profile became a symlink during install: ${rc}"
+  fi
+  if [[ -f "$rc" ]]; then
+    current_identity=$(require_file_identity "$rc" "shell profile")
+    current_sha256=$(hash_file "$rc")
+  else
+    current_identity="missing"
+    current_sha256="missing"
+  fi
+  if [[ "$current_identity" != "$before_identity" || "$current_sha256" != "$before_sha256" ]]; then
+    rm -f "$temp"
+    die "Shell profile changed during install: ${rc}"
+  fi
+  assert_lifecycle_lock_owned
+
+  if [[ "$before_identity" != "missing" ]]; then
+    claim="${rc}.lore-original.${lifecycle_lock_token}.${before_identity/:/.}.${before_sha256}"
+    if [[ -e "$claim" || -L "$claim" ]]; then
+      rm -f -- "$temp"
+      die "Refusing occupied shell profile recovery claim: ${claim}"
+    fi
+    mv "$rc" "$claim"
+    if ! file_is_generation "$claim" "$before_identity" "$before_sha256"; then
+      if [[ ! -e "$rc" && ! -L "$rc" ]]; then
+        ln "$claim" "$rc" || true
+      fi
+      rm -f -- "$temp"
+      die "Shell profile changed during install: ${rc}"
+    fi
+    sync_path "$claim"
+    sync_path "$parent"
+  else
+    claim=""
+  fi
+
+  assert_lifecycle_lock_owned
+  if ! ln "$temp" "$rc"; then
+    if [[ -n "$claim" && ! -e "$rc" && ! -L "$rc" ]]; then
+      ln "$claim" "$rc" || true
+    fi
+    rm -f -- "$temp"
+    die "Shell profile was replaced during install: ${rc}"
+  fi
+  if ! file_is_generation "$rc" "$temp_identity" "$temp_sha256"; then
+    rm -f -- "$temp"
+    die "Shell profile changed during publication: ${rc}"
+  fi
+  rm -f -- "$temp"
+  if [[ -n "$claim" ]]; then
+    if file_is_generation "$claim" "$before_identity" "$before_sha256"; then
+      rm -f -- "$claim"
+    elif [[ -e "$claim" || -L "$claim" ]]; then
+      die "Shell profile recovery claim was replaced: ${claim}"
+    fi
+  fi
+  sync_path "$rc"
+  sync_path "$parent"
+}
 
 # Detect shell config files to modify
 configs=()
@@ -257,16 +2027,19 @@ case "$shell_name" in
 esac
 
 for rc in "${configs[@]}"; do
-  if [[ -f "$rc" ]] && grep -qF "$install_dir" "$rc" 2>/dev/null; then
+  if [[ "$shell_name" == "fish" ]]; then
+    line="$fish_path_line"
+  else
+    line="$path_line"
+  fi
+  if [[ -L "$rc" ]]; then
+    echo -e "${MUTED}Skipped symlinked shell profile ${rc}${NC}" >&2
+    continue
+  fi
+  if [[ -f "$rc" ]] && grep -Fqx "$line" "$rc" 2>/dev/null; then
     continue  # Already configured
   fi
-  echo "" >> "$rc"
-  echo "# Added by lore installer" >> "$rc"
-  if [[ "$shell_name" == "fish" ]]; then
-    echo "set -gx PATH \"${install_dir}\" \$PATH" >> "$rc"
-  else
-    echo "$path_line" >> "$rc"
-  fi
+  append_path_block "$rc" "$line"
   modified=true
   echo -e "${MUTED}Updated ${rc}${NC}"
 done
@@ -276,3 +2049,30 @@ if [[ "$modified" == "true" ]]; then
   echo "Restart your shell or run:"
   echo "  $path_line"
 fi
+}
+
+# The binary, receipt, and release channel have already committed. Run PATH
+# convenience setup as a separate best-effort phase: a profile error must not
+# report the durable installation as failed.
+(
+  trap - EXIT ERR
+  set -e
+  configure_path
+)
+path_setup_status=$?
+if [[ "$path_setup_status" -ne 0 ]]; then
+  echo "Warning: lore was installed, but automatic PATH setup failed." >&2
+  echo "Add lore to your PATH manually:" >&2
+  printf '  export PATH=%s:"%sPATH"\n' "$(quote_posix "$install_dir")" '$' >&2
+fi
+if ! lifecycle_lock_is_owned; then
+  echo "Warning: lore was installed, but lifecycle lock ownership was lost during PATH setup." >&2
+  echo "Verify the current installation before retrying." >&2
+fi
+release_lifecycle_lock
+if [[ -n "$lifecycle_state_dir_fd" ]]; then
+  exec {lifecycle_state_dir_fd}<&-
+  lifecycle_state_dir_fd=""
+  lifecycle_state_dir_fd_path=""
+fi
+exit 0

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -36,6 +36,8 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | Variable | Description |
 |---|---|
 | `LORE_CONFIG_DIR` | Get the Lore config directory. Uses $LORE_CONFIG_DIR if set, otherwise ~/.lore |
+| `LORE_DB_PATH` | Resolved path of the SQLite database file. Reads `LORE_DB_PATH` first; falls back to `${dataDir}/lore.db` (typically `~/.local/share/lore/lore.db`). The test preload (`packages/core/test/setup.ts`) sets `LORE_DB_PATH` to a temp directory so tests never touch the production DB. Setting it to a non-existent path will create the file on first use. The gateway itself does not set this — it expects a stable location for the DB so the SQLite WAL and FTS5 indices persist across restarts. Env: `LORE_DB_PATH`. |
+| `LORE_GATEWAY_AUTH_TOKEN` | Gateway access credential required for remote/hosted data-plane requests. It is sent as `x-lore-gateway-token` and remains separate from provider API keys/bearer tokens. Remote/hosted startup fails closed unless it is 32-256 visible ASCII characters without commas. OpenCode/Pi consume LORE_REMOTE_URL + LORE_GATEWAY_AUTH_TOKEN in their adapters; Claude Code supports a per-request custom header directly. Never place it in a URL or CLI argument. Env: LORE_GATEWAY_AUTH_TOKEN. |
 | `LORE_GIT_REMOTE` | Git remote URL (e.g. `git@github.com:org/repo.git`) of the project the spawned Codex CLI is operating in. Exported by the gateway so a user-defined `env_http_headers` in `~/.codex/config.toml` can map it to a custom header for upstream telemetry. Set only when `git remote get-url origin` returns a value; the gateway does not read this env var itself. |
 | `LORE_HOSTED_MODE` | Hosted/remote mode — disables all filesystem operations that use client-controlled paths (git subprocess, .lore.json/.lore.md read/write, lat.md/ directory scan, file watchers). Env: LORE_HOSTED_MODE. |
 | `LORE_INSTALL_DIR` | Determine the install directory for a curl-installed binary. Priority: 1. $LORE_INSTALL_DIR environment variable 2. ~/.local/bin (if exists AND in $PATH) 3. ~/bin (if exists AND in $PATH) 4. ~/.lore/bin (fallback) |
@@ -44,7 +46,6 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | `LORE_PROJECT` | Expose project path & git remote as env vars so downstream agents can map them to custom headers if supported in the future. The gateway resolves the project from system-prompt inference and cwd for now. |
 | `LORE_REMOTE_GATEWAY` | Remote/central gateway mode. When true, the gateway is serving agents running on OTHER machines, so its own `process.cwd()` has no relationship to any client's project. In this mode the gateway MUST NOT attribute path-less requests to its own cwd (doing so merges unrelated projects). Instead, requests that cannot resolve a confident project path are routed to a per-session synthetic "unattributed" bucket (`/__lore_unattributed__/<sessionID>`) that can later self-heal or be consolidated. Env: LORE_REMOTE_GATEWAY. Note: hosted mode (`LORE_HOSTED_MODE`) implies remote-gateway behavior — a hosted gateway never shares a filesystem with its clients. Auto-detection: when neither `LORE_REMOTE_GATEWAY` nor `LORE_HOSTED_MODE` is set, the gateway auto-enables remote-gateway mode if its bind address(es) include any non-loopback host. This catches the common case of running a long-lived gateway on a server (Tailscale, LAN IP, `0.0.0.0`, etc.) without requiring an explicit env var. |
 | `LORE_REMOTE_URL` | CLI remote helper — shared utilities for CLI commands that need to call the remote gateway REST API when `LORE_REMOTE_URL` is set. |
-| `LORE_SHUTDOWN_TIMEOUT_MS` | Hard cap (ms) on how long graceful shutdown may run before the gateway force-exits, so Ctrl+C can never hang. Env: `LORE_SHUTDOWN_TIMEOUT_MS` (default 4000). Invalid / non-positive / non-finite values fall back to the default — the timeout can never be disabled. |
 | `LORE_TARGET`<br>**Default:** ``${process.platform}-${process.arch}`` | Platform target string used to locate the vendored embedding model directory when running the SEA (single executable) binary. Format: `${platform}-${arch}` (e.g. `darwin-arm64`, `linux-x64`). Defaults to the current host. Override this to pre-warm the embedding model cache on a machine of one platform and run the binary on another (CI cross-builds, OCI images). Env: `LORE_TARGET=<platform>-<arch>`. |
 | `LORE_UPSTREAM_EXTRA_HEADERS` | Forward LORE_UPSTREAM_EXTRA_HEADERS to Codex via the `openai_provider_headers` config key (TOML map of header name → value). Codex appends these to every outbound request to the OpenAI-compatible upstream, which now points at the Lore gateway. The gateway reads the same env var and re-injects them on the actual upstream call — this is a belt-and-suspenders pass-through so a user with a custom corporate proxy gets headers on both hops. |
 | `LORE_WORKER_MODEL`<br>**Parser:** `parseWorkerModelEnv` | Parse the `LORE_WORKER_MODEL` env-var override into a `{providerID, modelID}`. Format: `"providerID/modelID"` (e.g. `openai/gpt-5.4-mini`) or a bare `"modelID"` which assumes the `anthropic` provider (the historical default). Returns `undefined` only for an unset/empty value. Single source of truth shared by the live worker-model selection ({@link getWorkerModel}) and standalone `lore import`, so the env override behaves identically in both paths. |
@@ -54,6 +55,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 | Variable | Description |
 |---|---|
 | `LORE_BEDROCK_REGION` | AWS Bedrock region. Selects both the bedrock-mantle Anthropic endpoint and the bedrock-runtime Converse/InvokeModel endpoint. Resolves from `LORE_BEDROCK_REGION` first, then falls back to `AWS_REGION` / `AWS_DEFAULT_REGION`, finally defaulting to `"us-east-1"`. Env: LORE_BEDROCK_REGION |
+| `LORE_CALLER_UPSTREAM_ALLOWLIST` | Normalized HTTPS origins that remote/hosted clients may select with `X-Lore-Upstream-URL`. Empty by default, so caller-selected upstreams are denied unless the gateway administrator explicitly allows their origins. Local gateways do not consult this list. Env: LORE_CALLER_UPSTREAM_ALLOWLIST (comma-separated origins). |
 | `LORE_DEBUG`<br>**Parser:** `isTruthy` | Whether to log requests. Default: false. Env: LORE_DEBUG |
 | `LORE_IDLE_TIMEOUT`<br>**Default:** `parsePositiveInt(60)`<br>**Parser:** `parsePositiveInt` | Idle timeout in seconds. After this many seconds with no active request, the gateway stops the per-session in-memory cache warmer and distillation loop to free resources. State is preserved in the DB so a new request resumes from where the session left off. Default: 60. Env: `LORE_IDLE_TIMEOUT`. |
 | `LORE_LISTEN_HOST`<br>**Parser:** `parseHosts` | Hosts to bind to. Default: ["127.0.0.1"]. Env: LORE_LISTEN_HOST (comma-separated for multiple addresses). CLI: --host (can be specified multiple times, or comma-separated). |
@@ -72,12 +74,25 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 |---|---|
 | `LORE_BATCH_DISABLED` | Disables the batch-queue wrapper for non-urgent worker calls (distillation, curation, embedding). With batching on, the gateway groups these calls and submits them via the Anthropic Message Batches API for ~50% cost savings. Set `LORE_BATCH_DISABLED=1` to bypass batching and dispatch each call immediately (useful for low-latency debugging or when the upstream rejects batch submissions). Env: `LORE_BATCH_DISABLED=1`. |
 
+## runtime-files
+
+| Variable | Description |
+|---|---|
+| `LORE_RUNTIME_ACL_ACTION` | _no description in source_ |
+| `LORE_RUNTIME_ACL_KIND` | _no description in source_ |
+| `LORE_RUNTIME_ACL_PATH` | _no description in source_ |
+
+## shutdown-deadline
+
+| Variable | Description |
+|---|---|
+| `LORE_SHUTDOWN_TIMEOUT_MS` | Bound for the bounded vector-pool shutdown on graceful shutdown (#1599). The pool teardown must wait for every worker's SQLite reader to close before the writer can TRUNCATE the WAL — leaving readers up would strand the `-wal` file and force WAL recovery on the next boot. Sized to fit under the global deadline after the embedding drain (60%) so a stuck worker still leaves room for the writer's checkpoint+close. Mirrors {@link EMBED_DRAIN_DEADLINE_MS}'s safety floor of 500ms so an aggressive `LORE_SHUTDOWN_TIMEOUT_MS` (e.g. 1000ms) doesn't shrink the pool budget into a guaranteed timeout. |
+
 ## Memory engine (`@loreai/core`)
 
 | Variable | Description |
 |---|---|
 | `LORE_BACKFILL_CPU_DUTY` | Resolve the configured backfill CPU duty cycle: `LORE_BACKFILL_CPU_DUTY` wins, then `search.embeddings.backfillCpuDuty`, else `undefined` (auto-scaled by CPU count — full speed on roomy hosts, gentler on small ones). Invalid values are ignored (fall through). Read per-call so config reloads take effect. |
-| `LORE_DB_PATH` | Resolved path of the SQLite database file. Reads `LORE_DB_PATH` first; falls back to `${dataDir}/lore.db` (typically `~/.local/share/lore/lore.db`). The test preload (`packages/core/test/setup.ts`) sets `LORE_DB_PATH` to a temp directory so tests never touch the production DB. Setting it to a non-existent path will create the file on first use. The gateway itself does not set this — it expects a stable location for the DB so the SQLite WAL and FTS5 indices persist across restarts. Env: `LORE_DB_PATH`. |
 | `LORE_DISABLE_VEC` | LORE_DISABLE_VEC=1 forces the JS brute-force vector-search path. Useful as a production kill-switch if the native extension causes issues, and as a test seam for the JS fallback. Set before the first `db()` call — once attempted=true is sticky for the connection lifetime, the env var won't be re-read until resetVecState() runs (in close()). |
 | `LORE_DISABLE_VEC_WORKER` | Kill switch: force the in-process vector-search path, disabling the off-thread read-worker pool. Default-on escape hatch, not opt-in. |
 | `LORE_EMBED_POOL_SIZE` | Resolve the configured embedding-pool ceiling: `LORE_EMBED_POOL_SIZE` wins (the escape hatch — `=1` forces today's single worker), then `search.embeddings.embedPoolSize`, else `undefined` (memory-gated default). Read per-construction (not cached) so config reloads / env changes take effect on the next provider. Invalid values are ignored (fall through). |

--- a/packages/website/src/content/docs/docs/guides/custom-upstreams.md
+++ b/packages/website/src/content/docs/docs/guides/custom-upstreams.md
@@ -15,7 +15,7 @@ This guide is for the advanced counterpart to the per-harness setup: pointing Lo
 
 Lore's gateway resolves the upstream URL in this order, highest priority first:
 
-1. `X-Lore-Upstream-URL` request header (explicit user override).
+1. `X-Lore-Upstream-URL` request header (explicit user override; restricted by the administrator allowlist in remote/hosted mode).
 2. `X-Lore-Provider` request header → static `PROVIDER_ROUTES` table.
 3. Model-prefix route (e.g. `claude-` → Anthropic, `gpt-` → OpenAI).
 4. Config defaults: `LORE_UPSTREAM_ANTHROPIC`, `LORE_UPSTREAM_OPENAI`.
@@ -61,7 +61,17 @@ curl -X POST http://127.0.0.1:3207/v1/messages \
   -d '{"model": "claude-3-5-sonnet", "max_tokens": 1024, "messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
-The header is sanitized (control characters stripped, length-capped at 2048, must be http/https, no embedded credentials) before use.
+The header is sanitized (control characters stripped, length-capped at 2048, must be http/https, no embedded credentials) before use. A local, non-remote gateway continues to allow loopback, private-network, and custom inference endpoints.
+
+Remote and hosted gateways deny every caller-selected upstream origin by default. The gateway administrator must explicitly allow HTTPS origins before clients can use them:
+
+```bash
+export LORE_CALLER_UPSTREAM_ALLOWLIST="https://internal-llm.corp.example.com,https://litellm.corp.example.com:8443"
+```
+
+Entries are comma-separated **origins**, not endpoint URLs: paths, credentials, queries, fragments, wildcards, HTTP origins, malformed values, and duplicates after normalization are rejected at startup. Matching is by exact normalized origin, including the port; allowing `https://example.com` does not allow a subdomain, `http://example.com`, or `https://example.com:8443`. Request paths under an allowed origin remain usable.
+
+This allowlist applies only to client-provided `X-Lore-Upstream-URL` values. Administrator-configured defaults such as `LORE_UPSTREAM_ANTHROPIC` and `LORE_UPSTREAM_OPENAI`, plus built-in provider routes, remain available without an allowlist entry.
 
 ## Custom auth headers
 
@@ -143,10 +153,14 @@ Two caveats:
 Hosted mode is for running the Lore gateway as a central service that multiple clients connect to from different machines. In hosted mode, the gateway is always a **remote gateway** — it has no shared filesystem with its clients.
 
 ```bash
+# Generate and configure a high-entropy access credential. Remote/hosted
+# startup fails closed when this is absent or malformed.
+export LORE_GATEWAY_AUTH_TOKEN="$(openssl rand -hex 32)"
+
 # Enable hosted mode
 export LORE_HOSTED_MODE=1
 
-# Or equivalently (implies hosted mode)
+# Or enable remote-gateway tenant/routing policy without hosted filesystem restrictions
 export LORE_REMOTE_GATEWAY=1
 ```
 
@@ -157,6 +171,10 @@ In hosted mode, the gateway disables filesystem operations that depend on client
 - No `lat.md/` directory scan.
 - No file watchers.
 
+Hosted and remote gateways also reject caller-provided `X-Lore-Upstream-URL` destinations unless their exact HTTPS origin appears in `LORE_CALLER_UPSTREAM_ALLOWLIST`. Leave the variable unset for the secure deny-all default.
+
+Every remote/hosted **data-plane** request must carry the configured token in `x-lore-gateway-token`. This credential authorizes access to Lore; `x-api-key`, `x-goog-api-key`, and bearer tokens authorize an upstream provider and never substitute for it. The gateway compares the access token exactly, strips it before request parsing, and never forwards or stores it. Health remains public, while the dashboard and management API remain socket-loopback-only.
+
 Requests that cannot resolve a confident project path are routed to a per-session synthetic "unattributed" bucket so unrelated sessions are never merged. The bucket self-heals when a confident path arrives in a later turn.
 
 ### Connecting clients to a remote gateway
@@ -166,18 +184,45 @@ Clients find the remote gateway via the same discovery chain as the local one:
 ```bash
 # Explicit override (highest priority)
 export LORE_REMOTE_URL=https://lore.corp.example.com
-
-# Or set the same env var the local-discovery uses
-export LORE_GATEWAY_URL=https://lore.corp.example.com
+export LORE_GATEWAY_AUTH_TOKEN='<the server-configured token>'
 ```
 
-Both the OpenCode and Pi plugins probe the URL on startup.
+Both the OpenCode and Pi plugins probe `LORE_REMOTE_URL` on startup and inject the token as a request header. Keep the token in the environment or a secret manager; do not put it in the remote URL or command-line arguments. `LORE_GATEWAY_URL` remains a local/custom discovery override and does not opt an adapter into remote-token injection.
+
+Direct clients that support custom headers must set the same header explicitly:
+
+```bash
+curl https://lore.corp.example.com/v1/models \
+  -H "x-lore-gateway-token: $LORE_GATEWAY_AUTH_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_API_KEY"
+```
+
+Clients that can change only a base URL, but cannot attach a custom header, cannot securely use a remote/hosted gateway directly. Use the OpenCode or Pi adapter, `lore run` with a supported header-capable client, or a trusted edge proxy that injects the header from server-side secret storage.
+
+### Accessing remote management safely
+
+Non-loopback clients can use the LLM data-plane routes, but the dashboard and `/api/*` management endpoints are loopback-only. This remains true when the gateway listens on `0.0.0.0`, a LAN address, or Tailscale; proxy forwarding headers do not grant management access.
+
+Use an SSH tunnel when you need the dashboard or management CLI from another machine:
+
+```bash
+# Run on your workstation
+ssh -N -L 3207:127.0.0.1:3207 user@gateway-host
+
+# Dashboard: http://localhost:3207/ui
+# For management CLI commands through the tunnel:
+export LORE_REMOTE_URL=http://localhost:3207
+```
+
+The gateway must listen on `127.0.0.1` (or `0.0.0.0`) for that tunnel target. If you configure individual interfaces, include loopback, for example `LORE_LISTEN_HOST=127.0.0.1,100.100.100.100`.
 
 ## Gotchas
 
 | Problem | Cause | Fix |
 |---|---|---|
 | Upstream URL ignored | A request-level `X-Lore-Upstream-URL` header is overriding the config | Remove the header, or rely on `LORE_UPSTREAM_<PROVIDER>` for provider-scoped URLs |
+| Remote custom upstream rejected | Remote/hosted mode denies caller-selected origins by default | Add the exact HTTPS origin to the gateway administrator's `LORE_CALLER_UPSTREAM_ALLOWLIST`, or configure the protocol default on the gateway |
+| Remote request returns 401 | The gateway access token is missing, wrong, malformed, or duplicated | Set matching `LORE_GATEWAY_AUTH_TOKEN` values on the gateway and adapter, or send one exact `x-lore-gateway-token` header from a direct client |
 | Custom header not arriving | The header is in the gateway-managed blocklist (`x-lore-*`, `x-api-key`, `authorization`, framing headers) | Use a different header name, or remove the conflicting client-side header |
 | Worker calls hitting public Anthropic | `LORE_WORKER_UPSTREAM` is unset and the session uses a non-default upstream | Set `LORE_WORKER_UPSTREAM` to the worker's URL |
 | Multiple clients sharing memory unexpectedly | Hosted mode is off but sessions come from different machines | Set `LORE_HOSTED_MODE=1` on the gateway so it stops attributing to its own cwd |

--- a/packages/website/src/content/docs/docs/guides/local-inference.md
+++ b/packages/website/src/content/docs/docs/guides/local-inference.md
@@ -7,7 +7,7 @@ sidebar:
 
 This guide is for the privacy-maximalist / tinkerer path. If you'd rather not have your conversations touch a third-party API — or you just want to experiment with smaller open-weight models — Lore can run against any OpenAI-compatible local server.
 
-Lore's gateway already runs locally. Your database lives at `~/.local/share/lore/lore.db` and never leaves your machine. With a local LLM server, even the distillation and curation calls stay on your hardware. There is no external API key required and no telemetry.
+Lore's gateway already runs locally. Your database lives at `~/.local/share/lore/lore.db` and never leaves your machine. With a local LLM server, even the distillation and curation calls stay on your hardware, and no external LLM API key is required. Production builds still send privacy-filtered operational telemetry by default; set `SENTRY_ENABLED=0` before starting Lore to disable it. Lore does not include prompts, response bodies, credentials, file paths, or project names in this telemetry. See [Operational telemetry](/docs/install/#operational-telemetry) for the metadata that can be sent.
 
 ## Server setup
 

--- a/packages/website/src/content/docs/docs/guides/with-opencode.md
+++ b/packages/website/src/content/docs/docs/guides/with-opencode.md
@@ -58,6 +58,7 @@ The URL is the server root — do not include `/v1` (the gateway appends API pat
 - **Compaction is disabled.** OpenCode's built-in compaction would defeat Lore's gradient context manager. The plugin sets `cfg.compaction = { auto: false, prune: false }` in the OpenCode config.
 - **Project identity is automatic.** The plugin detects your project root (`ctx.worktree` / `ctx.directory`), walks up to find the workspace root, and injects the path + git remote as `x-lore-project` / `x-lore-git-remote` headers on every request.
 - **The gateway auto-starts.** If no Lore gateway is running, the plugin starts one in-process. The gateway listens on a deterministic port (`3207` by default, falling back to `5673`) and the plugin probes for it before assuming it needs to spawn.
+- **Remote access is separate from provider auth.** For a remote/hosted gateway, set both `LORE_REMOTE_URL` and `LORE_GATEWAY_AUTH_TOKEN`. The plugin injects `x-lore-gateway-token` only for that remote URL; API keys and bearer tokens remain provider credentials.
 
 ## Next steps
 

--- a/packages/website/src/content/docs/docs/guides/with-pi.md
+++ b/packages/website/src/content/docs/docs/guides/with-pi.md
@@ -62,6 +62,7 @@ The URL is the server root — do not include `/v1` (the gateway appends API pat
 - **Compaction is intercepted.** Pi's compaction goes through its extension API rather than HTTP. The Pi extension calls the gateway's `POST /v1/compact` endpoint to get a full LLM-synthesized compaction summary (force-distill + knowledge + compact prompt).
 - **Provider headers are auto-injected.** The extension's `registerProviders()` walks the configured providers and sets the gateway base URL, `x-lore-session-id`, `x-lore-project`, and `x-lore-git-remote` headers on each request.
 - **`LORE_GATEWAY_URL` overrides auto-detection.** If the gateway is on a non-default host or port, set `LORE_GATEWAY_URL` in your environment before launching Pi.
+- **Remote access is separate from provider auth.** For a remote/hosted gateway, set both `LORE_REMOTE_URL` and `LORE_GATEWAY_AUTH_TOKEN`. The extension adds `x-lore-gateway-token` to provider registrations, intercepted fetches, and `/v1/compact` calls without treating it as model-provider auth.
 
 ## Next steps
 

--- a/packages/website/src/content/docs/docs/install.md
+++ b/packages/website/src/content/docs/docs/install.md
@@ -19,6 +19,75 @@ lore run
 
 Lore auto-detects Claude Code, OpenCode, Pi, Codex, and Hermes Agent when you run `lore run`. For harness-specific setup, see the Guides section.
 
+## Operational telemetry
+
+Production builds send privacy-filtered operational telemetry to Sentry by default. It can include a random persistent installation ID, credential and project-path hashes, conversation/session IDs, model and upstream origin, gateway port, token usage, estimated cost, performance traces, and fixed-category errors. Lore disables automatic collection of prompts, model responses, request or response bodies, headers, cookies, URL query values, file paths, project names, application logs, and stack-frame variables; a final transport scrubber removes those fields before transmission.
+
+To opt out, set `SENTRY_ENABLED=0` before starting Lore:
+
+```bash
+export SENTRY_ENABLED=0
+lore run
+```
+
+Development builds do not send telemetry unless explicitly enabled with `SENTRY_ENABLED=1`. Test processes always disable it.
+
+## What the installer writes
+
+The hosted install script downloads one standalone executable to `${LORE_INSTALL_DIR:-$HOME/.local/bin}/lore` (`lore.exe` on Windows). If that directory is not already on `PATH`, the script appends this marked block to the active shell profile (`~/.zshrc`, `~/.bashrc`, `~/.bash_profile`, `~/.profile`, or `~/.config/fish/config.fish`):
+
+```sh
+# Added by lore installer
+export PATH='/home/you/.local/bin':"$PATH"
+```
+
+The installer records a generation-bound executable receipt in `~/.lore/install-path` so uninstall can distinguish the exact hosted standalone binary from package-managed copies. It writes the selected release channel (`stable` or `nightly`) to `${LORE_CONFIG_DIR:-$HOME/.lore}/channel`. Running Lore may subsequently create:
+
+- `${XDG_DATA_HOME:-$HOME/.local/share}/lore/` for `lore.db`, logs, gateway PID/port files, and account/sync state
+- `${LORE_CONFIG_DIR:-$HOME/.lore}/` for the release channel and update metadata (`channel`, `latest-version`, `version-check.json`, and `patch-cache/`); the standalone binary's extracted embedding model is always under `~/.lore/embeddings-vendored/`
+- `~/.cache/lore/` for extracted worker files
+- `.lore.md`, `.lore.json`, and a managed section in `AGENTS.md` or `CLAUDE.md` inside projects where those features are used
+
+Lifecycle serialization and hosted-install provenance use the fixed per-user `~/.lore/` directory even when `LORE_CONFIG_DIR` is customized. `~/.lore/lifecycle.lock/` exists only while a normal setup/start/stop/upgrade/install/uninstall transition owns the lock; stale token-named lock claims may be retained after crash recovery. A successful verified hosted self-removal intentionally leaves `~/.lore/uninstalled.json` as a persistent, owner-only tombstone. It prevents an already-running old hosted binary from starting Lore again. A fresh hosted install, or a fresh invocation of the declared `@loreai/gateway` package CLI after package installation, verifies its own install generation before atomically clearing that tombstone. Unverified and Windows invocations that preserve the running executable do not create this tombstone.
+
+`lore setup <app>` is separate from installation. It changes that app's config and saves a backup; see [Undoing setup](/docs/setup/#undoing-setup). `lore setup status` is read-only and recognizes both `~/.config/opencode/opencode.json` and OpenCode's supported `opencode.jsonc` form.
+
+## Uninstall
+
+To restore app configs, remove the hosted standalone executable recorded by the installer, remove the exact marked `PATH` block written by the installer, and clear disposable Lore caches while keeping your memory database:
+
+```bash
+lore uninstall
+```
+
+Inspect the resolved cleanup and preservation plan first with `lore uninstall --dry-run`. Setup restoration and shell-profile cleanup are summarized because their exact files are discovered and validated during execution. Preview mode does not run the live gateway, setup-backup, or filesystem preflight checks; the real command runs all of them before its first mutation. Uninstall refuses to continue while a gateway appears to be running; run `lore stop`, verify it stopped, and retry.
+
+The command prints the preserved data directory. To also permanently delete the database, logs, stored Folk Lore session, and gateway state in the default data directory, use:
+
+```bash
+lore uninstall --purge
+```
+
+`--purge` prints the resolved cleanup plan, then asks for confirmation. Review the paths before answering. Use `lore uninstall --purge --yes` in a non-interactive shell only after previewing the same environment with `lore uninstall --purge --dry-run` immediately beforehand; the preview is not a filesystem snapshot.
+
+For safety, uninstall does not recursively delete custom `XDG_DATA_HOME` / `LORE_CONFIG_DIR` locations or an external/relative `LORE_DB_PATH`; it prints those paths as preserved for manual review. Purgeable default directories are generation-bound: uninstall quarantines and verifies the exact directory checked during preflight, and refuses or preserves a replacement raced into the same pathname. A package-managed or otherwise unverified standalone executable is also preserved and must be removed through its installer or package manager. On Windows, the running standalone executable cannot delete itself. A fully verified hosted-install receipt still allows uninstall to transactionally remove only the exact installer-owned marked `PATH` block; unrelated profile content is preserved. The command retains the executable and receipt and prints their exact paths so you can delete both after uninstall exits. Preserved databases are never opened or modified during uninstall.
+
+Uninstall never searches for or removes project-owned `.lore.md`, `.lore.json`, `AGENTS.md`, or `CLAUDE.md` files. Review and remove those per project if you no longer want the exported knowledge or managed instruction section.
+
+If Lore was installed through npm rather than the hosted standalone installer, `lore uninstall` still restores setup and handles Lore data/cache cleanup, then prints the package-manager command to remove the CLI itself. It does not create a tombstone for a package-managed uninstall. If a valid tombstone remains from an earlier hosted uninstall, a fresh installed `@loreai/gateway` package invocation verifies its declared package entry before clearing it; stale hosted binaries remain blocked:
+
+```bash
+npm uninstall -g @loreai/gateway
+```
+
+If `lore setup opencode` installed the optional global OpenCode plugin, remove the package after setup has been undone:
+
+```bash
+npm uninstall -g @loreai/opencode
+```
+
+Pi extensions added manually to `~/.pi/settings.json` are not owned by the installer; remove `npm:@loreai/pi@latest` from the `packages` array and run `pi install`.
+
 If you'd rather configure Codex manually (for the Codex Desktop app, or to run `codex` without going through `lore run`), run [`lore setup codex`](/docs/setup/) once — it writes `~/.codex/config.toml` with the gateway URL and the no-auto-compact override. See the [Setup command](/docs/setup/) page for the full reference.
 
 You can also run the gateway directly with npm:

--- a/packages/website/src/content/docs/docs/setup.md
+++ b/packages/website/src/content/docs/docs/setup.md
@@ -17,6 +17,8 @@ sidebar:
 - **Hermes Agent without `lore run`** — `lore setup hermes` writes `~/.hermes/.env` with `OPENAI_BASE_URL` (the gateway URL, including `/v1`) and `HERMES_INFERENCE_PROVIDER=custom`. Hermes loads that `.env` at launch (via python-dotenv), so a standalone `hermes` routes through the gateway — the persistent equivalent of what `lore run hermes` injects.
 - **Remote gateway** — `lore setup <app> -r http://remote:3207` writes the config pointing at a non-default gateway URL, useful when the gateway runs on a different machine (Tailscale, LAN, a hosted deployment) and you want the local client to talk to it.
 
+Remote/hosted gateways require a separate access credential. `lore setup -r` intentionally writes only non-secret routing configuration; it never persists the token. Export `LORE_REMOTE_URL` and `LORE_GATEWAY_AUTH_TOKEN` when launching an adapter-capable client (OpenCode or Pi), or configure the direct client to send one `x-lore-gateway-token` header. A provider API key or bearer token is not gateway authorization. Clients that support only a base URL and no custom headers need an adapter or a trusted header-injecting edge proxy.
+
 If you launch your agent through `lore run`, you do **not** need `lore setup` — `lore run` injects the right config (env vars or `-c` overrides) into the child process at launch. `lore setup <app>` is for the other case: launching the agent directly (a GUI/IDE app, or a standalone CLI) where a persistent config file is the only integration point. Each supported app reads provider config from its own file — Codex/Pi from a JSON/TOML config, Claude Code/Hermes from an env file, OpenCode from JSON plus a plugin — so `lore setup` writes the persistent config they need.
 
 ## Usage
@@ -50,7 +52,19 @@ If the named app isn't installed (for example, `lore setup codex` on a machine w
 
 `model_auto_compact_token_limit = 999999999` disables Codex's built-in auto-compaction so Lore's gradient context manager and distillation pipeline can do their job. Re-running `lore setup` resets this value to `999999999` — any custom value you set is overwritten.
 
-To remove the configuration and restore Codex's default behavior, delete the relevant lines from `~/.codex/config.toml` or run `git checkout -- ~/.codex/config.toml` if you keep the file under version control.
+## Undoing setup
+
+`lore setup undo [app]` restores only settings previously changed by `lore setup`. Lore records each prior value and restores it only when the current value still matches what Lore wrote, so a setting you changed afterward is left untouched.
+
+```bash
+lore setup undo              # Restore every app with a Lore setup backup
+lore setup undo codex        # Restore one app
+lore setup undo opencode
+```
+
+This command does not remove the `lore` executable, Lore's database or caches, project `.lore.md` files, or globally installed npm packages. Copilot setup is guidance-only and writes no config, so there is nothing to restore; if `COPILOT_API_URL` or `COPILOT_PROVIDER_BASE_URL` is set outside `lore run`, unset it where your shell or service defines it.
+
+To remove the standalone installation as well, use [`lore uninstall`](/docs/install/#uninstall). It first validates every setup backup, stages the verified standalone executable for reversible removal, applies setup undo, then finalizes executable and installer-owned file removal. If setup restoration fails, the executable is restored. Use `lore uninstall --purge` only when you also want to delete the default local Lore runtime data; custom data paths are always preserved for manual review.
 
 ## Verifying the setup
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       google-auth-library:
         specifier: ^10.9.0
         version: 10.9.0
+      jsonc-parser:
+        specifier: 3.3.1
+        version: 3.3.1
       p-limit:
         specifier: '7'
         version: 7.3.0

--- a/scripts/generate-release-checksums.mjs
+++ b/scripts/generate-release-checksums.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { access, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const TARGETS = Object.freeze([
+  "lore-darwin-arm64",
+  "lore-linux-arm64",
+  "lore-linux-x64",
+  "lore-windows-x64.exe",
+]);
+
+const [rawDirectory, compressedDirectory, outputPath] = process.argv.slice(2);
+if (!rawDirectory || !compressedDirectory || !outputPath) {
+  console.error(
+    "Usage: generate-release-checksums.mjs <raw-dir> <compressed-dir> <output>",
+  );
+  process.exit(2);
+}
+
+async function sha256(path) {
+  await access(path);
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+const files = TARGETS.flatMap((target) => [
+  { name: target, path: join(rawDirectory, target) },
+  { name: `${target}.gz`, path: join(compressedDirectory, `${target}.gz`) },
+]).sort((left, right) =>
+  left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+);
+
+const lines = [];
+for (const file of files) {
+  lines.push(`${await sha256(file.path)}  ${file.name}`);
+}
+
+// Fixed target list, lexical order, lowercase SHA-256, two-space separator,
+// and one terminal newline make the metadata byte-for-byte deterministic.
+await writeFile(outputPath, `${lines.join("\n")}\n`, { mode: 0o644 });


### PR DESCRIPTION
## Summary
Makes Lore setup, upgrades, shutdown, and uninstall reversible and crash-safe while preserving user data by default.

Closes #1621.

## Changes
- Adds `lore uninstall` with transactional profile/config cleanup, guarded `--purge`, package-manager detection, and Windows-safe behavior.
- Adds lifecycle locks, generation-bound receipts/tombstones, and fresh-process recovery for setup, installer, upgrade, and purge interruptions.
- Adds authenticated, cross-platform, deadline-bounded gateway shutdown with active-stream cancellation and coordinated child termination.
- Hardens tenant/credential isolation, routing attribution, and final telemetry/log redaction.
- Updates installer and documentation with reversible PATH/channel handling and adversarial regression coverage.

## Validation
- `pnpm exec vitest run --maxWorkers=2`: 8,518 passed, 227 skipped
- `pnpm run typecheck`
- `pnpm run lint` (warnings only)
- `pnpm run format:check`
- `pnpm run build`
- `pnpm --filter @loreai/gateway run bundle`
- `bash -n packages/website/public/install`
- Independent correctness review: MERGE
- Independent security review: MERGE