### PR TITLE
fix: omit Copilot Responses temperature

### DIFF
--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -2209,8 +2209,9 @@ function buildCodexWorkerRequest(
  *
  * Unlike Codex, this path allows `max_output_tokens` (Copilot's `/responses`
  * honors it just like the Responses API spec) and threads `reasoningEffort`
- * through to nested `reasoning.{effort}`. Same `openAIReasoningEffort` returns
- * null on `off`/undefined so we omit both forms when the caller did not set it.
+ * through to nested `reasoning.{effort}`. Copilot's Responses models reject
+ * `temperature` under their default/explicit reasoning modes, so sampling is
+ * omitted there while other Responses providers retain it.
  */
 function buildOpenAIResponsesWorkerRequest(
   target: ProviderTarget,
@@ -2248,7 +2249,8 @@ function buildOpenAIResponsesWorkerRequest(
       store: false,
       stream: false,
       max_output_tokens: maxTokens,
-      ...(temperature != null && { temperature }),
+      ...(temperature != null &&
+        model.providerID !== "github-copilot" && { temperature }),
       ...(effort != null && { reasoning: { effort } }),
       instructions: system,
       input: [

--- a/packages/gateway/test/worker-copilot-responses.test.ts
+++ b/packages/gateway/test/worker-copilot-responses.test.ts
@@ -202,6 +202,7 @@ describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
       workerID: "lore-invariant-check",
       model: { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
       reasoningEffort: "off",
+      temperature: 0,
       upstreamProviderID: "github-copilot",
     });
 
@@ -209,6 +210,7 @@ describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
       String((mockFetch.mock.calls[0]?.[1] as { body?: string })?.body ?? "{}"),
     ) as Record<string, unknown>;
     expect(body.reasoning).toBeUndefined();
+    expect(body.temperature).toBeUndefined();
   });
 
   test("effort off remains explicit for other Responses providers", async () => {
@@ -225,12 +227,14 @@ describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
       protocol: "openai-responses",
       upstreamProviderID: "openai",
       reasoningEffort: "off",
+      temperature: 0,
     });
 
     const body = JSON.parse(
       String((mockFetch.mock.calls[0]?.[1] as { body?: string })?.body ?? "{}"),
     ) as Record<string, unknown>;
     expect(body.reasoning).toEqual({ effort: "none" });
+    expect(body.temperature).toBe(0);
   });
 
   test("detailed outcome distinguishes missing auth from invalid model output", async () => {


### PR DESCRIPTION
## Summary
Prevents GitHub Copilot Responses workers from failing with HTTP 400 when callers request deterministic sampling.

## Changes
- Omits `temperature` only for GitHub Copilot Responses worker requests, whose reasoning models reject the parameter.
- Preserves temperature forwarding for Copilot chat-completions fallbacks and other Responses providers.
- Adds regression coverage for the semantic-lint caller shape (`reasoningEffort: off` with `temperature: 0`).

## Validation
- Live patched-adapter probe against `github-copilot/gpt-5.6-luna` succeeds with the previously failing caller options.
- 268 related adapter and Copilot tests pass.
- Workspace lint, formatting, typecheck, and gateway bundle pass.
- Independent review found no actionable issues.