### PR TITLE
fix(ci): restore GitHub Copilot semantic judge

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -24,6 +24,12 @@ inputs:
     description: "Judge credential (sets LORE_WORKER_API_KEY)."
     required: false
     default: ""
+  github-token:
+    description: >-
+      Actions GITHUB_TOKEN for the official Copilot SDK bridge. Requires
+      copilot-requests: write; do not also set worker-api-key.
+    required: false
+    default: ""
   lore-command:
     description: "Command used to invoke Lore."
     required: false
@@ -44,6 +50,43 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate judge credential inputs
+      shell: bash
+      env:
+        LORE_IC_MODEL: ${{ inputs.model }}
+        LORE_WORKER_API_KEY: ${{ inputs.worker-api-key }}
+        LORE_GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        if [ -n "$LORE_GITHUB_TOKEN" ] && [ -n "$LORE_WORKER_API_KEY" ]; then
+          echo "github-token and worker-api-key are mutually exclusive" >&2
+          exit 1
+        fi
+        if [ -n "$LORE_GITHUB_TOKEN" ] && [[ ! "$LORE_IC_MODEL" =~ ^github-copilot/gpt-5\.6-[A-Za-z0-9._-]+$ ]]; then
+          echo "github-token requires a Responses-compatible github-copilot/gpt-5.6-* model" >&2
+          exit 1
+        fi
+
+    - name: Install official Copilot SDK bridge
+      if: inputs.github-token != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        install_dir="${GITHUB_ACTION_PATH}/copilot-sdk"
+        npm ci --prefix "$install_dir" --ignore-scripts --no-audit --no-fund
+
+    - name: Start official Copilot SDK bridge
+      id: copilot
+      if: inputs.github-token != ''
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        install_dir="${GITHUB_ACTION_PATH}/copilot-sdk"
+        node "${GITHUB_ACTION_PATH}/copilot-proxy.mjs" launch \
+          "$install_dir/node_modules/@github/copilot-sdk/dist/index.js"
+
     - name: Compute invariant-DB cache key
       id: key
       shell: bash
@@ -72,7 +115,8 @@ runs:
         LORE_IC_HEAD: ${{ inputs.head }}
         LORE_IC_MODEL: ${{ inputs.model }}
         LORE_IC_EFFORT: ${{ inputs.effort }}
-        LORE_WORKER_API_KEY: ${{ inputs.worker-api-key }}
+        LORE_WORKER_API_KEY: ${{ inputs.worker-api-key != '' && inputs.worker-api-key || inputs.github-token != '' && 'copilot-sdk-bridge' || '' }}
+        LORE_WORKER_UPSTREAM: ${{ steps.copilot.outputs.url }}
         LORE_CMD: ${{ inputs.lore-command }}
         LORE_DB_PATH: ${{ steps.key.outputs.db }}
         LORE_IC_GATE: ${{ inputs.gate }}
@@ -140,3 +184,12 @@ runs:
         "${LORE_LINT_REPORT_FILE:-${RUNNER_TEMP}/lore-semantic-lint-report.json}"
         "${LORE_LINT_GATE:-false}"
         "${LORE_LINT_EXIT_CODE:-1}"
+
+    - name: Stop official Copilot SDK bridge
+      if: always() && steps.copilot.outputs.pid != ''
+      shell: bash
+      env:
+        LORE_COPILOT_PROXY_PID: ${{ steps.copilot.outputs.pid }}
+      run: >-
+        node "${{ github.action_path }}/copilot-proxy.mjs"
+        stop "$LORE_COPILOT_PROXY_PID"

