### PR TITLE
fix(gateway): preserve OpenAI recall continuations

### DIFF
--- a/packages/gateway/src/pipeline.ts
+++ b/packages/gateway/src/pipeline.ts
@@ -231,6 +231,7 @@ import {
   AnthropicSSEValidator,
   cancelAndReleaseReader,
   readStreamChunk,
+  SSEStreamTransportError,
   DEFAULT_MAX_SSE_FRAMES,
   type StreamAccumulator,
   type RecallAwareAccumulator,
@@ -7589,6 +7590,8 @@ export function streamResponsesRecallAware(
       signal: AbortSignal;
     }) => Promise<{
       reader: ReadableStreamDefaultReader<Uint8Array>;
+      /** Advance request state only after this continuation starts another recall. */
+      commit?: () => void;
     }>;
   },
 ): Response {
@@ -7766,6 +7769,7 @@ export function streamResponsesRecallAware(
   const maxSSEFrames = opts.maxSSEFrames ?? 100_000;
   const frameCounter = { count: 0 };
   const sseInactivityMs = FOREGROUND_SSE_INACTIVITY_MS;
+  const maxRecallContinuationTransportRetries = 1;
 
   const parseRecallArguments = (
     value: unknown,
@@ -10025,8 +10029,28 @@ export function streamResponsesRecallAware(
                       signal,
                     });
                     let recallDepth = pendingRecalls.length;
+                    let recallContinuationTransportRetries = 0;
+                    let continuationFollowUpInput: Parameters<
+                      typeof opts.runFollowUp
+                    >[0] = {
+                      anchorText: executed.anchorText,
+                      resultText: executed.resultText,
+                      acc: recallAcc,
+                      toolUseId: recall.toolUseId,
+                      contentPosition,
+                      signal,
+                    };
+                    let continuationRetryBaseline = {
+                      transactionalEvents: transactionalEvents.length,
+                      transactionalBytes,
+                      retainedStateBytes,
+                      hiddenRecallBytes,
+                      outputIdentities: new Set(outputIdentities),
+                      referenceIdentities: new Set(referenceIdentities),
+                    };
                     for (;;) {
                       activeReader = follow.reader;
+                      let retryFollowUp = false;
                       const contState = makeResponsesAccState();
                       const contRecallIndices = new Set<number>();
                       const contReferenceIndices = new Map<
@@ -10420,8 +10444,44 @@ export function streamResponsesRecallAware(
                             } else queueTransactional(chunk);
                           }
                         }
+                      } catch (error) {
+                        if (
+                          error instanceof SSEStreamTransportError &&
+                          recallContinuationTransportRetries <
+                            maxRecallContinuationTransportRetries
+                        ) {
+                          recallContinuationTransportRetries++;
+                          transactionalEvents.length =
+                            continuationRetryBaseline.transactionalEvents;
+                          transactionalBytes =
+                            continuationRetryBaseline.transactionalBytes;
+                          retainedStateBytes =
+                            continuationRetryBaseline.retainedStateBytes;
+                          hiddenRecallBytes =
+                            continuationRetryBaseline.hiddenRecallBytes;
+                          outputIdentities.clear();
+                          for (const identity of continuationRetryBaseline.outputIdentities) {
+                            outputIdentities.add(identity);
+                          }
+                          referenceIdentities.clear();
+                          for (const identity of continuationRetryBaseline.referenceIdentities) {
+                            referenceIdentities.add(identity);
+                          }
+                          log.warn(
+                            `retrying recall continuation after ${error.kind} transport failure${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
+                          );
+                          retryFollowUp = true;
+                        } else {
+                          throw error;
+                        }
                       } finally {
                         cancelAndReleaseReader(follow.reader, signal.reason);
+                      }
+                      if (retryFollowUp) {
+                        follow = await settleFollowUp(
+                          continuationFollowUpInput,
+                        );
+                        continue;
                       }
                       const mergeContinuation = (): void => {
                         for (const item of contState.rawItems.values()) {
@@ -10532,61 +10592,84 @@ export function streamResponsesRecallAware(
                       let nextAcc: GatewayResponse | undefined;
                       if (contPending.length === 1) {
                         if (recallDepth >= maxRecallDepth) {
-                          throw new Error(
-                            `recall depth exhausted (${maxRecallDepth}) in Responses continuation`,
+                          const exhaustedRecall = contPending[0];
+                          const shiftedRecallIndex = shiftedOutputIndex(
+                            exhaustedRecall.outputIndex,
+                            contIndex,
                           );
-                        }
-                        recallDepth++;
-                        nextAcc = finalizeResponsesAcc(contState);
-                        const pendingNextRecall = contPending[0];
-                        const contentPosition = nextAcc.content.findIndex(
-                          (block) =>
-                            block.type === "tool_use" &&
-                            block.id === pendingNextRecall.toolUseId,
-                        );
-                        if (contentPosition < 0) {
-                          throw new Error(
-                            "recall block not found in finalized continuation",
-                          );
-                        }
-                        nextRecall = {
-                          ...pendingNextRecall,
-                          contentPosition,
-                        };
-                        const shiftedRecallIndex = shiftedOutputIndex(
-                          nextRecall.outputIndex,
-                          contIndex,
-                        );
-                        const nextSyntheticId = `msg_${state.id || "lore"}_${shiftedRecallIndex}`;
-                        reserveSyntheticIdentity(nextSyntheticId, [
-                          state,
-                          contState,
-                        ]);
-                        nextExecuted = await settleRecall({
-                          ...nextRecall,
-                          acc: nextAcc,
-                          signal,
-                        });
-                        if (nextExecuted.commit) {
-                          pendingCommits.push(nextExecuted.commit);
-                        }
-                        if (nextExecuted.rollback) {
-                          transactionRollbacks.push(nextExecuted.rollback);
-                        }
-                        const nextRecallIndex = nextRecall.outputIndex;
-                        contState.items.set(nextRecallIndex, {
-                          type: "text",
-                          id: nextSyntheticId,
-                          text: nextExecuted.anchorText,
-                        });
-                        queueTransactional(
-                          encoder.encode(
-                            emitTextItem(
-                              shiftedRecallIndex,
-                              nextExecuted.anchorText,
+                          const marker = `Recall depth limit reached (${maxRecallDepth}).`;
+                          const syntheticId = `msg_${state.id || "lore"}_${shiftedRecallIndex}`;
+                          reserveSyntheticIdentity(syntheticId, [
+                            state,
+                            contState,
+                          ]);
+                          contState.items.set(exhaustedRecall.outputIndex, {
+                            type: "text",
+                            id: syntheticId,
+                            text: marker,
+                          });
+                          queueTransactional(
+                            encoder.encode(
+                              emitTextItem(
+                                shiftedRecallIndex,
+                                marker,
+                                syntheticId,
+                              ),
                             ),
-                          ),
-                        );
+                          );
+                        } else {
+                          recallDepth++;
+                          nextAcc = finalizeResponsesAcc(contState);
+                          const pendingNextRecall = contPending[0];
+                          const contentPosition = nextAcc.content.findIndex(
+                            (block) =>
+                              block.type === "tool_use" &&
+                              block.id === pendingNextRecall.toolUseId,
+                          );
+                          if (contentPosition < 0) {
+                            throw new Error(
+                              "recall block not found in finalized continuation",
+                            );
+                          }
+                          nextRecall = {
+                            ...pendingNextRecall,
+                            contentPosition,
+                          };
+                          const shiftedRecallIndex = shiftedOutputIndex(
+                            nextRecall.outputIndex,
+                            contIndex,
+                          );
+                          const nextSyntheticId = `msg_${state.id || "lore"}_${shiftedRecallIndex}`;
+                          reserveSyntheticIdentity(nextSyntheticId, [
+                            state,
+                            contState,
+                          ]);
+                          nextExecuted = await settleRecall({
+                            ...nextRecall,
+                            acc: nextAcc,
+                            signal,
+                          });
+                          if (nextExecuted.commit) {
+                            pendingCommits.push(nextExecuted.commit);
+                          }
+                          if (nextExecuted.rollback) {
+                            transactionRollbacks.push(nextExecuted.rollback);
+                          }
+                          const nextRecallIndex = nextRecall.outputIndex;
+                          contState.items.set(nextRecallIndex, {
+                            type: "text",
+                            id: nextSyntheticId,
+                            text: nextExecuted.anchorText,
+                          });
+                          queueTransactional(
+                            encoder.encode(
+                              emitTextItem(
+                                shiftedRecallIndex,
+                                nextExecuted.anchorText,
+                              ),
+                            ),
+                          );
+                        }
                       }
                       for (const held of heldContinuationEvents) {
                         queueTransactional(held.chunk);
@@ -10601,14 +10684,25 @@ export function streamResponsesRecallAware(
                         state.terminalResponse = contState.terminalResponse;
                         break;
                       }
-                      follow = await settleFollowUp({
+                      follow.commit?.();
+                      continuationFollowUpInput = {
                         anchorText: nextExecuted.anchorText,
                         resultText: nextExecuted.resultText,
                         acc: nextAcc ?? finalizeResponsesAcc(contState),
                         toolUseId: nextRecall.toolUseId,
                         contentPosition: nextRecall.contentPosition,
                         signal,
-                      });
+                      };
+                      continuationRetryBaseline = {
+                        transactionalEvents: transactionalEvents.length,
+                        transactionalBytes,
+                        retainedStateBytes,
+                        hiddenRecallBytes,
+                        outputIdentities: new Set(outputIdentities),
+                        referenceIdentities: new Set(referenceIdentities),
+                      };
+                      follow = await settleFollowUp(continuationFollowUpInput);
+                      recallContinuationTransportRetries = 0;
                     }
                     state.items.set(recall.outputIndex, {
                       type: "text",
@@ -10617,8 +10711,7 @@ export function streamResponsesRecallAware(
                     });
                   } catch (err) {
                     log.error(
-                      `recall follow-up stream error${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}:`,
-                      err,
+                      `recall follow-up stream failed${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
                     );
                     throw err;
                   }
@@ -10753,8 +10846,7 @@ export function streamResponsesRecallAware(
             }
           } else {
             log.error(
-              `openai-responses recall-aware stream error${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}:`,
-              err,
+              `openai-responses recall-aware stream failed${sessionID ? ` (session=${sessionID.slice(0, 16)})` : ""}`,
             );
           }
           const failedResponse = finalizeResponsesAcc(state);
@@ -17768,9 +17860,10 @@ async function handleConversationTurn(
                     );
                   },
                 };
