### PR TITLE
fix(core): avoid temporal vec0 deletion scans

### DIFF
--- a/packages/core/src/db/vec-store.ts
+++ b/packages/core/src/db/vec-store.ts
@@ -23,6 +23,7 @@
 // vector-query.ts). It takes the connection as a parameter.
 
 import { toBlob } from "../vector-query";
+import { MAX_TEMPORAL_CHUNKS_PER_MESSAGE } from "../embedding-units";
 
 /** How a DB file physically stores embeddings. Recorded in `kv_meta`. */
 export type VecStorageMode = "blob" | "vec0";
@@ -79,6 +80,11 @@ export const TEMPORAL_CHUNK_SIZE_KEY = "vec.temporal_chunk_size";
 
 /** sqlite-vec slots per temporal chunk (~192 KB at 768 dims). */
 export const TEMPORAL_CHUNK_SIZE = 64;
+
+const DELETE_TEMPORAL_CHUNKS_SQL = `DELETE FROM temporal_vec WHERE ${Array.from(
+  { length: MAX_TEMPORAL_CHUNKS_PER_MESSAGE },
+  () => "chunk_id = ?",
+).join(" OR ")}`;
 
 /** Logical table → physical base table name. */
 const BASE_TABLE: Record<EmbeddingTable, string> = {
@@ -335,14 +341,12 @@ function storeEmbeddingVec0(
  * via {@link storeEmbedding}. NO-OP outside vec0 mode.
  *
  * Re-embed semantics: a content update calls this again, so it first DELETEs
- * ALL chunks of the message (by the aux `message_id`) then re-inserts the new
- * set — vec0 has no upsert, and the chunk count can change between embeds, so a
- * per-`chunk_id` replace would orphan now-removed ords. Partition (and aux)
- * values come from the just-written base row; if it is gone (a delete raced the
- * fire-and-forget embed) there is nothing to index — skip. The DELETE + N
- * INSERTs are left unguarded (matching {@link storeEmbedding}'s vec0 path): a
- * crash mid-loop leaves the message with fewer chunks until its next re-embed —
- * bounded, non-corrupting, and the read collapses whatever chunks exist.
+ * every possible exact `chunk_id`, then inserts the new set. vec0 has no upsert,
+ * and the chunk count can shrink between embeds. Partition and auxiliary values
+ * come from the just-written base row; if it is gone (a delete raced the
+ * fire-and-forget embed) there is nothing to index. The replacement runs in a
+ * savepoint so readers never observe a partial chunk set. An empty replacement
+ * is a no-op because there is no complete new set to install.
  */
 export function storeTemporalChunks(
   conn: EmbeddingWriteConn,
@@ -350,26 +354,62 @@ export function storeTemporalChunks(
   vecs: Float32Array[],
 ): void {
   if (readStorageMode(conn) !== "vec0") return;
-  const row = conn
-    .query("SELECT project_id, session_id FROM temporal_messages WHERE id = ?")
-    .get(messageId) as
-    | { project_id: string; session_id: string }
-    | null
-    | undefined;
-  if (!row) return;
-  conn.query("DELETE FROM temporal_vec WHERE message_id = ?").run(messageId);
-  const insert = conn.query(
-    "INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) VALUES (?, ?, ?, ?, ?)",
-  );
-  for (let ord = 0; ord < vecs.length; ord++) {
-    insert.run(
-      `${messageId}#${ord}`,
-      messageId,
-      row.project_id,
-      row.session_id,
-      toBlob(vecs[ord]),
+  if (!vecs.length) return;
+  if (vecs.length > MAX_TEMPORAL_CHUNKS_PER_MESSAGE) {
+    throw new Error(
+      `storeTemporalChunks: ${vecs.length} chunks exceeds the ${MAX_TEMPORAL_CHUNKS_PER_MESSAGE}-chunk limit`,
     );
   }
+  withSavepointOn(conn, "store_temporal_chunks", () => {
+    const row = conn
+      .query(
+        "SELECT project_id, session_id FROM temporal_messages WHERE id = ?",
+      )
+      .get(messageId) as
+      | { project_id: string; session_id: string }
+      | null
+      | undefined;
+    if (!row) return;
+    deleteTemporalChunks(conn, [messageId]);
+    const insert = conn.query(
+      "INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) VALUES (?, ?, ?, ?, ?)",
+    );
+    for (let ord = 0; ord < vecs.length; ord++) {
+      insert.run(
+        `${messageId}#${ord}`,
+        messageId,
+        row.project_id,
+        row.session_id,
+        toBlob(vecs[ord]),
+      );
+    }
+  });
+}
+
+function deleteTemporalChunks(
+  conn: EmbeddingWriteConn,
+  messageIds: readonly string[],
+): void {
+  const del = conn.query(DELETE_TEMPORAL_CHUNKS_SQL);
+  const hasChunk = conn.query(
+    "SELECT chunk_id FROM temporal_vec WHERE chunk_id = ?",
+  );
+  messageIds.forEach((messageId) => {
+    let firstOrd = 0;
+    do {
+      del.run(
+        ...Array.from(
+          { length: MAX_TEMPORAL_CHUNKS_PER_MESSAGE },
+          (_, offset) => `${messageId}#${firstOrd + offset}`,
+        ),
+      );
+      firstOrd += MAX_TEMPORAL_CHUNKS_PER_MESSAGE;
+      // Older remote providers trusted response cardinality, so malformed
+      // overlong responses could persist a canonical contiguous legacy tail
+      // beyond the current cap. Probe the next exact key and clean only when it
+      // exists. Sparse or malformed keys require a separate repair path.
+    } while (hasChunk.get(`${messageId}#${firstOrd}`));
+  });
 }
 
 /**
@@ -377,9 +417,9 @@ export function storeTemporalChunks(
  *
  * NO-OP in blob layout: the embedding lives on the base row, so whatever deleted
  * the base row already removed it. Only the `vec0` layout keeps a separate index
- * row that must be deleted explicitly. `temporal_vec` is chunk-keyed, so it is
- * deleted by the aux `message_id` column (removes every chunk of each message).
- * Chunked under SQLite's bound-variable ceiling.
+ * row that must be deleted explicitly. `temporal_vec` is chunk-keyed, so cleanup
+ * probes every canonical contiguous `chunk_id`, including legacy tails beyond
+ * the current per-message chunk cap.
  */
 export function deleteEmbeddings(
   conn: EmbeddingWriteConn,
@@ -388,13 +428,16 @@ export function deleteEmbeddings(
 ): void {
   if (!ids.length) return;
   if (readStorageMode(conn) !== "vec0") return;
+  if (table === "temporal") {
+    deleteTemporalChunks(conn, ids);
+    return;
+  }
   const vt = VEC_TABLE[table];
-  const keyCol = table === "temporal" ? "message_id" : "id";
   const CHUNK = 900;
   for (let i = 0; i < ids.length; i += CHUNK) {
     const batch = ids.slice(i, i + CHUNK);
     const ph = batch.map(() => "?").join(",");
-    conn.query(`DELETE FROM ${vt} WHERE ${keyCol} IN (${ph})`).run(...batch);
+    conn.query(`DELETE FROM ${vt} WHERE id IN (${ph})`).run(...batch);
   }
 }
 

--- a/packages/core/src/embedding-units.ts
+++ b/packages/core/src/embedding-units.ts
@@ -49,6 +49,9 @@ const REASONING_PREFIX = "[reasoning] ";
  */
 export const TOOL_FIRST_LINE_MAX = 200;
 
+/** Maximum logical vec0 chunks stored for one temporal message. */
+export const MAX_TEMPORAL_CHUNKS_PER_MESSAGE = 64;
+
 export type EmbedUnitKind = "text" | "reasoning" | "tool";
 
 export interface EmbedUnit {

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -44,7 +44,11 @@ import {
 import { config } from "./config";
 import * as log from "./log";
 import { recordVecReadLatency } from "./vec-latency";
-import { buildEmbeddingText, buildEmbeddingUnits } from "./embedding-units";
+import {
+  buildEmbeddingText,
+  buildEmbeddingUnits,
+  MAX_TEMPORAL_CHUNKS_PER_MESSAGE,
+} from "./embedding-units";
 import { vendorModelInfo } from "./embedding-vendor";
 import { nativeIntraOpThreads } from "./ort-native";
 import {
@@ -2971,7 +2975,7 @@ export function warmupEmbedding(): void {
  * by max-sim (then widen-retry over) — stays bounded, without silently dropping
  * any unit's text from the vector (FTS indexes the full content regardless).
  */
-export const MAX_TEMPORAL_CHUNKS_PER_MESSAGE = 64;
+export { MAX_TEMPORAL_CHUNKS_PER_MESSAGE } from "./embedding-units";
 
 /**
  * Embed `texts` in token-area-bounded sub-batches (via {@link nextBatch}) and
@@ -2997,6 +3001,9 @@ export async function embedInTokenBatches(
       batch.map((b) => b.text),
       inputType,
     );
+    if (vecs.length !== batch.length) {
+      throw new Error("embedding provider returned an unexpected vector count");
+    }
     out.push(...vecs);
   }
   return out;
@@ -3011,8 +3018,8 @@ export async function embedInTokenBatches(
  * vec0 only — the caller guarantees vec0 mode. Splits the stored content back
  * into its units (prose, reasoning, reduced tool envelopes), drops empties,
  * caps the per-message chunk fan-out (#1072), sub-batches the embeds, then
- * stores the COMPLETE set. `storeTemporalChunks` DELETEs-then-INSERTs by
- * `message_id`, so a re-embed replaces the whole set and the chunk count may
+ * stores the COMPLETE set. `storeTemporalChunks` DELETEs-then-INSERTs by exact
+ * `chunk_id`, so a re-embed replaces the whole set and the chunk count may
  * shrink or grow. Returns the number of chunks written (0 when the message has
  * no embeddable units — in which case nothing is stored OR deleted, so an
  * existing chunk set is never wiped without a replacement).

--- a/packages/core/test/vec0-cutover.test.ts
+++ b/packages/core/test/vec0-cutover.test.ts
@@ -6,7 +6,15 @@
 // All run against the real vec0-capable test connection (the vendored sqlite-vec
 // loads in the node test runtime). The suite is skipped if the extension is
 // somehow unavailable so a vec-less CI lane stays green.
-import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { config } from "../src/config";
 import {
   close,
@@ -44,6 +52,7 @@ import {
   _saveAndClearProvider,
   backfillTemporalEmbeddings,
   checkConfigChange,
+  embedInTokenBatches,
   embedTemporalMessage,
   LocalProviderUnavailableError,
   MAX_TEMPORAL_CHUNKS_PER_MESSAGE,
@@ -114,6 +123,37 @@ function unit4(rng: () => number): Float32Array {
 
 let pid: string;
 
+const passthroughSink: log.LogSink = {
+  info() {},
+  warn() {},
+  error() {},
+  captureException() {},
+};
+
+function recordSql(calls: string[]): log.LogSink {
+  return {
+    ...passthroughSink,
+    withDbSpan<T>(sql: string, fn: () => T): T {
+      calls.push(sql);
+      return fn();
+    },
+  };
+}
+
+function expectExactTemporalDeletes(calls: string[], count: number): void {
+  const deletes = calls.filter((sql) =>
+    sql.startsWith("DELETE FROM temporal_vec WHERE "),
+  );
+  expect(deletes).toHaveLength(count);
+  deletes.forEach((sql) => {
+    expect(sql).not.toContain("message_id");
+    expect(sql).not.toContain(" IN ");
+    expect(sql.match(/chunk_id = \?/g)).toHaveLength(
+      MAX_TEMPORAL_CHUNKS_PER_MESSAGE,
+    );
+  });
+}
+
 /** Return every test to a clean blob-layout state: drop vec0 tables, re-add any
  *  base `embedding` column a cutover test dropped, clear kv flags + base rows. */
 function resetToBlob(): void {
@@ -137,8 +177,13 @@ function resetToBlob(): void {
 }
 
 beforeEach(() => {
+  log.registerSink(passthroughSink);
   pid = ensureProject(PROJECT);
   resetToBlob();
+});
+
+afterEach(() => {
+  log.registerSink(passthroughSink);
 });
 
 afterAll(() => {
@@ -852,8 +897,11 @@ describeVec("delete maintenance + GC", () => {
     storeEmbedding(db(), "knowledge", "k1", v(1, 0, 0, 0));
     storeEmbedding(db(), "temporal", "t1", v(1, 0, 0, 0));
 
+    const calls: string[] = [];
+    log.registerSink(recordSql(calls));
     deleteEmbeddings(db(), "knowledge", ["k1"]);
-    deleteEmbeddings(db(), "temporal", ["t1"]); // by message_id (aux)
+    deleteEmbeddings(db(), "temporal", ["t1"]);
+    expectExactTemporalDeletes(calls, 1);
     expect(
       (
         db().query("SELECT COUNT(*) n FROM knowledge_vec").get() as {
@@ -871,6 +919,39 @@ describeVec("delete maintenance + GC", () => {
     expect(() =>
       deleteEmbeddings(db(), "knowledge", ["whatever"]),
     ).not.toThrow();
+  });
+
+  test("deleteEmbeddings removes legacy temporal chunks beyond the current cap", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("legacy-over-cap", "s", 1);
+    const insert = db().query(
+      "INSERT INTO temporal_vec(chunk_id, message_id, project_id, session_id, embedding) VALUES (?, ?, ?, 's', ?)",
+    );
+    Array.from(
+      { length: MAX_TEMPORAL_CHUNKS_PER_MESSAGE + 1 },
+      (_, ord) => ord,
+    ).forEach((ord) =>
+      insert.run(
+        `legacy-over-cap#${ord}`,
+        "legacy-over-cap",
+        pid,
+        toBlob(v(1, 0, 0, 0)),
+      ),
+    );
+    db()
+      .query("DELETE FROM temporal_messages WHERE id = ?")
+      .run("legacy-over-cap");
+
+    const calls: string[] = [];
+    log.registerSink(recordSql(calls));
+    deleteEmbeddings(db(), "temporal", ["legacy-over-cap"]);
+
+    expectExactTemporalDeletes(calls, 2);
+    expect(
+      (db().query("SELECT COUNT(*) n FROM temporal_vec").get() as { n: number })
+        .n,
+    ).toBe(0);
   });
 
   test("gcVec0DanglingRows reclaims vec0 rows whose base row is gone", () => {
@@ -1579,8 +1660,111 @@ describeVec("multi-vector temporal writes (storeTemporalChunks)", () => {
       v(0, 0, 1, 0),
     ]);
     // Re-embed to FEWER chunks: #1 and #2 must be deleted, not left dangling.
+    const calls: string[] = [];
+    log.registerSink(recordSql(calls));
     storeTemporalChunks(db(), "m1", [v(0, 0, 0, 1)]);
+    expectExactTemporalDeletes(calls, 1);
     expect(chunkIds("m1")).toEqual(["m1#0"]);
+  });
+
+  test("empty replacement preserves the prior complete chunk set", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("m1", "sX", 1000);
+    storeTemporalChunks(db(), "m1", [
+      v(1, 0, 0, 0),
+      v(0, 1, 0, 0),
+      v(0, 0, 1, 0),
+    ]);
+
+    const calls: string[] = [];
+    log.registerSink(recordSql(calls));
+    storeTemporalChunks(db(), "m1", []);
+
+    expect(
+      calls.some((sql) => sql.startsWith("DELETE FROM temporal_vec")),
+    ).toBe(false);
+    expect(chunkIds("m1")).toEqual(["m1#0", "m1#1", "m1#2"]);
+  });
+
+  test("re-embed restores the prior complete chunk set when an insert fails", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("m1", "sX", 1000);
+    storeTemporalChunks(db(), "m1", [
+      v(1, 0, 0, 0),
+      v(0, 1, 0, 0),
+      v(0, 0, 1, 0),
+    ]);
+
+    let inserts = 0;
+    log.registerSink({
+      ...passthroughSink,
+      withDbSpan<T>(sql: string, fn: () => T): T {
+        if (sql.startsWith("INSERT INTO temporal_vec")) {
+          inserts++;
+          if (inserts === 2)
+            throw new Error("injected temporal insert failure");
+        }
+        return fn();
+      },
+    });
+
+    expect(() =>
+      storeTemporalChunks(db(), "m1", [v(0, 0, 0, 1), v(1, 1, 0, 0)]),
+    ).toThrow("injected temporal insert failure");
+    expect(chunkIds("m1")).toEqual(["m1#0", "m1#1", "m1#2"]);
+  });
+
+  test("rejects chunk sets that cleanup cannot address", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("m1", "sX", 1000);
+
+    expect(() =>
+      storeTemporalChunks(
+        db(),
+        "m1",
+        Array.from({ length: MAX_TEMPORAL_CHUNKS_PER_MESSAGE + 1 }, () =>
+          v(1, 0, 0, 0),
+        ),
+      ),
+    ).toThrow(
+      `storeTemporalChunks: ${MAX_TEMPORAL_CHUNKS_PER_MESSAGE + 1} chunks exceeds the ${MAX_TEMPORAL_CHUNKS_PER_MESSAGE}-chunk limit`,
+    );
+    expect(chunkIds("m1")).toEqual([]);
+  });
+
+  test("rejects incomplete provider output before replacing a complete chunk set", async () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("m1", "sX", 1000);
+    storeTemporalChunks(db(), "m1", [
+      v(1, 0, 0, 0),
+      v(0, 1, 0, 0),
+      v(0, 0, 1, 0),
+    ]);
+
+    const token = _saveAndClearProvider();
+    try {
+      _restoreProvider({
+        provider: {
+          maxBatchSize: 8,
+          async embed() {
+            return [v(0, 0, 0, 1)];
+          },
+        },
+      });
+      await expect(
+        embedInTokenBatches(["first chunk", "second chunk"], "document"),
+      ).rejects.toThrow(
+        "embedding provider returned an unexpected vector count",
+      );
+    } finally {
+      _saveAndClearProvider();
+      _restoreProvider(token);
+    }
+    expect(chunkIds("m1")).toEqual(["m1#0", "m1#1", "m1#2"]);
   });
 
   test("is a no-op (and never throws) outside vec0 mode", () => {
@@ -1602,6 +1786,30 @@ describeVec("multi-vector temporal writes (storeTemporalChunks)", () => {
       storeTemporalChunks(db(), "ghost", [v(1, 0, 0, 0)]),
     ).not.toThrow();
     expect(chunkIds("ghost")).toEqual([]);
+  });
+
+  test("does not recreate chunks when base-row deletion finishes before replacement starts", () => {
+    setStorageMode(db(), "vec0");
+    ensureVec0Store(db(), DIM);
+    insTemporal("m1", "sX", 1000);
+    storeTemporalChunks(db(), "m1", [v(1, 0, 0, 0)]);
+
+    let raced = false;
+    log.registerSink({
+      ...passthroughSink,
+      withDbSpan<T>(sql: string, fn: () => T): T {
+        if (!raced && sql === "SAVEPOINT store_temporal_chunks") {
+          raced = true;
+          db().query("DELETE FROM temporal_messages WHERE id = ?").run("m1");
+          deleteEmbeddings(db(), "temporal", ["m1"]);
+        }
+        return fn();
+      },
+    });
+
+    storeTemporalChunks(db(), "m1", [v(0, 1, 0, 0)]);
+    expect(raced).toBe(true);
+    expect(chunkIds("m1")).toEqual([]);
   });
 
   test("embedTemporalMessage (vec0) embeds each part-aware unit and stores one chunk per unit", async () => {


### PR DESCRIPTION
## Summary

Replaces temporal vec0 cleanup by unindexed auxiliary `message_id` with bounded exact `chunk_id` probes, removing a measured full-table scan from every temporal embedding completion.

## Changes

- Deletes each message's complete 64-key chunk address space with one sqlite-vec exact-key OR query.
- Replaces temporal chunks atomically under a savepoint and rechecks base-row ownership inside it.
- Rejects malformed provider cardinality and chunk sets beyond the cleanup bound before replacing existing vectors.
- Shares the logical temporal chunk cap between embedding fan-out and storage cleanup.
- Adds fail-first regressions for SQL strategy, rollback, malformed provider output, delete races, and the 64-chunk boundary.

## Evidence

- Old auxiliary-column miss: 1.59s over roughly 382,000 rows.
- New 64-key exact-probe query: 0.53ms in the same production database.
- Restoring the old implementation makes the SQL-strategy regressions fail.

## Validation

- `pnpm exec vitest run packages/core/test/vec0-cutover.test.ts` (75 passed)
- Core: 3,545 passed, 6 skipped
- Gateway: 5,804 passed, 191 skipped across four shards
- OpenCode/Pi: 80 passed
- `pnpm run typecheck`
- `pnpm run lint` (existing warnings only)
- `pnpm run format:check`
- `pnpm --filter @loreai/gateway run bundle`

Closes #1679. The separate startup orphan anti-join remains tracked by #1681.