--- a/.github/actions/lint/copilot-proxy.mjs
+++ b/.github/actions/lint/copilot-proxy.mjs
@@ -1,0 +1,431 @@
+import { fork } from "node:child_process";
+import { appendFileSync, closeSync, mkdirSync, openSync } from "node:fs";
+import { createServer } from "node:http";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { randomUUID } from "node:crypto";
+
+const MAX_REQUEST_BYTES = 4 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 85_000;
+const CLEANUP_TIMEOUT_MS = 2_000;
+const DISABLED_TOOLS = ["builtin:*", "mcp:*", "custom:*"];
+
+async function settleWithin(operation, timeoutMs) {
+  let timeout;
+  const result = await Promise.race([
+    Promise.resolve()
+      .then(operation)
+      .then(
+        (value) => ({ status: "fulfilled", value }),
+        (error) => ({ status: "rejected", error }),
+      ),
+    new Promise((resolveTimeout) => {
+      timeout = setTimeout(
+        () => resolveTimeout({ status: "timeout" }),
+        timeoutMs,
+      );
+    }),
+  ]);
+  clearTimeout(timeout);
+  return result;
+}
+
+function requestText(input) {
+  if (!Array.isArray(input)) return "";
+  return input
+    .filter((item) => item && item.role === "user")
+    .flatMap((item) => {
+      if (typeof item.content === "string") return [item.content];
+      if (!Array.isArray(item.content)) return [];
+      return item.content
+        .filter(
+          (block) =>
+            block &&
+            (block.type === "input_text" || block.type === "text") &&
+            typeof block.text === "string",
+        )
+        .map((block) => block.text);
+    })
+    .join("\n");
+}
+
+function reasoningEffort(body) {
+  const effort = body?.reasoning?.effort;
+  return ["low", "medium", "high", "xhigh", "max"].includes(effort)
+    ? effort
+    : undefined;
+}
+
+function maxOutputTokens(body) {
+  const value = body?.max_output_tokens;
+  return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+export function copilotSessionConfig(body) {
+  if (!body || typeof body !== "object") {
+    throw new Error("request body must be an object");
+  }
+  if (typeof body.model !== "string" || body.model.length === 0) {
+    throw new Error("request model is required");
+  }
+  if (!/^gpt-5\.6-[A-Za-z0-9._-]+$/.test(body.model)) {
+    throw new Error("request model must be in the gpt-5.6-* family");
+  }
+  if (typeof body.instructions !== "string") {
+    throw new Error("request instructions are required");
+  }
+  const prompt = requestText(body.input);
+  if (prompt.length === 0) throw new Error("request user input is required");
+  const effort = reasoningEffort(body);
+  const outputTokens = maxOutputTokens(body);
+
+  return {
+    prompt,
+    config: {
+      clientName: "lore-semantic-linter",
+      model: body.model,
+      ...(effort ? { reasoningEffort: effort } : {}),
+      ...(outputTokens
+        ? { modelCapabilities: { limits: { max_output_tokens: outputTokens } } }
+        : {}),
+      systemMessage: { mode: "replace", content: body.instructions },
+      tools: [],
+      availableTools: [],
+      excludedTools: DISABLED_TOOLS,
+      defaultAgent: { excludedTools: DISABLED_TOOLS },
+      enableConfigDiscovery: false,
+      enableSkills: false,
+      enableSessionStore: false,
+      infiniteSessions: { enabled: false },
+      memory: { enabled: false },
+      streaming: false,
+      enableSessionTelemetry: false,
+    },
+  };
+}
+
+export async function runCopilotResponse(client, body, signal) {
+  const { prompt, config } = copilotSessionConfig(body);
+  const session = await client.createSession(config);
+  let rejectAborted;
+  let abortRequest;
+  const aborted = new Promise((_resolve, reject) => {
+    rejectAborted = reject;
+  });
+  const abort = () => {
+    abortRequest ??= Promise.resolve().then(() => session.abort());
+    const reject = rejectAborted;
+    rejectAborted = undefined;
+    reject?.(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+  };
+  signal?.addEventListener("abort", abort, { once: true });
+  try {
+    if (signal?.aborted) {
+      abort();
+    }
+    const response = await Promise.race([
+      session.sendAndWait({ prompt }, REQUEST_TIMEOUT_MS),
+      aborted,
+    ]);
+    rejectAborted = undefined;
+    const text = response?.data?.content;
+    if (typeof text !== "string" || text.length === 0) {
+      throw new Error("Copilot returned no assistant message");
+    }
+    return {
+      id: `resp_${randomUUID()}`,
+      object: "response",
+      created_at: Math.floor(Date.now() / 1000),
+      model: body.model,
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          id: `msg_${randomUUID()}`,
+          role: "assistant",
+          status: "completed",
+          content: [
+            {
+              type: "output_text",
+              text,
+              annotations: [],
+              logprobs: [],
+            },
+          ],
+        },
+      ],
+    };
+  } finally {
+    rejectAborted = undefined;
+    signal?.removeEventListener("abort", abort);
+    if (abortRequest) {
+      await settleWithin(() => abortRequest, CLEANUP_TIMEOUT_MS);
+    }
+    await settleWithin(() => session.disconnect(), CLEANUP_TIMEOUT_MS);
+  }
+}
+
+function writeJson(response, status, body) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+export function copilotProxyErrorResponse(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/rate limit|429/i.test(message)) {
+    return { status: 429, message: "Copilot rate limit exceeded" };
+  }
+  if (/billing|credit|quota|spending limit/i.test(message)) {
+    return { status: 402, message: "insufficient credit or Copilot quota" };
+  }
+  if (
+    /model.{0,80}(not supported|unsupported|not found|unavailable|must be in)|unknown model/i.test(
+      message,
+    )
+  ) {
+    return { status: 400, message: "Copilot model is not supported" };
+  }
+  if (
+    /\b(?:auth|authentication|authorization|unauthorized|forbidden|permission|policy)\b|\bnot (?:authorized|authenticated)\b|\baccess denied\b|\b(?:401|403)\b|\b(?:(?:invalid|expired|rejected) (?:github )?token|token (?:is )?(?:invalid|expired|rejected))\b/i.test(
+      message,
+    )
+  ) {
+    return {
+      status: 403,
+      message: "Copilot authentication or policy rejected",
+    };
+  }
+  return { status: 502, message: "Copilot SDK request failed" };
+}
+
+async function readJson(request) {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of request) {
+    bytes += chunk.length;
+    if (bytes > MAX_REQUEST_BYTES) throw new Error("request body is too large");
+    chunks.push(chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+export function createCopilotProxyHandler(client) {
+  return async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      return writeJson(response, 200, { status: "ok" });
+    }
+    if (
+      request.method !== "POST" ||
+      (request.url !== "/responses" && request.url !== "/v1/responses")
+    ) {
+      return writeJson(response, 404, { error: { message: "not found" } });
+    }
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const abortIfUnfinished = () => {
+      if (!response.writableEnded) controller.abort();
+    };
+    request.once("aborted", abort);
+    response.once("close", abortIfUnfinished);
+    try {
+      const body = await readJson(request);
+      const result = await runCopilotResponse(client, body, controller.signal);
+      if (!controller.signal.aborted) writeJson(response, 200, result);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      const failure = copilotProxyErrorResponse(error);
+      writeJson(response, failure.status, {
+        error: { message: failure.message },
+      });
+    } finally {
+      request.off("aborted", abort);
+      response.off("close", abortIfUnfinished);
+    }
+  };
+}
+
+export async function stopCopilotClient(client) {
+  const stopped = await settleWithin(() => client.stop(), CLEANUP_TIMEOUT_MS);
+  if (
+    stopped.status !== "fulfilled" ||
+    (Array.isArray(stopped.value) && stopped.value.length > 0)
+  ) {
+    await settleWithin(() => client.forceStop(), CLEANUP_TIMEOUT_MS);
+  }
+}
+
+export async function startCopilotProxy(client) {
+  await client.start();
+  const handler = createCopilotProxyHandler(client);
+  const server = createServer((request, response) => {
+    void handler(request, response);
+  });
+  await new Promise((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Copilot proxy did not bind a TCP port");
+  }
+
+  let shutdownPromise;
+  const shutdown = () => {
+    shutdownPromise ??= (async () => {
+      const closed = new Promise((resolveClose) => server.close(resolveClose));
+      server.closeAllConnections();
+      await closed;
+      await stopCopilotClient(client);
+    })();
+    return shutdownPromise;
+  };
+  return { url: `http://127.0.0.1:${address.port}`, shutdown };
+}
+
+async function serve(sdkModulePath) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+  const baseDirectory =
+    process.env.LORE_COPILOT_PROXY_HOME ??
+    resolve(process.env.RUNNER_TEMP ?? "/tmp", "lore-copilot-proxy-home");
+  mkdirSync(baseDirectory, { recursive: true });
+
+  const { CopilotClient } = await import(
+    pathToFileURL(resolve(sdkModulePath)).href
+  );
+  const client = new CopilotClient({
+    mode: "empty",
+    baseDirectory,
+    workingDirectory: process.cwd(),
+    gitHubToken: token,
+    useLoggedInUser: false,
+    logLevel: "error",
+  });
+  const proxy = await startCopilotProxy(client);
+  const shutdown = async () => {
+    await proxy.shutdown();
+    process.exit(0);
+  };
+  process.once("SIGTERM", () => void shutdown());
+  process.once("SIGINT", () => void shutdown());
+  process.send?.({ type: "ready", url: proxy.url });
+}
+
+export async function launch(sdkModulePath, spawnChild = fork) {
+  const output = process.env.GITHUB_OUTPUT;
+  if (!output) throw new Error("GITHUB_OUTPUT is required");
+  const runnerTemp = process.env.RUNNER_TEMP ?? "/tmp";
+  const logPath = resolve(runnerTemp, "lore-copilot-proxy.log");
+  const log = openSync(logPath, "a");
+  const child = spawnChild(
+    fileURLToPath(import.meta.url),
+    ["serve", sdkModulePath],
+    {
+      detached: true,
+      env: {
+        ...process.env,
+        LORE_COPILOT_PROXY_HOME: resolve(runnerTemp, "lore-copilot-proxy-home"),
+      },
+      stdio: ["ignore", log, log, "ipc"],
+    },
+  );
+  closeSync(log);
+
+  await new Promise((resolveReady, reject) => {
+    let settled = false;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (child.pid) killProcess(child.pid, "SIGKILL", true);
+      reject(error);
+    };
+    const timeout = setTimeout(() => {
+      fail(new Error("Copilot SDK bridge did not start within 60 seconds"));
+    }, 60_000);
+    child.once("error", fail);
+    child.once("exit", (code) =>
+      fail(new Error(`Copilot SDK bridge exited during startup (${code})`)),
+    );
+    child.on("message", (message) => {
+      if (
+        !message ||
+        message.type !== "ready" ||
+        typeof message.url !== "string"
+      ) {
+        return;
+      }
+      if (settled) return;
+      try {
+        appendFileSync(output, `url=${message.url}\npid=${child.pid}\n`);
+      } catch (error) {
+        fail(error);
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      child.removeAllListeners();
+      child.disconnect();
+      child.unref();
+      resolveReady();
+    });
+  });
+}
+
+export function processIsAlive(pid, processGroup = false) {
+  try {
+    process.kill(processGroup && process.platform !== "win32" ? -pid : pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+export function killProcess(pid, signal, processGroup = false) {
+  try {
+    process.kill(
+      processGroup && process.platform !== "win32" ? -pid : pid,
+      signal,
+    );
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    if (processGroup && error?.code === "EPERM") {
+      process.kill(pid, signal);
+      return true;
+    }
+    throw error;
+  }
+}
+
+export async function stop(pidValue) {
+  if (!/^[1-9][0-9]*$/.test(pidValue ?? "")) return;
+  const pid = Number(pidValue);
+  if (!killProcess(pid, "SIGTERM", true)) return;
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (!processIsAlive(pid, true)) return;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  killProcess(pid, "SIGKILL", true);
+}
+
+const isMain =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const [command, value] = process.argv.slice(2);
+  const operation =
+    command === "serve"
+      ? serve(value)
+      : command === "launch"
+        ? launch(value)
+        : command === "stop"
+          ? stop(value)
+          : Promise.reject(new Error("expected serve, launch, or stop"));
+  operation.catch(() => {
+    process.send?.({ type: "error" });
+    console.error(`Copilot SDK bridge ${command ?? "operation"} failed`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/actions/lint/copilot-sdk/package-lock.json
+++ b/.github/actions/lint/copilot-sdk/package-lock.json
@@ -1,0 +1,485 @@
+{
+  "name": "lore-semantic-linter-copilot-bridge",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lore-semantic-linter-copilot-bridge",
+      "dependencies": {
+        "@github/copilot": "1.0.80",
+        "@github/copilot-sdk": "1.0.11"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.80.tgz",
+      "integrity": "sha512-6tf93ZF56KOiTTAjK/UhLZkl1W543IzaTQly288kockJZFswpRTnQEI00Yvacpb39DTvTYu3/ha9SeKpo/pgZQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.80",
+        "@github/copilot-darwin-x64": "1.0.80",
+        "@github/copilot-linux-arm64": "1.0.80",
+        "@github/copilot-linux-x64": "1.0.80",
+        "@github/copilot-linuxmusl-arm64": "1.0.80",
+        "@github/copilot-linuxmusl-x64": "1.0.80",
+        "@github/copilot-win32-arm64": "1.0.80",
+        "@github/copilot-win32-x64": "1.0.80"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.80.tgz",
+      "integrity": "sha512-fzn4PnSx3+O/a3ip72KVsjnzORsEygK+0i21bFAnFBYS+0Wi1Pk+o/CmNsJ7aRbf1enSJrcH8UDVkyc9pMGEBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.80.tgz",
+      "integrity": "sha512-PKsyGk5DccNzR3bYXcYTGB9N6sHzhzGqEwq/2t1qBwqPbrC98Zo2dOT2G40/QYpJ4XdrGmTmdmfPJQ9PJknlIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.80.tgz",
+      "integrity": "sha512-8oXwN2luyHEjIoSk8AkATBjXDhRoQtuiUvC93GpfQKFHI+I1eoOVwIsAq5fKP8jNCF2rOrYFIcTjwmRt38kCcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.80.tgz",
+      "integrity": "sha512-qv1ytVNwA3IDK7kcQow+fAikD67t42+AQ8X42bK/7oudNiv4frVZMO0yh1DYIebVRcmEhmPvbVPY/ptVUK3cbA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.80.tgz",
+      "integrity": "sha512-Qjyi+OlVnPC4Lkuy7blDMMwMUQI/yELl7gDnqQlaN8TEbhZqZueuf3p0a+kEjXcNsw4XtNYQc0eMJqSIYy/Pjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.80.tgz",
+      "integrity": "sha512-rBg8pugf+5FhiZxi2zkOr+rlcOVF6Xg63j1FvryfwPT4DJ2w5Na7O3lpS4sgu8QmsP5H+dAqjlXYLYsvSoVQ0g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.11.tgz",
+      "integrity": "sha512-ngrnfa9052fLTOMoY0iiQS2B6pFDYJpWNj3syCdjzdje0R5mWoij9b8exJZciLvX7BbJjKz2/lIdwo24av3e3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.79",
+        "koffi": "^3.1.0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.80.tgz",
+      "integrity": "sha512-+f7Vkd3vt2DYOxRnS8dStvYu3DY638N/AuLuIjxZp1F9GgwCUZK69wspqIxg2L59PmRRQcH4AGTrRDR60ENIZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.80",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.80.tgz",
+      "integrity": "sha512-PO0kPqhRTWQfsqGaj4UN3cj8ttkcJYy4wmXiArtFm+03AIFu8xTvuhQDPn2xEOsUome7m7t2XomKoavcrCcRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.5.tgz",
+      "integrity": "sha512-IpqITl2fJi3QN9bTtNnygWPdK7ScSjw3xtGu8e6feYGvimCysu+spgI5KyeslY2jTnqxGS9xr8pLAbLhGJ8edA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.5.tgz",
+      "integrity": "sha512-4Tia4BS5EV/+vN9eIrdToanVe+U/2VqTZCBgOzoUbPKjgky51eqM+3J4qdRUvmYJohcJNPob5/hsxeItUZrl1g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.5.tgz",
+      "integrity": "sha512-bP94uzseFO79NG3flpU3WxfyvltD+jzC/kN8FDZLi8J0VUZNW1Wmu8yq87KEzjX1qT9KyX4Y+elVbGqHXHTv2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-raFXXAPHzvCQWhaoMUF+Cc2ZWgg2UBU0RVoowHZhaw9nQYPC1pERcPRH+JA+SNIN6g4d2GFW6uPFc+QbUhsagA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.5.tgz",
+      "integrity": "sha512-h6RyBZmPMBIDWTABkJIhzDdYwSnYAJvTacHpEjbT55Arkmw1H15Rl7CFtXuEuBrqh+uivoCrRgA6vszl9CsJ9g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.5.tgz",
+      "integrity": "sha512-u0vCmKPu4yQDhl/ri1J6U3vDnvYtYjoZaIWb+oMbRXhVZeiqdE53MGPb+q2A7Dj2n9IbYloAfEICQbL6l0pmiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.5.tgz",
+      "integrity": "sha512-Xa5JbumWglwPVZgrJcLhqyC1wCWlfm7+C00p3FuOTNGp0qoYuf2/tOoAh0/q7+taVm30cMopu/6lRHwdmF6I/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.5.tgz",
+      "integrity": "sha512-F3i2CeTcqVBUQiSRUBSEzX1VgtXmLLiZb/ouZtXHkWpTLhJNd9TH7s3CizTofci0VRqlKdexGUYhK5vzPDAAHA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.5.tgz",
+      "integrity": "sha512-2TgQuzy+4PfDg+rw3kOmN6lywEWdzKT3eaLPbOp0b/9DaN7CLBJ/QIR5GhGsMNpeI30zU0YzFeYFxoVoJ/LqFw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.5.tgz",
+      "integrity": "sha512-2yaIg/1V0m4CiAUMzG4CIlWmq1WJ+QBMlFfaGr9su+OH5fuIqC7V3BbMiB03IwIl1VofIZO5JA4Db4lID8tpbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.5.tgz",
+      "integrity": "sha512-8/OXd+u9omMooykhvdJPEP7u6FFzzrrFo9gOmSHc9/DPt3XkVYOtSsE97PDk6zYaAzwIYHSKjHvIXsfFwFc7sg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.5.tgz",
+      "integrity": "sha512-SpeqldKkuDk2aTj5PVWumy7eq6Tr2GtBPAOI1NiDHhg8xe433KraxrA9V9UjEd+1+kSGJQGR04nQByN3MPA9PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.5.tgz",
+      "integrity": "sha512-uej3YAEKAhlfVPoIo5sOwtxhTLRVJ01LgtWrKGpnnAQU3C+Ilmaxdh+Oc2xc1G3NK30N5eCVJpyO9r3pjKC6Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.5.tgz",
+      "integrity": "sha512-d42jv2f4PwtJGNJS19Xfn/BRtGsBNNVkw0O0K5tkIGI+yNq4MnPTSUsaGbDIkCLNsCgk/LFqAaE8BExyCdrujA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.5.tgz",
+      "integrity": "sha512-Pyo1WEHEP6Ek2NEn2pquwJzSPLOdY4vymoPSz0an1DgvFWSkOyBYYkGVoxL1ajfj5I1pPdXysYqixtVTzAtOfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.5.tgz",
+      "integrity": "sha512-XVwwrxg0Ca6IEUQF4YtGIU4XN0LSselFYpYvgfhh8wafCunhEEx5hPr7LZhp5QyeFA/LcRsKHTqncCdjWjWAlg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.5",
+        "@koromix/koffi-darwin-x64": "3.1.5",
+        "@koromix/koffi-freebsd-arm64": "3.1.5",
+        "@koromix/koffi-freebsd-ia32": "3.1.5",
+        "@koromix/koffi-freebsd-x64": "3.1.5",
+        "@koromix/koffi-linux-arm64": "3.1.5",
+        "@koromix/koffi-linux-ia32": "3.1.5",
+        "@koromix/koffi-linux-loong64": "3.1.5",
+        "@koromix/koffi-linux-riscv64": "3.1.5",
+        "@koromix/koffi-linux-x64": "3.1.5",
+        "@koromix/koffi-openbsd-ia32": "3.1.5",
+        "@koromix/koffi-openbsd-x64": "3.1.5",
+        "@koromix/koffi-win32-arm64": "3.1.5",
+        "@koromix/koffi-win32-ia32": "3.1.5",
+        "@koromix/koffi-win32-x64": "3.1.5"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.github/actions/lint/copilot-sdk/package.json
+++ b/.github/actions/lint/copilot-sdk/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lore-semantic-linter-copilot-bridge",
+  "private": true,
+  "dependencies": {
+    "@github/copilot": "1.0.80",
+    "@github/copilot-sdk": "1.0.11"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         # run: blocks have cosmetic shellcheck findings (SC2086, SC2129,
         # SC2035, SC2012) that are not bugs. The value of actionlint is
         # in workflow schema validation, not shell style.
-        run: ./actionlint -color
+        run: ./actionlint -color -config-file .github/actionlint.yaml
 
   test:
     needs: [changes]

--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -17,6 +17,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  copilot-requests: write
 
 jobs:
   lint:
@@ -67,21 +68,17 @@ jobs:
           head: ${{ github.event.pull_request.head.sha }}
           # Run the built CJS binary under Node (see the build step above).
           lore-command: "node packages/gateway/dist/bin.cjs"
-          # Judge model + credential. LORE_WORKER_API_KEY remains the explicit
-          # override and pairs with LORE_INVARIANT_MODEL when configured. This
-          # repository otherwise uses its ANTHROPIC_API_KEY secret with Haiku.
-          # A raw Actions GITHUB_TOKEN is not a Copilot API bearer credential:
-          # official Copilot CLI support performs private auth/billing handling
-          # that direct /responses calls do not. With no supported secret, pass
-          # no credential so Lore reports a precise no-auth health failure.
+          # Judge model + credential. A paired LORE_WORKER_API_KEY and
+          # LORE_INVARIANT_MODEL override the default. Otherwise the workflow's
+          # bare GitHub token is resolved through GitHub's official Copilot SDK;
+          # the copilot-requests permission above grants inference and billing.
           #
           # Model precedence:
-          #   - LORE_WORKER_API_KEY + LORE_INVARIANT_MODEL → explicit model.
-          #   - LORE_WORKER_API_KEY only → CLI/config default model.
-          #   - ANTHROPIC_API_KEY set    → anthropic/claude-haiku-4-5.
-          #   - no supported secret      → CLI default with no auth (reported).
-          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4-5' || '') }}
-          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          #   - paired override → explicit model + dedicated credential.
+          #   - otherwise       → GitHub Copilot Luna + workflow token.
+          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || 'github-copilot/gpt-5.6-luna' }}
+          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && secrets.LORE_WORKER_API_KEY || '' }}
+          github-token: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && '' || github.token }}
           # Reserve five minutes of the 25-minute job for report publication and
           # bounded gateway shutdown.
           deadline-seconds: "1200"

--- a/packages/gateway/src/auth.ts
+++ b/packages/gateway/src/auth.ts
@@ -27,10 +27,10 @@ export type AuthCredential =
  * The auth scheme a DEDICATED worker key (`LORE_WORKER_API_KEY`) must use for a
  * given worker-model provider. Defaults to `api-key` (→ `x-api-key`), the shape
  * the Anthropic/OpenAI/MiniMax dedicated-key paths have always used. GitHub
- * Copilot (`github-copilot`, api.githubcopilot.com) authenticates with a GitHub
- * token (OAuth bearer or the workflow's `GITHUB_TOKEN` under
- * `copilot-requests: write`) as `Authorization: Bearer`, so it is the one
- * provider that needs `bearer`.
+ * Copilot (`github-copilot`, api.githubcopilot.com) API credentials use
+ * `Authorization: Bearer`, so it is the one provider that needs `bearer`.
+ * Actions installation tokens require GitHub's official Copilot SDK resolution;
+ * the reference semantic-lint action provides that bridge separately.
  *
  * Single source of truth shared by every dedicated-key call site (the worker
  * pipeline and the `lore lint` CLI) so a new bearer provider is added in

--- a/packages/gateway/src/cli/invariant-check.ts
+++ b/packages/gateway/src/cli/invariant-check.ts
@@ -291,18 +291,23 @@ export async function runSemanticLint(
           value: workerKey,
         })
       : resolveAuth;
-    const client = createGatewayLLMClient(
-      {
-        anthropic: gateway.config.upstreamAnthropic,
-        openai: gateway.config.upstreamOpenAI,
-      },
-      judgeAuth,
-      model,
-      { dedicatedWorkerKey: !!workerKey },
-    );
+    const judgeUpstreams = gateway.config.workerUpstream
+      ? {
+          anthropic: gateway.config.workerUpstream,
+          openai: gateway.config.workerUpstream,
+        }
+      : {
+          anthropic: gateway.config.upstreamAnthropic,
+          openai: gateway.config.upstreamOpenAI,
+        };
+    const client = createGatewayLLMClient(judgeUpstreams, judgeAuth, model, {
+      dedicatedWorkerKey: !!workerKey,
+      disableModelFallbacks: workerKey === "copilot-sdk-bridge",
+    });
     const judge = createGatewayInvariantJudge({
       client,
       model,
+      upstreamUrl: gateway.config.workerUpstream,
       effort,
       sessionID: `invariant-check-${Date.now()}`,
       candidateTimeoutMs: options.candidateTimeoutMs,

--- a/packages/gateway/src/llm-adapter.ts
+++ b/packages/gateway/src/llm-adapter.ts
@@ -3404,12 +3404,15 @@ export function createGatewayLLMClient(
   defaultModel: { providerID: string; modelID: string },
   opts?: {
     dedicatedWorkerKey?: boolean;
+    /** Keep protocol-specific proxies on the selected model. */
+    disableModelFallbacks?: boolean;
     vertexProject?: string;
     /** Called with body-independent, URL-sanitized auth rejection details. */
     onAuthRejected?: (info: AuthRejectionInfo) => void;
   },
 ): GatewayLLMClient {
   const hasDedicatedKey = opts?.dedicatedWorkerKey === true;
+  const disableModelFallbacks = opts?.disableModelFallbacks === true;
   // Configured GCP project for Vertex workers (else derived from ADC at call
   // time). Threaded so an explicit LORE_VERTEX_PROJECT (without GOOGLE_CLOUD_*)
   // is honored — the session base URL carries the region but never the project.
@@ -3447,7 +3450,10 @@ export function createGatewayLLMClient(
       // though a working backup exists — so pick up where the fallback left off
       // instead of re-failing the swap every chunk. Data stays recallable if
       // none is usable.
-      for (const cand of workerModelCandidates(model)) {
+      const candidates = disableModelFallbacks
+        ? [model]
+        : workerModelCandidates(model);
+      for (const cand of candidates) {
         if (!candidateBlocked(cand)) {
           model = cand;
           break;
@@ -3834,11 +3840,13 @@ export function createGatewayLLMClient(
             // from workerModelCandidates minus the active model and any already
             // blocklisted (incapable) candidate; each unsupported-model 400 pops
             // the next one.
-            const modelFallbacks = workerModelCandidates(model)
-              .slice(1)
-              .filter(
-                (c) => c.modelID !== model.modelID && !candidateBlocked(c),
-              );
+            const modelFallbacks = disableModelFallbacks
+              ? []
+              : workerModelCandidates(model)
+                  .slice(1)
+                  .filter(
+                    (c) => c.modelID !== model.modelID && !candidateBlocked(c),
+                  );
             // Resolve the retry budget once per call (not per attempt) — the
             // value can't change mid-loop and re-reading the env each iteration
             // is wasteful.
@@ -5166,6 +5174,7 @@ export function createGatewayLLMClient(
 export interface GatewayInvariantJudgeOptions {
   client: GatewayLLMClient;
   model: { providerID: string; modelID: string };
+  upstreamUrl?: string;
   effort?: ReasoningEffort;
   sessionID: string;
   candidateTimeoutMs?: number;
@@ -5199,6 +5208,12 @@ export function createGatewayInvariantJudge(
           user,
           {
             model: options.model,
+            ...(options.upstreamUrl
+              ? {
+                  upstreamUrl: options.upstreamUrl,
+                  upstreamProviderID: options.model.providerID,
+                }
+              : {}),
             workerID: "lore-invariant-check",
             thinking: false,
             reasoningEffort: options.effort,

--- a/packages/gateway/src/worker-model.ts
+++ b/packages/gateway/src/worker-model.ts
@@ -1233,6 +1233,7 @@ const WORKER_MODEL_FALLBACKS: Record<string, string[]> = {
     "gpt-5-mini",
     "gpt-4o-mini",
     "claude-sonnet-4.6",
+    // Copilot's wire ID uses a dot; direct Anthropic uses claude-haiku-4-5.
     "claude-haiku-4.5",
   ],
 };

--- a/packages/gateway/test/invariant-check-orchestration.test.ts
+++ b/packages/gateway/test/invariant-check-orchestration.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe("runSemanticLint cancellation", () => {
-  it("proves embedding readiness before importing invariant fan-out", async () => {
+  it("proves readiness before import and honors the worker upstream", async () => {
     const events: string[] = [];
     const range = { base: "base", head: "head", source: "test" };
     let releaseReadiness: (() => void) | undefined;
@@ -96,9 +96,11 @@ describe("runSemanticLint cancellation", () => {
       },
       parseReasoningEffort: vi.fn(),
     }));
+    const createGatewayLLMClient = vi.fn(() => ({}));
+    const createGatewayInvariantJudge = vi.fn(() => ({}));
     vi.doMock("../src/llm-adapter", () => ({
-      createGatewayLLMClient: () => ({}),
-      createGatewayInvariantJudge: () => ({}),
+      createGatewayLLMClient,
+      createGatewayInvariantJudge,
     }));
     vi.doMock("../src/cli/start", () => ({
       startGateway: async () => {
@@ -106,7 +108,8 @@ describe("runSemanticLint cancellation", () => {
         return {
           owned: true,
           config: {
-            workerApiKey: undefined,
+            workerApiKey: "copilot-sdk-bridge",
+            workerUpstream: "http://copilot-bridge.test",
             upstreamAnthropic: "http://anthropic.test",
             upstreamOpenAI: "http://openai.test",
           },
@@ -139,6 +142,20 @@ describe("runSemanticLint cancellation", () => {
       "check",
       "cleanup",
     ]);
+    expect(createGatewayLLMClient).toHaveBeenCalledWith(
+      {
+        anthropic: "http://copilot-bridge.test",
+        openai: "http://copilot-bridge.test",
+      },
+      expect.any(Function),
+      expect.any(Object),
+      { dedicatedWorkerKey: true, disableModelFallbacks: true },
+    );
+    expect(createGatewayInvariantJudge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        upstreamUrl: "http://copilot-bridge.test",
+      }),
+    );
   });
 
   it("completes zero-hunk work without gateway, import, or embeddings", async () => {

--- a/packages/gateway/test/invariant-judge.test.ts
+++ b/packages/gateway/test/invariant-judge.test.ts
@@ -23,6 +23,37 @@ function clientWith(outcomes: PromptOutcome[]): GatewayLLMClient {
 }
 
 describe("createGatewayInvariantJudge", () => {
+  test("forwards worker upstream with matching provider provenance", async () => {
+    let promptOptions: Record<string, unknown> | undefined;
+    const client: GatewayLLMClient = {
+      prompt: vi.fn(async () => null),
+      promptDetailed: vi.fn(async (_system, _user, options) => {
+        promptOptions = options;
+        return {
+          kind: "success",
+          text: JSON.stringify({ verdict: "satisfies", reason: "covered" }),
+          model: "github-copilot/gpt-5.6-luna",
+          protocol: "openai-responses",
+          attempts: 1,
+        } satisfies PromptOutcome;
+      }),
+    };
+    const judge = createGatewayInvariantJudge({
+      client,
+      model: MODEL,
+      upstreamUrl: "http://127.0.0.1:12345",
+      effort: "off",
+      sessionID: "lint-upstream",
+    });
+
+    await judge.judge(INPUT);
+
+    expect(promptOptions).toMatchObject({
+      upstreamUrl: "http://127.0.0.1:12345",
+      upstreamProviderID: "github-copilot",
+    });
+  });
+
   test("repairs one invalid verdict and sums transport attempts", async () => {
     const client = clientWith([
       {

--- a/packages/gateway/test/lint-action-report.test.ts
+++ b/packages/gateway/test/lint-action-report.test.ts
@@ -1,8 +1,11 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { createServer } from "node:http";
+import { EventEmitter } from "node:events";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   failedSemanticLintReport,
   MAX_LINT_REPORT_CANDIDATES,
@@ -539,7 +542,583 @@ describe("semantic lint action reporter", () => {
     expect(action).toContain('default: "90"');
     expect(action).toContain("--report-file");
     expect(action).toContain("if: always()");
+    expect(action).toContain(
+      "github-token and worker-api-key are mutually exclusive",
+    );
+    expect(action).toContain(
+      "github-token requires a Responses-compatible github-copilot/gpt-5.6-* model",
+    );
+    expect(action).toContain("npm ci --prefix");
+    expect(action).toContain("--ignore-scripts");
+    expect(action).not.toContain("npm install");
+    expect(action).toContain("'copilot-sdk-bridge'");
+    expect(action).not.toContain(
+      "LORE_WORKER_API_KEY: ${{ inputs.worker-api-key != '' && inputs.worker-api-key || inputs.github-token }}",
+    );
     expect(action).not.toMatch(/>\s*\/tmp\/lore-ic\.json/);
+
+    const actionlint = readFileSync(
+      resolve(actionDirectory, "../../actionlint.yaml"),
+      "utf8",
+    );
+    expect(actionlint).toContain(".github/workflows/semantic-linter.yml:");
+    expect(actionlint).toContain('unknown permission scope "copilot-requests"');
+    const ci = readFileSync(
+      resolve(actionDirectory, "../../workflows/ci.yml"),
+      "utf8",
+    );
+    expect(ci).toContain("-config-file .github/actionlint.yaml");
+  });
+
+  test("Copilot bridge disables ambient tools and translates Responses output", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    let sessionConfig: Record<string, unknown> | undefined;
+    const client = {
+      async createSession(config: Record<string, unknown>) {
+        sessionConfig = config;
+        return {
+          async sendAndWait({ prompt }: { prompt: string }) {
+            expect(prompt).toBe("judge this hunk");
+            return { data: { content: "SATISFIES: covered" } };
+          },
+          async abort() {},
+          async disconnect() {},
+        };
+      },
+    };
+
+    const response = await proxy.runCopilotResponse(client, {
+      model: "gpt-5.6-luna",
+      instructions: "Return one verdict line.",
+      input: [{ role: "user", content: "judge this hunk" }],
+      reasoning: { effort: "medium" },
+      max_output_tokens: 25_600,
+    });
+
+    expect(sessionConfig).toMatchObject({
+      model: "gpt-5.6-luna",
+      reasoningEffort: "medium",
+      modelCapabilities: { limits: { max_output_tokens: 25_600 } },
+      systemMessage: { mode: "replace", content: "Return one verdict line." },
+      tools: [],
+      availableTools: [],
+      enableConfigDiscovery: false,
+      enableSkills: false,
+      enableSessionStore: false,
+      infiniteSessions: { enabled: false },
+      memory: { enabled: false },
+    });
+    expect(sessionConfig?.excludedTools).toEqual([
+      "builtin:*",
+      "mcp:*",
+      "custom:*",
+    ]);
+    expect(response.output[0].content[0].text).toBe("SATISFIES: covered");
+    expect(response.usage).toBeUndefined();
+    expect(
+      proxy.copilotProxyErrorResponse(
+        new Error("billing_not_configured: quota exceeded"),
+      ),
+    ).toEqual({ status: 402, message: "insufficient credit or Copilot quota" });
+    expect(
+      proxy.copilotProxyErrorResponse(new Error("policy denied token")),
+    ).toEqual({
+      status: 403,
+      message: "Copilot authentication or policy rejected",
+    });
+    expect(
+      proxy.copilotProxyErrorResponse(
+        new Error('The requested model "gpt-5.6-luna" is not supported'),
+      ),
+    ).toEqual({ status: 400, message: "Copilot model is not supported" });
+  });
+
+  test("Copilot bridge aborts an in-flight SDK session", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    const controller = new AbortController();
+    let requestStarted = false;
+    const abort = vi.fn(async () => {});
+    const disconnect = vi.fn(async () => {});
+    const client = {
+      async createSession() {
+        return {
+          sendAndWait: () =>
+            new Promise(() => {
+              requestStarted = true;
+            }),
+          abort,
+          disconnect,
+        };
+      },
+    };
+    const pending = proxy.runCopilotResponse(
+      client,
+      {
+        model: "gpt-5.6-luna",
+        instructions: "Return one verdict line.",
+        input: [{ role: "user", content: "judge this hunk" }],
+      },
+      controller.signal,
+    );
+
+    await vi.waitFor(() => expect(requestStarted).toBe(true));
+    controller.abort(new Error("downstream closed"));
+
+    await expect(pending).rejects.toThrow("downstream closed");
+    expect(abort).toHaveBeenCalledOnce();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  test("Copilot bridge safely ignores a late abort after the response wins", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    const controller = new AbortController();
+    const abort = vi.fn(async () => {});
+    const disconnect = vi.fn(async () => {});
+    const response = await proxy.runCopilotResponse(
+      {
+        async createSession() {
+          return {
+            async sendAndWait() {
+              return {
+                data: {
+                  get content() {
+                    controller.abort(new Error("late disconnect"));
+                    return "SATISFIES: completed";
+                  },
+                },
+              };
+            },
+            abort,
+            disconnect,
+          };
+        },
+      },
+      {
+        model: "gpt-5.6-luna",
+        instructions: "Return one verdict line.",
+        input: [{ role: "user", content: "judge this hunk" }],
+      },
+      controller.signal,
+    );
+
+    expect(response.output[0].content[0].text).toBe("SATISFIES: completed");
+    expect(abort).toHaveBeenCalledOnce();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  test("Copilot bridge validates and normalizes request controls", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    expect(() => proxy.copilotSessionConfig(null)).toThrow(
+      "request body must be an object",
+    );
+    expect(() => proxy.copilotSessionConfig({})).toThrow(
+      "request model is required",
+    );
+    expect(() => proxy.copilotSessionConfig({ model: "gpt-5.6-luna" })).toThrow(
+      "request instructions are required",
+    );
+    expect(() =>
+      proxy.copilotSessionConfig({
+        model: "gpt-5.6-luna",
+        instructions: "judge",
+        input: { role: "user", content: "not an array" },
+      }),
+    ).toThrow("request user input is required");
+
+    const result = proxy.copilotSessionConfig({
+      model: "gpt-5.6-luna",
+      instructions: "judge",
+      input: [
+        { role: "assistant", content: "ignore" },
+        {
+          role: "user",
+          content: [
+            null,
+            { type: "input_image", text: "ignore" },
+            { type: "input_text", text: "first" },
+            { type: "text", text: "second" },
+          ],
+        },
+        { role: "user", content: 42 },
+      ],
+      reasoning: { effort: "invalid" },
+      max_output_tokens: 0,
+    });
+
+    expect(result.prompt).toBe("first\nsecond");
+    expect(result.config.reasoningEffort).toBeUndefined();
+    expect(result.config.modelCapabilities).toBeUndefined();
+  });
+
+  test("Copilot bridge classifies rate limits and generic failures", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    expect(proxy.copilotProxyErrorResponse(new Error("HTTP 429"))).toEqual({
+      status: 429,
+      message: "Copilot rate limit exceeded",
+    });
+    expect(proxy.copilotProxyErrorResponse("unexpected failure")).toEqual({
+      status: 502,
+      message: "Copilot SDK request failed",
+    });
+    for (const message of [
+      "author lookup failed",
+      "OAuth request timed out",
+      "authority unavailable",
+    ]) {
+      expect(proxy.copilotProxyErrorResponse(message)).toEqual({
+        status: 502,
+        message: "Copilot SDK request failed",
+      });
+    }
+    for (const message of [
+      "Unauthorized",
+      "not authorized",
+      "not authenticated",
+      "Forbidden",
+      "access denied",
+    ]) {
+      expect(proxy.copilotProxyErrorResponse(message)).toEqual({
+        status: 403,
+        message: "Copilot authentication or policy rejected",
+      });
+    }
+  });
+
+  test("Copilot proxy runtime serves requests and shuts down idempotently", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    const start = vi.fn(async () => {});
+    const stop = vi.fn(async () => []);
+    const forceStop = vi.fn(async () => {});
+    const runtime = await proxy.startCopilotProxy({
+      start,
+      stop,
+      forceStop,
+      async createSession() {
+        return {
+          async sendAndWait() {
+            return { data: { content: "SATISFIES: runtime" } };
+          },
+          async abort() {},
+          async disconnect() {},
+        };
+      },
+    });
+    try {
+      const health = await fetch(`${runtime.url}/health`);
+      expect(health.status).toBe(200);
+      await expect(health.json()).resolves.toEqual({ status: "ok" });
+
+      const missing = await fetch(`${runtime.url}/missing`);
+      expect(missing.status).toBe(404);
+
+      const invalid = await fetch(`${runtime.url}/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "not-json",
+      });
+      expect(invalid.status).toBe(502);
+
+      const response = await fetch(`${runtime.url}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.6-luna",
+          instructions: "Return one verdict line.",
+          input: [{ role: "user", content: "judge" }],
+        }),
+      });
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        status: "completed",
+      });
+    } finally {
+      await Promise.all([runtime.shutdown(), runtime.shutdown()]);
+    }
+    expect(start).toHaveBeenCalledOnce();
+    expect(stop).toHaveBeenCalledOnce();
+    expect(forceStop).not.toHaveBeenCalled();
+  });
+
+  test("Copilot bridge propagates an HTTP client disconnect", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    let requestStarted = false;
+    const abort = vi.fn(async () => {});
+    const disconnect = vi.fn(async () => {});
+    const handler = proxy.createCopilotProxyHandler({
+      async createSession() {
+        return {
+          sendAndWait: () =>
+            new Promise(() => {
+              requestStarted = true;
+            }),
+          abort,
+          disconnect,
+        };
+      },
+    });
+    const server = createServer((request, response) => {
+      void handler(request, response);
+    });
+    await new Promise<void>((resolveListen) => {
+      server.listen(0, "127.0.0.1", resolveListen);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("test server did not bind a TCP port");
+      }
+      const controller = new AbortController();
+      const pending = fetch(`http://127.0.0.1:${address.port}/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.6-luna",
+          instructions: "Return one verdict line.",
+          input: [{ role: "user", content: "judge this hunk" }],
+        }),
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(requestStarted).toBe(true));
+
+      controller.abort();
+
+      await expect(pending).rejects.toThrow();
+      await vi.waitFor(() => expect(abort).toHaveBeenCalledOnce());
+      expect(disconnect).toHaveBeenCalledOnce();
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolveClose) =>
+        server.close(() => resolveClose()),
+      );
+    }
+  });
+
+  test("Copilot bridge rejects models outside the Responses family with HTTP 400", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    expect(() =>
+      proxy.copilotSessionConfig({
+        model: "gpt-5-mini",
+        instructions: "Return one verdict line.",
+        input: [{ role: "user", content: "judge this hunk" }],
+      }),
+    ).toThrow("request model must be in the gpt-5.6-* family");
+
+    const createSession = vi.fn();
+    const handler = proxy.createCopilotProxyHandler({ createSession });
+    const server = createServer((request, response) => {
+      void handler(request, response);
+    });
+    await new Promise<void>((resolveListen) => {
+      server.listen(0, "127.0.0.1", resolveListen);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("test server did not bind a TCP port");
+      }
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/responses`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            model: "gpt-5-mini",
+            instructions: "Return one verdict line.",
+            input: [{ role: "user", content: "judge this hunk" }],
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: { message: "Copilot model is not supported" },
+      });
+      expect(createSession).not.toHaveBeenCalled();
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolveClose) =>
+        server.close(() => resolveClose()),
+      );
+    }
+  });
+
+  test.each([
+    ["rejection", () => Promise.reject(new Error("stop failed"))],
+    ["partial cleanup", () => Promise.resolve([new Error("session failed")])],
+  ])("Copilot bridge force-stops after SDK %s", async (_name, stop) => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    const forceStop = vi.fn(async () => {});
+
+    await proxy.stopCopilotClient({ stop, forceStop });
+
+    expect(forceStop).toHaveBeenCalledOnce();
+  });
+
+  test("Copilot launcher writes outputs and detaches its child", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    const directory = mkdtempSync(join(tmpdir(), "lore-copilot-launch-"));
+    directories.push(directory);
+    const output = join(directory, "output.txt");
+    writeFileSync(output, "");
+    const oldOutput = process.env.GITHUB_OUTPUT;
+    const oldTemp = process.env.RUNNER_TEMP;
+    process.env.GITHUB_OUTPUT = output;
+    process.env.RUNNER_TEMP = directory;
+    const child = Object.assign(new EventEmitter(), {
+      pid: 4242,
+      disconnect: vi.fn(),
+      unref: vi.fn(),
+    });
+    const spawnChild = vi.fn(() => {
+      queueMicrotask(() => {
+        child.emit("message", null);
+        child.emit("message", { type: "ignored" });
+        child.emit("message", {
+          type: "ready",
+          url: "http://127.0.0.1:12345",
+        });
+      });
+      return child;
+    });
+    try {
+      await proxy.launch("sdk.js", spawnChild);
+    } finally {
+      if (oldOutput === undefined) delete process.env.GITHUB_OUTPUT;
+      else process.env.GITHUB_OUTPUT = oldOutput;
+      if (oldTemp === undefined) delete process.env.RUNNER_TEMP;
+      else process.env.RUNNER_TEMP = oldTemp;
+    }
+
+    expect(readFileSync(output, "utf8")).toBe(
+      "url=http://127.0.0.1:12345\npid=4242\n",
+    );
+    expect(spawnChild).toHaveBeenCalledOnce();
+    expect(child.disconnect).toHaveBeenCalledOnce();
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  test("Copilot launcher rejects a child startup failure", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    const directory = mkdtempSync(join(tmpdir(), "lore-copilot-launch-fail-"));
+    directories.push(directory);
+    const output = join(directory, "output.txt");
+    writeFileSync(output, "");
+    const oldOutput = process.env.GITHUB_OUTPUT;
+    const oldTemp = process.env.RUNNER_TEMP;
+    process.env.GITHUB_OUTPUT = output;
+    process.env.RUNNER_TEMP = directory;
+    const child = Object.assign(new EventEmitter(), {
+      pid: undefined,
+      disconnect: vi.fn(),
+      unref: vi.fn(),
+    });
+    const spawnChild = vi.fn(() => {
+      queueMicrotask(() => child.emit("error", new Error("spawn failed")));
+      return child;
+    });
+    try {
+      await expect(proxy.launch("sdk.js", spawnChild)).rejects.toThrow(
+        "spawn failed",
+      );
+    } finally {
+      if (oldOutput === undefined) delete process.env.GITHUB_OUTPUT;
+      else process.env.GITHUB_OUTPUT = oldOutput;
+      if (oldTemp === undefined) delete process.env.RUNNER_TEMP;
+      else process.env.RUNNER_TEMP = oldTemp;
+    }
+  });
+
+  test("Copilot process helpers preserve process-group semantics", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    const kill = vi.spyOn(process, "kill");
+    try {
+      kill.mockImplementation(() => true);
+      expect(proxy.processIsAlive(42, true)).toBe(true);
+      const groupPid = process.platform === "win32" ? 42 : -42;
+      expect(kill).toHaveBeenLastCalledWith(groupPid, 0);
+      expect(proxy.killProcess(42, "SIGTERM", true)).toBe(true);
+      expect(kill).toHaveBeenLastCalledWith(groupPid, "SIGTERM");
+
+      kill.mockImplementation(() => {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      });
+      expect(proxy.processIsAlive(42)).toBe(false);
+      expect(proxy.killProcess(42, "SIGTERM")).toBe(false);
+
+      kill
+        .mockImplementationOnce(() => {
+          throw Object.assign(new Error("denied"), { code: "EPERM" });
+        })
+        .mockImplementationOnce(() => true);
+      expect(proxy.killProcess(42, "SIGTERM", true)).toBe(true);
+      expect(kill).toHaveBeenLastCalledWith(42, "SIGTERM");
+
+      kill.mockImplementation(() => {
+        throw new Error("unexpected");
+      });
+      expect(() => proxy.processIsAlive(42)).toThrow("unexpected");
+      expect(() => proxy.killProcess(42, "SIGTERM")).toThrow("unexpected");
+    } finally {
+      kill.mockRestore();
+    }
+  });
+
+  test("Copilot stop bounds graceful shutdown before killing the group", async () => {
+    const proxyPath = join(actionDirectory, "copilot-proxy.mjs");
+    const proxy = await import(pathToFileURL(proxyPath).href);
+    await proxy.stop("invalid");
+
+    vi.useFakeTimers();
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      const pending = proxy.stop("42");
+      await vi.advanceTimersByTimeAsync(5_100);
+      await pending;
+      const groupPid = process.platform === "win32" ? 42 : -42;
+      expect(kill).toHaveBeenCalledWith(groupPid, "SIGTERM");
+      expect(kill).toHaveBeenCalledWith(groupPid, "SIGKILL");
+    } finally {
+      kill.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  test("Copilot SDK dependency graph is integrity-locked", () => {
+    const lock = JSON.parse(
+      readFileSync(
+        join(actionDirectory, "copilot-sdk/package-lock.json"),
+        "utf8",
+      ),
+    ) as {
+      packages: Record<string, { version?: string; integrity?: string }>;
+    };
+    expect(lock.packages["node_modules/@github/copilot-sdk"]).toMatchObject({
+      version: "1.0.11",
+    });
+    expect(lock.packages["node_modules/@github/copilot-sdk"].integrity).toMatch(
+      /^sha512-/,
+    );
+    expect(lock.packages["node_modules/@github/copilot"]).toMatchObject({
+      version: "1.0.80",
+    });
+    for (const [name, entry] of Object.entries(lock.packages)) {
+      if (!name.startsWith("node_modules/")) continue;
+      expect(entry.integrity, `${name} is not integrity-locked`).toMatch(
+        /^sha512-/,
+      );
+    }
   });
 
   test("reference workflow runs trusted base code and diffs exact event SHAs", () => {
@@ -568,13 +1147,15 @@ describe("semantic lint action reporter", () => {
     expect(workflow).toContain("continue-on-error: true");
     expect(workflow).toContain("pull_request_target:");
     expect(workflow).toContain(
-      "model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4-5' || '') }}",
+      "model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || 'github-copilot/gpt-5.6-luna' }}",
     );
     expect(workflow).toContain(
-      "worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || secrets.ANTHROPIC_API_KEY }}",
+      "worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && secrets.LORE_WORKER_API_KEY || '' }}",
     );
-    expect(workflow).not.toContain("|| github.token");
-    expect(workflow).not.toContain("copilot-requests: write");
+    expect(workflow).toContain(
+      "github-token: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && '' || github.token }}",
+    );
+    expect(workflow).toContain("copilot-requests: write");
     expect(workflow).not.toMatch(/^\s+pull_request:\s*$/m);
   });
 
@@ -591,9 +1172,9 @@ describe("semantic lint action reporter", () => {
     expect(guide).toContain(
       "secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL",
     );
-    expect(guide).toContain("secrets.ANTHROPIC_API_KEY");
-    expect(guide).not.toContain("|| github.token");
-    expect(guide).not.toContain("copilot-requests: write");
+    expect(guide).toContain("github-token:");
+    expect(guide).toContain("official Copilot SDK bridge");
+    expect(guide).toContain("copilot-requests: write");
     expect(guide).not.toMatch(/^\s+pull_request:\s*$/m);
   });
 });

--- a/packages/gateway/test/llm-adapter.test.ts
+++ b/packages/gateway/test/llm-adapter.test.ts
@@ -5774,9 +5774,13 @@ describe("workerModelCandidates", () => {
       modelID: "gpt-5-mini",
     });
     const ids = out.map((c) => c.modelID);
-    // Preferred appears exactly once (dedup), and Claude backups are present.
-    expect(ids.filter((m) => m === "gpt-5-mini")).toHaveLength(1);
-    expect(ids).toContain("claude-sonnet-4.6");
+    expect(ids).toEqual([
+      "gpt-5-mini",
+      "gpt-4o-mini",
+      "claude-sonnet-4.6",
+      // The official Copilot catalog uses a dot in its Haiku wire ID.
+      "claude-haiku-4.5",
+    ]);
     // Every candidate stays on the same provider — a worker must never switch.
     expect(out.every((c) => c.providerID === "github-copilot")).toBe(true);
   });
@@ -5933,6 +5937,40 @@ describe("worker 400 model-not-supported: fall back to a same-provider backup", 
     expect(secondBody.input).toBeUndefined();
     expect(secondBody.max_completion_tokens).toEqual(expect.any(Number));
     expect(secondBody.max_completion_tokens as number).toBeGreaterThan(256);
+  });
+
+  test("a protocol-specific bridge can disable incompatible model fallbacks", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(UNSUPPORTED_400, {
+        status: 400,
+        statusText: "Bad Request",
+      }),
+    );
+    const client = createGatewayLLMClient(
+      {
+        anthropic: "http://127.0.0.1:3207",
+        openai: "http://127.0.0.1:3207",
+      },
+      () => ({ scheme: "bearer", value: "copilot-sdk-bridge" }),
+      { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+      { dedicatedWorkerKey: true, disableModelFallbacks: true },
+    );
+
+    const outcome = await client.promptDetailed("system", "user", {
+      workerID: "lore-invariant-check",
+      sessionID: "sess-sdk-bridge",
+      upstreamProviderID: "github-copilot",
+      upstreamUrl: "http://127.0.0.1:3207",
+    });
+
+    expect(outcome).toMatchObject({
+      kind: "failure",
+      code: "model-unsupported",
+      model: "github-copilot/gpt-5.6-luna",
+      attempts: 1,
+    });
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(fetchArgUrl(mockFetch.mock.calls[0]?.[0])).toContain("/responses");
   });
 
   test("a provider with NO backup list surfaces the 400 (no swap, one call)", async () => {

--- a/packages/gateway/test/worker-copilot-responses.test.ts
+++ b/packages/gateway/test/worker-copilot-responses.test.ts
@@ -213,6 +213,26 @@ describe("worker github-copilot Responses API path (gpt-5.6-*)", () => {
     expect(body.temperature).toBeUndefined();
   });
 
+  test("explicit worker upstream keeps Copilot protocol and provider provenance", async () => {
+    const client = createGatewayLLMClient(
+      UPSTREAMS,
+      () => ({ scheme: "bearer", value: "sdk-bridge" }),
+      { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+    );
+    await client.prompt("sys", "user", {
+      sessionID: "sess-copilot-upstream",
+      workerID: "lore-invariant-check",
+      model: { providerID: "github-copilot", modelID: "gpt-5.6-luna" },
+      upstreamUrl: "http://127.0.0.1:12345",
+      upstreamProviderID: "github-copilot",
+      reasoningEffort: "off",
+    });
+
+    expect(fetchArgUrl(mockFetch.mock.calls[0]?.[0])).toBe(
+      "http://127.0.0.1:12345/v1/responses",
+    );
+  });
+
   test("effort off remains explicit for other Responses providers", async () => {
     const client = createGatewayLLMClient(
       UPSTREAMS,

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -23,7 +23,7 @@ It is **not** a replacement for tests, type checking, or a linter. It has no gro
 
 ## Quick start (GitHub Actions)
 
-The repository ships a reusable composite action and a reference workflow. Add an `ANTHROPIC_API_KEY` Actions secret for the default `anthropic/claude-haiku-4-5` judge, or configure the custom credential and model pair described below.
+The repository ships a reusable composite action and a reference workflow. It uses the workflow's GitHub token with GitHub Copilot by default, or you can configure the custom credential and model pair described below.
 
 Add `.github/workflows/semantic-linter.yml`:
 
@@ -41,6 +41,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  copilot-requests: write
 
 jobs:
   lint:
@@ -77,8 +78,9 @@ jobs:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
           lore-command: "node packages/gateway/dist/bin.cjs"
-          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL || (secrets.LORE_WORKER_API_KEY == '' && secrets.ANTHROPIC_API_KEY != '' && 'anthropic/claude-haiku-4-5' || '') }}
-          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && secrets.LORE_WORKER_API_KEY || secrets.ANTHROPIC_API_KEY }}
+          model: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && vars.LORE_INVARIANT_MODEL || 'github-copilot/gpt-5.6-luna' }}
+          worker-api-key: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && secrets.LORE_WORKER_API_KEY || '' }}
+          github-token: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && '' || github.token }}
 ```
 
 Open a PR and the check runs, posting any suspected contradictions as annotations plus a job summary. The reference workflow passes a 20-minute overall deadline and a 90-second per-candidate timeout, leaving five minutes for report publication and gateway shutdown.
@@ -91,24 +93,26 @@ Use `pull_request_target` only with the trusted-base checkout pattern above. The
 
 The credential and model are selected as a pair to prevent sending one provider's key to another provider.
 
-**Credential** (the `worker-api-key` input):
+**Credential** (`worker-api-key` or `github-token`):
 
-- **Default.** Set `ANTHROPIC_API_KEY`; the reference workflow pairs it with `anthropic/claude-haiku-4-5`.
-- **Custom provider.** Set `LORE_WORKER_API_KEY` and `LORE_INVARIANT_MODEL` together. The dedicated key takes precedence over `ANTHROPIC_API_KEY`.
-- **No supported secret.** The action passes no credential and reports an explicit `no-auth` health failure. A raw Actions `GITHUB_TOKEN` is not forwarded to provider APIs.
+- **Default.** The reference workflow passes `github.token` to the action's loopback-only official Copilot SDK bridge. The SDK resolves the Actions installation token and its billing identity; `copilot-requests: write` grants inference access. The token is not forwarded directly to `api.githubcopilot.com`.
+- **Custom provider.** Set `LORE_WORKER_API_KEY` and `LORE_INVARIANT_MODEL` together. The custom pair takes precedence over the workflow token.
 
 **Model** (the `model` input, `provider/id`):
 
 | Situation | Model used |
 | --- | --- |
 | `LORE_WORKER_API_KEY` and `LORE_INVARIANT_MODEL` are set | the variable value, authenticated by the dedicated key |
-| `LORE_WORKER_API_KEY` only | your repo's configured default worker model |
-| `ANTHROPIC_API_KEY` only (or a stale model variable without a dedicated key) | `anthropic/claude-haiku-4-5` |
-| Neither supported secret | no authenticated judge; the report is inconclusive with `no-auth` |
+| Only one custom override is set | `github-copilot/gpt-5.6-luna`, authenticated by the workflow token |
+| Neither custom override is set | `github-copilot/gpt-5.6-luna`, authenticated by the workflow token |
 
 :::note
-The model id must match the credential. `LORE_INVARIANT_MODEL` is honored only when `LORE_WORKER_API_KEY` is also set; otherwise the Anthropic fallback forces its matching model. Official Copilot CLI support for Actions tokens includes authentication and billing behavior that is not equivalent to forwarding `GITHUB_TOKEN` directly to `api.githubcopilot.com`.
+The model id must match the credential. The custom model and key are honored only when both are set; a partial override falls back atomically to the Copilot model and workflow token, so one provider's credential is never sent to another provider.
 :::
+
+The `github-token` bridge accepts only the Responses-compatible `github-copilot/gpt-5.6-*` family. Use `worker-api-key` for a different provider or a Copilot model that uses Chat Completions.
+
+For a personally owned repository, Copilot usage is billed to the repository owner's Copilot seat. Organization-owned repositories must enable **Allow use of Copilot CLI billed to the organization** in their Copilot policy settings. These billing and policy requirements are separate from the workflow permission.
 
 ## How it works
 


### PR DESCRIPTION
## Summary
Restore semantic lint judging through the official GitHub Copilot SDK so Actions installation tokens use supported authentication and billing instead of being forwarded directly to the Copilot API.

## Changes
- Add a loopback-only, tool-disabled SDK bridge with locked dependencies, Responses-model enforcement, cancellation propagation, and bounded shutdown.
- Route invariant-judge requests through the bridge while preventing incompatible Chat Completions model fallbacks.
- Make GitHub Copilot Luna the atomic default model/credential pair while preserving explicit custom-provider overrides.
- Document repository billing policy and add regression coverage for routing, lifecycle, output limits, credentials, and workflow security.

## Validation
- 320 focused tests
- Gateway typecheck and bundle
- Lint, formatting, docs, links, preview links, social metadata, and configured actionlint
- Live direct SDK, detached bridge, full gateway, and shutdown probes