### PR TITLE
fix: stabilize semantic lint execution

### DIFF
--- a/.github/actions/lint/report.mjs
+++ b/.github/actions/lint/report.mjs
@@ -34,6 +34,7 @@ const phaseFailureCodes = new Set([
   "diff-command-failed",
   "invariant-source-read-failed",
   "invariant-source-import-failed",
+  "embedding-provider-readiness-failed",
   "invariant-vector-load-failed",
   "hunk-vectors-all-missing",
   "hunk-vector-embedding-failed",

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -15,7 +15,14 @@
 
 import { availableParallelism, freemem } from "node:os";
 import { performance } from "node:perf_hooks";
-import { db, getKV, setKV } from "./db";
+import {
+  databaseInTransaction,
+  db,
+  getKV,
+  setKV,
+  withSavepoint,
+  withTransaction,
+} from "./db";
 import { isVecAvailable } from "./db/vec";
 import {
   clearAllEmbeddings,
@@ -107,6 +114,7 @@ export interface EmbeddingOperationOptions {
 
 /** Stable phase names for orchestration callers (notably semantic lint). */
 export type EmbeddingAbortPhase =
+  | "provider-readiness"
   | "settle-document-embeds"
   | "knowledge-backfill";
 
@@ -1920,10 +1928,12 @@ class EmbeddingPool implements EmbeddingProvider {
       if (s.inflight < best.inflight) best = s;
     }
 
-    // Every worker is busy: add capacity if we're below the ceiling and a full
-    // per-worker memory budget is free right now (re-checked live, so a box that
-    // has since gone tight won't load another ~680 MB model).
+    // Every worker is busy: add capacity only after one slot has completed a
+    // real embed. Cold workers share the same HuggingFace cache; starting two
+    // before either is healthy lets one read/purge the other's partial download.
+    // Once bootstrap succeeds, retain the normal lazy, memory-gated growth.
     const canGrow =
+      healthySlots.length > 0 &&
       best.inflight > 0 &&
       this.slots.length < this.ceiling &&
       this.liveFreemem() >= PER_WORKER_MEM_BUDGET_BYTES;
@@ -2421,6 +2431,88 @@ export function embeddingStatus(): EmbeddingHealth {
     provider: "remote",
     detail: "remote embedding provider active (vector recall enabled)",
   };
+}
+
+async function waitForEmbeddingRetry(
+  delayMs: number,
+  guard: EmbeddingAbortGuard,
+): Promise<void> {
+  if (delayMs <= 0) {
+    throwIfEmbeddingAborted(guard);
+    return;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const wait = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, delayMs);
+  });
+  try {
+    await awaitEmbeddingOperation(wait, guard);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Await a proven local embedding worker, including bounded transient-init
+ * retries. Remote providers return immediately to avoid spending API quota.
+ *
+ * This is for orchestration that requires vectors (not normal recall, which may
+ * degrade to FTS). The readiness probe serializes cold model download/load,
+ * waits for the provider-owned 2s/8s retry deadlines, and stops on the caller's
+ * cancellation boundary or a terminal/exhausted provider failure.
+ */
+export async function ensureEmbeddingReady(
+  options: EmbeddingOperationOptions = {},
+): Promise<void> {
+  const guard = createEmbeddingAbortGuard("provider-readiness", options);
+  throwIfEmbeddingAborted(guard);
+
+  for (;;) {
+    throwIfEmbeddingAborted(guard);
+    const provider = getProvider();
+    if (!provider) {
+      throw new LocalProviderUnavailableError(
+        "no embedding provider is configured",
+      );
+    }
+    if (!(provider instanceof EmbeddingPool)) {
+      throwIfEmbeddingAborted(guard);
+      return;
+    }
+    if (
+      localProviderFailureCause === "terminal" ||
+      (localProviderFailureCause === "transient-init-exhausted" &&
+        !provider.hasHealthySlot())
+    ) {
+      throw new LocalProviderUnavailableError(
+        "local embedding provider is unavailable",
+      );
+    }
+    if (provider.hasHealthySlot()) {
+      throwIfEmbeddingAborted(guard);
+      return;
+    }
+
+    try {
+      await awaitEmbeddingOperation(
+        provider.embed(["warmup"], "document"),
+        guard,
+      );
+      throwIfEmbeddingAborted(guard);
+      return;
+    } catch (error) {
+      if (error instanceof EmbeddingAbortError) throw error;
+      if (!(error instanceof LocalProviderUnavailableError)) throw error;
+      throwIfEmbeddingAborted(guard);
+      if (localProviderFailureCause !== null || localInitRetryAt <= 0) {
+        throw error;
+      }
+      await waitForEmbeddingRetry(
+        Math.max(0, localInitRetryAt - Date.now()),
+        guard,
+      );
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -3062,54 +3154,65 @@ const EMBEDDING_CONFIG_KEY = "lore:embedding_config";
  * Returns true if embeddings were cleared (full re-embed needed).
  */
 export function checkConfigChange(): boolean {
-  // Read stored fingerprint from kv_meta
-  const stored = db()
-    .query("SELECT value FROM kv_meta WHERE key = ?")
-    .get(EMBEDDING_CONFIG_KEY) as { value: string } | null;
-
   const current = configFingerprint();
+  const readStored = (): { value: string } | null =>
+    db()
+      .query("SELECT value FROM kv_meta WHERE key = ?")
+      .get(EMBEDDING_CONFIG_KEY) as { value: string } | null;
+  const observed = readStored();
 
-  if (stored && stored.value === current) return false;
+  if (observed?.value === current) return false;
 
-  const mode = readStorageMode(db());
+  const reconcile = (): boolean => {
+    // Re-check after BEGIN IMMEDIATE serializes competing processes. Without
+    // this, a late reconciler can clear vectors another process just rebuilt.
+    const stored = readStored();
+    if (stored?.value === current) return false;
 
-  // A vec0-store DB whose extension didn't load (degraded) cannot manage its
-  // embeddings — it can neither count/clear the unreadable vec0 tables nor
-  // recreate them. Leave the stored fingerprint UNCHANGED so the change is
-  // re-detected and handled the next time the DB opens on a capable runtime.
-  if (mode === "vec0" && !isVecAvailable()) return false;
+    const mode = readStorageMode(db());
 
-  // Config changed (or first run) — clear all embeddings in all tables
-  if (stored) {
-    const total =
-      mode === "vec0" ? countVec0Embeddings() : countBlobEmbeddings();
-    if (total > 0) {
-      clearAllEmbeddings(db());
-      log.info(
-        `embedding config changed (${stored.value} → ${current}), cleared ${total} stale embeddings`,
-      );
+    // A vec0-store DB whose extension didn't load (degraded) cannot manage its
+    // embeddings — it can neither count/clear the unreadable vec0 tables nor
+    // recreate them. Leave the stored fingerprint UNCHANGED so the change is
+    // re-detected and handled the next time the DB opens on a capable runtime.
+    if (mode === "vec0" && !isVecAvailable()) return false;
+
+    // Config changed (or first run) — clear all embeddings in all tables
+    if (stored) {
+      const total =
+        mode === "vec0" ? countVec0Embeddings() : countBlobEmbeddings();
+      if (total > 0) {
+        clearAllEmbeddings(db());
+        log.info(
+          `embedding config changed (${stored.value} → ${current}), cleared ${total} stale embeddings`,
+        );
+      }
+      // A *dimension* change makes the fixed-width vec0 tables incompatible:
+      // recreate them at the new dimension (clearAllEmbeddings emptied the old
+      // rows; ensureVec0Store drops + recreates when the stored dim differs, and
+      // is a no-op for a same-dimension model/provider swap).
+      if (mode === "vec0") {
+        ensureVec0Store(db(), config().search.embeddings.dimensions);
+      }
+      // The clear wiped temporal vectors too, and temporal has no dedicated
+      // backfill loop above — re-arm the resumable re-chunk walk so it refills
+      // the corpus under the new model/dimension on this same startup.
+      resetTemporalRechunkProgress();
     }
-    // A *dimension* change makes the fixed-width vec0 tables incompatible:
-    // recreate them at the new dimension (clearAllEmbeddings emptied the old
-    // rows; ensureVec0Store drops + recreates when the stored dim differs, and
-    // is a no-op for a same-dimension model/provider swap).
-    if (mode === "vec0") {
-      ensureVec0Store(db(), config().search.embeddings.dimensions);
-    }
-    // The clear wiped temporal vectors too, and temporal has no dedicated
-    // backfill loop above — re-arm the resumable re-chunk walk so it refills
-    // the corpus under the new model/dimension on this same startup.
-    resetTemporalRechunkProgress();
-  }
 
-  // Store new fingerprint
-  db()
-    .query(
-      "INSERT INTO kv_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?",
-    )
-    .run(EMBEDDING_CONFIG_KEY, current, current);
+    // Store new fingerprint
+    db()
+      .query(
+        "INSERT INTO kv_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?",
+      )
+      .run(EMBEDDING_CONFIG_KEY, current, current);
 
-  return true;
+    return true;
+  };
+
+  return databaseInTransaction(db())
+    ? withSavepoint("embedding_config_reconcile", reconcile)
+    : withTransaction(reconcile);
 }
 
 /** Count blob-layout embeddings across all four tables (config-change logging). */

--- a/packages/core/src/invariant-check.ts
+++ b/packages/core/src/invariant-check.ts
@@ -1336,6 +1336,11 @@ export async function checkInvariants(
     );
   }
 
+  // Never compare vectors produced by different provider/model/dimension
+  // configurations. This clears stale rows before they can yield a false-clean
+  // cosine result; normal startup/import backfill repopulates the missing rows.
+  embedding.checkConfigChange();
+
   // Load invariant embeddings (same helper contradiction.ts uses).
   const invariantVecResult = loadInvariantVecs(allEntries);
   if (invariantVecResult.health.status === "failed") {
@@ -1945,10 +1950,21 @@ async function embedHunks(
   const texts = hunks.map((h) =>
     `${h.file}\n${h.text}`.slice(0, MAX_EMBED_CHARS_PER_HUNK),
   );
+  const deadlineAt =
+    options.deadlineMs === undefined
+      ? undefined
+      : Date.now() + options.deadlineMs;
   try {
+    await embedding.ensureEmbeddingReady(options);
     const vecs = await awaitHunkEmbedding(
       () => embedding.embedInTokenBatches(texts, "document"),
-      options,
+      {
+        ...options,
+        deadlineMs:
+          deadlineAt === undefined
+            ? undefined
+            : Math.max(0, deadlineAt - Date.now()),
+      },
     );
     const aligned = hunks.map((_, i) => vecs[i] ?? null);
     const available = aligned.filter((vec) => vec !== null).length;

--- a/packages/core/test/embedding-init-retry.test.ts
+++ b/packages/core/test/embedding-init-retry.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 import type { Worker } from "node:worker_threads";
 import {
   embed,
+  ensureEmbeddingReady,
+  EmbeddingAbortError,
   isAvailable,
   LocalProviderUnavailableError,
   _resetLocalProviderProbe,
@@ -85,6 +87,7 @@ describe("local embedding init retry (transient self-heal)", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     _setTestWorkerFactory(null);
     _setLocalInitCooldownMsForTest(null);
     _resetLocalProviderProbe();
@@ -142,6 +145,100 @@ describe("local embedding init retry (transient self-heal)", () => {
     const r2 = await p2;
     expect(r2.ok).toBe(true);
     expect(isAvailable()).toBe(true);
+  });
+
+  it("readiness waits through a transient failure and proves a fresh worker", async () => {
+    _setLocalInitCooldownMsForTest(0);
+    const fakes = installFakeWorkers();
+    const ready = ensureEmbeddingReady({ deadlineMs: 1_000 });
+
+    await flush();
+    expect(fakes).toHaveLength(1);
+    fakes[0].emit("message", { type: "init-error", error: TRANSIENT_ERR });
+    await flush();
+
+    expect(fakes).toHaveLength(2);
+    const recovered = fakes[1];
+    recovered.emit("message", {
+      type: "result",
+      id: recovered.lastPosted().id,
+      vectors: [new Float32Array([1, 2, 3])],
+    });
+    await expect(ready).resolves.toBeUndefined();
+    expect(isAvailable()).toBe(true);
+  });
+
+  it("readiness cancellation interrupts an active retry cooldown", async () => {
+    _setLocalInitCooldownMsForTest(60_000);
+    const fakes = installFakeWorkers();
+    const controller = new AbortController();
+    const ready = settle(
+      ensureEmbeddingReady({ signal: controller.signal, deadlineMs: 60_000 }),
+    );
+
+    await flush();
+    fakes[0].emit("message", { type: "init-error", error: TRANSIENT_ERR });
+    await flush();
+    controller.abort(new DOMException("stop readiness", "AbortError"));
+
+    const outcome = await ready;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.err).toBeInstanceOf(EmbeddingAbortError);
+      expect((outcome.err as EmbeddingAbortError).phase).toBe(
+        "provider-readiness",
+      );
+    }
+    expect(fakes).toHaveLength(1);
+  });
+
+  it("does not report ready when the probe completes at its deadline", async () => {
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const fakes = installFakeWorkers();
+    const ready = settle(ensureEmbeddingReady({ deadlineMs: 5 }));
+
+    await flush();
+    now = 5;
+    const worker = fakes[0];
+    worker.emit("message", {
+      type: "result",
+      id: worker.lastPosted().id,
+      vectors: [new Float32Array([1, 2, 3])],
+    });
+
+    const outcome = await ready;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.err).toBeInstanceOf(EmbeddingAbortError);
+      expect((outcome.err as EmbeddingAbortError).code).toBe(
+        "deadline-exceeded",
+      );
+    }
+  });
+
+  it("readiness stops after transient retry exhaustion", async () => {
+    _setLocalInitCooldownMsForTest(0);
+    const fakes = installFakeWorkers();
+    const ready = settle(ensureEmbeddingReady({ deadlineMs: 1_000 }));
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await flush();
+      expect(fakes).toHaveLength(attempt + 1);
+      fakes[attempt].emit("message", {
+        type: "init-error",
+        error: TRANSIENT_ERR,
+      });
+    }
+
+    const outcome = await ready;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.err).toBeInstanceOf(LocalProviderUnavailableError);
+    }
+    await flush();
+    expect(fakes).toHaveLength(3);
+    expect(isAvailable()).toBe(false);
   });
 
   it("latches permanently only after the retry budget is exhausted", async () => {

--- a/packages/core/test/embedding-pool.test.ts
+++ b/packages/core/test/embedding-pool.test.ts
@@ -3,7 +3,9 @@ import { EventEmitter } from "node:events";
 import type { Worker } from "node:worker_threads";
 import {
   embed,
+  ensureEmbeddingReady,
   isAvailable,
+  LocalProviderUnavailableError,
   recallEmbedsInFlight,
   resetProvider,
   _configuredEmbedPoolSize,
@@ -116,6 +118,14 @@ function settle<T>(
   );
 }
 
+async function warmPool(fakes: FakeWorker[]): Promise<void> {
+  const warm = embed(["bootstrap"], "document");
+  await flush();
+  expect(fakes).toHaveLength(1);
+  fakes[0].completeAll();
+  await warm;
+}
+
 describe("EmbeddingPool dispatch (#999)", () => {
   let savedProvider: unknown;
   let savedVoyage: string | undefined;
@@ -159,7 +169,7 @@ describe("EmbeddingPool dispatch (#999)", () => {
     else delete process.env.NODE_ENV;
   });
 
-  it("dispatches concurrent embeds to distinct workers in parallel", async () => {
+  it("serializes cold bootstrap before dispatching concurrent embeds in parallel", async () => {
     _setEmbedPoolSizeForTest(2);
     _setPoolFreememForTest(64 * GB); // ample → growth allowed
     const fakes = installFakeWorkers();
@@ -168,16 +178,26 @@ describe("EmbeddingPool dispatch (#999)", () => {
     const p2 = embed(["beta"], "query");
     await flush();
 
-    // Two workers spawned, each carrying exactly one request — not serialized
-    // through a single worker (the whole point of #999).
+    // Until a real result proves model readiness, all cold requests share one
+    // worker so sibling initializers cannot race the shared model cache.
+    expect(fakes).toHaveLength(1);
+    expect(fakes[0].embedIds).toHaveLength(2);
+
+    fakes[0].completeAll();
+    expect(await p1).toHaveLength(1);
+    expect(await p2).toHaveLength(1);
+
+    // After bootstrap, genuine concurrent demand grows the pool as before.
+    const p3 = embed(["gamma"], "query");
+    const p4 = embed(["delta"], "query");
+    await flush();
     expect(fakes).toHaveLength(2);
     expect(fakes[0].embedIds).toHaveLength(1);
     expect(fakes[1].embedIds).toHaveLength(1);
-
     fakes[0].completeAll();
     fakes[1].completeAll();
-    expect(await p1).toHaveLength(1);
-    expect(await p2).toHaveLength(1);
+    expect(await p3).toHaveLength(1);
+    expect(await p4).toHaveLength(1);
   });
 
   it("does not spawn a second worker for sequential (non-concurrent) embeds", async () => {
@@ -261,28 +281,28 @@ describe("EmbeddingPool dispatch (#999)", () => {
     _setEmbedPoolSizeForTest(2);
     _setPoolFreememForTest(64 * GB);
     const fakes = installFakeWorkers();
+    await warmPool(fakes);
 
-    const first = settle(embed(["first"], "document"));
-    const second = embed(["second"], "document");
+    const healthy = embed(["healthy"], "document");
+    const failed = settle(embed(["failed"], "document"));
     await flush();
     expect(fakes).toHaveLength(2);
 
-    fakes[0].initError(
+    fakes[1].initError(
       "Can't create a session. ERROR_CODE: 7, ERROR_MESSAGE: Failed to load model because protobuf parsing failed.",
     );
-    fakes[1].completeAll();
-    const failed = await first;
-    expect(failed.ok).toBe(false);
-    expect(await second).toHaveLength(1);
+    fakes[0].completeAll();
+    expect((await failed).ok).toBe(false);
+    expect(await healthy).toHaveLength(1);
     expect(isAvailable()).toBe(true);
 
-    const failedSlotPosts = fakes[0].embedIds.length;
+    const failedSlotPosts = fakes[1].embedIds.length;
     const next = embed(["backfill"], "document");
     await flush();
     expect(fakes).toHaveLength(2);
-    expect(fakes[0].embedIds).toHaveLength(failedSlotPosts);
-    expect(fakes[1].embedIds).toHaveLength(1);
-    fakes[1].completeAll();
+    expect(fakes[1].embedIds).toHaveLength(failedSlotPosts);
+    expect(fakes[0].embedIds).toHaveLength(1);
+    fakes[0].completeAll();
     expect(await next).toHaveLength(1);
   });
 
@@ -295,8 +315,8 @@ describe("EmbeddingPool dispatch (#999)", () => {
     const first = settle(embed(["first"], "document"));
     const second = settle(embed(["second"], "document"));
     await flush();
+    expect(fakes).toHaveLength(1);
     fakes[0].initError("transient one");
-    fakes[1].initError("transient two");
     expect((await first).ok).toBe(false);
     expect((await second).ok).toBe(false);
     await flush();
@@ -304,13 +324,13 @@ describe("EmbeddingPool dispatch (#999)", () => {
 
     const cooling = await settle(embed(["too soon"], "document"));
     expect(cooling.ok).toBe(false);
-    expect(fakes).toHaveLength(2);
+    expect(fakes).toHaveLength(1);
 
     _setLocalInitRetryAtForTest(Date.now() - 1);
     const retry = embed(["after cooldown"], "document");
     await flush();
-    expect(fakes).toHaveLength(3);
-    fakes[2].completeAll();
+    expect(fakes).toHaveLength(2);
+    fakes[1].completeAll();
     expect(await retry).toHaveLength(1);
   });
 
@@ -554,30 +574,31 @@ describe("EmbeddingPool dispatch (#999)", () => {
     expect(resetDone).toBe(true);
   });
 
-  it("clears transient exhaustion when an in-flight sibling succeeds", async () => {
+  it("keeps a proven sibling available after transient failures", async () => {
     _setEmbedPoolSizeForTest(4);
     _setPoolFreememForTest(64 * GB);
     _setLocalInitCooldownMsForTest(0);
     const fakes = installFakeWorkers();
+    await warmPool(fakes);
 
     const requests = Array.from({ length: 4 }, (_, index) =>
       settle(embed([`request-${index}`], "document")),
     );
     await flush();
     expect(fakes).toHaveLength(4);
-    fakes[0].initError("transient one");
-    fakes[1].initError("transient two");
-    fakes[2].initError("transient three");
-    expect(isAvailable()).toBe(false);
+    fakes[1].initError("transient one");
+    fakes[2].initError("transient two");
+    fakes[3].initError("transient three");
+    expect(isAvailable()).toBe(true);
 
-    fakes[3].completeAll();
+    fakes[0].completeAll();
     const outcomes = await Promise.all(requests);
     expect(outcomes.filter((outcome) => outcome.ok)).toHaveLength(1);
     expect(isAvailable()).toBe(true);
 
     const next = embed(["after sibling recovery"], "document");
     await flush();
-    fakes[3].completeAll();
+    fakes[0].completeAll();
     expect(await next).toHaveLength(1);
   });
 
@@ -585,15 +606,19 @@ describe("EmbeddingPool dispatch (#999)", () => {
     _setEmbedPoolSizeForTest(2);
     _setPoolFreememForTest(64 * GB);
     const fakes = installFakeWorkers();
+    await warmPool(fakes);
 
-    const failed = settle(embed(["terminal"], "document"));
     const sibling = embed(["sibling"], "document");
+    const failed = settle(embed(["terminal"], "document"));
     await flush();
-    fakes[0].initError("Cannot find package 'onnxruntime-node'");
-    fakes[1].completeAll();
+    fakes[1].initError("Cannot find package 'onnxruntime-node'");
+    fakes[0].completeAll();
     expect((await failed).ok).toBe(false);
     expect(await sibling).toHaveLength(1);
     expect(isAvailable()).toBe(false);
+    await expect(ensureEmbeddingReady()).rejects.toBeInstanceOf(
+      LocalProviderUnavailableError,
+    );
   });
 
   it("settles an embed when reset races cold worker initialization", async () => {
@@ -633,16 +658,17 @@ describe("EmbeddingPool dispatch (#999)", () => {
     _setEmbedPoolSizeForTest(2);
     _setPoolFreememForTest(64 * GB);
     const fakes = installFakeWorkers();
-    const failed = settle(embed(["failed"], "document"));
+    await warmPool(fakes);
     const healthy = embed(["healthy"], "document");
+    const failed = settle(embed(["failed"], "document"));
     await flush();
-    fakes[0].exitOnShutdown = false;
-    fakes[0].initError("transient failure");
-    fakes[1].completeAll();
+    fakes[1].exitOnShutdown = false;
+    fakes[1].initError("transient failure");
+    fakes[0].completeAll();
     expect((await failed).ok).toBe(false);
     await healthy;
     await flush();
-    expect(fakes[0].gotShutdown).toBe(true);
+    expect(fakes[1].gotShutdown).toBe(true);
 
     let resetDone = false;
     const reset = resetProvider().then(() => {
@@ -650,16 +676,17 @@ describe("EmbeddingPool dispatch (#999)", () => {
     });
     await flush();
     expect(resetDone).toBe(false);
-    fakes[0].exit();
+    fakes[1].exit();
     await reset;
     expect(resetDone).toBe(true);
-    expect(fakes[1].gotShutdown).toBe(true);
+    expect(fakes[0].gotShutdown).toBe(true);
   });
 
   it("LORE_EMBED_POOL_SIZE sets the ceiling (env-driven, no test override)", async () => {
     process.env.LORE_EMBED_POOL_SIZE = "2";
     _setPoolFreememForTest(64 * GB);
     const fakes = installFakeWorkers();
+    await warmPool(fakes);
 
     const p1 = embed(["alpha"], "query");
     const p2 = embed(["beta"], "query");
@@ -728,6 +755,7 @@ describe("EmbeddingPool dispatch (#999)", () => {
     process.env.NODE_ENV = "production";
     _setPoolFreememForTest(64 * GB); // ample → default ceiling of 2
     const fakes = installFakeWorkers();
+    await warmPool(fakes);
 
     const p1 = embed(["alpha"], "query");
     const p2 = embed(["beta"], "query");
@@ -757,6 +785,7 @@ describe("EmbeddingPool dispatch (#999)", () => {
     _setEmbedPoolSizeForTest(2);
     _setPoolFreememForTest(64 * GB);
     const fakes = installFakeWorkers();
+    await warmPool(fakes);
 
     const p1 = embed(["alpha"], "query");
     const p2 = embed(["beta"], "query");

--- a/packages/core/test/embedding.test.ts
+++ b/packages/core/test/embedding.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, test, expect, beforeEach, vi } from "vitest";
 import { existsSync } from "node:fs";
-import { db, ensureProject } from "../src/db";
+import { db, ensureProject, withTransaction } from "../src/db";
 import { LOCAL_MODEL_PATH_ENV } from "../src/embedding-vendor";
 import {
   cosineSimilarity,
@@ -947,6 +947,20 @@ describe("checkConfigChange", () => {
     checkConfigChange();
     const changed = checkConfigChange();
     expect(changed).toBe(false);
+  });
+
+  test("reconciles a changed fingerprint inside an existing transaction", () => {
+    db()
+      .query("INSERT INTO kv_meta (key, value) VALUES (?, ?)")
+      .run("lore:embedding_config", "old-model:512");
+
+    const changed = withTransaction(() => checkConfigChange());
+
+    expect(changed).toBe(true);
+    const row = db()
+      .query("SELECT value FROM kv_meta WHERE key = 'lore:embedding_config'")
+      .get() as { value: string } | null;
+    expect(row?.value).toContain("local");
   });
 
   test("clears embeddings when fingerprint changes", () => {

--- a/packages/core/test/invariant-check.test.ts
+++ b/packages/core/test/invariant-check.test.ts
@@ -1538,6 +1538,12 @@ describe("checkInvariants typed judge outcomes", () => {
     vi.spyOn(embedding, "embedInTokenBatches").mockRejectedValue(
       new Error("embed worker unavailable"),
     );
+    const ensureEmbeddingReady = vi
+      .spyOn(embedding, "ensureEmbeddingReady")
+      .mockResolvedValue();
+    const checkConfigChange = vi
+      .spyOn(embedding, "checkConfigChange")
+      .mockReturnValue(false);
     const { judge, judgeCall } = stubJudge(() => ({
       kind: "verdict",
       verdict: "satisfies",
@@ -1554,6 +1560,8 @@ describe("checkInvariants typed judge outcomes", () => {
     });
 
     expect(judgeCall).not.toHaveBeenCalled();
+    expect(ensureEmbeddingReady).toHaveBeenCalledOnce();
+    expect(checkConfigChange).toHaveBeenCalledOnce();
     expect(result.status).toBe("failed");
     expect(result.health.hunkVectors).toMatchObject({
       status: "failed",

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -169,19 +169,85 @@ export async function runSemanticLint(
       return report;
     }
 
+    const invariantSource: LintPhaseHealth = { status: "healthy" };
+    if (diff.hunks.length === 0) {
+      // No changed code can violate an invariant. Preserve core's zero-work
+      // contract without starting the gateway, importing .lore.md, or requiring
+      // an embedding provider merely because the action requested import.
+      phase = "invariantVectors";
+      const result = await invariantCheck.checkInvariants({
+        projectPath,
+        diff,
+        range,
+        model,
+        effort,
+        sessionID: `invariant-check-${Date.now()}`,
+        signal: deadlineController.signal,
+        deadlineMs: Math.max(0, deadlineAt - Date.now()),
+      });
+      throwIfDeadlineExceeded();
+      const gate = invariantCheck.gateDecision(
+        result.findings,
+        [],
+        options.gate ? "gate" : "advisory",
+      );
+      report = buildSemanticLintReport({
+        result,
+        gate,
+        model: `${model.providerID}/${model.modelID}`,
+        effort,
+        elapsedMs: Date.now() - startedAt,
+        invariantSource,
+      });
+      throwIfDeadlineExceeded();
+      await options.publishReport?.(report);
+      return report;
+    }
+
     phase = "invariantSource";
     throwIfDeadlineExceeded();
+    if (options.importLoreMd && !existsSync(join(projectPath, ".lore.md"))) {
+      report = failedReport({
+        options,
+        startedAt,
+        model,
+        effort,
+        range,
+        phase,
+        code: "invariant-source-import-failed",
+        error: "Requested invariant source .lore.md does not exist",
+      });
+      await options.publishReport?.(report);
+      return report;
+    }
     const startOpts: StartOptions = { quiet: true, local: true };
     const gateway = await startGateway(startOpts);
     owned = gateway.owned;
     shutdown = gateway.shutdown;
     throwIfDeadlineExceeded();
-    const invariantSource: LintPhaseHealth = { status: "healthy" };
     if (options.importLoreMd) {
       try {
-        if (!existsSync(join(projectPath, ".lore.md"))) {
-          throw new Error("Requested invariant source .lore.md does not exist");
-        }
+        await embedding.ensureEmbeddingReady({
+          signal: deadlineController.signal,
+          deadlineMs: Math.max(1, deadlineAt - Date.now()),
+        });
+        throwIfDeadlineExceeded();
+      } catch (error) {
+        throwIfDeadlineExceeded();
+        report = failedReport({
+          options,
+          startedAt,
+          model,
+          effort,
+          range,
+          phase,
+          code: "embedding-provider-readiness-failed",
+          error,
+        });
+        await options.publishReport?.(report);
+        return report;
+      }
+      try {
         importLoreFile(projectPath);
         const remainingMs = Math.max(1, deadlineAt - Date.now());
         await embedding.settleDocumentEmbeds({
@@ -260,13 +326,22 @@ export async function runSemanticLint(
       deadlineMs: Math.max(0, deadlineAt - Date.now()),
       onJudge: options.onJudge,
     });
-    // Do not accept even a complete zero-work core result after the overall
-    // orchestration deadline has elapsed.
-    throwIfDeadlineExceeded();
-    const overrides = invariantCheck.parseOverrides(
-      invariantCheck.collectCommitMessages(projectPath, range.base, range.head),
-    );
-    throwIfDeadlineExceeded();
+    // Preserve a typed core failure returned at the cancellation boundary.
+    // Successful/partial work still must not cross the overall deadline.
+    const preserveFailedAtDeadline =
+      result.status === "failed" &&
+      (deadlineController.signal.aborted || Date.now() >= deadlineAt);
+    if (!preserveFailedAtDeadline) throwIfDeadlineExceeded();
+    const overrides = preserveFailedAtDeadline
+      ? []
+      : invariantCheck.parseOverrides(
+          invariantCheck.collectCommitMessages(
+            projectPath,
+            range.base,
+            range.head,
+          ),
+        );
+    if (!preserveFailedAtDeadline) throwIfDeadlineExceeded();
     const gate = invariantCheck.gateDecision(
       result.findings,
       overrides,

--- a/packages/gateway/src/cli/lint-report.ts
+++ b/packages/gateway/src/cli/lint-report.ts
@@ -164,6 +164,7 @@ const PHASE_FAILURE_CODES = new Set([
   "diff-too-large",
   "invariant-source-read-failed",
   "invariant-source-import-failed",
+  "embedding-provider-readiness-failed",
   "invariant-vector-load-failed",
   "hunk-vectors-all-missing",
   "hunk-vector-embedding-failed",

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -2222,10 +2222,14 @@ function buildOpenAIResponsesWorkerRequest(
   temperature?: number,
   reasoningEffort?: ReasoningEffort,
 ): { url: string; headers: Record<string, string>; body: string } {
-  // Copilot's Responses endpoint defaults an omitted effort to medium. `off`
-  // therefore has to be explicit; omission does not disable reasoning.
+  // Copilot's Responses endpoint rejects `effort:"none"` with an opaque 400
+  // under Actions GITHUB_TOKEN auth. Omit it there (the endpoint defaults to
+  // medium); other Responses providers retain explicit `none` plus the runtime
+  // strip-and-retry fallback for providers that return a diagnosable error.
   const effort =
-    reasoningEffort === "off" ? "none" : openAIReasoningEffort(reasoningEffort);
+    reasoningEffort === "off" && model.providerID !== "github-copilot"
+      ? "none"
+      : openAIReasoningEffort(reasoningEffort);
 
   return {
     // Host-aware URL construction: github-copilot omits /v1 (issue #1052),

--- a/packages/gateway/test/invariant-check-orchestration.test.ts
+++ b/packages/gateway/test/invariant-check-orchestration.test.ts
@@ -3,12 +3,335 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 afterEach(() => {
   vi.restoreAllMocks();
   vi.doUnmock("@loreai/core");
+  vi.doUnmock("node:fs");
   vi.doUnmock("../src/llm-adapter");
   vi.doUnmock("../src/cli/start");
   vi.resetModules();
 });
 
 describe("runSemanticLint cancellation", () => {
+  it("proves embedding readiness before importing invariant fan-out", async () => {
+    const events: string[] = [];
+    const range = { base: "base", head: "head", source: "test" };
+    let releaseReadiness: (() => void) | undefined;
+    const readiness = new Promise<void>((resolve) => {
+      releaseReadiness = resolve;
+    });
+    const ensureEmbeddingReady = vi.fn(async () => {
+      events.push("readiness-start");
+      await readiness;
+      events.push("readiness-complete");
+    });
+    const importLoreFile = vi.fn(() => events.push("import"));
+    const settleDocumentEmbeds = vi.fn(async () => events.push("settle"));
+    const backfillEmbeddings = vi.fn(async () => {
+      events.push("backfill");
+      return 1;
+    });
+    const checkInvariants = vi.fn(async () => {
+      events.push("check");
+      return {
+        range,
+        status: "complete",
+        health: {
+          diff: { status: "healthy", hunks: 1 },
+          invariantVectors: {
+            status: "healthy",
+            expected: 1,
+            available: 1,
+            missing: 0,
+          },
+          hunkVectors: {
+            status: "healthy",
+            expected: 1,
+            available: 1,
+            missing: 0,
+          },
+          judge: {
+            status: "healthy",
+            selected: 0,
+            resolved: 0,
+            unresolved: 0,
+            notAttempted: 0,
+          },
+        },
+        hunks: 1,
+        invariants: 1,
+        candidates: 0,
+        attempted: 0,
+        resolved: 0,
+        unresolved: 0,
+        notAttempted: 0,
+        semanticCalls: 0,
+        transportAttempts: 0,
+        candidateOutcomes: [],
+        findings: [],
+      };
+    });
+    vi.doMock("node:fs", () => ({ existsSync: () => true }));
+    vi.doMock("@loreai/core", () => ({
+      config: () => ({
+        model: undefined,
+        invariantCheck: { effort: "off" },
+      }),
+      embedding: {
+        ensureEmbeddingReady,
+        settleDocumentEmbeds,
+        backfillEmbeddings,
+      },
+      importLoreFile,
+      invariantCheck: {
+        resolveRange: () => range,
+        parseDiffResult: () => ({ kind: "success", hunks: [{}] }),
+        checkInvariants,
+        collectCommitMessages: () => [],
+        parseOverrides: () => [],
+        gateDecision: () => ({
+          mode: "advisory",
+          exitCode: 0,
+          blocking: [],
+          overridden: [],
+          advisory: [],
+        }),
+      },
+      parseReasoningEffort: vi.fn(),
+    }));
+    vi.doMock("../src/llm-adapter", () => ({
+      createGatewayLLMClient: () => ({}),
+      createGatewayInvariantJudge: () => ({}),
+    }));
+    vi.doMock("../src/cli/start", () => ({
+      startGateway: async () => {
+        events.push("gateway");
+        return {
+          owned: true,
+          config: {
+            workerApiKey: undefined,
+            upstreamAnthropic: "http://anthropic.test",
+            upstreamOpenAI: "http://openai.test",
+          },
+          shutdown: async () => events.push("cleanup"),
+        };
+      },
+    }));
+
+    const { runSemanticLint } = await import("../src/cli/invariant-check");
+    const pending = runSemanticLint({
+      project: ".",
+      gate: false,
+      importLoreMd: true,
+      deadlineMs: 1_000,
+      candidateTimeoutMs: 100,
+    });
+    await vi.waitFor(() => expect(ensureEmbeddingReady).toHaveBeenCalledOnce());
+    expect(events).toEqual(["gateway", "readiness-start"]);
+    expect(importLoreFile).not.toHaveBeenCalled();
+
+    releaseReadiness?.();
+    await expect(pending).resolves.toMatchObject({ status: "complete" });
+    expect(events).toEqual([
+      "gateway",
+      "readiness-start",
+      "readiness-complete",
+      "import",
+      "settle",
+      "backfill",
+      "check",
+      "cleanup",
+    ]);
+  });
+
+  it("completes zero-hunk work without gateway, import, or embeddings", async () => {
+    const range = { base: "base", head: "head", source: "test" };
+    const ensureEmbeddingReady = vi.fn(async () => {
+      throw new Error("provider unavailable");
+    });
+    const importLoreFile = vi.fn();
+    const startGateway = vi.fn();
+    const checkInvariants = vi.fn(async () => ({
+      range,
+      status: "complete",
+      health: {
+        diff: { status: "healthy", hunks: 0 },
+        invariantVectors: {
+          status: "healthy",
+          expected: 0,
+          available: 0,
+          missing: 0,
+        },
+        hunkVectors: {
+          status: "healthy",
+          expected: 0,
+          available: 0,
+          missing: 0,
+        },
+        judge: {
+          status: "healthy",
+          selected: 0,
+          resolved: 0,
+          unresolved: 0,
+          notAttempted: 0,
+        },
+      },
+      hunks: 0,
+      invariants: 0,
+      candidates: 0,
+      attempted: 0,
+      resolved: 0,
+      unresolved: 0,
+      notAttempted: 0,
+      semanticCalls: 0,
+      transportAttempts: 0,
+      candidateOutcomes: [],
+      findings: [],
+    }));
+    vi.doMock("node:fs", () => ({ existsSync: () => false }));
+    vi.doMock("@loreai/core", () => ({
+      config: () => ({
+        model: undefined,
+        invariantCheck: { effort: "off" },
+      }),
+      embedding: { ensureEmbeddingReady },
+      importLoreFile,
+      invariantCheck: {
+        resolveRange: () => range,
+        parseDiffResult: () => ({ kind: "success", hunks: [] }),
+        checkInvariants,
+        gateDecision: () => ({
+          mode: "advisory",
+          exitCode: 0,
+          blocking: [],
+          overridden: [],
+          advisory: [],
+        }),
+      },
+      parseReasoningEffort: vi.fn(),
+    }));
+    vi.doMock("../src/llm-adapter", () => ({
+      createGatewayLLMClient: vi.fn(),
+      createGatewayInvariantJudge: vi.fn(),
+    }));
+    vi.doMock("../src/cli/start", () => ({ startGateway }));
+
+    const { runSemanticLint } = await import("../src/cli/invariant-check");
+    const report = await runSemanticLint({
+      project: ".",
+      gate: false,
+      importLoreMd: true,
+      deadlineMs: 1_000,
+      candidateTimeoutMs: 100,
+    });
+
+    expect(report.status).toBe("complete");
+    expect(checkInvariants).toHaveBeenCalledOnce();
+    expect(startGateway).not.toHaveBeenCalled();
+    expect(importLoreFile).not.toHaveBeenCalled();
+    expect(ensureEmbeddingReady).not.toHaveBeenCalled();
+  });
+
+  it("reports readiness failure before import and cleanup", async () => {
+    const events: string[] = [];
+    const range = { base: "base", head: "head", source: "test" };
+    const importLoreFile = vi.fn();
+    const ensureEmbeddingReady = vi.fn(async () => {
+      throw new Error("provider did not recover");
+    });
+    vi.doMock("@loreai/core", () => ({
+      config: () => ({
+        model: undefined,
+        invariantCheck: { effort: "off" },
+      }),
+      embedding: { ensureEmbeddingReady },
+      importLoreFile,
+      invariantCheck: {
+        resolveRange: () => range,
+        parseDiffResult: () => ({ kind: "success", hunks: [{}] }),
+      },
+      parseReasoningEffort: vi.fn(),
+    }));
+    vi.doMock("../src/llm-adapter", () => ({
+      createGatewayLLMClient: () => ({}),
+      createGatewayInvariantJudge: () => ({}),
+    }));
+    vi.doMock("../src/cli/start", () => ({
+      startGateway: async () => ({
+        owned: true,
+        config: {
+          workerApiKey: undefined,
+          upstreamAnthropic: "http://anthropic.test",
+          upstreamOpenAI: "http://openai.test",
+        },
+        shutdown: async () => events.push("cleanup"),
+      }),
+    }));
+
+    const { runSemanticLint } = await import("../src/cli/invariant-check");
+    const report = await runSemanticLint({
+      project: ".",
+      gate: false,
+      importLoreMd: true,
+      deadlineMs: 1_000,
+      candidateTimeoutMs: 100,
+      publishReport: () => {
+        events.push("publish");
+      },
+    });
+
+    expect(report.health.invariantSource).toMatchObject({
+      status: "failed",
+      failure: {
+        code: "embedding-provider-readiness-failed",
+        message: "provider did not recover",
+      },
+    });
+    expect(importLoreFile).not.toHaveBeenCalled();
+    expect(events).toEqual(["publish", "cleanup"]);
+  });
+
+  it("reports a missing invariant source before gateway or embedding startup", async () => {
+    const range = { base: "base", head: "head", source: "test" };
+    const ensureEmbeddingReady = vi.fn();
+    const startGateway = vi.fn();
+    vi.doMock("node:fs", () => ({ existsSync: () => false }));
+    vi.doMock("@loreai/core", () => ({
+      config: () => ({
+        model: undefined,
+        invariantCheck: { effort: "off" },
+      }),
+      embedding: { ensureEmbeddingReady },
+      importLoreFile: vi.fn(),
+      invariantCheck: {
+        resolveRange: () => range,
+        parseDiffResult: () => ({ kind: "success", hunks: [{}] }),
+      },
+      parseReasoningEffort: vi.fn(),
+    }));
+    vi.doMock("../src/llm-adapter", () => ({
+      createGatewayLLMClient: () => ({}),
+      createGatewayInvariantJudge: () => ({}),
+    }));
+    vi.doMock("../src/cli/start", () => ({ startGateway }));
+
+    const { runSemanticLint } = await import("../src/cli/invariant-check");
+    const report = await runSemanticLint({
+      project: ".",
+      gate: false,
+      importLoreMd: true,
+      deadlineMs: 1_000,
+      candidateTimeoutMs: 100,
+    });
+
+    expect(report.health.invariantSource).toMatchObject({
+      status: "failed",
+      failure: {
+        code: "invariant-source-import-failed",
+        message: "Requested invariant source .lore.md does not exist",
+      },
+    });
+    expect(startGateway).not.toHaveBeenCalled();
+    expect(ensureEmbeddingReady).not.toHaveBeenCalled();
+  });
+
   it("preserves typed diff limit failures in the published report", async () => {
     const range = { base: "base", head: "head", source: "test" };
     const startGateway = vi.fn();
@@ -17,7 +340,7 @@ describe("runSemanticLint cancellation", () => {
         model: undefined,
         invariantCheck: { effort: "off" },
       }),
-      embedding: {},
+      embedding: { ensureEmbeddingReady: vi.fn(async () => {}) },
       importLoreFile: vi.fn(),
       invariantCheck: {
         resolveRange: () => range,
@@ -64,7 +387,7 @@ describe("runSemanticLint cancellation", () => {
         model: undefined,
         invariantCheck: { effort: "off" },
       }),
-      embedding: {},
+      embedding: { ensureEmbeddingReady: vi.fn(async () => {}) },
       importLoreFile: vi.fn(),
       invariantCheck: {
         resolveRange: () => {
@@ -105,6 +428,8 @@ describe("runSemanticLint cancellation", () => {
   it("threads its deadline into core and publishes a failed report before cleanup", async () => {
     const events: string[] = [];
     const range = { base: "base", head: "head", source: "test" };
+    const ensureEmbeddingReady = vi.fn(async () => {});
+    const collectCommitMessages = vi.fn(() => []);
     const checkInvariants = vi.fn(async (input: Record<string, unknown>) => {
       const signal = input.signal as AbortSignal;
       expect(signal).toBeInstanceOf(AbortSignal);
@@ -162,13 +487,13 @@ describe("runSemanticLint cancellation", () => {
         model: undefined,
         invariantCheck: { effort: "off" },
       }),
-      embedding: {},
+      embedding: { ensureEmbeddingReady },
       importLoreFile: vi.fn(),
       invariantCheck: {
         resolveRange: () => range,
         parseDiffResult: () => ({ kind: "success", hunks: [{}] }),
         checkInvariants,
-        collectCommitMessages: () => [],
+        collectCommitMessages,
         parseOverrides: () => [],
         gateDecision: () => ({
           mode: "advisory",
@@ -213,13 +538,15 @@ describe("runSemanticLint cancellation", () => {
 
     expect(checkInvariants).toHaveBeenCalledOnce();
     expect(report.status).toBe("failed");
+    expect(report.health.hunkVectors.failure?.code).toBe(
+      "hunk-vector-embedding-failed",
+    );
+    expect(ensureEmbeddingReady).not.toHaveBeenCalled();
+    expect(collectCommitMessages).not.toHaveBeenCalled();
     expect(events).toEqual(["publish", "cleanup"]);
   });
 
-  it.each([
-    { name: "zero hunks", hunks: [] },
-    { name: "zero enforceable invariants", hunks: [{}] },
-  ])(
+  it.each([{ name: "zero enforceable invariants", hunks: [{}] }])(
     "publishes deadline failure before cleanup when expiry precedes core with $name",
     async ({ hunks }) => {
       const events: string[] = [];
@@ -266,7 +593,7 @@ describe("runSemanticLint cancellation", () => {
           model: undefined,
           invariantCheck: { effort: "off" },
         }),
-        embedding: {},
+        embedding: { ensureEmbeddingReady: vi.fn(async () => {}) },
         importLoreFile: vi.fn(),
         invariantCheck: {
           resolveRange: () => range,

--- a/packages/gateway/test/lint-action-report.test.ts
+++ b/packages/gateway/test/lint-action-report.test.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, test } from "vitest";
 import {
+  failedSemanticLintReport,
   MAX_LINT_REPORT_CANDIDATES,
   MAX_LINT_REPORT_RESOLVED_REASON_LENGTH,
   validateSemanticLintReport,
@@ -178,6 +179,24 @@ function actionAccepts(value: unknown, cliExit = 0): boolean {
 }
 
 describe("semantic lint action reporter", () => {
+  test("accepts embedding readiness failures produced by the CLI validator", () => {
+    const value = failedSemanticLintReport({
+      model: "test/model",
+      effort: "off",
+      elapsedMs: 1,
+      range: { base: "a", head: "b", source: "test" },
+      failedPhase: "invariantSource",
+      failure: {
+        code: "embedding-provider-readiness-failed",
+        message: "local provider exhausted retries",
+      },
+      gateMode: "advisory",
+    });
+
+    expect(validateSemanticLintReport(value)).toBe(value);
+    expect(actionAccepts(value, 3)).toBe(true);
+  });
+
   test("accepts the same boundary report as the CLI validator", () => {
     const value = resolvedReport(
       MAX_LINT_REPORT_CANDIDATES,

--- a/packages/gateway/test/worker-copilot-responses.test.ts
+++ b/packages/gateway/test/worker-copilot-responses.test.ts
@@ -191,7 +191,7 @@ describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
     expect(bodyWithEffort.reasoning_effort).toBeUndefined();
   });
 
-  test("effort off explicitly disables Copilot Responses reasoning", async () => {
+  test("effort off omits unsupported Copilot Responses reasoning none", async () => {
     const client = createGatewayLLMClient(
       UPSTREAMS,
       () => ({ scheme: "bearer", value: "tok" }),
@@ -203,6 +203,28 @@ describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
       model: { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
       reasoningEffort: "off",
       upstreamProviderID: "github-copilot",
+    });
+
+    const body = JSON.parse(
+      String((mockFetch.mock.calls[0]?.[1] as { body?: string })?.body ?? "{}"),
+    ) as Record<string, unknown>;
+    expect(body.reasoning).toBeUndefined();
+  });
+
+  test("effort off remains explicit for other Responses providers", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      (_sid, providerID) =>
+        providerID === "openai" ? { scheme: "bearer", value: "tok" } : null,
+      { providerID: "openai", modelID: "gpt-5.6-luna" },
+    );
+    await client.prompt("sys", "user", {
+      sessionID: "sess-openai-off",
+      workerID: "lore-invariant-check",
+      model: { providerID: "openai", modelID: "gpt-5.6-luna" },
+      protocol: "openai-responses",
+      upstreamProviderID: "openai",
+      reasoningEffort: "off",
     });
 
     const body = JSON.parse(


### PR DESCRIPTION
## Summary
Prevents cold local embedding initialization and unsupported Copilot reasoning controls from making semantic lint inconclusive.

## Changes
- Serializes cold embedding-pool startup until one worker proves the shared model cache is usable, while preserving parallel growth afterward.
- Adds cancellable readiness retries that honor provider cooldown, terminal state, exhaustion, and the semantic-lint deadline.
- Probes readiness before invariant import fan-out and hunk embedding, while preserving a true zero-hunk fast path that requires no gateway or provider.
- Reconciles embedding configuration atomically across processes and safely nests reconciliation inside existing transactions.
- Omits unsupported `reasoning.effort: "none"` for GitHub Copilot Responses requests while preserving explicit `none` for other providers.
- Keeps the CLI and GitHub Action report validators in sync for typed readiness failures.
- Adds deterministic regressions for cold-start protobuf failures, retry exhaustion, cancellation, orchestration order, report contracts, zero-work runs, nested transactions, deadlines, and provider-specific reasoning controls.

## Validation
- Full core suite: 3,539 passed, 6 skipped.
- Latest focused config, embedding, invariant, action, gateway, and Copilot suites: 285 passed, 6 skipped.
- Workspace typecheck, lint, formatting, affected package builds, and platform binary smoke tests pass.
- Fresh independent adversarial review initially found three blockers; all were fixed and its second pass reports no actionable findings.