### PR TITLE
fix(cli): enforce entity destructive-operation policy

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -6,7 +6,14 @@
  * formatting for system prompt injection and recall query expansion.
  */
 import { uuidv7 } from "uuidv7";
-import { db, ensureProject, getKV, setKV, withTransaction } from "./db";
+import {
+  db,
+  ensureProject,
+  getKV,
+  projectId,
+  setKV,
+  withTransaction,
+} from "./db";
 import { embeddingByIdSource, readStorageMode } from "./db/vec-store";
 import { ftsQuery, ftsQueryOr, EMPTY_QUERY, filterTerms } from "./search";
 import {
@@ -1003,6 +1010,10 @@ export function forProject(
   includeCross = true,
 ): EntityWithAliases[] {
   const pid = ensureProject(projectPath);
+  return forProjectId(pid, includeCross);
+}
+
+function forProjectId(pid: string, includeCross: boolean): EntityWithAliases[] {
   const { sql, params } = forProjectEntityQuery(pid, includeCross);
   const rows = db()
     .query(sql)
@@ -1353,8 +1364,18 @@ export async function searchCrossProjectReposAsync(input: {
  * from `sourceId`, then delete `sourceId`.
  */
 export function merge(targetId: string, sourceId: string): void {
-  if (!get(targetId) || !get(sourceId)) {
+  const target = get(targetId);
+  const source = get(sourceId);
+  if (!target || !source) {
     throw new Error("cannot merge entities across tenant boundaries");
+  }
+  const selfPersonMerge =
+    (target.entity_type === "self" || target.entity_type === "person") &&
+    (source.entity_type === "self" || source.entity_type === "person");
+  if (target.entity_type !== source.entity_type && !selfPersonMerge) {
+    throw new Error(
+      `cannot merge ${source.entity_type} entity into ${target.entity_type} entity`,
+    );
   }
   const d = db();
   d.exec("BEGIN IMMEDIATE");
@@ -2372,7 +2393,18 @@ export async function deduplicateEntities(
   opts?: { dryRun?: boolean; threshold?: number },
 ): Promise<EntityDedupResult> {
   const dryRun = opts?.dryRun ?? true;
-  const entities = projectPath ? forProject(projectPath) : listAll();
+  const pid = projectPath
+    ? dryRun
+      ? projectId(projectPath)
+      : ensureProject(projectPath)
+    : undefined;
+  // A preview must never create or reconcile project rows merely to inspect
+  // entities. Unknown project paths therefore have no candidates.
+  const entities = projectPath
+    ? pid
+      ? forProjectId(pid, true)
+      : []
+    : listAll();
   const names = new Map(entities.map((e) => [e.id, e.canonical_name]));
 
   const empty: EntityDedupResult = {
@@ -2385,9 +2417,7 @@ export async function deduplicateEntities(
 
   const dedupThreshold =
     opts?.threshold ??
-    loadEntityCalibratedThreshold(
-      projectPath ? ensureProject(projectPath) : null,
-    ) ??
+    loadEntityCalibratedThreshold(pid ?? null) ??
     ENTITY_EMBEDDING_DEDUP_THRESHOLD;
 
   // --- Load embeddings for the candidate entities (if available) ---

--- a/packages/core/test/entities.test.ts
+++ b/packages/core/test/entities.test.ts
@@ -962,6 +962,25 @@ describe("entities", () => {
       );
       expect(githubAliases.length).toBe(1);
     });
+
+    test("merge rejects incompatible entity types", () => {
+      const target = entities.create({
+        projectPath: PROJECT,
+        entityType: "person",
+        canonicalName: "MergePerson",
+      });
+      const source = entities.create({
+        projectPath: PROJECT,
+        entityType: "service",
+        canonicalName: "MergeService",
+      });
+
+      expect(() => entities.merge(target.id, source.id)).toThrow(
+        "cannot merge service entity into person entity",
+      );
+      expect(entities.get(target.id)).not.toBeNull();
+      expect(entities.get(source.id)).not.toBeNull();
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/gateway/src/cli/commands/entity.ts
+++ b/packages/gateway/src/cli/commands/entity.ts
@@ -1,5 +1,5 @@
 /**
- * `lore entity` — typed Stricli command (Phase 3D.4 + 3D.4 follow-up).
+ * `lore entity` — typed Stricli command (Phase 3D.4).
  *
  * Wraps the legacy `commandEntity` from `../entity` via the shared
  * `runLegacyAndCollect` bridge. The legacy handler takes:
@@ -11,55 +11,36 @@
  *                      `entity alias add <alias> <target>`,
  *                      `entity relation add <from> <to>`)
  *
- * Flags forwarded to the legacy values dict (10 + auto-injected --json):
- *   --all, --cross, --interactive/-i, --json, --metadata,
+ * Flags forwarded to the legacy values dict (11 + auto-injected --json):
+ *   --all, --cross, --dry-run, --interactive/-i, --json, --metadata,
  *   --name, --project, --relation, --type, --value, --yes/-y
  *
  * Destructive-operation confirmation policy (Phase 3D.4 follow-up):
- *   - `delete`, `merge`, `alias rm`, `relation rm` write by default;
- *     the typed wrapper rejects non-interactive invocations without
- *     `--yes` (mirrors `lore data`).
- *   - `dedup` writes only when `--yes` is supplied. `--dry-run` overrides
- *     `--yes` and forces the legacy preview path.
+ *   - `delete`, `merge`, `alias rm/remove`, and `relation rm/remove` write by
+ *     default and always require `--yes` before legacy dispatch.
+ *   - Every destructive operation requires `--yes`; `--dry-run` is a
+ *     non-interactive dedup preview and never mutates.
  *   - `--json --interactive` is rejected before delegating, so the legacy
- *     handler never enters the interactive prompt-and-mutate path under
- *     machine output.
+ *     handler never enters an interactive path under machine output.
+ *
+ * Output shape:
+ *   - human: rendered legacy text
+ *   - JSON:  { output: <captured stdout> }
+ *
+ * Exit codes: legacy semantics preserved (0 success, 1 unknown
+ * subcommand / invalid args / destructive error).
  */
 import { UsageError } from "../lib/errors";
 import { buildOutputCommand } from "../lib/command";
 import { runLegacyAndCollect } from "../lib/legacy-bridge";
 import { commandEntity } from "../entity";
-
-// Destructive top-level subcommands that write by default (require
-// --yes when stdin is not a TTY). None of the legacy entity write
-// handlers prompt the user; the wrapper enforces the confirm gate so
-// CI runs cannot mutate state silently.
-const WRITE_BY_DEFAULT = new Set<string>(["delete", "merge"]);
-
-function isDestructive(
-  subcommand: string,
-  positionals: readonly string[],
-): boolean {
-  if (subcommand === "dedup") return true;
-  if (WRITE_BY_DEFAULT.has(subcommand)) return true;
-  // `alias rm` / `relation rm` reach the writer through a two-level
-  // dispatcher; treat them as destructive when the user invokes the
-  // rm/remove subverb.
-  if (subcommand === "alias" && positionals[0] === "rm") return true;
-  if (
-    subcommand === "relation" &&
-    (positionals[0] === "rm" || positionals[0] === "remove")
-  ) {
-    return true;
-  }
-  return false;
-}
+import { entityOperationPolicy } from "../lib/entity-policy";
 
 type EntityFlags = {
   all: boolean;
   cross: boolean;
-  "dry-run": boolean;
   interactive: boolean;
+  "dry-run"?: boolean;
   metadata?: string;
   name?: string;
   project?: string;
@@ -79,11 +60,11 @@ export const entityCommand = buildOutputCommand<
   fullDescription:
     "Knowledge entity CRUD + alias/relation/merge/dedup/search. " +
     "First positional is the subcommand; subsequent positionals " +
-    "are subcommand-specific args. Flags: --all, --cross, " +
+    "are subcommand-specific args. Flags: --all, --cross, --dry-run, " +
     "--interactive/-i, --json, --metadata, --name, --project, " +
     "--relation, --type, --value, --yes/-y. Destructive " +
-    "subcommands: delete, merge, dedup. Confirmation policy for " +
-    "destructive operations is deferred (Phase 3D.4 follow-up).",
+    "subcommands: delete, merge, dedup, alias rm/remove, relation " +
+    "rm/remove. Destructive operations require --yes.",
   parameters: {
     // Single-character flag aliases: -i → --interactive, -y → --yes
     // (matching the legacy OPTIONS table at packages/gateway/src/cli/main.ts).
@@ -101,8 +82,8 @@ export const entityCommand = buildOutputCommand<
       },
       "dry-run": {
         kind: "boolean",
-        brief: "Preview entity dedup without applying auto-merges",
-        default: false,
+        brief: "Show dedup changes without applying them",
+        optional: true,
       },
       interactive: {
         kind: "boolean",
@@ -175,43 +156,17 @@ export const entityCommand = buildOutputCommand<
     const subArgs = positionals.slice(1);
     const jsonFlag = (flags as { json?: boolean }).json;
 
-    // JSON + interactive prompt together would corrupt machine output
-    // and produce interactive prompt behavior. Reject before delegating.
-    if (
-      jsonFlag &&
-      flags.interactive &&
-      isDestructive(subcommand ?? "", subArgs)
-    ) {
-      throw new UsageError({
-        message: `Refusing \`--json --interactive\` for destructive \`lore entity ${subcommand}\`.`,
-        tryCommand: `lore entity ${subcommand} --json --yes`,
-      });
-    }
-
-    // Central destructive confirmation policy: a destructive subcommand
-    // is only flagged when it WILL mutate state. For `dedup`, legacy
-    // gates the apply path on --yes, so without --yes it's a preview
-    // (non-mutating). For other write-by-default subcommands (delete,
-    // merge, alias rm, relation rm), any invocation without --yes in a
-    // non-interactive environment will mutate state silently because
-    // the legacy handlers do not prompt.
     const sub = subcommand ?? "";
-    const destructive = isDestructive(sub, subArgs);
-    // Only dedup has a preview mode. Other entity writers ignore
-    // --dry-run, so it MUST NOT weaken their confirmation gate.
-    const dryRun = sub === "dedup" && flags["dry-run"];
-    const willWrite =
-      destructive && !dryRun && (sub === "dedup" ? flags.yes === true : true);
-    if (willWrite && !flags.yes && (!process.stdin.isTTY || !!jsonFlag)) {
-      throw new UsageError({
-        message: `Refusing non-interactive \`lore entity ${sub}\` without --yes.`,
-        tryCommand: `lore entity ${sub} --yes`,
-      });
-    }
 
+    // JSON + interactive prompt together would corrupt machine output and
+    // produce interactive prompt behavior. Reject before delegating.
     const values: Record<string, unknown> = {};
     if (flags.all) values.all = true;
     if (flags.cross) values.cross = true;
+    if (flags["dry-run"]) {
+      values["dry-run"] = true;
+      values.dryRun = true;
+    }
     if (flags.interactive) values.interactive = true;
     if (flags.metadata !== undefined) values.metadata = flags.metadata;
     if (flags.name !== undefined) values.name = flags.name;
@@ -219,18 +174,32 @@ export const entityCommand = buildOutputCommand<
     if (flags.relation !== undefined) values.relation = flags.relation;
     if (flags.type !== undefined) values.type = flags.type;
     if (flags.value !== undefined) values.value = flags.value;
-    // Legacy dedup applies only when values.yes is true. Do not forward it
-    // when --dry-run is present, so --dry-run always wins over --yes.
-    if (flags.yes && !dryRun) values.yes = true;
-    // F-4 (HIGH): forward --json (auto-injected by buildOutputCommand)
-    // to the legacy handler. Legacy cmdList gates JSON output on
-    // `flags.json` — without this, the legacy emits human table text
-    // even when the typed pipeline's --json envelope is active.
+    if (flags.yes) values.yes = true;
     if (jsonFlag) values.json = true;
+
+    const policy = entityOperationPolicy([sub, ...subArgs], values);
+    if (policy.jsonInteractive) {
+      throw new UsageError({
+        message: `Refusing \`--json --interactive\` for \`${policy.operation}\`.`,
+        tryCommand: `${policy.operation} --json`,
+      });
+    }
+    if (policy.invalidDryRun) {
+      throw new UsageError({
+        message: "`--dry-run` is supported only by `lore entity dedup`.",
+        tryCommand: "lore entity dedup --dry-run",
+      });
+    }
+    if (policy.requiresYes && !flags.yes) {
+      throw new UsageError({
+        message: `Refusing destructive \`${policy.operation}\` without --yes.`,
+        tryCommand: `${policy.operation} --yes`,
+      });
+    }
     // Stricli spreads the variadic positional array into individual
     // handler params; collect back into the legacy string[].
     const { exitCode, captured } = await runLegacyAndCollect(() =>
-      commandEntity([subcommand ?? "", ...subArgs], values),
+      commandEntity([...positionals], values),
     );
     if (exitCode !== 0) {
       process.exitCode = exitCode;

--- a/packages/gateway/src/cli/entity.ts
+++ b/packages/gateway/src/cli/entity.ts
@@ -15,6 +15,8 @@
  *   delete <id>                  Delete an entity
  */
 import { resolve } from "node:path";
+import { UsageError } from "./lib/errors";
+import { entityOperationPolicy } from "./lib/entity-policy";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -485,6 +487,14 @@ async function cmdMerge(
     console.error(`Source entity not found: ${sourceId}`);
     process.exit(1);
   }
+  const selfPersonMerge =
+    (target.entity_type === "self" || target.entity_type === "person") &&
+    (source.entity_type === "self" || source.entity_type === "person");
+  if (target.entity_type !== source.entity_type && !selfPersonMerge) {
+    throw new UsageError({
+      message: `Cannot merge ${source.entity_type} entity into ${target.entity_type} entity.`,
+    });
+  }
 
   entities.merge(targetId, sourceId);
   console.log(
@@ -624,24 +634,26 @@ async function cmdDedup(
     projectId: getProjectId,
   } = await import("@loreai/core");
 
-  const apply = !!flags.yes;
-  const interactive = !!flags.interactive;
+  const dryRun = flags["dry-run"] === true || flags.dryRun === true;
+  // A dry-run is always a non-interactive preview, even if callers supplied
+  // both flags. This prevents the prompt branch from mutating state.
+  const interactive = !!flags.interactive && !dryRun;
+  // In interactive mode --yes confirms that the destructive flow is allowed;
+  // it must not bypass the per-cluster prompts or trigger auto-apply setup.
+  const apply = !!flags.yes && !dryRun && !interactive;
   const asJson = !!flags.json;
   const projectPath = flags.all
     ? undefined
     : resolve((flags.project as string) ?? process.cwd());
 
-  if (interactive && apply) {
-    console.error("--interactive and --yes are mutually exclusive.");
-    process.exit(1);
-  }
   if (interactive && !process.stdin.isTTY) {
     console.error("--interactive requires a TTY.");
     process.exit(1);
   }
 
-  // Preflight: backfill missing entity embeddings so similarity has vectors.
-  if (emb.isAvailable()) {
+  // Applying dedup may need a preflight backfill. Preview paths must never
+  // write embeddings as a side effect of inspecting duplicate candidates.
+  if (apply && emb.isAvailable()) {
     try {
       const n = await emb.backfillEntityEmbeddings();
       if (n > 0) console.log(`Re-indexed ${n} entit${n === 1 ? "y" : "ies"}.`);
@@ -651,7 +663,7 @@ async function cmdDedup(
         err,
       );
     }
-  } else {
+  } else if (apply) {
     console.log(
       "Note: no embedding provider available — using name/alias signals only.",
     );
@@ -836,19 +848,39 @@ Options:
   --metadata <json>  JSON metadata (add, edit, relation add)
   --name <name>      New name (edit only)
   --cross            Cross-project flag (add, edit)
-  --yes, -y          Apply auto-merges (dedup)
+  --yes, -y          Confirm destructive operations / apply auto-merges
   --interactive, -i  Accept/reject each cluster (dedup)
 
 Examples:
   lore entity dedup                    # dry-run: show duplicate clusters
   lore entity dedup --yes              # apply: auto-merge high-confidence dupes
-  lore entity dedup --interactive      # decide per cluster
+  lore entity dedup --interactive --yes # decide per cluster
 `.trim();
 
 export async function commandEntity(
   args: string[],
   values: Record<string, unknown>,
 ): Promise<void> {
+  const policy = entityOperationPolicy(args, values);
+  if (policy.invalidDryRun) {
+    throw new UsageError({
+      message: "`--dry-run` is supported only by `lore entity dedup`.",
+      tryCommand: "lore entity dedup --dry-run",
+    });
+  }
+  if (policy.jsonInteractive) {
+    throw new UsageError({
+      message: `Refusing \`--json --interactive\` for \`${policy.operation}\`.`,
+      tryCommand: `${policy.operation} --json`,
+    });
+  }
+  if (policy.requiresYes && values.yes !== true) {
+    throw new UsageError({
+      message: `Refusing destructive \`${policy.operation}\` without --yes.`,
+      tryCommand: `${policy.operation} --yes`,
+    });
+  }
+
   const subcommand = args[0];
   const subArgs = args.slice(1);
 

--- a/packages/gateway/src/cli/entity.ts
+++ b/packages/gateway/src/cli/entity.ts
@@ -834,7 +834,7 @@ Subcommands:
   relation add <a-id> <b-id> --relation <type>  Add a relation
   relation rm <relation-id>            Remove a relation
   merge <target-id> <source-id>        Merge two entities
-  dedup                                Find/merge duplicate entities
+  dedup                                Preview with --dry-run; apply with --yes
   search <query>                       Search entities
   delete <id>                          Delete an entity
 
@@ -852,7 +852,7 @@ Options:
   --interactive, -i  Accept/reject each cluster (dedup)
 
 Examples:
-  lore entity dedup                    # dry-run: show duplicate clusters
+  lore entity dedup --dry-run          # show duplicate clusters without changes
   lore entity dedup --yes              # apply: auto-merge high-confidence dupes
   lore entity dedup --interactive --yes # decide per cluster
 `.trim();

--- a/packages/gateway/src/cli/lib/entity-policy.ts
+++ b/packages/gateway/src/cli/lib/entity-policy.ts
@@ -1,0 +1,36 @@
+export type EntityOperationPolicy = {
+  operation: string;
+  destructive: boolean;
+  dryRun: boolean;
+  invalidDryRun: boolean;
+  jsonInteractive: boolean;
+  requiresYes: boolean;
+};
+
+export function entityOperationPolicy(
+  args: readonly string[],
+  values: Record<string, unknown>,
+): EntityOperationPolicy {
+  const subcommand = args[0] ?? "";
+  const verb = args[1];
+  const operation =
+    (subcommand === "alias" || subcommand === "relation") && verb
+      ? `lore entity ${subcommand} ${verb}`
+      : `lore entity ${subcommand}`;
+  const destructive =
+    subcommand === "delete" ||
+    subcommand === "merge" ||
+    subcommand === "dedup" ||
+    ((subcommand === "alias" || subcommand === "relation") &&
+      (verb === "rm" || verb === "remove"));
+  const dryRun = values["dry-run"] === true || values.dryRun === true;
+
+  return {
+    operation,
+    destructive,
+    dryRun,
+    invalidDryRun: dryRun && subcommand !== "dedup",
+    jsonInteractive: values.json === true && values.interactive === true,
+    requiresYes: destructive && !dryRun,
+  };
+}

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -14,7 +14,8 @@
  *   help           → print usage
  */
 import { parseArgs } from "node:util";
-import { stringifyUnknown } from "./lib/errors";
+import { stringifyUnknown, UsageError } from "./lib/errors";
+import { entityOperationPolicy } from "./lib/entity-policy";
 import { printHelp, printVersion } from "./help";
 import { commandStart, type StartOptions } from "./start";
 import {
@@ -574,6 +575,25 @@ export async function _cli(): Promise<void> {
       }
 
       case "entity": {
+        const entityPolicy = entityOperationPolicy(rest, values);
+        if (entityPolicy.invalidDryRun) {
+          throw new UsageError({
+            message: "`--dry-run` is supported only by `lore entity dedup`.",
+            tryCommand: "lore entity dedup --dry-run",
+          });
+        }
+        if (entityPolicy.jsonInteractive) {
+          throw new UsageError({
+            message: `Refusing \`--json --interactive\` for \`${entityPolicy.operation}\`.`,
+            tryCommand: `${entityPolicy.operation} --json`,
+          });
+        }
+        if (entityPolicy.requiresYes && values.yes !== true) {
+          throw new UsageError({
+            message: `Refusing destructive \`${entityPolicy.operation}\` without --yes.`,
+            tryCommand: `${entityPolicy.operation} --yes`,
+          });
+        }
         const { commandEntity } = await import("./entity");
         await commandEntity(rest, values);
         break;

--- a/packages/gateway/test/cli-entity-contract.test.ts
+++ b/packages/gateway/test/cli-entity-contract.test.ts
@@ -96,6 +96,21 @@ describe("Phase 3D.4 — typed lore entity", () => {
     }
   });
 
+  test("entity help explains explicit dedup preview and apply flags", async () => {
+    const { commandEntity } = await import("../src/cli/entity");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    let help = "";
+    try {
+      await commandEntity(["help"], {});
+      help = logSpy.mock.calls.flat().join("\n");
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(help).toContain("lore entity dedup --dry-run");
+    expect(help).toContain("lore entity dedup --yes");
+    expect(help).not.toMatch(/lore entity dedup\s+# dry-run/);
+  });
+
   test("entity forwards subcommand + flags to legacy handler", async () => {
     vi.resetModules();
     const calls: EntityCall[] = [];

--- a/packages/gateway/test/cli-entity-contract.test.ts
+++ b/packages/gateway/test/cli-entity-contract.test.ts
@@ -13,7 +13,7 @@
  *   - F-3: -i alias added for --interactive
  *   - F-4: --json forwarded to legacy values.json (was missing —
  *     legacy cmdList gates JSON output on flags.json)
- *   - F-5: flag-count strings corrected to 10 (+ --json)
+ *   - F-5: flag-count strings corrected to 11 (+ --json)
  *   - F-6: --metadata changed to parsed String (was boolean; legacy
  *           parses it as JSON.stringify)
  *   - F-7: dead defensive positionals.filter removed (ARGS = string[]
@@ -492,7 +492,74 @@ describe("Phase 3D.4 — typed lore entity", () => {
     vi.resetModules();
   });
 
-  test("entity dedup without --yes runs in preview mode and reaches legacy handler", async () => {
+  test("entity --json --interactive rejects before any legacy handler", async () => {
+    vi.resetModules();
+    const entityImpl = vi.fn(async () => {});
+    vi.doMock("../src/cli/entity", () => ({ commandEntity: entityImpl }));
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = ["node", "lore", "entity", "add", "--json", "--interactive"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(entityImpl).not.toHaveBeenCalled();
+    expect(capturedExitCode).toBe(20);
+    vi.resetModules();
+  });
+
+  test("entity alias remove requires --yes before legacy handler", async () => {
+    vi.resetModules();
+    const entityImpl = vi.fn(async () => {});
+    vi.doMock("../src/cli/entity", () => ({ commandEntity: entityImpl }));
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = ["node", "lore", "entity", "alias", "remove", "alias-id"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(entityImpl).not.toHaveBeenCalled();
+    expect(capturedExitCode).toBe(20);
+    vi.resetModules();
+  });
+
+  test("entity --dry-run is limited to dedup", async () => {
+    vi.resetModules();
+    const entityImpl = vi.fn(async () => {});
+    vi.doMock("../src/cli/entity", () => ({ commandEntity: entityImpl }));
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = [
+      "node",
+      "lore",
+      "entity",
+      "delete",
+      "entry-id",
+      "--dry-run",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(entityImpl).not.toHaveBeenCalled();
+    expect(capturedExitCode).toBe(20);
+    vi.resetModules();
+  });
+
+  test("entity dedup requires --yes before reaching the legacy handler", async () => {
     vi.resetModules();
     const calls: EntityCall[] = [];
     const entityImpl = vi.fn(
@@ -505,18 +572,109 @@ describe("Phase 3D.4 — typed lore entity", () => {
     process.argv = ["node", "lore", "entity", "dedup"];
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(calls).toHaveLength(0);
+    expect(capturedExitCode).toBe(20);
+    vi.resetModules();
+  });
+
+  test("entity dedup --interactive requires --yes before reaching the legacy handler", async () => {
+    vi.resetModules();
+    const entityImpl = vi.fn(async () => {});
+    vi.doMock("../src/cli/entity", () => ({ commandEntity: entityImpl }));
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = ["node", "lore", "entity", "dedup", "--interactive"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    let capturedExitCode: number | undefined;
+    try {
+      await runCli();
+      capturedExitCode = process.exitCode;
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+    expect(entityImpl).not.toHaveBeenCalled();
+    expect(capturedExitCode).toBe(20);
+    vi.resetModules();
+  });
+
+  test("entity dedup --dry-run is allowed without --yes", async () => {
+    vi.resetModules();
+    const calls: EntityCall[] = [];
+    const entityImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+      },
+    );
+    vi.doMock("../src/cli/entity", () => ({ commandEntity: entityImpl }));
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = ["node", "lore", "entity", "dedup", "--dry-run"];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
     try {
       await runCli();
     } finally {
       process.exitCode = priorExitCode;
     }
-    // dedup without --yes is a preview-only operation; the legacy
-    // handler applies apply=false (dry-run) internally. The wrapper
-    // passes it through because dedup is non-mutating by default.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.values.yes).toBeUndefined();
+    expect(calls[0]?.values["dry-run"]).toBe(true);
+    vi.resetModules();
+  });
+
+  test("entity dedup --interactive --yes reaches the legacy handler", async () => {
+    vi.resetModules();
+    const calls: EntityCall[] = [];
+    const entityImpl = vi.fn(
+      async (positionals: string[], values: Record<string, unknown>) => {
+        calls.push({ positionals: [...positionals], values: { ...values } });
+      },
+    );
+    vi.doMock("../src/cli/entity", () => ({ commandEntity: entityImpl }));
+    const { runCli } = await import("../src/cli/cli");
+    process.argv = [
+      "node",
+      "lore",
+      "entity",
+      "dedup",
+      "--interactive",
+      "--yes",
+    ];
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await runCli();
+    } finally {
+      process.exitCode = priorExitCode;
+    }
     expect(calls).toHaveLength(1);
     expect(calls[0]?.positionals).toEqual(["dedup"]);
-    expect(calls[0]?.values.yes).toBeUndefined();
+    expect(calls[0]?.values.interactive).toBe(true);
+    expect(calls[0]?.values.yes).toBe(true);
     vi.resetModules();
+  });
+
+  test("direct legacy _cli enforces entity policy before dispatch", async () => {
+    vi.resetModules();
+    const priorArgv = process.argv;
+    process.argv = ["node", "lore", "entity", "dedup", "--interactive"];
+    try {
+      const { _cli } = await import("../src/cli/main");
+      await expect(_cli()).rejects.toMatchObject({
+        name: "UsageError",
+        exitCode: 20,
+        message: "Refusing destructive `lore entity dedup` without --yes.",
+      });
+    } finally {
+      process.argv = priorArgv;
+      vi.resetModules();
+    }
   });
 
   test("entity dedup --yes forwards apply path to legacy handler", async () => {
@@ -537,16 +695,13 @@ describe("Phase 3D.4 — typed lore entity", () => {
     } finally {
       process.exitCode = priorExitCode;
     }
-    // `dedup --yes` IS the explicit non-interactive apply path — the
-    // wrapper must not block it. The legacy handler enforces its own
-    // gate (calibrated threshold).
     expect(calls).toHaveLength(1);
     expect(calls[0]?.values.yes).toBe(true);
     expect(calls[0]?.values.json).toBe(true);
     vi.resetModules();
   });
 
-  test("entity dedup --dry-run overrides --yes before legacy dispatch", async () => {
+  test("entity dedup --dry-run overrides --yes in legacy handler", async () => {
     vi.resetModules();
     const calls: EntityCall[] = [];
     const entityImpl = vi.fn(
@@ -564,38 +719,10 @@ describe("Phase 3D.4 — typed lore entity", () => {
     } finally {
       process.exitCode = priorExitCode;
     }
-
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.values.yes).toBeUndefined();
-    vi.resetModules();
-  });
-
-  test("entity delete --dry-run still requires --yes in JSON mode", async () => {
-    vi.resetModules();
-    const entityImpl = vi.fn(async () => {});
-    vi.doMock("../src/cli/entity", () => ({ commandEntity: entityImpl }));
-    const { runCli } = await import("../src/cli/cli");
-    process.argv = [
-      "node",
-      "lore",
-      "entity",
-      "delete",
-      "entry-id",
-      "--dry-run",
-      "--json",
-    ];
-    const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
-    let capturedExitCode: number | undefined;
-    try {
-      await runCli();
-      capturedExitCode = process.exitCode;
-    } finally {
-      process.exitCode = priorExitCode;
-    }
-
-    expect(entityImpl).not.toHaveBeenCalled();
-    expect(capturedExitCode).toBe(20);
+    expect(calls[0]?.values.yes).toBe(true);
+    expect(calls[0]?.values["dry-run"]).toBe(true);
+    expect(calls[0]?.values.dryRun).toBe(true);
     vi.resetModules();
   });
 });

--- a/packages/gateway/test/entity-dedup-policy.test.ts
+++ b/packages/gateway/test/entity-dedup-policy.test.ts
@@ -1,56 +1,206 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { db, entities, projectId } from "@loreai/core";
+import { clearGitRemoteCache, db, embedding, entities } from "@loreai/core";
 import { commandEntity } from "../src/cli/entity";
 
 let projectDir: string;
 let logSpy: ReturnType<typeof vi.spyOn>;
 let errorSpy: ReturnType<typeof vi.spyOn>;
+let embeddingAvailabilitySpy: ReturnType<typeof vi.spyOn>;
+let embeddingBackfillSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   projectDir = mkdtempSync(join(tmpdir(), "lore-entity-dedup-"));
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  embeddingAvailabilitySpy = vi
+    .spyOn(embedding, "isAvailable")
+    .mockReturnValue(true);
+  embeddingBackfillSpy = vi
+    .spyOn(embedding, "backfillEntityEmbeddings")
+    .mockResolvedValue(0);
 });
 
 afterEach(() => {
   logSpy.mockRestore();
   errorSpy.mockRestore();
+  embeddingAvailabilitySpy.mockRestore();
+  embeddingBackfillSpy.mockRestore();
   rmSync(projectDir, { recursive: true, force: true });
 });
 
 describe("lore entity dedup safety policy", () => {
-  test("legacy dedup preview preserves entities without --yes", async () => {
-    const canonical = ensureEntity("tool", "Prefer idempotent writes");
-    const duplicate = ensureEntity("tool", "Use atomic skill writes");
-    const id = projectId(projectDir);
+  test("--dry-run overrides --yes and preserves a real duplicate cluster", async () => {
+    const canonical = ensureEntity("tool", "Prefer idempotent writes", {
+      type: "github",
+      value: "idempotent-writes",
+    });
+    const duplicate = ensureEntity("tool", "Use atomic skill writes", {
+      type: "nickname",
+      value: "idempotent-writes",
+    });
 
     expect(canonical).not.toBe(duplicate);
     expect(
-      db()
-        .query("SELECT COUNT(*) AS n FROM entities WHERE project_id = ?")
-        .get(id),
+      db().query("SELECT COUNT(*) AS n FROM entities").get(),
     ).toMatchObject({ n: 2 });
+
+    const preview = await entities.deduplicateEntities(projectDir, {
+      dryRun: true,
+    });
+    expect(preview.merged).toHaveLength(1);
 
     await commandEntity(["dedup"], {
       project: projectDir,
+      yes: true,
+      "dry-run": true,
     });
 
     expect(
-      db()
-        .query("SELECT COUNT(*) AS n FROM entities WHERE project_id = ?")
-        .get(id),
+      db().query("SELECT COUNT(*) AS n FROM entities").get(),
     ).toMatchObject({ n: 2 });
+    expect(embeddingBackfillSpy).not.toHaveBeenCalled();
+  });
+
+  test("--dry-run does not create an unknown project", async () => {
+    const before = db().query("SELECT COUNT(*) AS n FROM projects").get() as {
+      n: number;
+    };
+
+    await commandEntity(["dedup"], {
+      project: projectDir,
+      yes: true,
+      "dry-run": true,
+    });
+
+    const after = db().query("SELECT COUNT(*) AS n FROM projects").get() as {
+      n: number;
+    };
+    expect(after.n).toBe(before.n);
+    expect(embeddingBackfillSpy).not.toHaveBeenCalled();
+  });
+
+  test("--dry-run does not reconcile an unsettled project remote", async () => {
+    ensureEntity("tool", "Known tool", {
+      type: "github",
+      value: "known-tool",
+    });
+    ensureEntity("tool", "Another known tool", {
+      type: "nickname",
+      value: "known-tool",
+    });
+    execFileSync("git", ["init", "-q"], { cwd: projectDir });
+    execFileSync(
+      "git",
+      ["remote", "add", "origin", "https://github.com/test/preview.git"],
+      { cwd: projectDir },
+    );
+    clearGitRemoteCache();
+
+    const before = db()
+      .query("SELECT git_remote FROM projects WHERE path = ?")
+      .get(projectDir) as { git_remote: string | null };
+    expect(before.git_remote).toBeNull();
+
+    const preview = await entities.deduplicateEntities(projectDir, {
+      dryRun: true,
+    });
+
+    expect(preview.merged).toHaveLength(1);
+    const after = db()
+      .query("SELECT git_remote FROM projects WHERE path = ?")
+      .get(projectDir) as { git_remote: string | null };
+    expect(after.git_remote).toBeNull();
+  });
+
+  test("interactive dedup uses --yes as confirmation, not auto-apply", async () => {
+    const deduplicateSpy = vi
+      .spyOn(entities, "deduplicateEntities")
+      .mockResolvedValue({
+        merged: [],
+        suggested: [],
+        pairSimilarities: new Map(),
+        names: new Map(),
+      });
+
+    const isTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    try {
+      await commandEntity(["dedup"], {
+        project: projectDir,
+        interactive: true,
+        yes: true,
+      });
+    } finally {
+      if (isTTY) Object.defineProperty(process.stdin, "isTTY", isTTY);
+      else Reflect.deleteProperty(process.stdin, "isTTY");
+    }
+
+    expect(deduplicateSpy).toHaveBeenCalledWith(projectDir, { dryRun: true });
+    expect(embeddingBackfillSpy).not.toHaveBeenCalled();
+    deduplicateSpy.mockRestore();
+  });
+
+  test("manual merge rejects different entity types", async () => {
+    const person = ensureEntity("person", "A person", {
+      type: "nickname",
+      value: "person-one",
+    });
+    const service = ensureEntity("service", "A service", {
+      type: "nickname",
+      value: "service-one",
+    });
+
+    await expect(
+      commandEntity(["merge", person, service], {
+        project: projectDir,
+        yes: true,
+      }),
+    ).rejects.toMatchObject({ name: "UsageError", exitCode: 20 });
+    expect(entities.get(person)).not.toBeNull();
+    expect(entities.get(service)).not.toBeNull();
+  });
+
+  test("manual merge preserves the self/person compatibility exception", async () => {
+    const self = ensureEntity("self", "The user", {
+      type: "email",
+      value: "user@example.com",
+    });
+    const person = ensureEntity("person", "User", {
+      type: "nickname",
+      value: "the-user",
+    });
+
+    await commandEntity(["merge", self, person], {
+      project: projectDir,
+      yes: true,
+    });
+
+    expect(entities.get(self)).not.toBeNull();
+    expect(entities.get(person)).toBeNull();
   });
 });
 
-function ensureEntity(type: string, name: string): string {
+function ensureEntity(
+  type: string,
+  name: string,
+  alias: { type: string; value: string },
+): string {
   const result = entities.create({
     projectPath: projectDir,
     entityType: type as Parameters<typeof entities.create>[0]["entityType"],
     canonicalName: name,
+    aliases: [
+      alias as NonNullable<
+        Parameters<typeof entities.create>[0]["aliases"]
+      >[number],
+    ],
     crossProject: false,
   });
   return result.id;


### PR DESCRIPTION
## Summary
- enforce `--yes` before destructive `lore entity` operations at typed and legacy dispatch boundaries
- keep dedup previews read-only and reject JSON plus interactive mode
- prevent cross-type entity merges while preserving self/person consolidation
- make offloaded entity scans and project preview resolution behavior-identical and non-mutating

## Validation
- focused entity/core tests: 96 passed
- CLI regression battery: 204 passed across 14 files
- workspace typecheck: passed
- format check: passed
- lint: passed with existing warnings
- gateway bundle: passed
- full test suite: previously inconclusive after bounded timeout, with no assertion summary