### PR TITLE
feat(gateway): allow remote management access

### DIFF
--- a/packages/gateway/src/cli/commands/start.ts
+++ b/packages/gateway/src/cli/commands/start.ts
@@ -10,6 +10,8 @@
  *   opts.debug      — verbose banner (boolean, optional)
  *   opts.remoteUrl  — remote gateway URL (string, optional)
  *   opts.local      — disable hosted mode (boolean, optional)
+ *   opts.allowRemoteManagement — expose management routes to non-loopback
+ *                                peers (boolean, optional)
  *   opts.bg         — daemonize and exit (boolean, optional; aliased to
  *                     `--daemon`)
  *
@@ -28,6 +30,7 @@ type StartFlags = {
   debug?: boolean;
   remote?: string;
   local?: boolean;
+  allowRemoteManagement?: boolean;
   bg?: boolean;
   daemon?: boolean;
 };
@@ -39,7 +42,7 @@ export const startCommand = buildCommand<StartFlags, []>({
     "in the foreground until SIGINT/SIGTERM. With `--bg` (or `--daemon`) " +
     "the process detaches, prints the gateway address + PID + log path, " +
     "and exits 0. Flags: --port/-p, --host (repeatable), --debug/-d, " +
-    "--remote/-r, --local/-l, --bg/--daemon.",
+    "--remote/-r, --local/-l, --allow-remote-management, --bg/--daemon.",
   parameters: {
     // -H is reserved by Stricli for help, so --host has no short alias.
     // The remaining legacy aliases are retained.
@@ -74,6 +77,11 @@ export const startCommand = buildCommand<StartFlags, []>({
         brief: "Disable hosted mode even for lore start (alias: -l)",
         optional: true,
       },
+      allowRemoteManagement: {
+        kind: "boolean",
+        brief: "Allow non-loopback peers to access the dashboard and API",
+        optional: true,
+      },
       bg: {
         kind: "boolean",
         brief: "Detach and run as a background daemon",
@@ -98,6 +106,7 @@ export const startCommand = buildCommand<StartFlags, []>({
       debug: flags.debug,
       remoteUrl: flags.remote,
       local: flags.local,
+      allowRemoteManagement: flags.allowRemoteManagement,
       bg: flags.bg || flags.daemon || undefined,
     };
     // Foreground path returns Promise<never>; Stricli waits for handler

--- a/packages/gateway/src/cli/help.ts
+++ b/packages/gateway/src/cli/help.ts
@@ -59,6 +59,9 @@ Options:
   -l, --local         Disable hosted mode AND remote-gateway mode for
                       \`lore start\` (keep FS ops active; bucket cwd fallback)
                       (env: LORE_HOSTED_MODE=0)
+      --allow-remote-management
+                       Allow non-loopback access to /ui and /api
+                       (env: LORE_ALLOW_REMOTE_MANAGEMENT=1)
       --bg, --daemon  \`lore start\`: run the gateway detached in the background,
                       then print its address, PID, and log path and exit
   -d, --debug         Enable debug logging (env: LORE_DEBUG=1)

--- a/packages/gateway/src/cli/main.ts
+++ b/packages/gateway/src/cli/main.ts
@@ -150,6 +150,7 @@ const OPTIONS = {
   // `lore start --bg` / `--daemon` — run the gateway detached in the background
   bg: { type: "boolean" as const },
   daemon: { type: "boolean" as const },
+  "allow-remote-management": { type: "boolean" as const },
   // `lore login` / `lore whoami` flags
   email: { type: "string" as const },
   role: { type: "string" as const },
@@ -203,6 +204,7 @@ function buildStartOptions(values: {
   local?: boolean;
   bg?: boolean;
   daemon?: boolean;
+  "allow-remote-management"?: boolean;
 }): StartOptions {
   // Flatten: each --host value may itself be comma-separated
   const hosts = values.host?.flatMap((h) =>
@@ -218,6 +220,7 @@ function buildStartOptions(values: {
     remoteUrl: values.remote ?? undefined,
     local: values.local ?? undefined,
     bg: values.bg || values.daemon || undefined,
+    allowRemoteManagement: values["allow-remote-management"] ?? undefined,
   };
 }
 

--- a/packages/gateway/src/cli/start.ts
+++ b/packages/gateway/src/cli/start.ts
@@ -92,6 +92,8 @@ export interface StartOptions {
    * CLI: `--local` / `-l`.
    */
   local?: boolean;
+  /** Allow non-loopback peers to access the dashboard and management API. */
+  allowRemoteManagement?: boolean;
   /**
    * When true, `lore start` daemonizes: it re-spawns itself detached, polls
    * the gateway until healthy, prints the address + PID + log path, and exits 0.
@@ -444,6 +446,7 @@ export function buildStartChildArgs(opts: StartOptions): string[] {
   }
   if (opts.debug) args.push("--debug");
   if (opts.local) args.push("--local");
+  if (opts.allowRemoteManagement) args.push("--allow-remote-management");
   if (opts.remoteUrl) args.push("--remote", opts.remoteUrl);
   return args;
 }
@@ -897,6 +900,9 @@ async function startGatewayLocked(
   }
   if (opts.hosts?.length) config.hosts = opts.hosts;
   if (opts.debug !== undefined) config.debug = opts.debug;
+  if (opts.allowRemoteManagement !== undefined) {
+    config.allowRemoteManagement = opts.allowRemoteManagement;
+  }
 
   // Hosted mode: `--local` CLI flag takes precedence, then env var,
   // then the caller-provided default. `lore start` leaves `opts.local`

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -48,6 +48,11 @@ export interface GatewayConfig {
    * CLI: --host (can be specified multiple times, or comma-separated).
    */
   hosts: string[];
+  /**
+   * Allow non-loopback socket peers to access the dashboard and management API.
+   * Disabled by default. Env: LORE_ALLOW_REMOTE_MANAGEMENT.
+   */
+  allowRemoteManagement: boolean;
   /** Upstream Anthropic API URL. Default: "https://api.anthropic.com". Env: LORE_UPSTREAM_ANTHROPIC */
   upstreamAnthropic: string;
   /** Upstream OpenAI API URL. Default: "https://api.openai.com". Env: LORE_UPSTREAM_OPENAI */
@@ -240,6 +245,7 @@ export function loadConfig(): GatewayConfig {
     port: parsePort(env.LORE_LISTEN_PORT, DEFAULT_PORT),
     portExplicit: !!env.LORE_LISTEN_PORT,
     hosts,
+    allowRemoteManagement: isTruthy(env.LORE_ALLOW_REMOTE_MANAGEMENT),
     upstreamAnthropic,
     upstreamOpenAI,
     callerUpstreamAllowlist,

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -348,6 +348,7 @@ function managementCorsOrigin(
       hostname === "localhost" || isLoopbackAddress(hostname);
     if (!isLoopbackAddress(peerAddress)) {
       if (!allowRemoteManagement) return false;
+      if (loopbackOrigin) return false;
       const requestHost = req.headers.get("host");
       if (!requestHost) return false;
       const requestOrigin = new URL(`http://${requestHost}`);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -351,7 +351,10 @@ function managementCorsOrigin(
       if (loopbackOrigin) return false;
       const requestHost = req.headers.get("host");
       if (!requestHost) return false;
-      const requestOrigin = new URL(`http://${requestHost}`);
+      // Use the origin scheme only to normalize default ports. The scheme is
+      // not trusted for authorization; remote access is still gated by the
+      // socket peer and the origin/Host host-port match below.
+      const requestOrigin = new URL(`${parsed.protocol}//${requestHost}`);
       if (
         requestOrigin.username ||
         requestOrigin.password ||

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -318,10 +318,15 @@ function withoutGatewayAccessHeader(req: Request): Request {
 
 /**
  * Return an allowed CORS origin, null when Origin is absent, or false when an
- * untrusted web origin supplied the header. Only numeric loopback hosts and the
- * special-use `localhost` name are valid browser origins for management.
+ * untrusted web origin supplied the header. Loopback peers may use numeric
+ * loopback hosts or the special-use `localhost` name. Non-loopback peers must
+ * supply an origin that exactly matches Host.
  */
-function managementCorsOrigin(req: Request): string | null | false {
+function managementCorsOrigin(
+  req: Request,
+  allowRemoteManagement: boolean,
+  peerAddress: string | undefined,
+): string | null | false {
   const origin = req.headers.get("origin");
   if (!origin) return null;
   try {
@@ -339,7 +344,26 @@ function managementCorsOrigin(req: Request): string | null | false {
       return false;
     }
     const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
-    if (hostname !== "localhost" && !isLoopbackAddress(hostname)) return false;
+    const loopbackOrigin =
+      hostname === "localhost" || isLoopbackAddress(hostname);
+    if (!isLoopbackAddress(peerAddress)) {
+      if (!allowRemoteManagement) return false;
+      const requestHost = req.headers.get("host");
+      if (!requestHost) return false;
+      const requestOrigin = new URL(`http://${requestHost}`);
+      if (
+        requestOrigin.username ||
+        requestOrigin.password ||
+        requestOrigin.pathname !== "/" ||
+        requestOrigin.search ||
+        requestOrigin.hash ||
+        parsed.origin !== requestOrigin.origin
+      ) {
+        return false;
+      }
+    } else if (!loopbackOrigin) {
+      return false;
+    }
     return origin;
   } catch {
     return false;
@@ -755,6 +779,11 @@ export async function startServer(
     config = { ...config, port: DEFAULT_PORT };
   }
   assertGatewayAccessConfigured(config);
+  if (config.allowRemoteManagement) {
+    log.notice(
+      "warning: remote management access is enabled; every client accepted by the listener can access /ui and /api",
+    );
+  }
 
   // Bootstrap the daily spend counter from DB (recovers today's spend after restart)
   if (getDailyBudget() > 0) {
@@ -794,9 +823,15 @@ export async function startServer(
       // Authorize from node:http's socket metadata, never from Forwarded,
       // X-Forwarded-For, Host, or another client-controlled header. Keep this
       // before preflight handling, lazy imports, and request body consumption.
-      if (!isLoopbackAddress(peerAddress)) return hiddenManagementResponse();
+      if (!config.allowRemoteManagement && !isLoopbackAddress(peerAddress)) {
+        return hiddenManagementResponse();
+      }
 
-      const origin = managementCorsOrigin(req);
+      const origin = managementCorsOrigin(
+        req,
+        config.allowRemoteManagement,
+        peerAddress,
+      );
       if (origin === false) return hiddenManagementResponse();
       allowedManagementOrigin = origin;
 
@@ -1048,7 +1083,7 @@ export async function startServer(
         return withManagementCors(
           new Response(null, {
             status: 302,
-            headers: { location: new URL("/ui", url).toString() },
+            headers: { location: "/ui" },
           }),
           allowedManagementOrigin,
         );

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -357,7 +357,7 @@ function managementCorsOrigin(
         requestOrigin.pathname !== "/" ||
         requestOrigin.search ||
         requestOrigin.hash ||
-        parsed.origin !== requestOrigin.origin
+        parsed.host !== requestOrigin.host
       ) {
         return false;
       }

--- a/packages/gateway/test/cli-start-contract.test.ts
+++ b/packages/gateway/test/cli-start-contract.test.ts
@@ -43,6 +43,7 @@ describe("Phase 3B.2 - typed lore start", () => {
       "--remote",
       "https://gateway.example",
       "--local",
+      "--allow-remote-management",
       "--bg",
     ];
     try {
@@ -57,6 +58,7 @@ describe("Phase 3B.2 - typed lore start", () => {
       debug: true,
       remoteUrl: "https://gateway.example",
       local: true,
+      allowRemoteManagement: true,
       bg: true,
     });
   });

--- a/packages/gateway/test/daemon-args.test.ts
+++ b/packages/gateway/test/daemon-args.test.ts
@@ -60,6 +60,7 @@ describe("daemon arguments", () => {
         hosts: ["127.0.0.1", "100.64.0.1"],
         debug: true,
         local: true,
+        allowRemoteManagement: true,
         remoteUrl: "http://remote:3207",
       }),
     ).toEqual([
@@ -72,6 +73,7 @@ describe("daemon arguments", () => {
       "100.64.0.1",
       "--debug",
       "--local",
+      "--allow-remote-management",
       "--remote",
       "http://remote:3207",
     ]);

--- a/packages/gateway/test/eviction.test.ts
+++ b/packages/gateway/test/eviction.test.ts
@@ -50,6 +50,7 @@ function makeConfig(overrides?: Partial<GatewayConfig>): GatewayConfig {
     remoteGateway: false,
     upstreamExtraHeaders: {},
     ...overrides,
+    allowRemoteManagement: overrides?.allowRemoteManagement ?? false,
   };
 }
 

--- a/packages/gateway/test/gateway-auth-config.test.ts
+++ b/packages/gateway/test/gateway-auth-config.test.ts
@@ -13,6 +13,7 @@ const ENV_KEYS = [
   "LORE_GATEWAY_AUTH_TOKEN",
   "LORE_HOSTED_MODE",
   "LORE_LISTEN_HOST",
+  "LORE_ALLOW_REMOTE_MANAGEMENT",
   "LORE_REMOTE_GATEWAY",
   "LORE_UPSTREAM_EXTRA_HEADERS",
 ] as const;
@@ -89,6 +90,15 @@ describe("gateway access configuration", () => {
         gatewayAuthToken: undefined,
       }),
     ).not.toThrow();
+  });
+
+  test("keeps remote management disabled unless explicitly enabled", () => {
+    const disabled = loadConfig();
+    expect(disabled.allowRemoteManagement).toBe(false);
+
+    process.env.LORE_ALLOW_REMOTE_MANAGEMENT = "1";
+    const enabled = loadConfig();
+    expect(enabled.allowRemoteManagement).toBe(true);
   });
 
   test("rejects a weak token supplied through a programmatic config", () => {

--- a/packages/gateway/test/management-access.test.ts
+++ b/packages/gateway/test/management-access.test.ts
@@ -136,6 +136,38 @@ describe("management route access control", () => {
     expect(response.allowOrigin).not.toBe("*");
   });
 
+  test("allows an HTTPS browser origin behind TLS termination", async () => {
+    const host = `labs.sheep-fir.ts.net:${remoteManagementPeer.port}`;
+    const origin = `https://${host}`;
+    const response = await new Promise<{
+      status: number;
+      allowOrigin: string | undefined;
+    }>((resolve, reject) => {
+      const req = request(
+        {
+          host: "127.0.0.1",
+          port: remoteManagementPeer.port,
+          path: "/api/v1/projects",
+          headers: { host, origin },
+        },
+        (res) => {
+          res.resume();
+          res.once("end", () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              allowOrigin: res.headers["access-control-allow-origin"],
+            }),
+          );
+        },
+      );
+      req.once("error", reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.allowOrigin).toBe(origin);
+  });
+
   test("keeps the external host when redirecting the dashboard root", async () => {
     const host = `labs.sheep-fir.ts.net:${remoteManagementPeer.port}`;
     const response = await new Promise<{

--- a/packages/gateway/test/management-access.test.ts
+++ b/packages/gateway/test/management-access.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { data, ensureProject, ltm } from "@loreai/core";
 import { connect } from "node:net";
+import { request } from "node:http";
 import { loadConfig, type GatewayConfig } from "../src/config";
 import { isLoopbackAddress, startServer } from "../src/server";
 
@@ -21,6 +22,7 @@ function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
 describe("management route access control", () => {
   let wideListener: ServerHandle;
   let remotePeer: ServerHandle;
+  let remoteManagementPeer: ServerHandle;
   let mappedLoopbackPeer: ServerHandle;
 
   beforeAll(async () => {
@@ -33,6 +35,10 @@ describe("management route access control", () => {
       // node:http bridge; requests still traverse a real TCP socket and server.
       peerAddressForRequest: () => "192.0.2.10",
     });
+    remoteManagementPeer = await startServer(
+      makeConfig({ allowRemoteManagement: true }),
+      { peerAddressForRequest: () => "192.0.2.10" },
+    );
     mappedLoopbackPeer = await startServer(makeConfig(), {
       peerAddressForRequest: () => "::ffff:127.0.0.1",
     });
@@ -42,6 +48,7 @@ describe("management route access control", () => {
     await Promise.all([
       wideListener.stop(),
       remotePeer.stop(),
+      remoteManagementPeer.stop(),
       mappedLoopbackPeer.stop(),
     ]);
   });
@@ -82,6 +89,110 @@ describe("management route access control", () => {
     expect(response.headers.get("content-security-policy")).toContain(
       "frame-ancestors 'none'",
     );
+  });
+
+  test.each(["/api/v1/projects", "/ui", "/"])(
+    "allows remote management route %s only with the explicit override",
+    async (path) => {
+      const response = await fetch(urlFor(remoteManagementPeer, path), {
+        redirect: "manual",
+      });
+
+      expect(response.status).not.toBe(404);
+      expect(response.status).not.toBe(500);
+    },
+  );
+
+  test("allows the external dashboard's exact browser origin", async () => {
+    const host = `labs.sheep-fir.ts.net:${remoteManagementPeer.port}`;
+    const origin = `http://${host}`;
+    const response = await new Promise<{
+      status: number;
+      allowOrigin: string | undefined;
+    }>((resolve, reject) => {
+      const req = request(
+        {
+          host: "127.0.0.1",
+          port: remoteManagementPeer.port,
+          path: "/api/v1/projects",
+          headers: { host, origin },
+        },
+        (res) => {
+          res.resume();
+          res.once("end", () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              allowOrigin: res.headers["access-control-allow-origin"],
+            }),
+          );
+        },
+      );
+      req.once("error", reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.allowOrigin).toBe(origin);
+    expect(response.allowOrigin).not.toBe("*");
+  });
+
+  test("keeps the external host when redirecting the dashboard root", async () => {
+    const host = `labs.sheep-fir.ts.net:${remoteManagementPeer.port}`;
+    const response = await new Promise<{
+      status: number;
+      location: string | undefined;
+    }>((resolve, reject) => {
+      const req = request(
+        {
+          host: "127.0.0.1",
+          port: remoteManagementPeer.port,
+          path: "/",
+          headers: { host },
+        },
+        (res) => {
+          res.resume();
+          res.once("end", () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              location: res.headers.location,
+            }),
+          );
+        },
+      );
+      req.once("error", reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.location).toBe("/ui");
+  });
+
+  test("still hides remote management from a different browser origin", async () => {
+    const host = `labs.sheep-fir.ts.net:${remoteManagementPeer.port}`;
+    const response = await fetch(
+      urlFor(remoteManagementPeer, "/api/v1/projects"),
+      { headers: { host, origin: "https://attacker.example" } },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("does not trust a loopback Origin from a remote peer", async () => {
+    const response = await fetch(
+      urlFor(remoteManagementPeer, "/api/v1/projects"),
+      {
+        headers: {
+          host: `labs.sheep-fir.ts.net:${remoteManagementPeer.port}`,
+          origin: `http://localhost:${remoteManagementPeer.port}`,
+        },
+      },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
   });
 
   test("allows IPv4-mapped IPv6 loopback peers", async () => {

--- a/packages/gateway/test/management-access.test.ts
+++ b/packages/gateway/test/management-access.test.ts
@@ -168,6 +168,38 @@ describe("management route access control", () => {
     expect(response.allowOrigin).toBe(origin);
   });
 
+  test("normalizes an explicit HTTPS default port", async () => {
+    const host = "labs.sheep-fir.ts.net:443";
+    const origin = `https://${host}`;
+    const response = await new Promise<{
+      status: number;
+      allowOrigin: string | undefined;
+    }>((resolve, reject) => {
+      const req = request(
+        {
+          host: "127.0.0.1",
+          port: remoteManagementPeer.port,
+          path: "/api/v1/projects",
+          headers: { host, origin },
+        },
+        (res) => {
+          res.resume();
+          res.once("end", () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              allowOrigin: res.headers["access-control-allow-origin"],
+            }),
+          );
+        },
+      );
+      req.once("error", reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.allowOrigin).toBe(origin);
+  });
+
   test("keeps the external host when redirecting the dashboard root", async () => {
     const host = `labs.sheep-fir.ts.net:${remoteManagementPeer.port}`;
     const response = await new Promise<{

--- a/packages/gateway/test/management-access.test.ts
+++ b/packages/gateway/test/management-access.test.ts
@@ -227,6 +227,41 @@ describe("management route access control", () => {
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
   });
 
+  test("does not trust matching forged loopback Host and Origin headers", async () => {
+    const origin = `http://localhost:${remoteManagementPeer.port}`;
+    const response = await new Promise<{
+      status: number;
+      body: string;
+    }>((resolve, reject) => {
+      const req = request(
+        {
+          host: "127.0.0.1",
+          port: remoteManagementPeer.port,
+          path: "/api/v1/projects",
+          headers: {
+            host: `localhost:${remoteManagementPeer.port}`,
+            origin,
+          },
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk: Buffer) => chunks.push(chunk));
+          res.once("end", () =>
+            resolve({
+              status: res.statusCode ?? 0,
+              body: Buffer.concat(chunks).toString(),
+            }),
+          );
+        },
+      );
+      req.once("error", reject);
+      req.end();
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toBe("");
+  });
+
   test("allows IPv4-mapped IPv6 loopback peers", async () => {
     const response = await fetch(
       urlFor(mappedLoopbackPeer, "/api/v1/projects"),

--- a/packages/website/src/content/docs/docs/environment.md
+++ b/packages/website/src/content/docs/docs/environment.md
@@ -54,6 +54,7 @@ Env vars override `.lore.json` for the same setting. To override a `.lore.json` 
 
 | Variable | Description |
 |---|---|
+| `LORE_ALLOW_REMOTE_MANAGEMENT`<br>**Parser:** `isTruthy` | Allow non-loopback socket peers to access the dashboard and management API. Disabled by default. Env: LORE_ALLOW_REMOTE_MANAGEMENT. |
 | `LORE_BEDROCK_REGION` | AWS Bedrock region. Selects both the bedrock-mantle Anthropic endpoint and the bedrock-runtime Converse/InvokeModel endpoint. Resolves from `LORE_BEDROCK_REGION` first, then falls back to `AWS_REGION` / `AWS_DEFAULT_REGION`, finally defaulting to `"us-east-1"`. Env: LORE_BEDROCK_REGION |
 | `LORE_CALLER_UPSTREAM_ALLOWLIST` | Normalized HTTPS origins that remote/hosted clients may select with `X-Lore-Upstream-URL`. Empty by default, so caller-selected upstreams are denied unless the gateway administrator explicitly allows their origins. Local gateways do not consult this list. Env: LORE_CALLER_UPSTREAM_ALLOWLIST (comma-separated origins). |
 | `LORE_DEBUG`<br>**Parser:** `isTruthy` | Whether to log requests. Default: false. Env: LORE_DEBUG |


### PR DESCRIPTION
## Summary

- add explicit `LORE_ALLOW_REMOTE_MANAGEMENT` and `--allow-remote-management` controls
- authorize management routes from socket peer metadata while preserving exact-origin CORS checks
- add regression coverage for allowed routes, redirects, origins, CLI forwarding, and daemon args

## Validation

- `env -u LORE_ALLOW_REMOTE_MANAGEMENT pnpm exec vitest run packages/gateway/test/management-access.test.ts packages/gateway/test/gateway-auth-config.test.ts packages/gateway/test/cli-start-contract.test.ts packages/gateway/test/daemon-args.test.ts`
- `env -u LORE_ALLOW_REMOTE_MANAGEMENT pnpm exec tsc -p packages/gateway/tsconfig.json --noEmit`
- `pnpm exec oxfmt --check ...`
- `pnpm exec oxlint ...`