### PR TITLE
fix(cli): surface invalid env credential upstreams

### DIFF
--- a/packages/gateway/src/cli/agents.ts
+++ b/packages/gateway/src/cli/agents.ts
@@ -188,6 +188,18 @@ function cleanBaseUrl(raw: string | undefined): string | null {
   return trimmed;
 }
 
+export class InvalidEnvCredentialUpstreamError extends Error {
+  constructor(
+    readonly agentDisplayName: string,
+    readonly envVarName: string,
+  ) {
+    super(
+      `${agentDisplayName} has an unsafe or invalid upstream URL in ${envVarName}`,
+    );
+    this.name = "InvalidEnvCredentialUpstreamError";
+  }
+}
+
 /**
  * A credential the user configured for an agent purely through shell env vars:
  * the agent's base-URL (`upstreamEnvVars`) plus its auth-token
@@ -196,9 +208,11 @@ function cleanBaseUrl(raw: string | undefined): string | null {
  * corporate-proxy setup (e.g. Claude Code with ANTHROPIC_BASE_URL=openrouter.ai
  * + ANTHROPIC_AUTH_TOKEN=<key>). Returns the token + scheme + captured upstream
  * URL, so `lore import` can route extraction to that upstream. Returns null if
- * the agent has no env-credential mechanism, or the token/base URL is missing.
+ * the agent has no env-credential mechanism or no token is configured.
  * A base URL is NOT required (some setups set only the token and rely on the
- * provider default), but a token IS.
+ * provider default), but a token IS. Throws when a configured base URL is
+ * present but unsafe or invalid, so callers do not silently discard a valid
+ * credential or detach it from the user's intended upstream.
  */
 export function captureUserEnvCredential(
   agent: AgentDef,
@@ -236,7 +250,9 @@ export function captureUserEnvCredential(
     const raw = env[key];
     if (!raw) continue;
     const clean = cleanBaseUrl(raw);
-    if (!clean) return null;
+    if (!clean) {
+      throw new InvalidEnvCredentialUpstreamError(agent.displayName, key);
+    }
     upstreamUrl = clean;
     break;
   }

--- a/packages/gateway/src/cli/import.ts
+++ b/packages/gateway/src/cli/import.ts
@@ -34,7 +34,11 @@ import {
 } from "../worker-model";
 import { resolveProviderRoute, providerForUpstreamOrigin } from "../config";
 import { hasRecentAuthRejectedFailure } from "../worker-health";
-import { AGENTS, captureUserEnvCredential } from "./agents";
+import {
+  AGENTS,
+  captureUserEnvCredential,
+  InvalidEnvCredentialUpstreamError,
+} from "./agents";
 import { exportLoreFile } from "@loreai/core";
 import { startGateway, type StartOptions } from "./start";
 import {
@@ -62,6 +66,19 @@ const {
 type StructuredSourceName = conversationImport.StructuredSourceName;
 type AgentResolvedAuth =
   import("@loreai/core").conversationImport.AgentResolvedAuth;
+
+function reportInvalidEnvCredentialUpstream(
+  error: unknown,
+  agentDisplayName: string,
+): boolean {
+  if (!(error instanceof InvalidEnvCredentialUpstreamError)) return false;
+  console.error(
+    `[lore] Can't import ${agentDisplayName}: ${error.envVarName} contains an unsafe or invalid upstream URL.\n` +
+      `[lore] Fix or unset ${error.envVarName}, then retry.`,
+  );
+  process.exitCode = 1;
+  return true;
+}
 
 /**
  * OpenAI-compatible aggregator providers that proxy model requests to any
@@ -1353,11 +1370,18 @@ export async function commandImport(
       // Tier-1 (explicit LORE_WORKER_API_KEY) is a deliberate user override —
       // single-shot, no fallback. Every other path goes through the
       // auto-fallback chain below.
-      const tier1 = resolveAgentImportAuth(
-        result.agentName,
-        workerApiKey,
-        cfgModel,
-      );
+      let tier1: ReturnType<typeof resolveAgentImportAuth>;
+      try {
+        tier1 = resolveAgentImportAuth(
+          result.agentName,
+          workerApiKey,
+          cfgModel,
+        );
+      } catch (error) {
+        if (!reportInvalidEnvCredentialUpstream(error, result.agentDisplayName))
+          throw error;
+        continue;
+      }
       if (tier1 === null) {
         console.log(
           `[lore] Skipping ${result.agentDisplayName}: no usable credential found ` +
@@ -1399,9 +1423,16 @@ export async function commandImport(
         // empty-cache path (which still tries WORKER_DEFAULTS
         // providers correctly).
       }
-      const chain = workerApiKey
-        ? []
-        : buildAuthFallbackChain(result.agentName, cfgModel);
+      let chain: AuthCandidate[];
+      try {
+        chain = workerApiKey
+          ? []
+          : buildAuthFallbackChain(result.agentName, cfgModel);
+      } catch (error) {
+        if (!reportInvalidEnvCredentialUpstream(error, result.agentDisplayName))
+          throw error;
+        continue;
+      }
       const candidates: Candidate[] = workerApiKey
         ? [{ auth: tier1, label: "LORE_WORKER_API_KEY" }]
         : chain.map((c) => ({

--- a/packages/gateway/test/agents.test.ts
+++ b/packages/gateway/test/agents.test.ts
@@ -462,12 +462,25 @@ describe("captureUserUpstream", () => {
     });
   });
 
-  test("does not detach an env credential from an unsafe configured upstream", () => {
-    expect(
+  test("reports an unsafe configured upstream instead of silently discarding its credential", () => {
+    expect(() =>
       captureUserEnvCredential(claude, {
         ANTHROPIC_AUTH_TOKEN: "private-proxy-token",
         ANTHROPIC_BASE_URL: "https://proxy.example/v1?api_key=secret",
       }),
-    ).toBeNull();
+    ).toThrow(/unsafe or invalid upstream URL in ANTHROPIC_BASE_URL/);
+  });
+
+  test("keeps an env credential when no upstream override is configured", () => {
+    expect(
+      captureUserEnvCredential(claude, {
+        ANTHROPIC_AUTH_TOKEN: "provider-default-token",
+      }),
+    ).toEqual({
+      token: "provider-default-token",
+      scheme: "bearer",
+      upstreamUrl: null,
+      envVarName: "ANTHROPIC_AUTH_TOKEN",
+    });
   });
 });

--- a/packages/gateway/test/import-command-e2e.test.ts
+++ b/packages/gateway/test/import-command-e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -301,4 +301,47 @@ describe("commandImport (local mode) — multi-agent e2e decision matrix", () =>
     expect(out()).toContain("Ways forward");
     expect(shutdownMock).toHaveBeenCalled();
   });
+
+  test.each([
+    { name: "initial auth resolution", onDisk: false },
+    { name: "fallback-chain construction", onDisk: true },
+  ])(
+    "reports an invalid env upstream without throwing during $name",
+    async ({ onDisk }) => {
+      registerProvider(
+        fakeProvider({ name: "claude-code", displayName: "Claude Code" }),
+      );
+      if (onDisk) {
+        mkdirSync(join(fakeHome, ".claude"), { recursive: true });
+        writeFileSync(
+          join(fakeHome, ".claude", ".credentials.json"),
+          JSON.stringify({
+            claudeAiOauth: { accessToken: "disk-oauth", expiresAt: null },
+          }),
+          "utf8",
+        );
+      }
+      process.env.ANTHROPIC_AUTH_TOKEN = "private-proxy-token";
+      process.env.ANTHROPIC_BASE_URL =
+        "https://proxy.example/v1?api_key=secret";
+      const priorExitCode = process.exitCode;
+
+      try {
+        await expect(
+          commandImport([], { project, yes: true }),
+        ).resolves.toBeUndefined();
+
+        expect(out()).toContain("Can't import Claude Code");
+        expect(out()).toContain("ANTHROPIC_BASE_URL");
+        expect(out()).toContain("Fix or unset");
+        expect(out()).not.toContain("private-proxy-token");
+        expect(out()).not.toContain("api_key=secret");
+        expect(llmClientCalls).toHaveLength(0);
+        expect(shutdownMock).toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+      } finally {
+        process.exitCode = priorExitCode;
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary
Reports an invalid configured upstream URL without silently discarding a valid shell credential or crashing `lore import`. Follow-up to Seer reviews on #1632 and this PR:

- https://github.com/BYK/loreai/pull/1632#discussion_r3790500659
- https://github.com/BYK/loreai/pull/1640#discussion_r3795070046

## Changes
- throw a typed, credential-safe error for invalid paired upstream environment variables
- catch that error during initial auth resolution and fallback-chain construction
- emit actionable output, set a nonzero exit code, skip the affected agent, and preserve gateway shutdown
- preserve token-only credentials that intentionally use the provider default upstream
- add load-bearing helper and command-level regressions for both import paths

## Verification
- focused CLI/import suites: 123 tests passed
- full suite: 9,333 tests passed; 227 skipped
- repeated command regressions: 10/10 passed
- `pnpm run typecheck`
- `pnpm run format:check`
- targeted type-aware lint (baseline warnings only)
- independent focused review: MERGE