### PR TITLE
fix(ci): use Anthropic wire model ID

### DIFF
--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -78,9 +78,9 @@ jobs:
           # Model precedence:
           #   - LORE_WORKER_API_KEY + LORE_INVARIANT_MODEL → explicit model.
           #   - LORE_WORKER_API_KEY only → CLI/config default model.
-          #   - ANTHROPIC_API_KEY set    → anthropic/claude-haiku-4.5.
+          #   - ANTHROPIC_API_KEY set    → anthropic/claude-haiku-4-5.
           #   - no supported secret      → CLI default with no auth (reported).
-          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4.5' || '') }}
+          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4-5' || '') }}
           worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || secrets.ANTHROPIC_API_KEY }}
           # Reserve five minutes of the 25-minute job for report publication and
           # bounded gateway shutdown.

--- a/packages/gateway/test/lint-action-report.test.ts
+++ b/packages/gateway/test/lint-action-report.test.ts
@@ -568,7 +568,7 @@ describe("semantic lint action reporter", () => {
     expect(workflow).toContain("continue-on-error: true");
     expect(workflow).toContain("pull_request_target:");
     expect(workflow).toContain(
-      "model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4.5' || '') }}",
+      "model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4-5' || '') }}",
     );
     expect(workflow).toContain(
       "worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || secrets.ANTHROPIC_API_KEY }}",

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -23,7 +23,7 @@ It is **not** a replacement for tests, type checking, or a linter. It has no gro
 
 ## Quick start (GitHub Actions)
 
-The repository ships a reusable composite action and a reference workflow. Add an `ANTHROPIC_API_KEY` Actions secret for the default `anthropic/claude-haiku-4.5` judge, or configure the custom credential and model pair described below.
+The repository ships a reusable composite action and a reference workflow. Add an `ANTHROPIC_API_KEY` Actions secret for the default `anthropic/claude-haiku-4-5` judge, or configure the custom credential and model pair described below.
 
 Add `.github/workflows/semantic-linter.yml`:
 
@@ -77,7 +77,7 @@ jobs:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
           lore-command: "node packages/gateway/dist/bin.cjs"
-          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4.5' || '') }}
+          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4-5' || '') }}
           worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || secrets.ANTHROPIC_API_KEY }}
 ```
 
@@ -93,7 +93,7 @@ The credential and model are selected as a pair to prevent sending one provider'
 
 **Credential** (the `worker-api-key` input):
 
-- **Default.** Set `ANTHROPIC_API_KEY`; the reference workflow pairs it with `anthropic/claude-haiku-4.5`.
+- **Default.** Set `ANTHROPIC_API_KEY`; the reference workflow pairs it with `anthropic/claude-haiku-4-5`.
 - **Custom provider.** Set `LORE_WORKER_API_KEY` and `LORE_INVARIANT_MODEL` together. The dedicated key takes precedence over `ANTHROPIC_API_KEY`.
 - **No supported secret.** The action passes no credential and reports an explicit `no-auth` health failure. A raw Actions `GITHUB_TOKEN` is not forwarded to provider APIs.
 
@@ -103,7 +103,7 @@ The credential and model are selected as a pair to prevent sending one provider'
 | --- | --- |
 | `LORE_WORKER_API_KEY` and `LORE_INVARIANT_MODEL` are set | the variable value, authenticated by the dedicated key |
 | `LORE_WORKER_API_KEY` only | your repo's configured default worker model |
-| `ANTHROPIC_API_KEY` only (or a stale model variable without a dedicated key) | `anthropic/claude-haiku-4.5` |
+| `ANTHROPIC_API_KEY` only (or a stale model variable without a dedicated key) | `anthropic/claude-haiku-4-5` |
 | Neither supported secret | no authenticated judge; the report is inconclusive with `no-auth` |
 
 :::note


### PR DESCRIPTION
## Summary
Uses Anthropic's valid Messages API model alias for the semantic-lint judge.

## Changes
- Replaces the models.dev-style `anthropic/claude-haiku-4.5` identifier with Anthropic's wire alias `anthropic/claude-haiku-4-5`.
- Keeps the reference workflow, contract assertion, and published setup guide consistent.

## Evidence
The post-#1645 verification reached `https://api.anthropic.com/v1/messages` with the correct API key but all requests returned HTTP 400 for `claude-haiku-4.5`. Anthropic's official model table and the installed `@anthropic-ai/sdk` both define `claude-haiku-4-5` as the API alias.

## Validation
- `actionlint .github/workflows/semantic-linter.yml`
- 24 semantic action/report contract tests
- Generated-doc checks, docs site build, and link check (0 broken links)
- Independent review: no actionable findings