### PR TITLE
fix(ci): permit semantic lint cache writes

### DIFF
--- a/.github/workflows/semantic-linter.yml
+++ b/.github/workflows/semantic-linter.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
   copilot-requests: write

--- a/packages/gateway/test/lint-action-report.test.ts
+++ b/packages/gateway/test/lint-action-report.test.ts
@@ -1155,7 +1155,9 @@ describe("semantic lint action reporter", () => {
     expect(workflow).toContain(
       "github-token: ${{ secrets.LORE_WORKER_API_KEY != '' && vars.LORE_INVARIANT_MODEL != '' && '' || github.token }}",
     );
-    expect(workflow).toContain("copilot-requests: write");
+    expect(workflow).toMatch(
+      /permissions:\n  actions: write\n  contents: read\n  pull-requests: read\n  copilot-requests: write\n\njobs:/,
+    );
     expect(workflow).not.toMatch(/^\s+pull_request:\s*$/m);
   });
 


### PR DESCRIPTION
## Summary
- Grant the semantic-linter workflow actions write permission so the cache action can reserve its post-job cache.
- Lock the complete workflow permission set in the semantic-lint workflow contract test.

## Validation
- Python YAML parse
- pnpm exec vitest run packages/gateway/test/lint-action-report.test.ts (39 passed)
- Regression proof: the focused test failed when actions write was removed, then passed after restoration.
- pnpm run format:check
- pnpm run lint (pre-existing warnings only)
- pnpm run typecheck
- pnpm test (inconclusive: suite exceeded ten minutes after the bundle completed)