+                const followUpBaseRequest = responsesRecallRequest;
                 const follow = await runRecallFollowUpStreaming(
                   followUpCtx,
-                  responsesRecallRequest,
+                  followUpBaseRequest,
                   acc,
                   resultText,
                   recallBlock,
@@ -17781,8 +17874,12 @@ async function handleConversationTurn(
                     `recall follow-up upstream error: ${follow.status ?? "?"}`,
                   );
                 }
-                responsesRecallRequest = follow.followUp;
-                return { reader: follow.reader };
+                return {
+                  reader: follow.reader,
+                  commit: () => {
+                    responsesRecallRequest = follow.followUp;
+                  },
+                };
               },
             }),
           );

--- a/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
+++ b/packages/gateway/test/openai-responses-recall-aware-stream.test.ts
@@ -692,6 +692,161 @@ describe("streamResponsesRecallAware", () => {
     expect(out).not.toContain("{not-json}");
   });
 
+  test("retries a dropped recall continuation before exposing any output", async () => {
+    const droppedFollowUp = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              created("resp_dropped_followup", "gpt-5.6-terra") +
+                sseEvent("response.output_item.added", {
+                  output_index: 0,
+                  item: {
+                    type: "message",
+                    id: "msg_retry_identity",
+                    role: "assistant",
+                  },
+                }),
+            ),
+          );
+          controller.error(new Error("socket reset"));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const recoveredFollowUp = streamFrom([
+      created("resp_recovered_followup", "gpt-5.6-terra"),
+      textItem(0, "recovered answer", "msg_retry_identity"),
+      completed("resp_recovered_followup"),
+    ]);
+    let followUps = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_retry_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "retry continuation" }),
+        completed("resp_retry_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("retry continuation"),
+          resultText: "memory",
+        }),
+        runFollowUp: async () => ({
+          reader: (followUps++ === 0
+            ? droppedFollowUp
+            : recoveredFollowUp
+          ).body!.getReader(),
+        }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(followUps).toBe(2);
+    expect(out).toContain("recovered answer");
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(
+      out.match(
+        /event: response\.output_text\.delta\ndata: [^\n]*"delta":"recovered answer"/g,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("counts failed continuation bytes against the request-wide stream limit", async () => {
+    const principal = [
+      created("resp_retry_limit_principal", "gpt-5.6-terra"),
+      recallCall(0, { query: "retry byte budget" }),
+      completed("resp_retry_limit_principal"),
+    ];
+    const dropped = created("resp_retry_limit_dropped", "gpt-5.6-terra");
+    const recovered = [
+      created("resp_retry_limit_recovered", "gpt-5.6-terra"),
+      textItem(0, "recovered after budget", "msg_retry_limit"),
+      completed("resp_retry_limit_recovered"),
+    ];
+    const droppedFollowUp = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(dropped));
+          controller.error(new Error("socket reset"));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const recoveredFollowUp = streamFrom(recovered);
+    let followUps = 0;
+    const client = streamResponsesRecallAware(streamFrom(principal), {
+      maxStreamBytes:
+        new TextEncoder().encode(recovered.join("")).byteLength + 1,
+      onComplete: () => {},
+      onRecall: async () => ({
+        anchorText: buildAnchor("retry byte budget"),
+        resultText: "memory",
+      }),
+      runFollowUp: async () => ({
+        reader: (followUps++ === 0
+          ? droppedFollowUp
+          : recoveredFollowUp
+        ).body!.getReader(),
+      }),
+    });
+
+    const out = await drain(client);
+    expect(followUps).toBe(2);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("recovered after budget");
+  });
+
+  test("counts failed continuation frames against the request-wide frame limit", async () => {
+    const droppedFollowUp = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              created("resp_retry_frame_dropped", "gpt-5.6-terra"),
+            ),
+          );
+          controller.error(new Error("socket reset"));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const recoveredFollowUp = streamFrom([
+      created("resp_retry_frame_recovered", "gpt-5.6-terra"),
+      textItem(0, "recovered after frames", "msg_retry_frame"),
+      completed("resp_retry_frame_recovered"),
+    ]);
+    let followUps = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_retry_frame_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "retry frame budget" }),
+        completed("resp_retry_frame_principal"),
+      ]),
+      {
+        // Principal (5 frames) + dropped continuation (1 frame) exhaust the
+        // budget before the retried continuation can emit its first frame.
+        maxSSEFrames: 6,
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("retry frame budget"),
+          resultText: "memory",
+        }),
+        runFollowUp: async () => ({
+          reader: (followUps++ === 0
+            ? droppedFollowUp
+            : recoveredFollowUp
+          ).body!.getReader(),
+        }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(followUps).toBe(2);
+    expect(out).toContain(PUBLIC_RECALL_ERROR);
+    expect(out).not.toContain("recovered after frames");
+  });
+
   test("rejects one content index changing type", async () => {
     const client = streamResponsesRecallAware(
       streamFrom([
@@ -1929,6 +2084,69 @@ describe("streamResponsesRecallAware", () => {
         ?.filter((item) => item.type === "reasoning")
         .map((item) => item.encrypted_content),
     ).toEqual(["ciphertext-B", "ciphertext-D"]);
+  });
+
+  test("retries the current follow-up in a chained recall", async () => {
+    const droppedSecondFollowUp = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              created("resp_chained_retry_dropped", "gpt-5.6-terra"),
+            ),
+          );
+          controller.error(new Error("socket reset"));
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const firstFollowUp = streamFrom([
+      created("resp_chained_retry_first", "gpt-5.6-terra"),
+      textItem(0, "first continuation preamble"),
+      recallCall(1, { query: "second recall" }, "fc_second", "call_second"),
+      completed("resp_chained_retry_first"),
+    ]);
+    const recoveredSecondFollowUp = streamFrom([
+      created("resp_chained_retry_recovered", "gpt-5.6-terra"),
+      textItem(0, "chained recovered answer", "msg_chained_retry_recovered"),
+      completed("resp_chained_retry_recovered"),
+    ]);
+    const inputs: string[] = [];
+    let followUps = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_chained_retry_principal", "gpt-5.6-terra"),
+        recallCall(0, { query: "first recall" }, "fc_first", "call_first"),
+        completed("resp_chained_retry_principal"),
+      ]),
+      {
+        onComplete: () => {},
+        onRecall: async ({ query }) => ({
+          anchorText: buildAnchor(query),
+          resultText: `${query} result`,
+        }),
+        runFollowUp: async (input) => {
+          inputs.push(input.resultText);
+          const followUp = [
+            firstFollowUp,
+            droppedSecondFollowUp,
+            recoveredSecondFollowUp,
+          ][followUps++];
+          if (!followUp) throw new Error("unexpected extra follow-up");
+          return { reader: followUp.body!.getReader() };
+        },
+      },
+    );
+
+    const out = await drain(client);
+    expect(out).toContain("first continuation preamble");
+    expect(out).toContain("chained recovered answer");
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(inputs).toEqual([
+      "first recall result",
+      "second recall result",
+      "second recall result",
+    ]);
   });
 
   test("rejects terminal omission of added-only provisional reasoning in Codex recall-aware mode", async () => {
@@ -4001,6 +4219,42 @@ describe("streamResponsesRecallAware", () => {
     expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
   });
 
+  test("replaces an exhausted continuation recall with a marker", async () => {
+    const followUp = streamFrom([
+      created("resp_depth_exhausted_followup", "gpt-5.6-terra"),
+      recallCall(0, { query: "more detail" }, "fc_depth", "call_depth"),
+      completed("resp_depth_exhausted_followup"),
+    ]);
+    let recalls = 0;
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_depth_exhausted_principal", "gpt-5.6-terra"),
+        recallCall(
+          0,
+          { query: "architecture" },
+          "fc_principal",
+          "call_principal",
+        ),
+        completed("resp_depth_exhausted_principal"),
+      ]),
+      {
+        maxRecallDepth: 1,
+        onComplete: () => {},
+        onRecall: async ({ query }) => {
+          recalls++;
+          return { anchorText: buildAnchor(query), resultText: "results" };
+        },
+        runFollowUp: async () => ({ reader: followUp.body!.getReader() }),
+      },
+    );
+
+    const out = await drain(client);
+    expect(recalls).toBe(1);
+    expect(out).toContain("Recall depth limit reached (1).");
+    expect(out).not.toContain(PUBLIC_RECALL_ERROR);
+    expect(out.match(/^event: response\.completed$/gm)).toHaveLength(1);
+  });
+
   test("recall-only: emits marker, pipes the continuation inline, rebuilds completed", async () => {
     // The follow-up stream includes its OWN lifecycle/terminal events
     // (response.created, response.in_progress, response.completed). These must
@@ -5133,6 +5387,58 @@ describe("streamResponsesRecallAware", () => {
     await cancelled;
     await followUpCancelled.promise;
     expect(cancelCalls).toBe(1);
+  });
+
+  test("does not retry when cancellation races a dropped continuation", async () => {
+    const foreground = new AbortController();
+    const followUpStarted = Promise.withResolvers<void>();
+    const droppedStarted = Promise.withResolvers<void>();
+    const releaseDrop = Promise.withResolvers<void>();
+    let followUps = 0;
+    let cancelCalls = 0;
+    const droppedFollowUp = new Response(
+      new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          droppedStarted.resolve();
+          await releaseDrop.promise;
+          controller.error(new Error("socket reset"));
+        },
+        cancel() {
+          cancelCalls++;
+        },
+      }),
+      { headers: { "content-type": "text/event-stream" } },
+    );
+    const client = streamResponsesRecallAware(
+      streamFrom([
+        created("resp_abort_retry", "gpt-5.6-terra"),
+        recallCall(0, { query: "cancel retry" }),
+        completed("resp_abort_retry"),
+      ]),
+      {
+        signal: foreground.signal,
+        onComplete: () => {},
+        onRecall: async () => ({
+          anchorText: buildAnchor("cancel retry"),
+          resultText: "memory",
+        }),
+        runFollowUp: async () => {
+          followUps++;
+          followUpStarted.resolve();
+          return { reader: droppedFollowUp.body!.getReader() };
+        },
+      },
+    );
+
+    const pending = drain(client);
+    await followUpStarted.promise;
+    await droppedStarted.promise;
+    foreground.abort(new DOMException("caller aborted", "AbortError"));
+    releaseDrop.resolve();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(followUps).toBe(1);
+    expect(cancelCalls).toBe(1);
+    expect(droppedFollowUp.body?.locked).toBe(false);
   });
 
   test("cancellation never waits for non-settling follow-up setup", async () => {

--- a/packages/gateway/test/recall-codex-stream.test.ts
+++ b/packages/gateway/test/recall-codex-stream.test.ts
@@ -131,6 +131,25 @@ function codexFinalStream(): Response {
   });
 }
 
