### PR TITLE
fix(gateway): add early-flush failure diagnostics

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -15152,6 +15152,7 @@ async function handleConversationTurn(
   downstreamSettled: Promise<void>,
   downstreamWasCancelled: () => boolean,
   claimSession: (sessionID: string) => Promise<void>,
+  onSessionIdentified?: (sessionID: string) => void,
 ): Promise<Response> {
   if (
     pipelineResetInProgress ||
@@ -15189,6 +15190,11 @@ async function handleConversationTurn(
   });
   const { identified } = admitted;
   const { sessionID, isNew, tier } = identified;
+  try {
+    onSessionIdentified?.(sessionID);
+  } catch (error) {
+    log.warn("session diagnostic failed:", error);
+  }
   if (!admitted.claimed) await claimSession(sessionID);
   if (identified.expectedUnowned && !legacyAdoptionTargetIsUnowned(sessionID)) {
     dropOwnedProvisionalKey(identified.provisionalKey, sessionID);
@@ -18741,6 +18747,7 @@ export function earlyFlushStreamingResponse(
   signal?: AbortSignal,
   trackOperation?: (operation: Promise<unknown>) => void,
   keepaliveMs = 5_000,
+  diagnosticContext?: () => string,
 ): Response {
   const encoder = new TextEncoder();
   const keepalive = encoder.encode(`: lore preparing\n\n`);
@@ -18872,7 +18879,16 @@ export function earlyFlushStreamingResponse(
           if (chunk.done) finish(controller);
           else controller.enqueue(chunk.value);
         } catch (err) {
-          log.error("early-flush stream failed:", err);
+          let context = "";
+          try {
+            context = diagnosticContext?.() ?? "";
+          } catch (contextError) {
+            log.warn("early-flush failure diagnostic failed:", contextError);
+          }
+          log.error(
+            `early-flush stream failed${context ? ` (${context})` : ""}:`,
+            err,
+          );
           if (!cancelled) {
             controller.enqueue(emitFailed("Gateway request failed"));
             finish(controller);
@@ -19063,6 +19079,7 @@ async function handleRequestInner(
     // within 10s; this guarantees they flush immediately and the client sees a
     // keepalive while the gateway prepares.
     if (req.stream && req.protocol === "openai-responses") {
+      let sessionID: string | undefined;
       return earlyFlushStreamingResponse(
         (signal) =>
           handleConversationTurn(
@@ -19073,10 +19090,16 @@ async function handleRequestInner(
             downstreamSettled,
             downstreamWasCancelled,
             claimSession,
+            (identifiedSessionID) => {
+              sessionID = identifiedSessionID;
+            },
           ),
         req.model,
         req.signal,
         trackOperation,
+        undefined,
+        () =>
+          `request=${requestOrder} session=${sessionID?.slice(0, 16) ?? "pending"} upstream=${upstreamUrlForLog(resolveRequestUpstreamRoute(req, config).effectiveUpstreamBase)}`,
       );
     }
     return await handleConversationTurn(

--- a/packages/gateway/test/early-flush-stream.test.ts
+++ b/packages/gateway/test/early-flush-stream.test.ts
@@ -170,7 +170,7 @@ describe("earlyFlushStreamingResponse", () => {
 
   test("emits a canonical response.failed envelope when the inner pipeline rejects", async () => {
     const resp = earlyFlushStreamingResponse(async () => {
-      throw new Error("boom");
+      throw new Error("fetch failed");
     }, "gpt-5.6-terra");
 
     const out = await drain(resp);
@@ -180,7 +180,32 @@ describe("earlyFlushStreamingResponse", () => {
     const match = out.match(FAILED_EVENT_RE);
     expect(match).not.toBeNull();
     expect(match?.[1]).toBe("Gateway request failed");
-    expect(out).not.toContain("boom");
+    const event = JSON.parse(match?.[0].split("\ndata: ")[1].trim() ?? "{}");
+    expect(event.response.error).toEqual({
+      type: "server_error",
+      message: "Gateway request failed",
+    });
+  });
+
+  test("still emits response.failed when failure diagnostics throw", async () => {
+    let diagnosticCalls = 0;
+    const resp = earlyFlushStreamingResponse(
+      async () => {
+        throw new Error("fetch failed");
+      },
+      "gpt-5.6-terra",
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        diagnosticCalls++;
+        throw new Error("diagnostic failed");
+      },
+    );
+
+    const out = await drain(resp);
+    expect(diagnosticCalls).toBe(1);
+    expect(out).toMatch(FAILED_EVENT_RE);
   });
 
   test("emits a canonical response.failed envelope when the inner response is a non-SSE error body", async () => {


### PR DESCRIPTION
## Summary
Adds actionable diagnostics when an early-flushed Responses stream fails after headers have been sent.

## Changes
- Records the resolved Lore session and selected upstream in the failure log
- Preserves the canonical `response.failed` SSE envelope
- Covers the complete failure envelope in the early-flush regression test