### PR TITLE
fix(website): replace bash 4.1 named fds so the install script runs on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,20 @@ jobs:
         # in workflow schema validation, not shell style.
         run: ./actionlint -color -config-file .github/actionlint.yaml
 
+  # ---------------------------------------------------------------------------
+  # Lint the install script for bash-4.x-only constructs.
+  # The installer runs on macOS via `curl ... | bash`, where the default
+  # /bin/bash is 3.2. Named file descriptors (bash 4.1+) and other 4.0+/4.1+
+  # features break there, so gate them in CI. Runs unconditionally — it is
+  # sub-second and a regression here blocks every macOS install.
+  # ---------------------------------------------------------------------------
+  install-script-bash-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check installer bash-3.2 compatibility
+        run: bash packages/website/scripts/check-install-script-bashisms.sh
+
   test:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'

--- a/packages/website/public/install
+++ b/packages/website/public/install
@@ -512,7 +512,8 @@ secure_lifecycle_state_dir() {
     die "Refusing installer state directory owned by another user: ${state_dir}"
   fi
   before=$(require_file_identity "$state_dir" "installer state directory")
-  if ! exec {lifecycle_state_dir_fd}<"$state_dir"; then
+  lifecycle_state_dir_fd=8
+  if ! exec 8<"$state_dir"; then
     die "Could not open installer state directory safely: ${state_dir}"
   fi
   lifecycle_state_dir_fd_path="/dev/fd/${lifecycle_state_dir_fd}"
@@ -856,12 +857,13 @@ quarantine_definitively_stale_lifecycle_lock() {
   # Pin the stale directory before adding a compatibility guard. An older Bash
   # reclaimer that already reserved claim/lock must not be able to wake later
   # and move a canonical successor beneath the archived token claim.
-  if ! exec {stale_fd}<"$lock_path"; then
+  if ! exec 10<"$lock_path"; then
     return 1
   fi
+  stale_fd=10
   stale_fd_path="/dev/fd/${stale_fd}"
   if [[ "$(stable_followed_file_identity "$stale_fd_path" 2>/dev/null || true)" != "$expected_dir" ]]; then
-    exec {stale_fd}<&-
+    exec 10<&-
     return 1
   fi
   # Portable mv treats an existing directory as a parent. Reserve the source
@@ -870,14 +872,14 @@ quarantine_definitively_stale_lifecycle_lock() {
   portable_guard="$stale_fd_path/lifecycle.lock"
   if [[ -e "$portable_guard" || -L "$portable_guard" ]]; then
     if ! lifecycle_portable_reclaim_guard_is_valid "$portable_guard"; then
-      exec {stale_fd}<&-
+      exec 10<&-
       return 1
     fi
   else
     set -o noclobber
     if ! : > "$portable_guard"; then
       set +o noclobber
-      exec {stale_fd}<&-
+      exec 10<&-
       return 1
     fi
     set +o noclobber
@@ -887,7 +889,7 @@ quarantine_definitively_stale_lifecycle_lock() {
   if [[ "$os" != "darwin" ]]; then
     if [[ -e "$stale_fd_path/lock" || -L "$stale_fd_path/lock" ]]; then
       if ! lifecycle_reclaim_guard_is_valid "$stale_fd_path/lock"; then
-        exec {stale_fd}<&-
+        exec 10<&-
         return 1
       fi
     else
@@ -899,12 +901,12 @@ quarantine_definitively_stale_lifecycle_lock() {
         rmdir "$guard_tmp/lifecycle.lock/sentinel" 2>/dev/null || true
         rmdir "$guard_tmp/lifecycle.lock" 2>/dev/null || true
         rmdir "$guard_tmp" 2>/dev/null || true
-        exec {stale_fd}<&-
+        exec 10<&-
         return 1
       fi
     fi
   fi
-  exec {stale_fd}<&-
+  exec 10<&-
   same_inspected_lifecycle_generation \
     "$expected_token" "$expected_pid" "$expected_process_identity" \
     "$expected_dir" "$expected_owner" "$expected_content" "$lock_path" || return 1
@@ -1097,11 +1099,12 @@ acquire_lifecycle_lock() {
   # tokenized initialization claim is published before the canonical directory
   # can exist, leaving only mkdir -> hard-link as the crash-sensitive window.
   set -o noclobber
-  if ! exec {owner_fd}>"$lifecycle_initialization_stage_path"; then
+  if ! exec 9>"$lifecycle_initialization_stage_path"; then
     set +o noclobber
     die "Could not stage Lore lifecycle lock owner"
   fi
   set +o noclobber
+  owner_fd=9
   owner_fd_path="/dev/fd/${owner_fd}"
   if ! chmod 600 "$owner_fd_path" ||
      ! printf '%s\n' "$owner_content" >&"$owner_fd" ||
@@ -1109,19 +1112,19 @@ acquire_lifecycle_lock() {
      [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]] ||
      { [[ "$os" != "windows" && ! -O "$lifecycle_initialization_stage_path" ]] ||
         ! followed_path_has_exact_mode "$owner_fd_path" 600; }; then
-    exec {owner_fd}>&- 2>/dev/null || true
+    exec 9>&- 2>/dev/null || true
     remove_lifecycle_initialization_stage
     die "Could not stage Lore lifecycle lock owner"
   fi
   sync_path "$owner_fd_path" 2>/dev/null || true
   if ! lifecycle_state_dir_is_trusted ||
      [[ "$(stable_file_identity "$lifecycle_initialization_stage_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]]; then
-    exec {owner_fd}>&- 2>/dev/null || true
+    exec 9>&- 2>/dev/null || true
     remove_lifecycle_initialization_stage
     die "Lifecycle owner generation changed before claim publication"
   fi
   if ! ln "$lifecycle_initialization_stage_path" "$lifecycle_initialization_claim_path"; then
-    exec {owner_fd}>&- 2>/dev/null || true
+    exec 9>&- 2>/dev/null || true
     remove_lifecycle_initialization_stage
     die "Could not publish Lore lifecycle initialization claim"
   fi
@@ -1134,13 +1137,13 @@ acquire_lifecycle_lock() {
         "$inspected_lock_process_identity" != "$process_identity" ||
         "$inspected_lock_owner_content" != "$owner_content" ||
         "$(stable_file_identity "$lifecycle_initialization_claim_path" 2>/dev/null || true)" != "$lifecycle_initialization_stage_identity" ]]; then
-    exec {owner_fd}>&- 2>/dev/null || true
+    exec 9>&- 2>/dev/null || true
     release_lifecycle_initialization_claim
     remove_lifecycle_initialization_stage
     die "Lore lifecycle initialization claim changed during publication"
   fi
   lifecycle_initialization_claim_identity="$inspected_lock_owner_identity"
-  exec {owner_fd}>&-
+  exec 9>&-
   sync_path "$lifecycle_initialization_claim_path" 2>/dev/null || true
 
   while true; do
@@ -1392,7 +1395,7 @@ cleanup_installer() {
   release_lifecycle_initialization_claim
   remove_lifecycle_initialization_stage
   if [[ -n "$lifecycle_state_dir_fd" ]]; then
-    exec {lifecycle_state_dir_fd}<&-
+    exec 8<&-
     lifecycle_state_dir_fd=""
     lifecycle_state_dir_fd_path=""
   fi
@@ -2071,7 +2074,7 @@ if ! lifecycle_lock_is_owned; then
 fi
 release_lifecycle_lock
 if [[ -n "$lifecycle_state_dir_fd" ]]; then
-  exec {lifecycle_state_dir_fd}<&-
+  exec 8<&-
   lifecycle_state_dir_fd=""
   lifecycle_state_dir_fd_path=""
 fi

--- a/packages/website/scripts/check-install-script-bashisms.sh
+++ b/packages/website/scripts/check-install-script-bashisms.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Lint packages/website/public/install for bash-4.x-only constructs.
+#
+# The installer is run via `curl ... | bash` on macOS, whose default /bin/bash
+# is 3.2. It must stay compatible with that interpreter, so it can use neither
+# named file descriptors (bash 4.1+) nor any other 4.0+/4.1+ feature. This
+# script rejects the constructs that break on macOS stock bash.
+#
+# Usage: check-install-script-bashisms.sh [path-to-install-script]
+set -euo pipefail
+
+target="${1:-packages/website/public/install}"
+
+if [[ ! -f "$target" ]]; then
+  echo "error: install script not found at: $target" >&2
+  exit 2
+fi
+
+failures=()
+
+# Patterns that require bash 4.0+ or 4.1+ and break on macOS stock bash 3.2.
+# These are deliberately strict: only flag the modifier immediately following
+# the variable name (e.g. ${var,} ${var^}), not the harmless ${var:-default}.
+patterns=(
+  'exec \{[a-zA-Z_]+[0-9]*\}[<>]'            # named fds (4.1)
+  'exec \{[a-zA-Z_]+[0-9]*\}[<>]&-'          # named fd close (4.1)
+  '\[\[[[:space:]]*-v[[:space:]]+[a-zA-Z_]'  # test -v (4.1)
+  '\bmapfile\b|\breadarray\b'                # mapfile (4.0)
+  '\bcoproc\b'                              # coproc (4.0)
+  ';;&|;&'                                  # case fallthrough (4.0)
+  'declare[[:space:]]+-A[[:space:]]|local[[:space:]]+-A[[:space:]]' # assoc arrays (4.0)
+  '\$\{[a-zA-Z_][a-zA-Z0-9_]*[,^]'           # case-modifying expansion (4.0)
+  '\$\{[a-zA-Z_][a-zA-Z0-9_]*@(U|L|E|P|Q|a|A)\}' # transform expansion (4.0)
+)
+
+labels=(
+  'named file descriptor (bash 4.1+)'
+  'named file descriptor close (bash 4.1+)'
+  '[[ -v var ]] (bash 4.1+)'
+  'mapfile/readarray (bash 4.0+)'
+  'coproc (bash 4.0+)'
+  'case fallthrough ;& / ;;& (bash 4.0+)'
+  'associative arrays (bash 4.0+)'
+  'case-modifying parameter expansion (bash 4.0+)'
+  'parameter transformation expansion (bash 4.0+)'
+)
+
+while IFS= read -r line; do
+  lineno="${line%%:*}"
+  content="${line#*:}"
+  for i in "${!patterns[@]}"; do
+    if [[ "$content" =~ ${patterns[$i]} ]]; then
+      failures+=("$lineno: ${labels[$i]}")
+    fi
+  done
+done < <(grep -nE . "$target")
+
+if [[ "${#failures[@]}" -gt 0 ]]; then
+  echo "bash-3.2 incompatibility detected in $target:" >&2
+  for f in "${failures[@]}"; do
+    echo "  line ${f}" >&2
+  done
+  echo "The installer runs on macOS stock bash 3.2 via 'curl | bash';" >&2
+  echo "remove these bash-4.x-only constructs." >&2
+  exit 1
+fi
+
+echo "ok: $target is compatible with bash 3.2"


### PR DESCRIPTION
## Summary

The installer (`packages/website/public/install`) ran `curl ... | bash` on macOS and failed with:

```
bash: line 515: exec: {lifecycle_state_dir_fd}: not found
```

Root cause: the script used **named file descriptors** (`exec {var}<file`), a bash 4.1+ feature. macOS ships `/bin/bash` 3.2, which parses the braces literally and tries to exec a command named `{lifecycle_state_dir_fd}`.

## Changes

- Converted the three named fds to fixed numeric fds (8/9/10), valid on bash 3.2 and distinct across their lifetimes:
  - `lifecycle_state_dir_fd` → fd 8 (opened once, spans the whole script)
  - `owner_fd` → fd 9 (inside `acquire_lifecycle_lock`)
  - `stale_fd` → fd 10 (inside `quarantine_definitively_stale_lifecycle_lock`)
- Added `packages/website/scripts/check-install-script-bashisms.sh`, which fails on any bash-4.x-only construct (named fds, `[[ -v ]]`, `mapfile`, `coproc`, `;&`, assoc arrays, `${var,}`/`${var^}`, `${var@...}`).
- Added a CI job `install-script-bash-compat` that runs unconditionally so this regression class cannot slip through again.

## Verification

- New linter passes on the fixed script; fails on `main` (which still has the named fds).
- Existing `packages/gateway/test/install-script.test.ts` — 29/29 pass.

🤖 Generated with [Lore](https://withlore.ai)