### PR TITLE
docs: explain Copilot action runtime

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -72,6 +72,9 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        # Lore already speaks Copilot's model APIs. This optional runtime handles
+        # the supported Actions installation-token and billing flow. See
+        # copilot-sdk/README.md for the architectural boundary.
         install_dir="${GITHUB_ACTION_PATH}/copilot-sdk"
         npm ci --prefix "$install_dir" --ignore-scripts --no-audit --no-fund
 

--- a/.github/actions/lint/copilot-sdk/README.md
+++ b/.github/actions/lint/copilot-sdk/README.md
@@ -1,0 +1,69 @@
+# Copilot action runtime
+
+Lore already supports GitHub Copilot's Chat Completions and Responses wire
+formats. This directory does not add another model transport. It installs the
+official Copilot runtime used only when the composite action receives an
+Actions `GITHUB_TOKEN` through its `github-token` input.
+
+## Why the runtime is required
+
+Lore's direct `github-copilot` provider works with a bearer credential already
+accepted by the Copilot model API, such as the user OAuth credential stored by
+OpenCode. An Actions `GITHUB_TOKEN` is instead a short-lived GitHub App
+installation token. The `copilot-requests: write` permission authorizes Copilot
+use through supported GitHub tooling, but does not make the installation token
+a supported bearer credential for direct requests to `api.githubcopilot.com`.
+
+This distinction was verified in CI before PR #1649: forwarding the installation
+token directly to the corrected `/responses` request returned HTTP 400 for every
+judge call, while the official runtime completed the same workload. The runtime
+owns GitHub's authentication, entitlement, policy, endpoint-selection, and
+billing-attribution behavior for that token class.
+
+The responsibilities are therefore split deliberately:
+
+- Lore owns candidate selection, prompts, model routing, timeouts, retries,
+  verdict parsing, and reports.
+- `@github/copilot` owns the supported Copilot runtime and Actions-token flow.
+- `@github/copilot-sdk` provides typed JSON-RPC control of that runtime, including
+  isolated sessions, an exact replacement system prompt, disabled tools and
+  repository configuration, cancellation, and bounded cleanup.
+- `copilot-proxy.mjs` is a loopback-only adapter between Lore's worker request
+  and an SDK session. The action token is never forwarded by Lore to the model
+  endpoint.
+
+Calling `copilot -p` directly would still require the runtime while losing the
+session controls above. Implementing its private JSON-RPC or authentication flow
+inside Lore would duplicate the SDK or rely on an unsupported GitHub contract.
+
+## Why this is a separate package
+
+A composite action cannot declare npm dependencies. The private `package.json`
+and `package-lock.json` let the action run `npm ci` with exact versions and
+integrity hashes. Keeping these dependencies here also avoids shipping a large,
+platform-specific Copilot CLI binary with every Lore installation when only the
+zero-secret CI path needs it.
+
+The explicit `@github/copilot` pin fixes the runtime version instead of relying
+on the SDK's compatible transitive range. `@github/copilot-sdk` supplies the
+client API; it also expects the CLI runtime to be available.
+
+## When it can be removed
+
+Remove this runtime only if one of these contracts changes:
+
+1. The action requires callers to provide a bearer credential already accepted
+   by the Copilot model API and gives up the zero-secret `github.token` path.
+2. GitHub publishes and supports a direct Actions installation-token API flow
+   that Lore can implement without copying private CLI behavior.
+
+Do not replace the runtime by forwarding `github.token` directly or by
+reverse-engineering the CLI's private authentication and billing exchange.
+
+## Model support
+
+The official SDK supports every model available in Copilot CLI. Any model
+allowlist in `action.yml` or `copilot-proxy.mjs` is a Lore bridge implementation
+constraint, not an SDK limitation and not evidence that other models are absent
+from Copilot. The proxy's local HTTP envelope is likewise independent of the
+wire API the runtime ultimately uses for a selected model.

--- a/packages/website/src/content/docs/docs/guides/semantic-linter.md
+++ b/packages/website/src/content/docs/docs/guides/semantic-linter.md
@@ -110,7 +110,17 @@ The credential and model are selected as a pair to prevent sending one provider'
 The model id must match the credential. The custom model and key are honored only when both are set; a partial override falls back atomically to the Copilot model and workflow token, so one provider's credential is never sent to another provider.
 :::
 
-The `github-token` bridge accepts only the Responses-compatible `github-copilot/gpt-5.6-*` family. Use `worker-api-key` for a different provider or a Copilot model that uses Chat Completions.
+#### Why use the Copilot SDK bridge?
+
+Lore already knows how to call GitHub Copilot's Chat Completions and Responses endpoints. The bridge exists for **credential handling, not model transport**.
+
+A bearer credential already accepted by the Copilot model API, such as the user OAuth credential stored by OpenCode, can use Lore's direct `github-copilot` provider path. The workflow's `github.token` is different: it is a short-lived GitHub App installation token. `copilot-requests: write` authorizes Copilot use through supported GitHub tooling, but does not turn that installation token into a supported bearer credential for direct requests to `api.githubcopilot.com`. Direct forwarding was tried before the bridge was introduced and produced HTTP 400 responses even after the request body was corrected.
+
+The official Copilot runtime handles GitHub's authentication, entitlement, repository policy, endpoint selection, and billing attribution for the installation token. The SDK gives the action structured control over that runtime: it creates tool-disabled sessions with Lore's exact judge prompt, propagates cancellation, and performs bounded cleanup. Lore still owns candidate selection, model routing, retries, verdict parsing, and reporting; the action token is never forwarded by Lore to the model endpoint.
+
+The SDK and CLI are installed from the isolated, integrity-locked `.github/actions/lint/copilot-sdk` package so this optional CI path does not add a platform-specific Copilot binary to every Lore installation. That runtime could be removed if the action required a bearer credential already accepted by the Copilot model API instead, or if GitHub published a supported direct API contract for Actions installation tokens. Reimplementing the CLI's private authentication and billing behavior in Lore would be brittle and unsupported.
+
+The `github-token` bridge currently accepts only `github-copilot/gpt-5.6-*`. This is a Lore bridge implementation constraint, not an official SDK model limitation: the SDK supports every model available in Copilot CLI. Supporting other Copilot models requires updating the bridge and its local gateway route together. Use `worker-api-key` until then for a different provider or direct Copilot credential.
 
 For a personally owned repository, Copilot usage is billed to the repository owner's Copilot seat. Organization-owned repositories must enable **Allow use of Copilot CLI billed to the organization** in their Copilot policy settings. These billing and policy requirements are separate from the workflow permission.
 


### PR DESCRIPTION
## Summary
Explain why the semantic-linter action uses the official Copilot runtime even though Lore already supports Copilot wire protocols.

## Changes
- Document the Actions installation-token authentication and billing boundary
- Explain the isolated, integrity-locked SDK/CLI dependency root and removal criteria
- Clarify that the current `gpt-5.6-*` allowlist is a Lore bridge constraint, not an SDK limitation
- Add an inline pointer from the composite action to the architecture note

## Validation
- `pnpm vitest run packages/gateway/test/lint-action-report.test.ts`
- `pnpm format:check`
- `pnpm check:links`