### PR TITLE
fix(gateway): keep SSE streams alive while waiting

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -18740,6 +18740,7 @@ export function earlyFlushStreamingResponse(
   modelId: string,
   signal?: AbortSignal,
   trackOperation?: (operation: Promise<unknown>) => void,
+  keepaliveMs = 5_000,
 ): Response {
   const encoder = new TextEncoder();
   const keepalive = encoder.encode(`: lore preparing\n\n`);
@@ -18775,8 +18776,26 @@ export function earlyFlushStreamingResponse(
 
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let responsePromise: Promise<Response> | undefined;
+  let innerPromise: Promise<Response> | undefined;
+  let readPromise: ReturnType<typeof readStreamChunk> | undefined;
   let cancelled = false;
   let finished = false;
+
+  async function awaitWithKeepalive<T>(
+    operation: Promise<T>,
+  ): Promise<{ value: T } | { keepalive: true }> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation.then((value) => ({ value }) as const),
+        new Promise<{ keepalive: true }>((resolve) => {
+          timeout = setTimeout(() => resolve({ keepalive: true }), keepaliveMs);
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
 
   const finish = (
     controller: ReadableStreamDefaultController<Uint8Array>,
@@ -18806,10 +18825,17 @@ export function earlyFlushStreamingResponse(
               responsePromise = run(operationSignal);
               trackOperation?.(responsePromise);
             }
-            const inner = await responseAgainstAbort(
+            innerPromise ??= responseAgainstAbort(
               () => responsePromise as Promise<Response>,
               operationSignal,
             );
+            const pendingInner = awaitWithKeepalive(innerPromise);
+            const innerResult = await pendingInner;
+            if ("keepalive" in innerResult) {
+              controller.enqueue(keepalive);
+              return;
+            }
+            const inner = innerResult.value;
             if (cancelled) {
               void inner.body?.cancel().catch(() => {});
               return;
@@ -18832,9 +18858,16 @@ export function earlyFlushStreamingResponse(
             }
             reader = inner.body.getReader();
           }
-          const chunk = await readStreamChunk(reader, {
+          const pendingRead = (readPromise ??= readStreamChunk(reader, {
             signal: operationSignal,
-          });
+          }));
+          const chunkResult = await awaitWithKeepalive(pendingRead);
+          if ("keepalive" in chunkResult) {
+            controller.enqueue(keepalive);
+            return;
+          }
+          readPromise = undefined;
+          const chunk = chunkResult.value;
           if (cancelled) return;
           if (chunk.done) finish(controller);
           else controller.enqueue(chunk.value);

--- a/packages/gateway/test/early-flush-stream.test.ts
+++ b/packages/gateway/test/early-flush-stream.test.ts
@@ -39,6 +39,12 @@ function innerStream(
 
 async function drain(resp: Response): Promise<string> {
   const reader = resp.body!.getReader();
+  return drainReader(reader);
+}
+
+async function drainReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
   const decoder = new TextDecoder();
   let out = "";
   for (;;) {
@@ -96,6 +102,70 @@ describe("earlyFlushStreamingResponse", () => {
     const keepaliveIdx = out.indexOf(KEEPALIVE);
     const createdIdx = out.indexOf("event: response.output_item.added");
     expect(keepaliveIdx).toBeLessThan(createdIdx);
+  });
+
+  test("keeps the connection active while waiting for a slow inner response", async () => {
+    let resolveInner!: (response: Response) => void;
+    const resp = earlyFlushStreamingResponse(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveInner = resolve;
+        }),
+      "gpt-5.6-terra",
+      undefined,
+      undefined,
+      5,
+    );
+    const reader = resp.body!.getReader();
+
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe(
+      KEEPALIVE,
+    );
+    for (let index = 0; index < 3; index++) {
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe(
+        KEEPALIVE,
+      );
+    }
+    resolveInner(innerStream(["event: response.completed\n\n"], 0));
+    const out = await drainReader(reader);
+    expect(out).toContain("event: response.completed");
+  });
+
+  test("keeps the connection active while waiting for a stalled upstream chunk", async () => {
+    let emitChunk!: () => void;
+    const response = earlyFlushStreamingResponse(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              emitChunk = () => {
+                controller.enqueue(
+                  new TextEncoder().encode("event: response.completed\n\n"),
+                );
+                controller.close();
+              };
+            },
+          }),
+          { headers: SSE },
+        ),
+      "gpt-5.6-terra",
+      undefined,
+      undefined,
+      5,
+    );
+    const reader = response.body!.getReader();
+
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe(
+      KEEPALIVE,
+    );
+    for (let index = 0; index < 3; index++) {
+      expect(new TextDecoder().decode((await reader.read()).value)).toBe(
+        KEEPALIVE,
+      );
+    }
+    emitChunk();
+    const out = await drainReader(reader);
+    expect(out).toContain("event: response.completed");
   });
 
   test("emits a canonical response.failed envelope when the inner pipeline rejects", async () => {


### PR DESCRIPTION
## Summary
Prevents OpenCode SSE read timeouts while Lore awaits a delayed upstream response.

## Changes
- Emits periodic SSE comments during delayed pipeline and upstream reads.
- Preserves pending response and read operations across heartbeats.
- Adds a regression test for delayed inner responses.