+/** A follow-up that sends headers and then loses its SSE body. */
+function droppedCodexFollowUpStream(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            sseEvent("response.created", {
+              response: { id: "resp_dropped", model: "gpt-5.5" },
+            }),
+          ),
+        );
+        controller.error(new Error("socket reset"));
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
 /** Mimic ChatGPT's backend rejecting a non-streaming request. */
 function codexStreamRequiredError(): Response {
   return new Response(
@@ -181,7 +200,8 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     // fix) → final text. A non-streaming upstream request always 400s, exactly
     // like the real backend.
     let upstreamCalls = 0;
-    let followUpStreamFlag: boolean | undefined;
+    const followUpBodies: unknown[] = [];
+    const followUpStreamFlags: boolean[] = [];
     const parallelToolCallFlags: unknown[] = [];
     setUpstreamInterceptor(async (upstreamBody) => {
       const body = upstreamBody as {
@@ -195,9 +215,14 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
         // Initial request — Pi's codex provider always streams.
         return streaming ? codexRecallStream() : codexStreamRequiredError();
       }
-      // Recall follow-up — record the stream flag the gateway sent upstream.
-      followUpStreamFlag = streaming;
-      return streaming ? codexFinalStream() : codexStreamRequiredError();
+      // The first follow-up loses its SSE body after headers. Retry must send
+      // this exact request again, not append another recall result.
+      followUpBodies.push(structuredClone(upstreamBody));
+      followUpStreamFlags.push(streaming);
+      if (!streaming) return codexStreamRequiredError();
+      return upstreamCalls === 2
+        ? droppedCodexFollowUpStream()
+        : codexFinalStream();
     });
 
     const config = loadConfig();
@@ -255,11 +280,13 @@ describe("recall follow-up — openai-codex (ChatGPT) path", () => {
     expect(resp.ok).toBe(true);
     const bodyText = await resp.text();
 
-    // The follow-up must have been issued AND streamed (the fix). Pre-fix it
-    // was sent with stream:false and ChatGPT 400'd.
-    expect(upstreamCalls).toBe(2);
-    expect(followUpStreamFlag).toBe(true);
-    expect(parallelToolCallFlags).toEqual([false, false]);
+    // The follow-up must be streamed, and an SSE-body retry must replay its
+    // already-built request exactly once rather than duplicating recall state.
+    expect(upstreamCalls).toBe(3);
+    expect(followUpStreamFlags).toEqual([true, true]);
+    expect(followUpBodies).toHaveLength(2);
+    expect(followUpBodies[1]).toEqual(followUpBodies[0]);
+    expect(parallelToolCallFlags).toEqual([false, false, false]);
 
     // The continuation must reach the client — proving the follow-up succeeded
     // instead of falling back to the bare recall marker.


### PR DESCRIPTION
## Summary
Preserves Responses recall continuations when the buffered upstream SSE reader drops or the recall-depth limit is reached.

## Changes
- Retry one withheld continuation only for transport failures, preserving request identity and request-wide byte/frame budgets.
- Replace depth-exhausted recall tool uses with marker text and rebuild one terminal response.
- Add regressions for exact retry-body replay, chained anchors, cancellation, and byte/frame limits.